### PR TITLE
Added PodDisruptionBudgets to helm chart

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -121,6 +121,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `prometheus.servicemonitor.honorLabels` | Enable label honoring for metrics scraped by Prometheus (see [Prometheus scrape config docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) for details). By setting `honorLabels` to `true`, Prometheus will prefer label contents given by cert-manager on conflicts. Can be used to remove the "exported_namespace" label for example.  | `false` |
 | `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 | `deploymentAnnotations` | Annotations to add to the cert-manager deployment | `{}` |
+| `podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
@@ -138,6 +141,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.podLabels` | Labels to add to the cert-manager webhook pod | `{}` |
 | `webhook.serviceLabels` | Labels to add to the cert-manager webhook service | `{}` |
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
+| `webhook.podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `webhook.podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `webhook.podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `webhook.mutatingWebhookConfigurationAnnotations` | Annotations to add to the mutating webhook configuration | `{}` |
 | `webhook.validatingWebhookConfigurationAnnotations` | Annotations to add to the validating webhook configuration | `{}` |
 | `webhook.serviceAnnotations` | Annotations to add to the webhook service | `{}` |
@@ -180,6 +186,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |
 | `cainjector.podLabels` | Labels to add to the cert-manager cainjector pod | `{}` |
 | `cainjector.deploymentAnnotations` | Annotations to add to the cainjector deployment | `{}` |
+| `cainjector.podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `cainjector.podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `cainjector.podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
 | `cainjector.serviceAccount.create` | If `true`, create a new service account for the cainjector component | `true` |
 | `cainjector.serviceAccount.name` | Service account for the cainjector component to be used. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -38,11 +38,11 @@ Create the name of the service account to use
 Create the default PodDisruptionBudget to use
 */}}
 {{- define "podDisruptionBudget.spec" -}}
-{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
-{{- fail "Cannot set both .Values.podDisruptionBudget.minAvailable and .Values.podDisruptionBudget.maxUnavailable" -}}
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+minAvailable: 1
 {{- end }}
-{{- if not .Values.podDisruptionBudget.maxUnavailable }}
-minAvailable: {{ default 1 .Values.podDisruptionBudget.minAvailable }}
+{{- if .Values.podDisruptionBudget.minAvailable }}
+minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
 maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
@@ -57,14 +57,14 @@ Webhook templates
 Create the PodDisruptionBudget to use
 */}}
 {{- define "webhook.podDisruptionBudget.spec" -}}
-{{- if and .Values.webhook.podDisruptionBudget.minAvailable .Values.webhook.podDisruptionBudget.maxUnavailable }}
-{{- fail "Cannot set both .Values.webhook.podDisruptionBudget.minAvailable and .Values.webhook.podDisruptionBudget.maxUnavailable" -}}
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+minAvailable: 1
 {{- end }}
-{{- if not .Values.webhook.podDisruptionBudget.maxUnavailable }}
-minAvailable: {{ default 1 .Values.webhook.podDisruptionBudget.minAvailable }}
+{{- if .Values.podDisruptionBudget.minAvailable }}
+minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
-{{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
 {{- end }}
 
@@ -110,14 +110,14 @@ cainjector templates
 Create the PodDisruptionBudget to use
 */}}
 {{- define "cainjector.podDisruptionBudget.spec" -}}
-{{- if and .Values.cainjector.podDisruptionBudget.minAvailable .Values.cainjector.podDisruptionBudget.maxUnavailable }}
-{{- fail "Cannot set both .Values.cainjector.podDisruptionBudget.minAvailable and .Values.cainjector.podDisruptionBudget.maxUnavailable" -}}
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+minAvailable: 1
 {{- end }}
-{{- if not .Values.cainjector.podDisruptionBudget.maxUnavailable }}
-minAvailable: {{ default 1 .Values.cainjector.podDisruptionBudget.minAvailable }}
+{{- if .Values.webhook.podDisruptionBudget.minAvailable }}
+minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
 {{- end }}
-{{- if .Values.cainjector.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+{{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
 {{- end }}
 {{- end }}
 

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -35,6 +35,21 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the default PodDisruptionBudget to use
+*/}}
+{{- define "podDisruptionBudget.spec" -}}
+{{- if and .Values.global.podDisruptionBudget.minAvailable .Values.global.podDisruptionBudget.maxUnavailable }}
+{{- fail "Cannot set both .Values.global.podDisruptionBudget.minAvailable and .Values.global.podDisruptionBudget.maxUnavailable" -}}
+{{- end }}
+{{- if not .Values.global.podDisruptionBudget.maxUnavailable }}
+minAvailable: {{ default 1 .Values.global.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.global.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.global.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- end }}
+
+{{/*
 Webhook templates
 */}}
 

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -35,38 +35,8 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Create the default PodDisruptionBudget to use
-*/}}
-{{- define "podDisruptionBudget.spec" -}}
-{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
-minAvailable: 1
-{{- end }}
-{{- if .Values.podDisruptionBudget.minAvailable }}
-minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-{{- end }}
-{{- if .Values.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
-{{- end }}
-{{- end }}
-
-{{/*
 Webhook templates
 */}}
-
-{{/*
-Create the PodDisruptionBudget to use
-*/}}
-{{- define "webhook.podDisruptionBudget.spec" -}}
-{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
-minAvailable: 1
-{{- end }}
-{{- if .Values.podDisruptionBudget.minAvailable }}
-minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-{{- end }}
-{{- if .Values.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
-{{- end }}
-{{- end }}
 
 {{/*
 Expand the name of the chart.
@@ -105,21 +75,6 @@ Create the name of the service account to use
 {{/*
 cainjector templates
 */}}
-
-{{/*
-Create the PodDisruptionBudget to use
-*/}}
-{{- define "cainjector.podDisruptionBudget.spec" -}}
-{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
-minAvailable: 1
-{{- end }}
-{{- if .Values.webhook.podDisruptionBudget.minAvailable }}
-minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
-{{- end }}
-{{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
-{{- end }}
-{{- end }}
 
 {{/*
 Expand the name of the chart.

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -38,20 +38,35 @@ Create the name of the service account to use
 Create the default PodDisruptionBudget to use
 */}}
 {{- define "podDisruptionBudget.spec" -}}
-{{- if and .Values.global.podDisruptionBudget.minAvailable .Values.global.podDisruptionBudget.maxUnavailable }}
-{{- fail "Cannot set both .Values.global.podDisruptionBudget.minAvailable and .Values.global.podDisruptionBudget.maxUnavailable" -}}
+{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+{{- fail "Cannot set both .Values.podDisruptionBudget.minAvailable and .Values.podDisruptionBudget.maxUnavailable" -}}
 {{- end }}
-{{- if not .Values.global.podDisruptionBudget.maxUnavailable }}
-minAvailable: {{ default 1 .Values.global.podDisruptionBudget.minAvailable }}
+{{- if not .Values.podDisruptionBudget.maxUnavailable }}
+minAvailable: {{ default 1 .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
-{{- if .Values.global.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.global.podDisruptionBudget.maxUnavailable }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
 {{- end }}
 
 {{/*
 Webhook templates
 */}}
+
+{{/*
+Create the PodDisruptionBudget to use
+*/}}
+{{- define "webhook.podDisruptionBudget.spec" -}}
+{{- if and .Values.webhook.podDisruptionBudget.minAvailable .Values.webhook.podDisruptionBudget.maxUnavailable }}
+{{- fail "Cannot set both .Values.webhook.podDisruptionBudget.minAvailable and .Values.webhook.podDisruptionBudget.maxUnavailable" -}}
+{{- end }}
+{{- if not .Values.webhook.podDisruptionBudget.maxUnavailable }}
+minAvailable: {{ default 1 .Values.webhook.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- end }}
 
 {{/*
 Expand the name of the chart.
@@ -90,6 +105,21 @@ Create the name of the service account to use
 {{/*
 cainjector templates
 */}}
+
+{{/*
+Create the PodDisruptionBudget to use
+*/}}
+{{- define "cainjector.podDisruptionBudget.spec" -}}
+{{- if and .Values.cainjector.podDisruptionBudget.minAvailable .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+{{- fail "Cannot set both .Values.cainjector.podDisruptionBudget.minAvailable and .Values.cainjector.podDisruptionBudget.maxUnavailable" -}}
+{{- end }}
+{{- if not .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+minAvailable: {{ default 1 .Values.cainjector.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- end }}
 
 {{/*
 Expand the name of the chart.

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.podDisruptionBudget.enabled }}
+{{- if .Values.cainjector.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "cainjector.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-{{- include "podDisruptionBudget.spec" . | indent 2 }}
+{{- include "cainjector.podDisruptionBudget.spec" . | indent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cainjector.name" . }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ include "cainjector.name" . }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ template "cert-manager.chart" . }}
+  name: {{ include "cainjector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+{{- include "podDisruptionBudget.spec" . | indent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cainjector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -2,17 +2,25 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: {{ include "cainjector.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
   labels:
     app: {{ include "cainjector.name" . }}
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
-  name: {{ include "cainjector.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/component: "cainjector"
+    {{- include "labels" . | nindent 4 }}
 spec:
-{{- include "cainjector.podDisruptionBudget.spec" . | indent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cainjector.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "cainjector"
+
+  {{- with .Values.cainjector.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cainjector.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.podDisruptionBudget.enabled }}
+{{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ template "cert-manager.chart" . }}
+  name: {{ template "cert-manager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+{{- include "podDisruptionBudget.spec" . | indent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -3,10 +3,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    {{- include "labels" . | nindent 4 }}
   name: {{ template "cert-manager.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -2,17 +2,25 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: {{ include "cert-manager.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
   labels:
     app: {{ include "cert-manager.name" . }}
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
-  name: {{ template "cert-manager.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
 spec:
-{{- include "podDisruptionBudget.spec" . | indent 2 }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+      app.kubernetes.io/name: {{ include "cert-manager.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
+
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ include "webhook.name" . }}
+    app.kubernetes.io/name: {{ include "webhook.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ template "cert-manager.chart" . }}
+  name: {{ include "webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+{{- include "podDisruptionBudget.spec" . | indent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "webhook.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.podDisruptionBudget.enabled }}
+{{- if .Values.webhook.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "webhook.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-{{- include "podDisruptionBudget.spec" . | indent 2 }}
+{{- include "webhook.podDisruptionBudget.spec" . | indent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "webhook.name" . }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -2,17 +2,25 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  name: {{ include "webhook.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
-  name: {{ include "webhook.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/component: "webhook"
+    {{- include "labels" . | nindent 4 }}
 spec:
-{{- include "webhook.podDisruptionBudget.spec" . | indent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "webhook.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "webhook"
+
+  {{- with .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.webhook.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -62,7 +62,8 @@ strategy: {}
 
 podDisruptionBudget:
   enabled: false
-  # minAvailable: 1
+
+  minAvailable: 1
   # maxUnavailable: 1
 
   # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
@@ -286,7 +287,8 @@ webhook:
 
   podDisruptionBudget:
     enabled: false
-    # minAvailable: 1
+
+    minAvailable: 1
     # maxUnavailable: 1
 
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
@@ -466,7 +468,8 @@ cainjector:
 
   podDisruptionBudget:
     enabled: false
-    # minAvailable: 1
+
+    minAvailable: 1
     # maxUnavailable: 1
 
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -24,6 +24,11 @@ global:
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
     aggregateClusterRoles: true
 
+  podDisruptionBudget:
+    enabled: true
+    # minAvailable: 1
+    # maxUnavailable: 1
+
   podSecurityPolicy:
     enabled: false
     useAppArmor: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -24,11 +24,6 @@ global:
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
     aggregateClusterRoles: true
 
-  podDisruptionBudget:
-    enabled: true
-    # minAvailable: 1
-    # maxUnavailable: 1
-
   podSecurityPolicy:
     enabled: false
     useAppArmor: true
@@ -64,6 +59,14 @@ strategy: {}
   # rollingUpdate:
   #   maxSurge: 0
   #   maxUnavailable: 1
+
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 1
+
+  # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+  # or a percentage value (e.g. 25%)
 
 # Comma separated list of feature gates that should be enabled on the
 # controller pod & webhook pod.
@@ -281,6 +284,14 @@ webhook:
     seccompProfile:
       type: RuntimeDefault
 
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+
+    # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+    # or a percentage value (e.g. 25%)
+
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
@@ -452,6 +463,14 @@ cainjector:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+
+    # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+    # or a percentage value (e.g. 25%)
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Added PodDisruptionBudgets to helm chart. It is configurable via the values.yaml.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3898

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added PodDisruptionBudgets for cert-manager components to the Helm chart (disabled by default).
```
