### PR TITLE
Add possibility to use ambient credentials for login to vault

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1057,7 +1057,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -1066,7 +1065,7 @@ spec:
                               description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
                               type: string
                             secretRef:
-                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              description: The Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If unspecified, the default use ambient credentials.
                               type: object
                               required:
                                 - name

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1057,7 +1057,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -1066,7 +1065,7 @@ spec:
                               description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
                               type: string
                             secretRef:
-                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              description: The Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. If unspecified, the default use ambient credentials.
                               type: object
                               required:
                                 - name

--- a/internal/vault/fake/vault.go
+++ b/internal/vault/fake/vault.go
@@ -28,7 +28,7 @@ import (
 
 // Vault is a mock implementation of the Vault interface
 type Vault struct {
-	NewFn                           func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)
+	NewFn                           func(string, corelisters.SecretLister, v1.GenericIssuer, bool) (*Vault, error)
 	SignFn                          func([]byte, time.Duration) ([]byte, []byte, error)
 	IsVaultInitializedAndUnsealedFn func() error
 }
@@ -44,7 +44,7 @@ func New() *Vault {
 		},
 	}
 
-	v.NewFn = func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error) {
+	v.NewFn = func(string, corelisters.SecretLister, v1.GenericIssuer, bool) (*Vault, error) {
 		return v, nil
 	}
 
@@ -65,14 +65,14 @@ func (v *Vault) WithSign(certPEM, caPEM []byte, err error) *Vault {
 }
 
 // WithNew sets the fake Vault's New function.
-func (v *Vault) WithNew(f func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)) *Vault {
+func (v *Vault) WithNew(f func(string, corelisters.SecretLister, v1.GenericIssuer, bool) (*Vault, error)) *Vault {
 	v.NewFn = f
 	return v
 }
 
 // New call NewFn and returns a pointer to the fake Vault.
-func (v *Vault) New(ns string, sl corelisters.SecretLister, iss v1.GenericIssuer) (*Vault, error) {
-	_, err := v.NewFn(ns, sl, iss)
+func (v *Vault) New(ns string, sl corelisters.SecretLister, iss v1.GenericIssuer, ambient bool) (*Vault, error) {
+	_, err := v.NewFn(ns, sl, iss, ambient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/certmanager/v1/const.go
+++ b/pkg/apis/certmanager/v1/const.go
@@ -40,4 +40,6 @@ const (
 	// (/v1/auth/kubernetes). The endpoint will then be called at `/login`, so
 	// left as the default, `/v1/auth/kubernetes/login` will be called.
 	DefaultVaultKubernetesAuthMountPath = "/v1/auth/kubernetes"
+
+	DefaultJWTFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -257,9 +257,10 @@ type VaultKubernetesAuth struct {
 	// +optional
 	Path string `json:"mountPath,omitempty"`
 
-	// The required Secret field containing a Kubernetes ServiceAccount JWT used
-	// for authenticating with Vault. Use of 'ambient credentials' is not
-	// supported.
+	// The Secret field containing a Kubernetes ServiceAccount JWT used
+	// for authenticating with Vault. If unspecified, the default use ambient
+	// credentials.
+	// +optional
 	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
 
 	// A required field containing the Vault Role to assume. A Role binds a

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -74,7 +74,7 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
-	client, err := v.vaultClientBuilder(resourceNamespace, v.secretsLister, issuerObj)
+	client, err := v.vaultClientBuilder(resourceNamespace, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
 	if k8sErrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -526,8 +526,8 @@ func runTest(t *testing.T, test testT) {
 
 	if test.fakeVault != nil {
 		vault.vaultClientBuilder = func(ns string, sl corelisters.SecretLister,
-			iss cmapi.GenericIssuer) (internalvault.Interface, error) {
-			return test.fakeVault.New(ns, sl, iss)
+			iss cmapi.GenericIssuer, ambient bool) (internalvault.Interface, error) {
+			return test.fakeVault.New(ns, sl, iss, false)
 		}
 	}
 

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -86,7 +86,7 @@ func (v *Vault) Sign(ctx context.Context, csr *certificatesv1.CertificateSigning
 
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
-	client, err := v.clientBuilder(resourceNamespace, v.secretsLister, issuerObj)
+	client, err := v.clientBuilder(resourceNamespace, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
 	if apierrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 		log.Error(err, message)

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -128,7 +128,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -189,7 +189,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -233,7 +233,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New(), nil
 			},
 			builder: &testpkg.Builder{
@@ -295,7 +295,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New().WithSign(nil, nil, errors.New("sign error")), nil
 			},
 			builder: &testpkg.Builder{
@@ -356,7 +356,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New().WithSign([]byte("signed-cert"), []byte("signing-ca"), nil), nil
 			},
 			builder: &testpkg.Builder{

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -96,13 +96,13 @@ func (v *Vault) Setup(ctx context.Context) error {
 	}
 
 	// check if all mandatory Vault Kubernetes fields are set.
-	if kubeAuth != nil && (len(kubeAuth.SecretRef.Name) == 0 || len(kubeAuth.Role) == 0) {
+	if kubeAuth != nil && len(kubeAuth.Role) == 0 {
 		logf.V(logf.WarnLevel).Infof("%s: %s", v.issuer.GetObjectMeta().Name, messageKubeAuthFieldsRequired)
 		apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, messageKubeAuthFieldsRequired)
 		return nil
 	}
 
-	client, err := vaultinternal.New(v.resourceNamespace, v.secretsLister, v.issuer)
+	client, err := vaultinternal.New(v.resourceNamespace, v.secretsLister, v.issuer, false)
 	if err != nil {
 		s := messageVaultClientInitFailed + err.Error()
 		logf.V(logf.WarnLevel).Infof("%s: %s", v.issuer.GetObjectMeta().Name, s)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Made `secretRef` field optionally in kubernetes auth and when it's omit and flag `cluster-issuer-ambient-credentials` set to true will use  ambient credentials (mounted service-account token).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4733

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/area vault