### PR TITLE
Auto generate README.md, Chart.yaml, values.schema.json and values.yaml using tem & helm-jsonschema-gen

### DIFF
--- a/deploy/charts/cert-manager/.helmignore
+++ b/deploy/charts/cert-manager/.helmignore
@@ -20,6 +20,8 @@
 .idea/
 *.tmproj
 
+values/
+
 BUILD.bazel
 Chart.template.yaml
 README.template.md

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -236,7 +236,7 @@ webhook:
   # This allows setting options that'd usually be provided via flags.
   # An APIVersion and Kind must be specified in your values.yaml file.
   # Flags will override options that are set here.
-  config:
+  # config:
     # apiVersion: webhook.config.cert-manager.io/v1alpha1
     # kind: WebhookConfiguration
 

--- a/deploy/charts/cert-manager/values/cainjector.go
+++ b/deploy/charts/cert-manager/values/cainjector.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type CaInjector struct {
+	// Toggles whether the cainjector component should be installed (required for the webhook component to work)
+	Enabled bool `json:"enabled"`
+
+	Deployment `json:",inline"`
+}

--- a/deploy/charts/cert-manager/values/deployment.go
+++ b/deploy/charts/cert-manager/values/deployment.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type Deployment struct {
+	// Number of replicas
+	// +optional
+	ReplicaCount *int32 `json:"replicaCount"`
+
+	// Annotations to add to the deployment
+	DeploymentAnnotations map[string]string `json:"deploymentAnnotations,omitempty"`
+
+	// Deployment strategy
+	// +optional
+	DeploymentStrategy appsv1.DeploymentStrategy `json:"strategy,omitempty"`
+
+	Pod `json:",inline"`
+}

--- a/deploy/charts/cert-manager/values/doc.go
+++ b/deploy/charts/cert-manager/values/doc.go
@@ -1,0 +1,2 @@
+// +k8s:openapi-gen=true
+package values

--- a/deploy/charts/cert-manager/values/global.go
+++ b/deploy/charts/cert-manager/values/global.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Global struct {
+	// Reference to one or more secrets to be used when pulling images
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets"`
+
+	// Labels to apply to all resources
+	// Please note that this does not add labels to the resources created dynamically by the controllers.
+	// For these resources, you have to add the labels in the template in the cert-manager custom resource:
+	// eg. podTemplate/ ingressTemplate in ACMEChallengeSolverHTTP01Ingress
+	//    ref: https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01Ingress
+	// eg. secretTemplate in CertificateSpec
+	//    ref: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+	// +optional
+	CommonLabels map[string]string `json:"commonLabels,omitempty"`
+
+	// Priority class name for cert-manager and webhook pods
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	GlobalRbac GlobalRbac `json:"rbac"`
+
+	PodSecurityPolicy PodSecurityPolicy `json:"podSecurityPolicy"`
+
+	// Set the verbosity of cert-manager.
+	// Range of 0 - 6 with 6 being the most verbose
+	LogLevel int `json:"logLevel"`
+
+	LeaderElection LeaderElection `json:"leaderElection"`
+}
+
+type GlobalRbac struct {
+	// If `true`, create and use RBAC resources (includes sub-charts)
+	Create bool `json:"create"`
+
+	// Aggregate ClusterRoles to Kubernetes default user-facing roles.
+	// Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+	AggregateClusterRoles bool `json:"aggregateClusterRoles"`
+}
+
+type PodSecurityPolicy struct {
+	// If `true`, create and use PodSecurityPolicy (includes sub-charts)
+	Enabled bool `json:"enabled"`
+
+	// If `true`, use Apparmor seccomp profile in PSP
+	UseAppArmor bool `json:"useAppArmor"`
+}
+
+type LeaderElection struct {
+	// Override the namespace used to store the ConfigMap for leader election
+	Namespace string `json:"namespace"`
+
+	// The duration that non-leader candidates will wait after observing a
+	// leadership renewal until attempting to acquire leadership of a led but
+	// unrenewed leader slot. This is effectively the maximum duration that a
+	// leader can be stopped before it is replaced by another candidate
+	LeaseDuration metav1.Duration `json:"leaseDuration,omitempty"`
+
+	// The interval between attempts by the acting master to renew a leadership
+	// slot before it stops leading. This must be less than or equal to the
+	// lease duration
+	RenewDeadline metav1.Duration `json:"renewDeadline,omitempty"`
+
+	// The duration the clients should wait between attempting acquisition and
+	// renewal of a leadership
+	RetryPeriod metav1.Duration `json:"retryPeriod,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/image.go
+++ b/deploy/charts/cert-manager/values/image.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Image struct {
+	// Image repository
+	Repository string `json:"repository"`
+
+	// You can manage a registry with
+	// Example:
+	//  registry: quay.io
+	//  repository: jetstack/cert-manager-controller
+	Registry string `json:"registry,omitempty"`
+
+	// Image tag
+	Tag string `json:"tag,omitempty"`
+
+	// Setting a digest will override any tag
+	Digest string `json:"digest,omitempty"`
+
+	// Image pull policy
+	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/ingress_shim.go
+++ b/deploy/charts/cert-manager/values/ingress_shim.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type IngressShim struct {
+	// Optional default issuer group to use for ingress resources
+	DefaultIssuerGroup string `json:"defaultIssuerGroup,omitempty"`
+	// Optional default issuer kind to use for ingress resources
+	DefaultIssuerKind string `json:"defaultIssuerKind,omitempty"`
+	// Optional default issuer to use for ingress resources
+	DefaultIssuerName string `json:"defaultIssuerName,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/job.go
+++ b/deploy/charts/cert-manager/values/job.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type Job struct {
+	// Job backoffLimit
+	BackoffLimit int `json:"backoffLimit"`
+
+	// Annotations to add to the Job
+	JobAnnotations map[string]string `json:"jobAnnotations,omitempty"`
+
+	Pod `json:",inline"`
+}

--- a/deploy/charts/cert-manager/values/pod.go
+++ b/deploy/charts/cert-manager/values/pod.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Pod struct {
+	// Annotations to add to the pods
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	// Annotations to add to the pods
+	PodLabels map[string]string `json:"podLabels,omitempty"`
+
+	// Node labels for pod assignment
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Node affinity for pod assignment
+	// +optional
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
+	// Node tolerations for pod assignment
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	Image Image `json:"image"`
+
+	// CPU/memory resource requests/limits
+	// +optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// Optional additional arguments for pod
+	ExtraArgs []string `json:"extraArgs,omitempty"`
+
+	// Optional additional environment variables for pod
+	ExtraEnv []corev1.EnvVar `json:"extraEnv,omitempty"`
+
+	// Service account configuration for pod
+	ServiceAccount ServiceAccount `json:"serviceAccount"`
+
+	// AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted.
+	// Can be overridden at the pod level.
+	// +optional
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
+
+	// Pod Security Context
+	// ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+	// +optional
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext"`
+
+	// Container Security Context to be set on the controller component container
+	// ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+	// +optional
+	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
+
+	// TopologySpreadConstraints describes how a group of pods ought to spread across topology
+	// domains. Scheduler will schedule pods in a way which abides by the constraints.
+	// All topologySpreadConstraints are ANDed.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/probe.go
+++ b/deploy/charts/cert-manager/values/probe.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type Probe struct {
+	// Minimum consecutive failures for the probe to be considered failed after having succeeded.
+	// +optional
+	FailureThreshold int32 `json:"failureThreshold"`
+
+	// Number of seconds after the container has started before liveness probes are initiated.
+	// ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	InitialDelaySeconds int32 `json:"initialDelaySeconds"`
+
+	// How often (in seconds) to perform the probe.
+	// +optional
+	PeriodSeconds int32 `json:"periodSeconds"`
+
+	// Minimum consecutive successes for the probe to be considered successful after having failed.
+	// +optional
+	SuccessThreshold int32 `json:"successThreshold"`
+
+	// Number of seconds after which the probe times out.
+	// ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	TimeoutSeconds int32 `json:"timeoutSeconds"`
+}

--- a/deploy/charts/cert-manager/values/prometheus.go
+++ b/deploy/charts/cert-manager/values/prometheus.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type Prometheus struct {
+	// Enable Prometheus monitoring
+	Enabled bool `json:"enabled"`
+
+	Servicemonitor Servicemonitor `json:"servicemonitor"`
+}
+
+type Servicemonitor struct {
+	// Enable Prometheus Operator ServiceMonitor monitoring
+	Enabled bool `json:"enabled"`
+
+	// Define namespace where to deploy the ServiceMonitor resource
+	Namespace string `json:"namespace,omitempty"`
+
+	// Prometheus Instance definition
+	PrometheusInstance string `json:"prometheusInstance"`
+
+	//Prometheus scrape port
+	TargetPort int `json:"targetPort"`
+
+	// Prometheus scrape path
+	Path string `json:"path"`
+
+	// Prometheus scrape interval
+	Interval metav1.Duration `json:"interval"`
+
+	// Prometheus scrape timeout
+	ScrapeTimeout metav1.Duration `json:"scrapeTimeout"`
+
+	// Add custom labels to ServiceMonitor
+	Labels map[string]string `json:"labels,omitempty"`
+
+	HonorLabels bool `json:"honorLabels,omitempty"`
+
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/rbac.go
+++ b/deploy/charts/cert-manager/values/rbac.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type Rbac struct {
+	// Annotations to add to the rbac resources
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/deploy/charts/cert-manager/values/serviceaccount.go
+++ b/deploy/charts/cert-manager/values/serviceaccount.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type ServiceAccount struct {
+	// If `true`, create a new service account
+	Create bool `json:"create"`
+
+	// Service account to be used.
+	// If not set and `serviceAccount.create` is `true`, a name is generated using
+	// the fullname template
+	Name string `json:"name,omitempty"`
+
+	// Annotations to add to the service account
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to add to the service account
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Automount API credentials for the cert-manager service account
+	AutomountServiceAccountToken bool `json:"automountServiceAccountToken"`
+}

--- a/deploy/charts/cert-manager/values/startupapicheck.go
+++ b/deploy/charts/cert-manager/values/startupapicheck.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type StartupApiCheck struct {
+	// Toggles whether the startupapicheck Job should be installed
+	Enabled bool `json:"enabled"`
+
+	// Timeout for 'kubectl check api' command
+	Timeout metav1.Duration `json:"timeout"`
+
+	Rbac Rbac `json:"rbac"`
+
+	Job `json:",inline"`
+}

--- a/deploy/charts/cert-manager/values/values.go
+++ b/deploy/charts/cert-manager/values/values.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+type HelmValues struct {
+	Global Global `json:"global"`
+
+	// If true, CRD resources will be installed as part of the Helm chart.
+	// If enabled, when uninstalling CRD resources will be deleted causing all
+	// installed custom resources to be DELETED
+	InstallCRDs bool `json:"installCRDs"`
+
+	Deployment `json:",inline"`
+
+	CaInjector CaInjector `json:"cainjector"`
+	Prometheus Prometheus `json:"prometheus"`
+	Webhook    Webhook    `json:"webhook"`
+	// This startupapicheck is a Helm post-install hook that waits for the webhook
+	// endpoints to become available.
+	// The check is implemented using a Kubernetes Job- if you are injecting mesh
+	// sidecar proxies into cert-manager pods, you probably want to ensure that they
+	// are not injected into this Job's pod. Otherwise the installation may time out
+	// due to the Job never being completed because the sidecar proxy does not exit.
+	// See https://github.com/jetstack/cert-manager/pull/4414 for context.
+	StartupApiCheck StartupApiCheck `json:"startupapicheck"`
+
+	// This namespace allows you to define where the services will be installed into
+	// if not set then they will use the namespace of the release
+	// This is helpful when installing cert manager as a chart dependency (sub chart)
+	Namespace string `json:"namespace,omitempty"`
+
+	// Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
+	// resources
+	ClusterResourceNamespace string `json:"clusterResourceNamespace,omitempty"`
+
+	// Comma-separated list of feature gates to enable on the controller pod
+	FeatureGates string `json:"featureGates,omitempty"`
+
+	// Value of the `HTTP_PROXY` environment variable in the cert-manager pod
+	HttpProxy string `json:"http_proxy,omitempty"`
+	// Value of the `HTTPS_PROXY` environment variable in the cert-manager pod
+	HttpsProxy string `json:"https_proxy,omitempty"`
+	// Value of the `NO_PROXY` environment variable in the cert-manager pod
+	NoProxy string `json:"no_proxy,omitempty"`
+
+	IngressShim IngressShim `json:"ingressShim"`
+
+	// Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)
+	PodDnsConfig interface{} `json:"podDnsConfig,omitempty"`
+
+	// Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy)
+	PodDnsPolicy string `json:"podDnsPolicy,omitempty"`
+
+	// Labels to add to the cert-manager controller service
+	ServiceLabels map[string]string `json:"serviceLabels,omitempty"`
+
+	// Volume mounts to add to cert-manager
+	VolumeMounts []interface{} `json:"volumeMounts,omitempty"`
+
+	// Volumes to add to cert-manager
+	Volumes []interface{} `json:"volumes,omitempty"`
+
+	// Annotations to add to the prometheus service
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+
+	// (INTERNAL) Used to determine whether the helm.sh/chart label will be added to the rendered templates.
+	// Set to static when building static manifests so that the helm.sh labels
+	// will be omitted from the output.
+	Creator string `json:"creator,omitempty" jsonschema:"enum=static,enum=helm"`
+}

--- a/deploy/charts/cert-manager/values/webhook.go
+++ b/deploy/charts/cert-manager/values/webhook.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package values
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type WebhookUrl struct {
+	// The host to use to reach the webhook, instead of using internal cluster DNS for the service.
+	Host string `json:"host,omitempty"`
+}
+
+type Webhook struct {
+	Deployment `json:",inline"`
+
+	LivenessProbe  Probe `json:"livenessProbe"`
+	ReadinessProbe Probe `json:"readinessProbe"`
+
+	// The port that the webhook should listen on for requests.
+	SecurePort int `json:"securePort"`
+
+	// If `true`, run the Webhook on the host network.
+	HostNetwork bool `json:"hostNetwork"`
+
+	// The type of the `Service`.
+	ServiceType corev1.ServiceType `json:"serviceType"`
+
+	// The specific load balancer IP to use (when `serviceType` is `LoadBalancer`).
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
+
+	// Labels to add to the cert-manager webhook service
+	ServiceLabels map[string]string `json:"serviceLabels,omitempty"`
+
+	// Annotations to add to the cert-manager webhook service
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+
+	// Seconds the API server should wait the webhook to respond before treating the call as a failure.
+	TimeoutSeconds int `json:"timeoutSeconds"`
+
+	// Overrides the mutating webhook and validating webhook so they reach the webhook
+	// service using the `url` field instead of a service.
+	Url WebhookUrl `json:"url"`
+
+	// Annotations to add to the webhook MutatingWebhookConfiguration
+	MutatingWebhookConfigurationAnnotations map[string]string `json:"mutatingWebhookConfigurationAnnotations,omitempty"`
+
+	// Annotations to add to the webhook ValidatingWebhookConfiguration
+	ValidatingWebhookConfigurationAnnotations map[string]string `json:"validatingWebhookConfigurationAnnotations,omitempty"`
+
+	// NetworkPolicy
+	NetworkPolicy NetworkPolicy `json:"networkPolicy"`
+
+	// Used to configure options for the webhook pod.
+	// This allows setting options that'd usually be provided via flags.
+	// An APIVersion and Kind must be specified in your values.yaml file.
+	// Flags will override options that are set here.
+	// +optional
+	Config WebhookConfig `json:"config,omitempty"`
+}
+
+type NetworkPolicy struct {
+	// Toggles whether the NetworkPolicies should be installed
+	Enabled bool `json:"enabled"`
+
+	Ingress []networkingv1.NetworkPolicyIngressRule `json:"ingress"`
+
+	Egress []networkingv1.NetworkPolicyEgressRule `json:"egress"`
+}
+
+type WebhookConfig struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// The port that the webhook should listen on for requests.
+	// In GKE private clusters, by default kubernetes apiservers are allowed to
+	// talk to the cluster nodes only on 443 and 10250. so configuring
+	// securePort: 10250, will work out of the box without needing to add firewall
+	// rules or requiring NET_BIND_SERVICE capabilities to bind port numbers <1000.
+	// This should be uncommented and set as a default by the chart once we graduate
+	// the apiVersion of WebhookConfiguration past v1alpha1.
+	SecurePort int `json:"securePort"`
+}

--- a/hack/helm_jsonschema/main.go
+++ b/hack/helm_jsonschema/main.go
@@ -1,0 +1,104 @@
+//go:build exclude
+
+/*
+Copyright 2022 The Kubernetes Authors.
+Started from https://github.com/kubernetes/kubernetes/blob/f5956716e3a92fba30c81635c68187653f7567c2/pkg/generated/openapi/cmd/models-schema/main.go
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cert-manager/cert-manager/hack/helm_jsonschema/openapi"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// Outputs openAPI schema JSON containing the schema definitions in zz_generated.openapi.go.
+func main() {
+	err := output()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err))
+		os.Exit(1)
+	}
+}
+
+func pruneDefinitions(name string, from, to map[string]common.OpenAPIDefinition) {
+	if _, ok := to[name]; ok {
+		return
+	}
+
+	for _, dep := range from[name].Dependencies {
+		pruneDefinitions(dep, from, to)
+	}
+
+	to[name] = from[name]
+}
+
+type JsonSchema struct {
+	Schema string           `json:"$schema,omitempty"`
+	Ref    string           `json:"$ref,omitempty"`
+	Defs   spec.Definitions `json:"$defs,omitempty"`
+}
+
+func output() error {
+	refFunc := func(name string) spec.Ref {
+		return spec.MustCreateRef(fmt.Sprintf("#/$defs/%s", friendlyName(name)))
+	}
+	fromDefs := openapi.GetOpenAPIDefinitions(refFunc)
+
+	defs := map[string]common.OpenAPIDefinition{}
+	start := "github.com/cert-manager/cert-manager/deploy/charts/cert-manager/values.HelmValues"
+	pruneDefinitions(start, fromDefs, defs)
+
+	schemaDefs := make(map[string]spec.Schema, len(defs))
+	for k, v := range defs {
+		// Replace top-level schema with v2 if a v2 schema is embedded
+		// so that the output of this program is always in OpenAPI v2.
+		// This is done by looking up an extension that marks the embedded v2
+		// schema, and, if the v2 schema is found, make it the resulting schema for
+		// the type.
+		if schema, ok := v.Schema.Extensions[common.ExtensionV2Schema]; ok {
+			if v2Schema, isOpenAPISchema := schema.(spec.Schema); isOpenAPISchema {
+				schemaDefs[friendlyName(k)] = v2Schema
+				continue
+			}
+		}
+
+		if v.Schema.AdditionalProperties == nil {
+			// default to false
+			v.Schema.AdditionalProperties = &spec.SchemaOrBool{Allows: false}
+		}
+
+		schemaDefs[friendlyName(k)] = v.Schema
+	}
+
+	data, err := json.Marshal(JsonSchema{
+		Schema: "http://json-schema.org/draft-07/schema#",
+		Defs:   schemaDefs,
+		Ref:    "#/$defs/" + friendlyName(start),
+	})
+	if err != nil {
+		return fmt.Errorf("error serializing api definitions: %w", err)
+	}
+	os.Stdout.Write(data)
+	return nil
+}
+
+// From vendor/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
+func friendlyName(name string) string {
+	nameParts := strings.Split(name, "/")
+	// Reverse first part. e.g., io.k8s... instead of k8s.io...
+	if len(nameParts) > 0 && strings.Contains(nameParts[0], ".") {
+		parts := strings.Split(nameParts[0], ".")
+		for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+			parts[i], parts[j] = parts[j], parts[i]
+		}
+		nameParts[0] = strings.Join(parts, ".")
+	}
+	return strings.Join(nameParts, ".")
+}

--- a/hack/helm_jsonschema/openapi/.gitignore
+++ b/hack/helm_jsonschema/openapi/.gitignore
@@ -1,0 +1,1 @@
+zz_generated.openapi.go

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -332,7 +332,7 @@ $(BINDIR)/downloaded/tools/yq@$(YQ_VERSION)_%: | $(BINDIR)/downloaded/tools
 # k8s codegen tools #
 #####################
 
-K8S_CODEGEN_TOOLS := client-gen conversion-gen deepcopy-gen defaulter-gen informer-gen lister-gen
+K8S_CODEGEN_TOOLS := client-gen conversion-gen deepcopy-gen defaulter-gen informer-gen lister-gen openapi-gen
 K8S_CODEGEN_TOOLS_PATHS := $(K8S_CODEGEN_TOOLS:%=$(BINDIR)/tools/%)
 K8S_CODEGEN_TOOLS_DOWNLOADS := $(K8S_CODEGEN_TOOLS:%=$(BINDIR)/downloaded/tools/%@$(K8S_CODEGEN_VERSION))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Alternative implementation for solving #4199.
It uses a tool called [`tem`](https://github.com/amurant/tem), that I created.
`tem` combines the functionality of kubepack.dev/chart-doc-gen and github.com/gomatic/renderizer/v2.
It also allows us to create custom table layouts.
`tem` does not ONLY work for Helm, it can be used for any situation where templating using YAML as input is useful.

UPDATE: as requested by @wallrj, now the `values.schema.json` file is also auto-generated.
This is done using another custom tool https://github.com/amurant/helm-jsonschema-gen, that uses go code and 
translates it to a JSON schema definition.

**Which issue this PR fixes**

fixes #4010
fixes #2891

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The Helm chart README.md, Chart.yaml, values.yaml, values.schema.json files are now generated automatically
```
