### PR TITLE
Upgrade Kyverno

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -106,6 +106,9 @@ resources: {}
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
 # legacy securityContext parameter format: if enabled is set to true, only fsGroup and runAsUser are supported
 # securityContext:
 #   enabled: false
@@ -216,6 +219,8 @@ webhook:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -346,6 +351,8 @@ cainjector:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -420,6 +427,8 @@ startupapicheck:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Timeout for 'kubectl check api' command
   timeout: 1m

--- a/devel/addon/kyverno/BUILD.bazel
+++ b/devel/addon/kyverno/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
 container_bundle(
-    name = "bundle_v1.3.6",
+    name = "bundle_v1.4.3",
     images = {
-        "ghcr.io/kyverno/kyverno:v1.3.6": "@io_kyverno//image",
+        "ghcr.io/kyverno/kyverno:v1.4.3": "@io_kyverno//image",
     },
     tags = ["manual"],
 )
 
 container_bundle(
-    name = "pre_bundle_v1.3.6",
+    name = "pre_bundle_v1.4.3",
     images = {
-        "ghcr.io/kyverno/kyvernopre:v1.3.6": "@io_kyverno_pre//image",
+        "ghcr.io/kyverno/kyvernopre:v1.4.3": "@io_kyverno_pre//image",
     },
     tags = ["manual"],
 )

--- a/devel/addon/kyverno/README.md
+++ b/devel/addon/kyverno/README.md
@@ -1,0 +1,10 @@
+# README
+
+The `policy.yaml` file is generated using `kustomize`.
+
+```sh
+kustomize build . > policy.yaml
+```
+
+Kustomize is used to adapt the upstream Pod security policy for use in the cert-manager namespace.
+We change `ClusterPolicy` resources to namespaced `Policy`.

--- a/devel/addon/kyverno/README.md
+++ b/devel/addon/kyverno/README.md
@@ -8,3 +8,12 @@ kustomize build . > policy.yaml
 
 Kustomize is used to adapt the upstream Pod security policy for use in the cert-manager namespace.
 We change `ClusterPolicy` resources to namespaced `Policy`.
+
+We can't apply the upstream policy because it installs `ClusterPolicy` resources,
+which affect all namespaces.
+This breaks almost all of the other E2E addons (bind, pebble, etc) which do not meet the policy requirements.
+
+The compromise is to install `Policy` resources in the cert-manager namespace,
+which verifies that the cert-manager Pods adhere to the policy.
+This includes ACME HTTP-01 solver Pods, but only those associated with a `ClusterIssuer`,
+because these are created in the cert-manager namespace during E2E tests.

--- a/devel/addon/kyverno/install.sh
+++ b/devel/addon/kyverno/install.sh
@@ -31,9 +31,9 @@ source "${SCRIPT_ROOT}/../../lib/lib.sh"
 check_tool kubectl
 check_tool helm
 
-CHART_VERSION="v1.3.6"
-IMAGE_TAG="v1.3.6"
-PRE_IMAGE_TAG="v1.3.6"
+CHART_VERSION="v2.0.3"
+IMAGE_TAG="v1.4.3"
+PRE_IMAGE_TAG="v1.4.3"
 
 require_image "ghcr.io/kyverno/kyverno:${IMAGE_TAG}" "//devel/addon/kyverno:bundle_${IMAGE_TAG}"
 require_image "ghcr.io/kyverno/kyvernopre:${PRE_IMAGE_TAG}" "//devel/addon/kyverno:pre_bundle_${PRE_IMAGE_TAG}"
@@ -43,14 +43,23 @@ require_image "ghcr.io/kyverno/kyvernopre:${PRE_IMAGE_TAG}" "//devel/addon/kyver
 helm repo add kyverno https://kyverno.github.io/kyverno/
 helm repo update
 helm upgrade \
-  --debug \
+  --install \
+  --wait \
+  --namespace kyverno \
+  --create-namespace \
+  --version "${CHART_VERSION}" \
+  kyverno-crds \
+  kyverno/kyverno-crds
+helm upgrade \
   --install \
   --wait \
   --namespace kyverno \
   --create-namespace \
   --version "${CHART_VERSION}" \
   --set image.tag="${IMAGE_TAG}" \
+  --set image.pullPolicy=Never \
   --set initImage.tag="${PRE_IMAGE_TAG}" \
+  --set initImage.pullPolicy=Never \
   kyverno \
   kyverno/kyverno
 # Install cert-manager specific Pod security policy

--- a/devel/addon/kyverno/policy.yaml
+++ b/devel/addon/kyverno/policy.yaml
@@ -4,7 +4,8 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Privilege escalation, such as via set-user-ID
-      or set-group-ID file mode, should not be allowed.
+      or set-group-ID file mode, should not be allowed. This policy ensures the `allowPrivilegeEscalation`
+      fields are either undefined or set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: deny-privilege-escalation
@@ -38,7 +39,8 @@ metadata:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Capabilities permit privileged actions without
       giving full root access. Adding capabilities beyond the default set must not
-      be allowed.
+      be allowed. This policy ensures users cannot add any additional capabilities
+      to a Pod.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: disallow-add-capabilities
@@ -53,18 +55,18 @@ spec:
     name: capabilities
     validate:
       message: Adding of additional capabilities beyond the default set is not allowed.
-        The fields spec.containers[*].securityContext.capabilities.add and  spec.initContainers[*].securityContext.capabilities.add
+        The fields spec.containers[*].securityContext.capabilities.add and spec.initContainers[*].securityContext.capabilities.add
         must be empty.
       pattern:
         spec:
           =(initContainers):
           - =(securityContext):
               =(capabilities):
-                X(add): null
+                X(add): "null"
           containers:
           - =(securityContext):
               =(capabilities):
-                X(add): null
+                X(add): "null"
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
@@ -75,7 +77,8 @@ metadata:
     policies.kyverno.io/description: Host namespaces (Process ID namespace, Inter-Process
       Communication namespace, and network namespace) allow access to shared information
       and can be used to elevate privileges. Pods should not be allowed access to
-      host namespaces.
+      host namespaces. This policy ensures fields which make use of these host namespaces
+      are set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: disallow-host-namespaces
@@ -103,9 +106,10 @@ kind: Policy
 metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: HostPath volumes let pods use host directories
+    policies.kyverno.io/description: HostPath volumes let Pods use host directories
       and volumes in containers. Using host resources can be used to access shared
-      data or escalate privileges and should not be allowed.
+      data or escalate privileges and should not be allowed. This policy ensures no
+      hostPath volumes are in use.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: disallow-host-path
@@ -134,7 +138,7 @@ metadata:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Access to host ports allows potential snooping
       of network traffic and should not be allowed, or at minimum restricted to a
-      known list.
+      known list. This policy ensures the `hostPort` fields are empty.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: disallow-host-ports
@@ -166,7 +170,8 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Privileged mode disables most security mechanisms
-      and must not be allowed.
+      and must not be allowed. This policy ensures Pods do not call for privileged
+      mode.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: disallow-privileged-containers
@@ -198,7 +203,8 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: SELinux options can be used to escalate privileges
-      and should not be allowed.
+      and should not be allowed. This policy ensures that the `seLinuxOptions` field
+      is undefined.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Disallow SELinux
@@ -234,7 +240,8 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: The default /proc masks are set up to reduce
-      attack surface and should be required.
+      attack surface and should be required. This policy ensures nothing but the default
+      procMount can be specified.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: require-default-proc-mount
@@ -250,7 +257,7 @@ spec:
     validate:
       message: Changing the proc mount from the default is not allowed. The fields
         spec.containers[*].securityContext.procMount and spec.initContainers[*].securityContext.procMount
-        must not be changed  from `Default`.
+        must not be changed from `Default`.
       pattern:
         spec:
           =(initContainers):
@@ -267,7 +274,9 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Containers should be forbidden from running with
-      a root primary or supplementary GID.
+      a root primary or supplementary GID. This policy ensures the `runAsGroup`, `supplementalGroups`,
+      and `fsGroup` fields are set to a number greater than zero (i.e., non root).
+    policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: require-non-root-groups
@@ -281,9 +290,9 @@ spec:
         - Pod
     name: check-runasgroup
     validate:
-      message: "Running with root group IDs is disallowed. The fields\t spec.securityContext.runAsGroup,
-        spec.containers[*].securityContext.runAsGroup,\t and spec.initContainers[*].securityContext.runAsGroup
-        must be empty\t or greater than zero."
+      message: Running with root group IDs is disallowed. The fields spec.securityContext.runAsGroup,
+        spec.containers[*].securityContext.runAsGroup, and spec.initContainers[*].securityContext.runAsGroup
+        must be empty or greater than zero.
       pattern:
         spec:
           =(initContainers):
@@ -300,13 +309,12 @@ spec:
         - Pod
     name: check-supplementalGroups
     validate:
-      message: "Adding of supplemental group IDs is not allowed. The field\t spec.securityContext.supplementalGroups
-        must not be defined."
+      message: Adding of supplemental group IDs is not allowed. The field spec.securityContext.supplementalGroups
+        must not be defined.
       pattern:
         spec:
           =(securityContext):
-            =(supplementalGroups):
-            - "null"
+            =(supplementalGroups): '>0'
   - match:
       resources:
         kinds:
@@ -327,7 +335,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Containers must be required to run as non-root
-      users.
+      users. This policy ensures `runAsNonRoot` is set to `true`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: require-run-as-non-root
@@ -369,8 +377,9 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: On supported hosts, the 'runtime/default' AppArmor
-      profile is applied by default.  The default policy should prevent overriding
-      or disabling the policy, or restrict  overrides to an allowed set of profiles.
+      profile is applied by default. The default policy should prevent overriding
+      or disabling the policy, or restrict overrides to an allowed set of profiles.
+      This policy ensures Pods do not specify any other AppArmor profiles than `runtime/default`.
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod, Annotation
@@ -400,7 +409,9 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: The runtime default seccomp profile must be required,
-      or only specific additional profiles should be allowed.
+      or only specific additional profiles should be allowed. This policy, requiring
+      Kubernetes v1.19 or later, ensures that only the `RuntimeDefault` or `Localhost`
+      is used as a `type` and that it is not unset.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Restrict Seccomp
@@ -413,24 +424,40 @@ spec:
       resources:
         kinds:
         - Pod
-    name: seccomp
+    name: restrict-seccomp
     validate:
+      anyPattern:
+      - spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault | Localhost
+      - spec:
+          containers:
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
       message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
         spec.containers[*].securityContext.seccompProfile.type, and spec.initContainers[*].securityContext.seccompProfile.type
-        must be unset or set to `runtime/default`.
-      pattern:
-        spec:
+        must be set to `RuntimeDefault` or `Localhost`.
+  - match:
+      resources:
+        kinds:
+        - Pod
+    name: restrict-seccomp-initcontainers
+    validate:
+      anyPattern:
+      - spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault | Localhost
+      - spec:
           =(initContainers):
-          - =(securityContext):
-              =(seccompProfile):
-                =(type): runtime/default
-          =(securityContext):
-            =(seccompProfile):
-              =(type): runtime/default
-          containers:
-          - =(securityContext):
-              =(seccompProfile):
-                =(type): runtime/default
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+      message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
+        spec.containers[*].securityContext.seccompProfile.type, and spec.initContainers[*].securityContext.seccompProfile.type
+        must be set to `RuntimeDefault` or `Localhost`.
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
@@ -441,7 +468,8 @@ metadata:
     policies.kyverno.io/description: Sysctls can disable security mechanisms or affect
       all containers on a host, and should be disallowed except for an allowed "safe"
       subset. A sysctl is considered safe if it is namespaced in the container or
-      the Pod, and it is isolated from other Pods or processes on the same Node.
+      the Pod, and it is isolated from other Pods or processes on the same Node. This
+      policy ensures that only those "safe" subsets can be specified in a Pod.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: restrict-sysctls
@@ -474,7 +502,8 @@ metadata:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: In addition to restricting HostPath volumes,
       the restricted pod security profile limits usage of non-core volume types to
-      those defined through PersistentVolumes.
+      those defined through PersistentVolumes. This policy blocks a number of different
+      non-core volume types as named.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
   name: restrict-volume-types

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -172,6 +172,9 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: pointer.BoolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 			Containers: []corev1.Container{
 				{

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -57,16 +57,16 @@ def install():
         name = "io_kyverno",
         registry = "ghcr.io",
         repository = "kyverno/kyverno",
-        tag = "v1.3.6",
-        digest = "sha256:7d7972e7d9ed2a6da27b06ccb1c3c5d3544838d6cedb67a050ba7d655461ef52",
+        tag = "v1.4.3",
+        digest = "sha256:ff4284929d1485c83d0f649ec2e4eb1cc7493c0bdf1d706cd3f3556a85c23530",
     )
 
     container_pull(
         name = "io_kyverno_pre",
         registry = "ghcr.io",
         repository = "kyverno/kyvernopre",
-        tag = "v1.3.6",
-        digest = "sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df",
+        tag = "v1.4.3",
+        digest = "sha256:63adbffb25063e206fe79922def8482ca55578d1e7f4c4a447fc1a14dd37c749",
     )
 
     ## Fetch traefik for use during e2e tests.


### PR DESCRIPTION
Originally this was about fixing a broken sha checksum in one of the images, but we've learned that we should be using a newer version of Kyverno for compatibility with Kubernetes 1.22.

So I've renamed this to "Upgrade Kyverno"

---

I noticed the following error when attempting to fetch the Docker image via bazel:

```
$ bazel fetch  //devel/addon/kyverno:pre_bundle_v1.3.6 
Starting local Bazel server and connecting to it...
INFO: Repository io_kyverno_pre instantiated at:
  /home/richard/projects/cert-manager/cert-manager/WORKSPACE:100:19: in <toplevel>
  /home/richard/projects/cert-manager/cert-manager/test/e2e/images.bzl:64:19: in install
Repository rule container_pull defined at:
  /home/richard/.cache/bazel/_bazel_richard/1509f45cf9d8eb4bfa562d22de6a55ca/external/io_bazel_rules_docker/container/pull.bzl:270:33: in <toplevel>
ERROR: An error occurred during the fetch of repository 'io_kyverno_pre':
   Traceback (most recent call last):
	File "/home/richard/.cache/bazel/_bazel_richard/1509f45cf9d8eb4bfa562d22de6a55ca/external/io_bazel_rules_docker/container/pull.bzl", line 227, column 13, in _impl
		fail(("SHA256 of the image specified does not match SHA256 of the pulled image. " +
Error in fail: SHA256 of the image specified does not match SHA256 of the pulled image. Expected sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568, but pulled image with sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df. It is possible that you have a pin to a manifest list which points to another image, if so, change the pin to point at the actual Docker image
ERROR: Error fetching repository: Traceback (most recent call last):
	File "/home/richard/.cache/bazel/_bazel_richard/1509f45cf9d8eb4bfa562d22de6a55ca/external/io_bazel_rules_docker/container/pull.bzl", line 227, column 13, in _impl
		fail(("SHA256 of the image specified does not match SHA256 of the pulled image. " +
Error in fail: SHA256 of the image specified does not match SHA256 of the pulled image. Expected sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568, but pulled image with sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df. It is possible that you have a pin to a manifest list which points to another image, if so, change the pin to point at the actual Docker image
ERROR: /home/richard/projects/cert-manager/cert-manager/devel/addon/kyverno/BUILD.bazel:11:17: no such package '@io_kyverno_pre//image': SHA256 of the image specified does not match SHA256 of the pulled image. Expected sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568, but pulled image with sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df. It is possible that you have a pin to a manifest list which points to another image, if so, change the pin to point at the actual Docker image and referenced by '//devel/addon/kyverno:pre_bundle_v1.3.6'
ERROR: /home/richard/projects/cert-manager/cert-manager/devel/addon/kyverno/BUILD.bazel:11:17: no such package '@io_kyverno_pre//image': SHA256 of the image specified does not match SHA256 of the pulled image. Expected sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568, but pulled image with sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df. It is possible that you have a pin to a manifest list which points to another image, if so, change the pin to point at the actual Docker image and referenced by '//devel/addon/kyverno:pre_bundle_v1.3.6'
ERROR: Evaluation of query "deps(//devel/addon/kyverno:pre_bundle_v1.3.6)" failed: errors were encountered while computing transitive closure
Loading: 84 packages loaded
```

So I've updated the sha and checked that it's valid as follows:
 
```sh
$ docker inspect  ghcr.io/kyverno/kyvernopre@sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df
[
    {
        "Id": "sha256:967c44c0a279b64def7073f69745de1b5424d238215c656a6293f63580d0455a",
        "RepoTags": [
            "ghcr.io/kyverno/kyvernopre:v1.3.6"
        ],
        "RepoDigests": [
            "ghcr.io/kyverno/kyvernopre@sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df",
            "ghcr.io/kyverno/kyvernopre@sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568"
        ],
...
```

That seems to show both the current and the new sha256 sums for this image.
Does that mean that you can have two different Docker images with the same tag?
(v1.3.6 in this case) 

```release-note
NONE
```
