### PR TITLE
Bug: reproduce bug where the issuing controller picks up an oudated CertificateRequest

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -213,6 +213,44 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"if certificate is in Issuing state, one CertificateRequest, but has failed and rotationPolicy changed, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert,
+						gen.SetCertificateRotationPolicy("Never"),
+					),
+					gen.CertificateRequestFrom(
+						internaltest.MustCreateCryptoBundle(t,
+							gen.CertificateFrom(issuingCert,
+								gen.SetCertificateRotationPolicy("Always"), // Mismatch since the cert has "Never".
+							), fixedClock,
+						).CertificateRequest,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}), gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:    cmapi.CertificateRequestConditionReady,
+							Status:  cmmeta.ConditionFalse,
+							Reason:  cmapi.CertificateRequestReasonFailed,
+							Message: "The certificate request failed because of reasons",
+						}),
+					),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+			},
+			expectedErr: false,
+		},
 
 		"if certificate is in Issuing state, one CertificateRequest, but has failed, set failed state and log event": {
 			certificate: exampleBundle.Certificate,

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -104,6 +104,12 @@ func SetCertificateKeyEncoding(keyEncoding v1.PrivateKeyEncoding) CertificateMod
 	}
 }
 
+func SetCertificateRotationPolicy(policy v1.PrivateKeyRotationPolicy) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.PrivateKey.RotationPolicy = policy
+	}
+}
+
 func SetCertificateSecretName(secretName string) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		crt.Spec.SecretName = secretName


### PR DESCRIPTION
This PR relates to https://github.com/jetstack/cert-manager/issues/4642.

In 6484010f I made sure that the issuing controller would not use the status of an outdated CertificateRequest for setting its own status. This PR introduces a unit test that reproduces the issue.

By "outdated", I mean that the CertificateRequest was created at a moment when the Certificate had a different spec.

The bug fix I introduced in 6484010f is only able to detect changes in the Certificate resource that can be compared to the CertificateRequest. That includes the following fields in the Certificate:

- spec.commonName
- spec.dnsNames
- spec.ipAddresses
- spec.uris
- spec.emailAddresses
- spec.subject
- spec.isCA
- spec.keyUsages
- spec.duration
- spec.issuerRef

But some fields on the Certificate can't be compared to anything on the CertificateRequest, making it impossible for the issuing controller to know when it should not bubble up the CR status into the Certificate. The information that can't be detected are:

- spec.privateKey.rotationPolicy
- spec.privateKey.encoding
- spec.privateKey.algorithm
- spec.privateKey.size
- spec.encodeUsagesInRequest

> Note: some Certificate fields do not need to be compared since they do not need a re-issuance of the certificate when they are changed:
>
> - spec.keystores.jks
> - spec.keystores.pkcs12
> - spec.renewBefore
> - spec.revisionHistoryLimit
