### PR TITLE
Use multivalue records instead of simple records 

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -165,7 +165,7 @@ func NewDNSProvider(accessKeyID, secretAccessKey, hostedZoneID, region, role str
 // Present creates a TXT record using the specified parameters
 func (r *DNSProvider) Present(domain, fqdn, value string) error {
 	value = `"` + value + `"`
-	return r.changeRecord(route53.ChangeActionUpsert, fqdn, value, route53TTL)
+	return r.changeRecord(route53.ChangeActionCreate, fqdn, value, route53TTL)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
@@ -273,9 +273,11 @@ func (r *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 
 func newTXTRecordSet(fqdn, value string, ttl int) *route53.ResourceRecordSet {
 	return &route53.ResourceRecordSet{
-		Name: aws.String(fqdn),
-		Type: aws.String(route53.RRTypeTxt),
-		TTL:  aws.Int64(int64(ttl)),
+		Name:             aws.String(fqdn),
+		Type:             aws.String(route53.RRTypeTxt),
+		TTL:              aws.Int64(int64(ttl)),
+		MultiValueAnswer: aws.Bool(true),
+		SetIdentifier:    aws.String(value),
 		ResourceRecords: []*route53.ResourceRecord{
 			{Value: aws.String(value)},
 		},


### PR DESCRIPTION
Use multivalue records instead of simple records for the AWS Route53 ACME DNS challenge solver.
When using simple records, it would be impossible to create a second record in a Route53 hosted zone with the same name/type.

This way when either using the same domain name on multiple clusters or using the same CNAME record for multiple domains would create a new challenge instead of overwriting the other challenges.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
Fix https://github.com/jetstack/cert-manager/issues/3460
<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind
bug
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Use multivalue records instead of simple records for the AWS Route53 ACME DNS challenge solver, to allow for multiple challenges for the same domain at the same time
```
