### PR TITLE
Server Side Apply: Adds support for CertificateRequests controller to use SSA with Feature Gate

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -123,7 +123,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
     verbs: ["get", "list", "watch"]

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -188,6 +188,9 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
         "//internal/apis/config/webhook:all-srcs",
         "//internal/apis/meta:all-srcs",
         "//internal/cainjector/feature:all-srcs",
+        "//internal/controller/certificaterequests:all-srcs",
         "//internal/controller/certificates:all-srcs",
         "//internal/controller/feature:all-srcs",
         "//internal/ingress:all-srcs",

--- a/internal/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -129,6 +129,8 @@ type CertificateRequestSpec struct {
 type CertificateRequestStatus struct {
 	// List of status conditions to indicate the status of a CertificateRequest.
 	// Known condition types are `Ready` and `InvalidRequest`.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []CertificateRequestCondition `json:"conditions,omitempty"`
 

--- a/internal/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -129,6 +129,8 @@ type CertificateRequestSpec struct {
 type CertificateRequestStatus struct {
 	// List of status conditions to indicate the status of a CertificateRequest.
 	// Known condition types are `Ready` and `InvalidRequest`.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []CertificateRequestCondition `json:"conditions,omitempty"`
 

--- a/internal/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/internal/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -130,6 +130,8 @@ type CertificateRequestSpec struct {
 type CertificateRequestStatus struct {
 	// List of status conditions to indicate the status of a CertificateRequest.
 	// Known condition types are `Ready` and `InvalidRequest`.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []CertificateRequestCondition `json:"conditions,omitempty"`
 

--- a/internal/controller/certificaterequests/BUILD.bazel
+++ b/internal/controller/certificaterequests/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apply.go"],
+    importpath = "github.com/cert-manager/cert-manager/internal/controller/certificaterequests",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apply_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/internal/controller/certificaterequests/OWNERS
+++ b/internal/controller/certificaterequests/OWNERS
@@ -1,4 +1,4 @@
 filters:
-  "^apply(_test)?\\.go$":
+  "apply(_test)?\\.go$":
     required_reviewers:
     - joshvanl

--- a/internal/controller/certificaterequests/OWNERS
+++ b/internal/controller/certificaterequests/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  "^apply(_test)?\\.go$":
+    required_reviewers:
+    - joshvanl

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -32,8 +32,7 @@ import (
 // Apply will make an Apply API call with the given client to the
 // CertificateRequest's resource endpoint. All status data in the given
 // CertificateRequest object is dropped.
-// The given fieldManager is will be used as the FieldManager in
-// the Apply call.
+// The given fieldManager will be used as the FieldManager in the Apply call.
 // Always sets Force Apply to true.
 func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) (*cmapi.CertificateRequest, error) {
 	reqData, err := serializeApply(req)
@@ -50,8 +49,7 @@ func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req 
 // CertificateRequests's status sub-resource endpoint. All data in the given
 // CertificateRequest object is dropped; expect for the name, namespace, and
 // status object.
-// The given fieldManager is will be used as the FieldManager in the Apply
-// call.
+// The given fieldManager will be used as the FieldManager in the Apply call.
 // Always sets Force Apply to true.
 func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) error {
 	reqData, err := serializeApplyStatus(req)
@@ -71,6 +69,8 @@ func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string
 // The status object is unset.
 // TypeMeta will be populated with the Kind "CertificateRequest" and API
 // Version "cert-manager.io/v1" respectively.
+// Manually marshalling the object into JSON is required when using the Patch
+// API call for the cert-manager client.
 func serializeApply(req *cmapi.CertificateRequest) ([]byte, error) {
 	req = &cmapi.CertificateRequest{
 		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateRequestKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
@@ -90,8 +90,11 @@ func serializeApply(req *cmapi.CertificateRequest) ([]byte, error) {
 // serializeApplyStatus converts the given CertificateRequest object to JSON.
 // Only the name, namespace, and status field values will be copied and encoded
 // into the serialized slice. All other fields will be left at their zero
-// value.  TypeMeta will be populated with the Kind "CertificateRequest" and
-// API Version "cert-manager.io/v1" respectively.
+// value.
+// TypeMeta will be populated with the Kind "CertificateRequest" and API
+// Version "cert-manager.io/v1" respectively.
+// Manually marshalling the object into JSON is required when using the Patch
+// API call for the cert-manager client.
 func serializeApplyStatus(req *cmapi.CertificateRequest) ([]byte, error) {
 	req = &cmapi.CertificateRequest{
 		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateRequestKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -21,12 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 )
 
 // Apply will make an Apply API call with the given client to the

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -35,17 +35,15 @@ import (
 // The given fieldManager is will be used as the FieldManager in
 // the Apply call.
 // Always sets Force Apply to true.
-func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) error {
+func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) (*cmapi.CertificateRequest, error) {
 	reqData, err := serializeApplyStatus(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = cl.CertmanagerV1().CertificateRequests(req.Namespace).Patch(
+	return cl.CertmanagerV1().CertificateRequests(req.Namespace).Patch(
 		ctx, req.Name, apitypes.ApplyPatchType, reqData,
 		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager})
-
-	return err
 }
 
 // ApplyStatus will make an Apply API call with the given client to the

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// Apply will make an Apply API call with the given client to the
+// CertificateRequest's resource endpoint. All status data in the given
+// CertificateRequest object is dropped.
+// The given fieldManager is will be used as the FieldManager in
+// the Apply call.
+// Always sets Force Apply to true.
+func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) error {
+	reqData, err := serializeApplyStatus(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.CertmanagerV1().CertificateRequests(req.Namespace).Patch(
+		ctx, req.Name, apitypes.ApplyPatchType, reqData,
+		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager})
+
+	return err
+}
+
+// ApplyStatus will make an Apply API call with the given client to the
+// CertificateRequests's status sub-resource endpoint. All data in the given
+// CertificateRequest object is dropped; expect for the name, namespace, and
+// status object.
+// The given fieldManager is will be used as the FieldManager in the Apply
+// call.
+// Always sets Force Apply to true.
+func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) error {
+	reqData, err := serializeApplyStatus(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.CertmanagerV1().CertificateRequests(req.Namespace).Patch(
+		ctx, req.Name, apitypes.ApplyPatchType, reqData,
+		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",
+	)
+
+	return err
+}
+
+// serializeApply converts the given CertificateRequest object to JSON.
+// The status object is unset.
+// TypeMeta will be populated with the Kind "CertificateRequest" and API
+// Version "cert-manager.io/v1" respectively.
+func serializeApply(req *cmapi.CertificateRequest) ([]byte, error) {
+	req = &cmapi.CertificateRequest{
+		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateRequestKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+		ObjectMeta: *req.ObjectMeta.DeepCopy(),
+		Spec:       *req.Spec.DeepCopy(),
+		Status:     cmapi.CertificateRequestStatus{},
+	}
+	req.ObjectMeta.ManagedFields = nil
+
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal certificaterequest object: %w", err)
+	}
+	return reqData, nil
+}
+
+// serializeApplyStatus converts the given CertificateRequest object to JSON.
+// Only the name, namespace, and status field values will be copied and encoded
+// into the serialized slice. All other fields will be left at their zero
+// value.  TypeMeta will be populated with the Kind "CertificateRequest" and
+// API Version "cert-manager.io/v1" respectively.
+func serializeApplyStatus(req *cmapi.CertificateRequest) ([]byte, error) {
+	req = &cmapi.CertificateRequest{
+		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateRequestKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: req.Namespace, Name: req.Name},
+		Status:     *req.Status.DeepCopy(),
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal certificaterequest object: %w", err)
+	}
+	return reqData, nil
+}

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -36,7 +36,7 @@ import (
 // the Apply call.
 // Always sets Force Apply to true.
 func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, req *cmapi.CertificateRequest) (*cmapi.CertificateRequest, error) {
-	reqData, err := serializeApplyStatus(req)
+	reqData, err := serializeApply(req)
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +96,7 @@ func serializeApplyStatus(req *cmapi.CertificateRequest) ([]byte, error) {
 	req = &cmapi.CertificateRequest{
 		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateRequestKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
 		ObjectMeta: metav1.ObjectMeta{Namespace: req.Namespace, Name: req.Name},
+		Spec:       cmapi.CertificateRequestSpec{},
 		Status:     *req.Status.DeepCopy(),
 	}
 	reqData, err := json.Marshal(req)

--- a/internal/controller/certificaterequests/apply_test.go
+++ b/internal/controller/certificaterequests/apply_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequests
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// This test ensures that when a Certificate object is serialized in
+// preparation for a Certificate Apply call. Only object meta/type and spec
+// field should be present.
+func Test_serializeApply(t *testing.T) {
+	// Expected serialized Certificate Apply object. Should only contain base
+	// type object, object meta object, and spec. status should be empty. Empty
+	// spec should be deterministic.
+	const (
+		expReg      = `^{"kind":"CertificateRequest","apiVersion":"cert-manager.io/v1","metadata":{.*},"spec":{.*},"status":{}}$`
+		expEmptyReg = `^{"kind":"CertificateRequest","apiVersion":"cert-manager.io/v1","metadata":{.*},"spec":{"issuerRef":{"name":""},"request":null},"status":{}}$`
+		numJobs     = 10000
+	)
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	wg.Add(numJobs)
+	for i := 0; i < 3; i++ {
+		go func() {
+			for j := range jobs {
+				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
+					var req cmapi.CertificateRequest
+					fuzz.New().NilChance(0.5).Fuzz(&req)
+
+					// Test regex with non-empty spec.
+					reqData, err := serializeApply(&req)
+					assert.NoError(t, err)
+					assert.Regexp(t, expReg, string(reqData))
+
+					// String match on empty spec.
+					req.Spec = cmapi.CertificateRequestSpec{}
+					reqData, err = serializeApply(&req)
+					assert.NoError(t, err)
+					assert.Regexp(t, expEmptyReg, string(reqData))
+
+					wg.Done()
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < numJobs; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+// This test ensures that when a Certificate object is serialized in
+// preparation for a Certificate status Apply call. Only the required
+// metadata/type fields are present, and only empty spec fields are set. We
+// also ensure that all Certificate status fields are tagged omitempty, and are
+// not serialized if unset.
+func Test_serializeApplyStatus(t *testing.T) {
+	// Expected serialized Certificate Apply object. Should only contain base
+	// meta/type object, empty spec. Status should be matched both via regex, and
+	// when empty.
+	const (
+		expReg   = `^{"kind":"CertificateRequest","apiVersion":"cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"issuerRef":{"name":""},"request":null},"status":{.*}}$`
+		expEmpty = `{"kind":"CertificateRequest","apiVersion":"cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"issuerRef":{"name":""},"request":null},"status":{}}`
+		numJobs  = 10000
+	)
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	wg.Add(numJobs)
+	for i := 0; i < 3; i++ {
+		go func() {
+			for j := range jobs {
+				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
+					var req cmapi.CertificateRequest
+					fuzz.New().NilChance(0.5).Fuzz(&req)
+					req.Name = "foo"
+					req.Namespace = "bar"
+
+					// Test regex with non-empty status.
+					reqData, err := serializeApplyStatus(&req)
+					assert.NoError(t, err)
+					assert.Regexp(t, expReg, string(reqData))
+
+					// String match on empty status.
+					req.Status = cmapi.CertificateRequestStatus{}
+					reqData, err = serializeApplyStatus(&req)
+					assert.NoError(t, err)
+					assert.Equal(t, expEmpty, string(reqData))
+
+					wg.Done()
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < numJobs; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+}

--- a/internal/controller/certificaterequests/apply_test.go
+++ b/internal/controller/certificaterequests/apply_test.go
@@ -24,7 +24,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 // This test ensures that when a Certificate object is serialized in

--- a/internal/controller/certificaterequests/apply_test.go
+++ b/internal/controller/certificaterequests/apply_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ limitations under the License.
 package certificaterequests
 
 import (
+	"encoding/json"
 	"strconv"
 	"sync"
 	"testing"
@@ -55,6 +56,11 @@ func Test_serializeApply(t *testing.T) {
 					reqData, err := serializeApply(&req)
 					assert.NoError(t, err)
 					assert.Regexp(t, expReg, string(reqData))
+
+					// Test round trip preserves the spec and object meta.
+					var rtReq cmapi.CertificateRequest
+					assert.NoError(t, json.Unmarshal(reqData, &rtReq))
+					assert.Equal(t, req.Spec, rtReq.Spec)
 
 					// String match on empty spec.
 					req.Spec = cmapi.CertificateRequestSpec{}

--- a/internal/controller/certificaterequests/apply_test.go
+++ b/internal/controller/certificaterequests/apply_test.go
@@ -57,7 +57,7 @@ func Test_serializeApply(t *testing.T) {
 					assert.NoError(t, err)
 					assert.Regexp(t, expReg, string(reqData))
 
-					// Test round trip preserves the spec and object meta.
+					// Test round trip preserves the spec.
 					var rtReq cmapi.CertificateRequest
 					assert.NoError(t, json.Unmarshal(reqData, &rtReq))
 					assert.Equal(t, req.Spec, rtReq.Spec)
@@ -113,6 +113,11 @@ func Test_serializeApplyStatus(t *testing.T) {
 					reqData, err := serializeApplyStatus(&req)
 					assert.NoError(t, err)
 					assert.Regexp(t, expReg, string(reqData))
+
+					// Test round trip preserves the status.
+					var rtReq cmapi.CertificateRequest
+					assert.NoError(t, json.Unmarshal(reqData, &rtReq))
+					assert.Equal(t, req.Status, rtReq.Status)
 
 					// String match on empty status.
 					req.Status = cmapi.CertificateRequestStatus{}

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -46,6 +46,11 @@ const (
 	//
 	// AdditionalCertificateOutputFormats enable output additional format
 	AdditionalCertificateOutputFormats featuregate.Feature = "AdditionalCertificateOutputFormats"
+
+	// alpha: v1.8.0
+	//
+	// ServerSideApply enables the use of ServerSideApply in all API calls.
+	ServerSideApply featuregate.Feature = "ServerSideApply"
 )
 
 func init() {
@@ -60,4 +65,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalGatewayAPISupport:                    {Default: false, PreRelease: featuregate.Alpha},
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -132,6 +132,8 @@ type CertificateRequestSpec struct {
 type CertificateRequestStatus struct {
 	// List of status conditions to indicate the status of a CertificateRequest.
 	// Known condition types are `Ready` and `InvalidRequest`.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []CertificateRequestCondition `json:"conditions,omitempty"`
 

--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
+        "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
@@ -20,6 +22,7 @@ go_library(
         "//pkg/controller/certificaterequests/util:go_default_library",
         "//pkg/issuer:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_kr_pretty//:go_default_library",

--- a/pkg/controller/certificaterequests/approver/BUILD.bazel
+++ b/pkg/controller/certificaterequests/approver/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/approver",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
+        "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
@@ -16,6 +18,7 @@ go_library(
         "//pkg/client/listers/certmanager/v1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -47,6 +47,7 @@ type Controller struct {
 
 	certificateRequestLister cmlisters.CertificateRequestLister
 	cmClient                 cmclient.Interface
+	fieldManager             string
 
 	recorder record.EventRecorder
 
@@ -74,6 +75,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	c.certificateRequestLister = certificateRequestInformer.Lister()
 	c.cmClient = ctx.CMClient
+	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
 
 	c.log.V(logf.DebugLevel).Info("certificate request approver controller registered")

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -57,6 +57,9 @@ type Controller struct {
 	// clientset used to update cert-manager API resources
 	cmClient cmclient.Interface
 
+	// fieldManager is the manager name used for the Apply operations.
+	fieldManager string
+
 	certificateRequestLister cmlisters.CertificateRequestLister
 
 	queue workqueue.RateLimitingInterface
@@ -182,6 +185,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.recorder = ctx.Recorder
 	c.reporter = util.NewReporter(c.clock, c.recorder)
 	c.cmClient = ctx.CMClient
+	c.fieldManager = ctx.FieldManager
 
 	// Construct the issuer implementation with the built component context.
 	c.issuer = c.issuerConstructor(ctx)

--- a/pkg/controller/certificates/requestmanager/BUILD.bazel
+++ b/pkg/controller/certificates/requestmanager/BUILD.bazel
@@ -6,8 +6,6 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/certificates/requestmanager",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/controller/certificaterequests:go_default_library",
-        "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
@@ -17,7 +15,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/certificates:go_default_library",
         "//pkg/logs:go_default_library",
-        "//pkg/util/feature:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//pkg/util/predicate:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",

--- a/pkg/controller/certificates/requestmanager/BUILD.bazel
+++ b/pkg/controller/certificates/requestmanager/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/certificates/requestmanager",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
+        "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
@@ -15,6 +17,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/certificates:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//pkg/util/predicate:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -72,7 +72,7 @@ type controller struct {
 
 	// fieldManager is the string which will be used as the Field Manager on
 	// fields created or edited by the cert-manager Kubernetes client during
-	// Apply API calls.
+	// Create or Apply API calls.
 	fieldManager string
 }
 
@@ -395,7 +395,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		},
 	}
 
-	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{})
+	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
 	if err != nil {
 		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
 		return err

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//test/integration/acme:all-srcs",
+        "//test/integration/certificaterequests:all-srcs",
         "//test/integration/certificates:all-srcs",
         "//test/integration/conversion:all-srcs",
         "//test/integration/ctl:all-srcs",

--- a/test/integration/certificaterequests/BUILD.bazel
+++ b/test/integration/certificaterequests/BUILD.bazel
@@ -7,10 +7,12 @@ go_test(
         "condition_list_type_test.go",
     ],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
         "//test/integration/framework:go_default_library",
+        "//test/unit/crypto:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/test/integration/certificaterequests/BUILD.bazel
+++ b/test/integration/certificaterequests/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = ["condition_list_type_test.go"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
         "//test/integration/framework:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/test/integration/certificaterequests/BUILD.bazel
+++ b/test/integration/certificaterequests/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["condition_list_type_test.go"],
+    srcs = [
+        "apply_test.go",
+        "condition_list_type_test.go",
+    ],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",

--- a/test/integration/certificaterequests/BUILD.bazel
+++ b/test/integration/certificaterequests/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["condition_list_type_test.go"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/util:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/certificaterequests/apply_test.go
+++ b/test/integration/certificaterequests/apply_test.go
@@ -37,8 +37,8 @@ import (
 // the ObjectMeta and Status objects respectively.
 func Test_Apply(t *testing.T) {
 	const (
-		namespace = "test-condition-list-type"
-		name      = "test-condition-list-type"
+		namespace = "test-apply"
+		name      = "test-apply"
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)

--- a/test/integration/certificaterequests/apply_test.go
+++ b/test/integration/certificaterequests/apply_test.go
@@ -69,7 +69,7 @@ func Test_Apply(t *testing.T) {
 	req.Annotations = nil
 
 	t.Log("creating CertificateRequest")
-	_, err = cmClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{})
+	_, err = cmClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{FieldManager: "cert-manager-test"})
 	assert.NoError(t, err)
 
 	t.Log("ensuring apply will can set annotations and labels")

--- a/test/integration/certificaterequests/apply_test.go
+++ b/test/integration/certificaterequests/apply_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/integration/framework"
+	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
+)
+
+// Test_Apply ensures that the CertificateRequest Apply helpers can set both
+// the ObjectMeta and Status objects respectively.
+func Test_Apply(t *testing.T) {
+	const (
+		namespace = "test-condition-list-type"
+		name      = "test-condition-list-type"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	restConfig, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
+
+	kubeClient, _, cmClient, _ := framework.NewClients(t, restConfig)
+
+	t.Log("creating test Namespace")
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	bundle := testcrypto.MustCreateCryptoBundle(t, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: cmapi.CertificateSpec{
+			CommonName: "test-bundle-1",
+			IssuerRef:  cmmeta.ObjectReference{Name: "test-bundle-1"},
+		}},
+		&fakeclock.FakeClock{},
+	)
+	req := bundle.CertificateRequest
+	req.OwnerReferences = nil
+	req.Name = name
+	req.Labels = nil
+	req.Annotations = nil
+
+	t.Log("creating CertificateRequest")
+	_, err = cmClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	t.Log("ensuring apply will can set annotations and labels")
+	req, err = internalcertificaterequests.Apply(ctx, cmClient, "cert-manager-test", &cmapi.CertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: name,
+			Annotations: map[string]string{"test-1": "abc", "test-2": "def"},
+			Labels:      map[string]string{"123": "456", "789": "abc"},
+		},
+		Spec: req.Spec,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"test-1": "abc", "test-2": "def"}, req.Annotations, "annotations")
+	assert.Equal(t, map[string]string{"123": "456", "789": "abc"}, req.Labels, "labels")
+
+	t.Log("ensuring apply will can status")
+	assert.NoError(t,
+		internalcertificaterequests.ApplyStatus(ctx, cmClient, "cert-manager-test", &cmapi.CertificateRequest{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+			Status: cmapi.CertificateRequestStatus{
+				Conditions: []cmapi.CertificateRequestCondition{{Type: cmapi.CertificateRequestConditionType("Random"), Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"}},
+			},
+		}),
+	)
+	req, err = cmClient.CertmanagerV1().CertificateRequests(namespace).Get(ctx, name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, []cmapi.CertificateRequestCondition{{Type: cmapi.CertificateRequestConditionType("Random"), Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"}}, req.Status.Conditions)
+}

--- a/test/integration/certificaterequests/condition_list_type_test.go
+++ b/test/integration/certificaterequests/condition_list_type_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ func Test_ConditionsListType(t *testing.T) {
 	req.Name = name
 
 	t.Log("creating CertificateRequest")
-	_, err = aliceCMClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{})
+	_, err = aliceCMClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{FieldManager: "cert-manager-test"})
 	assert.NoError(t, err)
 
 	t.Log("ensuring alice can set Ready condition")

--- a/test/integration/certificaterequests/condition_list_type_test.go
+++ b/test/integration/certificaterequests/condition_list_type_test.go
@@ -26,12 +26,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
 
-	internalcertificaterequests "github.com/jetstack/cert-manager/internal/controller/certificaterequests"
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/util"
-	"github.com/jetstack/cert-manager/test/integration/framework"
-	testcrypto "github.com/jetstack/cert-manager/test/unit/crypto"
+	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/util"
+	"github.com/cert-manager/cert-manager/test/integration/framework"
+	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 )
 
 // Test_ConditionsListType ensures that the CertificateRequest's Conditions API

--- a/test/integration/certificaterequests/condition_list_type_test.go
+++ b/test/integration/certificaterequests/condition_list_type_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+	testcrypto "github.com/jetstack/cert-manager/test/unit/crypto"
+)
+
+// Test_ConditionsListType ensures that the CertificateRequest's Conditions API
+// field has been labelled as a list map. This is so that district field
+// managers are able to add and modify different Conditions without disrupting
+// each others entries. Conditions are keyed by `Type`.
+func Test_ConditionsListType(t *testing.T) {
+	const (
+		namespace = "test-condition-list-type"
+		name      = "test-condition-list-type"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	restConfig, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
+
+	// Build clients with different field managers.
+	aliceRestConfig := util.RestConfigWithUserAgent(restConfig, "alice")
+	aliceFieldManager := util.PrefixFromUserAgent(aliceRestConfig.UserAgent)
+	aliceKubeClient, _, aliceCMClient, _ := framework.NewClients(t, aliceRestConfig)
+
+	bobRestConfig := util.RestConfigWithUserAgent(restConfig, "bob")
+	bobFieldManager := util.PrefixFromUserAgent(bobRestConfig.UserAgent)
+	_, _, bobCMClient, _ := framework.NewClients(t, bobRestConfig)
+
+	t.Log("creating test Namespace")
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := aliceKubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	bundle := testcrypto.MustCreateCryptoBundle(t, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "test",
+			UID:       "test",
+		},
+		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-1"}},
+		&fakeclock.FakeClock{},
+	)
+
+	t.Log("creating CertificateRequest")
+	_, err = aliceCMClient.CertmanagerV1().CertificateRequests(namespace).Create(ctx, bundle.CertificateRequest, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	//t.Log("ensuring alice can set Ready condition")
+	//crt = &cmapi.Certificate{
+	//	TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+	//	ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	//	Status: cmapi.CertificateStatus{
+	//		Conditions: []cmapi.CertificateCondition{{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"}},
+	//	},
+	//}
+	//crtData, err := json.Marshal(crt)
+	//assert.NoError(t, err)
+	//_, err = aliceCMClient.CertmanagerV1().Certificates(namespace).Patch(
+	//	ctx, name, apitypes.ApplyPatchType, crtData,
+	//	metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: aliceFieldManager}, "status",
+	//)
+	//assert.NoError(t, err)
+
+	//t.Log("ensuring bob can set a district issuing condition, without changing the ready condition")
+	//crt = &cmapi.Certificate{
+	//	TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+	//	ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	//	Status: cmapi.CertificateStatus{
+	//		Conditions: []cmapi.CertificateCondition{{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"}},
+	//	},
+	//}
+	//crtData, err = json.Marshal(crt)
+	//assert.NoError(t, err)
+	//_, err = bobCMClient.CertmanagerV1().Certificates(namespace).Patch(
+	//	ctx, name, apitypes.ApplyPatchType, crtData,
+	//	metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: bobFieldManager}, "status",
+	//)
+	//assert.NoError(t, err)
+
+	//crt, err = bobCMClient.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+	//assert.NoError(t, err)
+	//assert.Equal(t, []cmapi.CertificateCondition{
+	//	{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"},
+	//	{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, Reason: "reason", Message: "message"},
+	//}, crt.Status.Conditions, "conditions did not match the expected 2 distinct condition types")
+
+	//t.Log("alice should override an existing condition by another manager, and can delete an existing owned condition type through omission")
+	//crt = &cmapi.Certificate{
+	//	TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+	//	ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	//	Status: cmapi.CertificateStatus{
+	//		Conditions: []cmapi.CertificateCondition{{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse, Reason: "another-reason", Message: "another-message"}},
+	//	},
+	//}
+	//crtData, err = json.Marshal(crt)
+	//assert.NoError(t, err)
+	//_, err = aliceCMClient.CertmanagerV1().Certificates(namespace).Patch(
+	//	ctx, name, apitypes.ApplyPatchType, crtData,
+	//	metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: aliceFieldManager}, "status",
+	//)
+	//assert.NoError(t, err)
+
+	//crt, err = aliceCMClient.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+	//assert.NoError(t, err)
+	//assert.Equal(t, []cmapi.CertificateCondition{
+	//	{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse, Reason: "another-reason", Message: "another-message"},
+	//}, crt.Status.Conditions, "conditions did not match expected deleted ready condition, and overwritten issuing condition")
+
+	//t.Log("bob can re-add a Ready condition and not change Issuing condition")
+	//crt = &cmapi.Certificate{
+	//	TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+	//	ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	//	Status: cmapi.CertificateStatus{
+	//		Conditions: []cmapi.CertificateCondition{{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionFalse, Reason: "reason", Message: "message"}},
+	//	},
+	//}
+	//crtData, err = json.Marshal(crt)
+	//assert.NoError(t, err)
+	//_, err = bobCMClient.CertmanagerV1().Certificates(namespace).Patch(
+	//	ctx, name, apitypes.ApplyPatchType, crtData,
+	//	metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: bobFieldManager}, "status",
+	//)
+	//assert.NoError(t, err)
+
+	//crt, err = bobCMClient.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+	//assert.NoError(t, err)
+	//assert.Equal(t, []cmapi.CertificateCondition{
+	//	{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse, Reason: "another-reason", Message: "another-message"},
+	//	{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionFalse, Reason: "reason", Message: "message"},
+	//}, crt.Status.Conditions, "expected bob to be able to add a distinct ready condition after no longer owning the issuing condition")
+}


### PR DESCRIPTION
Branched from #4773 which should be merged first.

This PR implements Server Side Apply for CertificateRequests's controllers when the `SeverSideApply` Feature Gate (default `disabled`) is enabled.

Where `Update` or `UpdateStatus` was previously, two new funcs are used to check for this feature gate. If the feature gate is enabled, a new CertificateRequest object is made, and the relevant fields are copied across. 

The Open API tags `+listType=map`, `+listMapKey=type` have been added to the CertificateRequest's Condition field so that each condition can be added, updated, removed, without a conflict, even if another independent manager is concerned with another existing condition. 

See  https://github.com/jetstack/cert-manager/pull/4758 for more details and design.

---

```release-note
ServerSideApply: The feature gate `ServerSideApply=true` configures the certificaterequest controllers to use Kubernetes Server Side Apply on CertificateRequest resources. 
```

/milestone Next
/kind feature