### PR TITLE
`RevisionHistoryLimit` has a default value of 25

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -200,7 +200,7 @@ spec:
                   description: How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration
                   type: string
                 revisionHistoryLimit:
-                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `0` or greater. If set to `0`, revisions will not be garbage collected. Default value is `25`.
                   type: integer
                   format: int32
                 secretName:

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -183,8 +183,8 @@ type CertificateSpec struct {
 	// a single `CertificateRequest` created by this Certificate, either when it
 	// was created, renewed, or Spec was changed. Revisions will be removed by
 	// oldest first if the number of revisions exceeds this number. If set,
-	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
-	// revisions will not be garbage collected. Default value is `nil`.
+	// revisionHistoryLimit must be a value of `0` or greater. If set to `0`,
+	// revisions will not be garbage collected. Default value is `25`.
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"` // Validated by the validating webhook.

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -112,9 +112,14 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	log = logf.WithResource(log, crt)
 
-	// If RevisionHistoryLimit is nil, don't attempt to garbage collect old
-	// CertificateRequests
+	// If RevisionHistoryLimit is nil, then default to 25
 	if crt.Spec.RevisionHistoryLimit == nil {
+		defaultVal := int32(25)
+		crt.Spec.RevisionHistoryLimit = &defaultVal
+	}
+
+	// If RevisionHistoryLimit is 0 then do not garbage collect old Certificates
+	if *crt.Spec.RevisionHistoryLimit == 0 {
 		return nil
 	}
 
@@ -139,7 +144,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	for _, req := range toDelete {
 		logf.WithRelatedResourceName(log, req.Name, req.Namespace, cmapi.CertificateRequestKind).
-			WithValues("revision", req.rev).Info("garbage collecting old certificate request revsion")
+			WithValues("revision", req.rev).Info("garbage collecting old certificate request revision")
 		err = c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			continue
@@ -169,13 +174,13 @@ func certificateRequestsToDelete(log logr.Logger, limit int, requests []*cmapi.C
 		log = logf.WithRelatedResource(log, req)
 
 		if req.Annotations == nil || req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey] == "" {
-			log.Error(errors.New("skipping processing request with missing revsion"), "")
+			log.Error(errors.New("skipping processing request with missing revision"), "")
 			continue
 		}
 
 		rn, err := strconv.Atoi(req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey])
 		if err != nil {
-			log.Error(err, "failed to parse request revsion")
+			log.Error(err, "failed to parse request revision")
 			continue
 		}
 
@@ -186,7 +191,7 @@ func certificateRequestsToDelete(log logr.Logger, limit int, requests []*cmapi.C
 		return revisions[i].rev < revisions[j].rev
 	})
 
-	// Return the oldest revsions which are over the limit
+	// Return the oldest revisions which are over the limit
 	remaining := len(revisions) - limit
 	if remaining < 0 {
 		return nil

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -156,6 +156,22 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
+		"do nothing if revision limit is 0": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(0),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+			},
+		},
 		"delete 1 request if limit is 1 and 2 requests exist": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),


### PR DESCRIPTION
Signed-off-by: Amir Mofasser <amimof@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
* Changes the default value of `RevisionHistoryLimit` to `25`
* If set to 0 then certificate requests are not garbage collected
* If set to nil then RevisionHistoryLimit is set to 25 by default

There needs to be a default value to prevent clusters from filling up with CR's which is very likely. With this, the default behaviour is to garbage collect old CR's 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
Fixes #4071

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
RevisionHistoryLimit now has a default value of 25
```
