### PR TITLE
WIP: A branch to test the speed of bazel unit-tests with and without remote-caching enabled

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,12 @@
+# Disable client-server mode
+startup --batch
 # Include git version info
 build --workspace_status_command hack/build/print-workspace-status.sh
-#
+# Disable TTY cursor control for clearer sequential output
+build --curses=no
+# Show timestamps with each bazel message
+build --show_timestamps
+# progress messages are suppressed
+build --noshow_progress
+# Suppress output package-loading progress messages
+build --noshow_loading_progress

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
 # Include git version info
 build --workspace_status_command hack/build/print-workspace-status.sh
+#


### PR DESCRIPTION
Experiments in shortening the time taken to run unit / integration tests.

PR test results:
 * https://prow.build-infra.jetstack.net/pr-history/?org=jetstack&repo=cert-manager&pr=4495

## Bazel remote-cache (-30min)

We've been using bazel remote-cache feature for a long time, but we wanted to confirm that it does appreciably shorten the test times. It does.

We used a temporary job to run bazel remote-cache disabled:
 * https://github.com/jetstack/testing/pull/595

Remote caching enabled:
 * 19m49s
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4495/pull-cert-manager-bazel/1445731558769037312

remote-cache disabled:
 * 50m56s
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4495/pull-cert-manager-bazel-nocache/1445736301205655552


## Bazel configured to use Go mod cache (-35s)

No significant improvement.

In CI, bazel runs all the tests with an empty disk cache, which means that it has to download all external dependencies each time it runs.
There are 2.4GiB of Go mod dependencies downloaded which would normally be cached by Go in `~/go/pkg/mod`.
I configured Bazel to use a Go mod cache of the host computer, and configured this directory to be a hostPath volume which gets populated on first use on each of the test-infra Kubernetes nodes.
Used a temporary job to run bazel configured to have access to a go mod cache on the host machine:
 * https://github.com/jetstack/testing/pull/596

With Caching:
 * 19m25s
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4495/pull-cert-manager-bazel-gocache/1446136481893584896
 * 648 log lines

No Caching:
 * 19m59s
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4495/pull-cert-manager-bazel/1446136481834864640
 * 2092 log lines

You can see from the log lines that with the cache enabled we avoided ~1450 go download events,
so this change may avoid test flakes due to temporary problems downloading from the Go module server.

```release-note
NONE
```