### PR TITLE
Add minimum Kubernetes version constraint to chart

### DIFF
--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -3,7 +3,7 @@ name: cert-manager
 # The version and appVersion fields are set automatically by the release tool
 version: v0.1.0
 appVersion: v0.1.0
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.19.0-0"
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo.png

--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -3,6 +3,7 @@ name: cert-manager
 # The version and appVersion fields are set automatically by the release tool
 version: v0.1.0
 appVersion: v0.1.0
+kubeVersion: ">= 1.16.0-0"
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo.png


### PR DESCRIPTION
Add minimum supported Kubernetes version to helm chart. Ref: https://cert-manager.io/docs/installation/supported-releases/

fixes https://github.com/jetstack/cert-manager/issues/4132

```release-note
NONE
```
