### PR TITLE
allow excluding tls from certificate shim

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1
 
+import (
+	"regexp"
+)
+
 // Common annotation keys added to resources.
 const (
 	// Annotation key for DNS subjectAltNames.
@@ -207,4 +211,30 @@ func DefaultKeyUsages() []KeyUsage {
 	// (in which case, 'serverAuth' on the CA can break a lot of clients).
 	// CAs can (and often do) opt to automatically add usages.
 	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
+}
+
+const (
+	// CertificatShimExclusionsAnnotationKey is used to specify TLS entries that should be
+	// ignored by the certificate shim when generating certificates.
+	CertificateShimExclusionsAnnotationKey = "certificate-shim.cert-manager.io/exclusions"
+)
+
+// CertificateExclusion is a regexp that may used to ignore TLS entries for
+// when generating certificates.
+//
+// Examples:
+//	- cluster-wildcard
+//	- (default\-.*)|(cluster-wildcard)
+//
+// When processed, interstitial spaces will be trimmed.
+type CertificateExclusion string
+
+// Matches returns true if the CertificateExclusion matches the provided name.
+// If the underlying expression cannot compile to a regexp, return an error.
+func (s CertificateExclusion) Matches(name string) (bool, error) {
+	expr, err := regexp.Compile(string(s))
+	if err != nil {
+		return false, err
+	}
+	return expr.MatchString(name), nil
 }


### PR DESCRIPTION
Sometimes not every certificate in an ingress needs to be managed by
certificate-shim. For example, some namespaces may have a wildcard
certificate installed for that namespace - at least that's a pattern we've used :)

In our wildcard certificate example, this does cause gotchas as the cert-manager shim competes with our own tooling, which generates a bespoke cert. If cert-manager shim discovers an ingress before we create it, it "squats" on the certificate.

This allows excluding certificates from certificate shim by using a regexp match against the secret name. I chose a regexp here because it's flexible if folks want to do:

- `^prefixes.*$`
- `^.*suffixes$`
- `^multiple|explicit|certificate|names$`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Introduces a new annotation `certificate-shim.cert-manager.io/exclusions` to cause certificate-shim to skip auto-generating certain certs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4604, at least for my use case.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
A new ingress/gateway annotation `certificate-shim.cert-manager.io/exclusions` allows specifying a regexp to skip certificates that reference the matching secret names. Effectively allows block-listing a subset of certificates from automation when using ingress-shim.
```
