### PR TITLE
Trigger controller: test the trigger cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.21
 	github.com/cloudflare/cloudflare-go v0.20.0
 	github.com/cpu/goacmedns v0.1.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/digitalocean/godo v1.65.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/gofuzz v1.2.0
@@ -89,7 +90,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.11+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.12+incompatible // indirect

--- a/internal/controller/certificates/policies/BUILD.bazel
+++ b/internal/controller/certificates/policies/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/logs:go_default_library",
         "//test/unit/crypto:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_github_go_logr_logr//testing:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2173,8 +2173,8 @@ func TestDefaultPolicyChain_triggerReIssuanceCases(t *testing.T) {
 	clock := &fakeclock.FakeClock{}
 	staticFixedPrivateKey := testcrypto.MustCreatePEMPrivateKey(t)
 	tests := []struct {
-		// Means that the CertificateRequest is available along with the Secret.
-		// When set to false, only the Secret is available.
+		// hasCR=true means that the CertificateRequest is available along with
+		// the Secret. When set to false, only the Secret is available.
 		hasCR bool
 
 		// Set this func to nil if no change is to be made.

--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -57,9 +57,15 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller/certificates/internal/test:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "@com_github_davecgh_go_spew//spew:go_default_library",
+        "@com_github_pmezard_go_difflib//difflib:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -152,7 +152,7 @@ func NewController(
 			fieldManager,
 		),
 		fieldManager:         fieldManager,
-		localTemporarySigner: certificates.GenerateLocallySignedTemporaryCertificate,
+		localTemporarySigner: certificate.GenerateLocallySignedTemporaryCertificate,
 	}, queue, mustSync
 }
 

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -228,55 +228,6 @@ func SecretDataAltNamesMatchSpec(secret *corev1.Secret, spec cmapi.CertificateSp
 	return violations, nil
 }
 
-// staticTemporarySerialNumber is a fixed serial number we use for temporary certificates
-const staticTemporarySerialNumber = "1234567890"
-
-// GenerateLocallySignedTemporaryCertificate signs a temporary certificate for
-// the given certificate resource using a one-use temporary CA that is then
-// discarded afterwards.
-// This is to mitigate a potential attack against x509 certificates that use a
-// predictable serial number and weak MD5 hashing algorithms.
-// In practice, this shouldn't really be a concern anyway.
-func GenerateLocallySignedTemporaryCertificate(crt *cmapi.Certificate, pkData []byte) ([]byte, error) {
-	// generate a throwaway self-signed root CA
-	caPk, err := pki.GenerateECPrivateKey(pki.ECCurve521)
-	if err != nil {
-		return nil, err
-	}
-	caCertTemplate, err := pki.GenerateTemplate(&cmapi.Certificate{
-		Spec: cmapi.CertificateSpec{
-			CommonName: "cert-manager.local",
-			IsCA:       true,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	_, caCert, err := pki.SignCertificate(caCertTemplate, caCertTemplate, caPk.Public(), caPk)
-	if err != nil {
-		return nil, err
-	}
-
-	// sign a temporary certificate using the root CA
-	template, err := pki.GenerateTemplate(crt)
-	if err != nil {
-		return nil, err
-	}
-	template.Subject.SerialNumber = staticTemporarySerialNumber
-
-	signeeKey, err := pki.DecodePrivateKeyBytes(pkData)
-	if err != nil {
-		return nil, err
-	}
-
-	b, _, err := pki.SignCertificate(template, caCert, signeeKey.Public(), caPk)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
-}
-
 //RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
 type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration) *metav1.Time
 

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -23,12 +23,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 )
 
 func mustGenerateRSA(t *testing.T, keySize int) crypto.PrivateKey {
@@ -360,4 +366,156 @@ func TestRenewalTime(t *testing.T) {
 
 		})
 	}
+}
+
+func TestRequestMatchesSpec(t *testing.T) {
+	type Cert cmapi.Certificate // Those long types are making the lines go wee!
+	staticFixedPrivateKey := testcrypto.MustCreatePEMPrivateKey(t)
+
+	originalCert := &cmapi.Certificate{Spec: cmapi.CertificateSpec{
+		CommonName: "does-not-matter.example.com",
+		Subject: &cmapi.X509Subject{
+			Organizations:       []string{"org1", "org2"},
+			Countries:           []string{"us"},
+			OrganizationalUnits: []string{"ou1", "ou2"},
+			Localities:          []string{"loc1", "loc2"},
+			Provinces:           []string{"prov1", "prov2"},
+			StreetAddresses:     []string{"street1", "street2"},
+			PostalCodes:         []string{"post1", "post2"},
+			SerialNumber:        "12345",
+		},
+		Duration:       &metav1.Duration{Duration: 30 * 24 * time.Hour},
+		RenewBefore:    &metav1.Duration{Duration: 90 * 24 * time.Hour},
+		DNSNames:       []string{"example.com"},
+		IPAddresses:    []string{"1.2.3.4"},
+		URIs:           []string{"http://example.com"},
+		EmailAddresses: []string{"foo@bar.com"},
+		SecretName:     "does-not-matter",
+		SecretTemplate: &cmapi.CertificateSecretTemplate{
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Keystores: &cmapi.CertificateKeystores{
+			JKS: &cmapi.JKSKeystore{
+				Create: true,
+				PasswordSecretRef: cmmeta.SecretKeySelector{
+					Key:                  "password",
+					LocalObjectReference: cmmeta.LocalObjectReference{Name: "foo"},
+				},
+			},
+			PKCS12: &cmapi.PKCS12Keystore{
+				Create: true,
+				PasswordSecretRef: cmmeta.SecretKeySelector{
+					Key:                  "password",
+					LocalObjectReference: cmmeta.LocalObjectReference{Name: "foo"},
+				},
+			},
+		},
+		IssuerRef: cmmeta.ObjectReference{
+			Name:  "testissuer",
+			Kind:  "IssuerKind",
+			Group: "group.example.com",
+		},
+		IsCA: true,
+		Usages: []cmapi.KeyUsage{
+			cmapi.UsageSigning,
+			cmapi.UsageDigitalSignature,
+			cmapi.UsageKeyEncipherment,
+		},
+		PrivateKey: &cmapi.CertificatePrivateKey{
+			Algorithm:      cmapi.RSAKeyAlgorithm,
+			Size:           2048,
+			RotationPolicy: cmapi.RotationPolicyNever,
+			Encoding:       cmapi.PKCS8,
+		},
+		EncodeUsagesInRequest: pointer.Bool(true),
+		RevisionHistoryLimit:  pointer.Int32(2),
+	}}
+	originalCR := &cmapi.CertificateRequest{Spec: cmapi.CertificateRequestSpec{
+		IssuerRef: cmmeta.ObjectReference{
+			Name:  "testissuer",
+			Kind:  "IssuerKind",
+			Group: "group.example.com",
+		},
+		Request: testcrypto.MustGenerateCSRImpl(t, staticFixedPrivateKey, originalCert),
+		IsCA:    true,
+		Usages: []cmapi.KeyUsage{
+			cmapi.UsageSigning,
+			cmapi.UsageDigitalSignature,
+			cmapi.UsageKeyEncipherment,
+		},
+		Duration: &metav1.Duration{Duration: 30 * 24 * time.Hour},
+	}}
+
+	tests := []struct {
+		change     func(c *Cert) // Nil if no change is to be made.
+		mismatches []string
+	}{
+		// Happy case: with no change to the Certificate, no mismatch is
+		// expected.
+		{change: nil, mismatches: nil},
+
+		// The following Certificate fields are looked up by the
+		// RequestMatchesSpec function.
+		{change: func(c *Cert) { c.Spec.CommonName = "changed" }, mismatches: []string{"spec.commonName"}},
+		{change: func(c *Cert) { c.Spec.DNSNames = []string{"changed"} }, mismatches: []string{"spec.dnsNames"}},
+		{change: func(c *Cert) { c.Spec.IPAddresses = []string{"4.3.2.1"} }, mismatches: []string{"spec.ipAddresses"}},
+		{change: func(c *Cert) { c.Spec.URIs = []string{"https://changed"} }, mismatches: []string{"spec.uris"}},
+		{change: func(c *Cert) { c.Spec.EmailAddresses = []string{"changed@bar.com"} }, mismatches: []string{"spec.emailAddresses"}},
+		{change: func(c *Cert) { c.Spec.Usages = []cmapi.KeyUsage{cmapi.UsageAny} }, mismatches: []string{"spec.usages"}},
+		{change: func(c *Cert) { c.Spec.IsCA = false }, mismatches: []string{"spec.isCA"}},
+		{change: func(c *Cert) { c.Spec.Duration = &metav1.Duration{Duration: 1 * time.Hour} }, mismatches: []string{"spec.duration"}},
+		{change: func(c *Cert) { c.Spec.IssuerRef = cmmeta.ObjectReference{Name: "changed"} }, mismatches: []string{"spec.issuerRef"}},
+
+		// The following Certificate fields are not looked at by the
+		// RequestMatchesSpec function.
+		{change: func(c *Cert) { c.Spec.PrivateKey.Algorithm = cmapi.ECDSAKeyAlgorithm }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.PrivateKey.Size = 4096 }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.EncodeUsagesInRequest = pointer.Bool(false) }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.Keystores = &cmapi.CertificateKeystores{} }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.RenewBefore = &metav1.Duration{Duration: 1 * time.Hour} }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.RevisionHistoryLimit = pointer.Int32(10) }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.SecretName = "changed" }, mismatches: nil}, // (1)
+		{change: func(c *Cert) { c.Spec.SecretTemplate = &cmapi.CertificateSecretTemplate{} }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.PrivateKey.Encoding = cmapi.PKCS1 }, mismatches: nil},
+		{change: func(c *Cert) { c.Spec.PrivateKey.RotationPolicy = cmapi.RotationPolicyAlways }, mismatches: nil},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			cert := originalCert.DeepCopy()
+			var diffCert string
+			if test.change != nil {
+				test.change((*Cert)(cert))
+				diffCert, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+					A:       difflib.SplitLines(spewConf.Sdump(originalCert)),
+					B:       difflib.SplitLines(spewConf.Sdump(cert)),
+					Context: 1,
+				})
+				if test.change != nil && diffCert == "" {
+					t.Fatal("incorrect test case: the func to change the Certificate is non-nil but no change has been detected on the Certificate")
+				}
+			}
+			gotMismatches, gotErr := RequestMatchesSpec(originalCR, cert.Spec)
+			require.NoError(t, gotErr)
+
+			if !reflect.DeepEqual(test.mismatches, gotMismatches) {
+				debug := ""
+				if diffCert == "" {
+					debug += "with no change to the Certificate"
+				} else {
+					debug += fmt.Sprintf("with the following changes to the Certificate : %s", diffCert)
+				}
+				t.Errorf("%s, expected mismatches=%v but got mismatches=%v", debug, test.mismatches, gotMismatches)
+			}
+		})
+	}
+}
+
+var spewConf = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	DisableMethods:          true,
+	MaxDepth:                10,
 }

--- a/test/unit/crypto/BUILD.bazel
+++ b/test/unit/crypto/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/controller/certificates:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/test/unit/crypto/crypto.go
+++ b/test/unit/crypto/crypto.go
@@ -30,7 +30,6 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -66,8 +65,6 @@ type CryptoBundle struct {
 	// cert is a signed certificate
 	Cert      *x509.Certificate
 	CertBytes []byte
-
-	LocalTemporaryCertificateBytes []byte
 
 	Clock clock.Clock
 }
@@ -179,11 +176,6 @@ func createCryptoBundle(originalCert *cmapi.Certificate, clock clock.Clock) (*Cr
 		}),
 	)
 
-	tempCertBytes, err := certificates.GenerateLocallySignedTemporaryCertificate(crt, privateKeyBytes)
-	if err != nil {
-		panic("failed to generate test fixture: " + err.Error())
-	}
-
 	return &CryptoBundle{
 		Certificate:                            originalCert,
 		ExpectedRequestName:                    reqName,
@@ -198,7 +190,6 @@ func createCryptoBundle(originalCert *cmapi.Certificate, clock clock.Clock) (*Cr
 		CertificateRequestFailedInvalidRequest: certificateRequestFailedInvalidRequest,
 		Cert:                                   cert,
 		CertBytes:                              certBytes,
-		LocalTemporaryCertificateBytes:         tempCertBytes,
 		Clock:                                  clock,
 	}, nil
 }


### PR DESCRIPTION
While looking at #4459, I realized that we don't have any tests around "what should trigger a re-issuance". For example, there is no test that says _"If only the Secret is available because the CertificateRequest was removed, and that the key usages have changed, then no-issuance is triggered"_ (in this case it would be better if the re-issuance did occur, but that's a tiny corner case that probably no one will meet).

I tried to make the test cases are glanceable as possible to ease the review.

I also discovered a weird case: when both the Secret and CertificateRequest are available, and the `secretName` is changed, no re-issuance is triggered. But I guess this case is handled by the "secret manager controller" as opposed to the "trigger controller".

To run the new tests:

```
go test ./internal/controller/certificates/policies -run TestDefaultPolicyChain_triggerReIssuanceCases
```

Closes #4459.

```release-note
NONE
```

