### PR TITLE
Allow whitelist-source-range ingress annotation to be overridden

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -215,6 +216,11 @@ func (s *Solver) mergeIngressObjectMetaWithIngressResourceTemplate(ingress *netw
 	}
 
 	for k, v := range ingressTempl.Annotations {
+		// check if the user set the whitelist-source-range annotation in the template
+		annotation := k[strings.LastIndex(k, "/")+1:]
+		if annotation == "whitelist-source-range" {
+			delete(ingress.Annotations, "nginx.ingress.kubernetes.io/whitelist-source-range")
+		}
 		ingress.Annotations[k] = v
 	}
 

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -566,3 +566,81 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
+	const createdIngressKey = "createdIngressKey"
+	tests := map[string]solverFixture{
+		"should use labels and annotations from the template": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+								Class: strPtr("nginx"),
+								IngressTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressTemplate{
+									ACMEChallengeSolverHTTP01IngressObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressObjectMeta{
+										Labels: map[string]string{
+											"this is a":           "label",
+											cmacme.DomainLabelKey: "44655555555",
+										},
+										Annotations: map[string]string{
+											"ingress.kubernetes.io/whitelist-source-range":        "0.0.0.0/0,::/0",
+											"nginx.org/mergeable-ingress-type":                    "minion",
+											"traefik.ingress.kubernetes.io/frontend-entry-points": "http",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				expectedIngress.Labels = map[string]string{
+					"this is a":                         "label",
+					cmacme.DomainLabelKey:               "44655555555",
+					cmacme.TokenLabelKey:                "1",
+					cmacme.SolverIdentificationLabelKey: "true",
+				}
+				expectedIngress.Annotations = map[string]string{
+					"ingress.kubernetes.io/whitelist-source-range":        "0.0.0.0/0,::/0",
+					"nginx.org/mergeable-ingress-type":                    "minion",
+					"traefik.ingress.kubernetes.io/frontend-entry-points": "http",
+					"kubernetes.io/ingress.class":                         "nginx",
+				}
+				s.testResources[createdIngressKey] = expectedIngress
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				expectedIngress := s.testResources[createdIngressKey].(*networkingv1.Ingress)
+
+				resp, ok := args[0].(*networkingv1.Ingress)
+				if !ok {
+					t.Errorf("expected ingress to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+
+				expectedIngress.OwnerReferences = resp.OwnerReferences
+				expectedIngress.Name = resp.Name
+
+				if !reflect.DeepEqual(resp, expectedIngress) {
+					t.Errorf("unexpected ingress generated from merge\nexp=%+v\ngot=%+v", expectedIngress, resp)
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.createIngress(context.TODO(), test.Challenge, "fakeservice")
+			test.Finish(t, resp, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR allows a user to override the hardcoded `whitelist-source-range` ingress annotation. This is needed as some users will have custom ingress prefixes set on their controllers, so the hardcoded annotation will not work as intended.

This also unblocks an issue with version >= 0.40.0 of ingress-nginx when using a custom prefix, as the ingress is blocked from being created because the prefix is not correct.

Fixes https://github.com/jetstack/cert-manager/issues/4760

### Kind

feature

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Ingress whitelist-source-range annotation prefix can now be overridden via an IngressTemplate
```
