### PR TITLE
namespaceSelector matchExpressions to be configured on ValidatingWebHookConfiguration

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -135,6 +135,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
 | `webhook.mutatingWebhookConfigurationAnnotations` | Annotations to add to the mutating webhook configuration | `{}` |
 | `webhook.validatingWebhookConfigurationAnnotations` | Annotations to add to the validating webhook configuration | `{}` |
+| `webhook.validatingWebhookConfigurationNamespaceSelectorMatchExpressions` | Additional matchExpressions for the namespaceSelector of the validating webhook configuration | `[]` |
 | `webhook.serviceAnnotations` | Annotations to add to the webhook service | `{}` |
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.serviceAccount.create` | If `true`, create a new service account for the webhook component | `true` |

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -25,6 +25,9 @@ webhooks:
         operator: "NotIn"
         values:
         - {{ .Release.Namespace }}
+      {{- if .Values.webhook.validatingWebhookConfigurationNamespaceSelectorMatchExpressions }}
+      {{- toYaml .Values.webhook.validatingWebhookConfigurationNamespaceSelectorMatchExpressions | nindent 6 }}
+      {{- end }}
     rules:
       - apiGroups:
           - "cert-manager.io"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -238,6 +238,9 @@ webhook:
   # Optional additional annotations to add to the webhook ValidatingWebhookConfiguration
   # validatingWebhookConfigurationAnnotations: {}
 
+  # Optional additional namespaceSelector matchExpressions to add to the webhook ValidatingWebhookConfiguration
+  # validatingWebhookConfigurationNamespaceSelectorMatchExpressions: []
+
   # Optional additional annotations to add to the webhook service
   # serviceAnnotations: {}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Azure Kubernetes Service force-injects an additional matchExpression on the namespaceSelector of this webhook... one that, if you don't template it out, causes continuous synchronization failures using most Continuous Delivery tools, namely ArgoCD in the parent issue.  It may also be the case that a user wishes to configure additional namespaceSelectors to their liking for their given cluster or cloud provider: not just AKS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4114

**Special notes for your reviewer**: none needed really.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow additional namespaceSelector matchExpressions to be configured on ValidatingWebHook
```