### PR TITLE
 Server Side Apply: Adds support for CertificateSigningRequest controllers to use SSA with Feature Gate

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -515,7 +515,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["signers"]
     resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -46,6 +46,11 @@ const (
 	//
 	// AdditionalCertificateOutputFormats enable output additional format
 	AdditionalCertificateOutputFormats featuregate.Feature = "AdditionalCertificateOutputFormats"
+
+	// alpha: v1.8.0
+	//
+	// ServerSideApply enables the use of ServerSideApply in all API calls.
+	ServerSideApply featuregate.Feature = "ServerSideApply"
 )
 
 func init() {
@@ -60,4 +65,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalGatewayAPISupport:                    {Default: false, PreRelease: featuregate.Alpha},
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/controller/certificatesigningrequests/ca/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/ca/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/certificates/v1:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",

--- a/pkg/controller/certificatesigningrequests/controller.go
+++ b/pkg/controller/certificatesigningrequests/controller.go
@@ -63,6 +63,9 @@ type Controller struct {
 	csrLister  certificateslisters.CertificateSigningRequestLister
 	sarClient  authzclient.SubjectAccessReviewInterface
 
+	// fieldManager is the manager name used for the Apply operations.
+	fieldManager string
+
 	queue workqueue.RateLimitingInterface
 
 	// logger to be used by this controller
@@ -180,6 +183,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// recorder records events about resources to the Kubernetes api
 	c.recorder = ctx.Recorder
 	c.certClient = kubeClient.CertificatesV1().CertificateSigningRequests()
+	c.fieldManager = ctx.FieldManager
 
 	// Construct the signer implementation with the built component context.
 	c.signer = c.signerConstructor(ctx)

--- a/pkg/controller/certificatesigningrequests/selfsigned/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/selfsigned/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/certificates/v1:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",

--- a/pkg/controller/certificatesigningrequests/sync.go
+++ b/pkg/controller/certificatesigningrequests/sync.go
@@ -119,11 +119,8 @@ func (c *Controller) Sync(ctx context.Context, csr *certificatesv1.CertificateSi
 			message := fmt.Sprintf("Requester may not reference Namespaced Issuer %s/%s", ref.Namespace, ref.Name)
 			c.recorder.Event(csr, corev1.EventTypeWarning, "DeniedReference", message)
 			util.CertificateSigningRequestSetFailed(csr, "DeniedReference", message)
-			if _, err := c.certClient.UpdateStatus(ctx, csr, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-
-			return nil
+			_, err := util.UpdateOrApplyStatus(ctx, c.certClient, csr, certificatesv1.CertificateFailed, c.fieldManager)
+			return err
 		}
 	}
 

--- a/pkg/controller/certificatesigningrequests/util/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/util/BUILD.bazel
@@ -3,25 +3,37 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "apply.go",
         "conditions.go",
         "signername.go",
     ],
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//applyconfigurations/certificates/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/certificates/v1:go_default_library",
         "@io_k8s_utils//clock:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["signername_test.go"],
+    srcs = [
+        "conditions_test.go",
+        "signername_test.go",
+    ],
     embed = [":go_default_library"],
+    deps = [
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//certificates/v1:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/controller/certificatesigningrequests/util/apply.go
+++ b/pkg/controller/certificatesigningrequests/util/apply.go
@@ -24,8 +24,8 @@ import (
 	certificatesapply "k8s.io/client-go/applyconfigurations/certificates/v1"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
 
-	"github.com/jetstack/cert-manager/internal/controller/feature"
-	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 // UpdateOrApplyStatus will update a CertificateSigningRequest's status, or

--- a/pkg/controller/certificatesigningrequests/util/apply.go
+++ b/pkg/controller/certificatesigningrequests/util/apply.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	certificatesapply "k8s.io/client-go/applyconfigurations/certificates/v1"
+	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
+
+	"github.com/jetstack/cert-manager/internal/controller/feature"
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
+)
+
+// UpdateOrApplyStatus will update a CertificateSigningRequest's status, or
+// Apply if the ServerSideApply feature gate is enabled.
+// When the ServerSideApply feature is enabled; condType is optional, and will
+// only be applied if non-empty and the condition with that type exists on the
+// CertificateSigningRequest.
+func UpdateOrApplyStatus(ctx context.Context,
+	cl certificatesclient.CertificateSigningRequestInterface,
+	csr *certificatesv1.CertificateSigningRequest,
+	condType certificatesv1.RequestConditionType,
+	fieldManager string,
+) (*certificatesv1.CertificateSigningRequest, error) {
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
+		status := certificatesapply.CertificateSigningRequestStatus().
+			WithCertificate(csr.Status.Certificate...)
+
+		if len(condType) > 0 {
+			cond := certificateSigningRequestGetCondition(csr, condType)
+			if cond != nil {
+				status = status.WithConditions(
+					&certificatesapply.CertificateSigningRequestConditionApplyConfiguration{
+						Type: &cond.Type, Status: &cond.Status, Reason: &cond.Reason, Message: &cond.Message,
+						LastTransitionTime: &cond.LastTransitionTime, LastUpdateTime: &cond.LastUpdateTime,
+					},
+				)
+			}
+		}
+
+		return cl.ApplyStatus(ctx, certificatesapply.CertificateSigningRequest(csr.Name).WithStatus(status),
+			metav1.ApplyOptions{Force: true, FieldManager: fieldManager},
+		)
+	} else {
+		return cl.UpdateStatus(ctx, csr, metav1.UpdateOptions{})
+	}
+}

--- a/pkg/controller/certificatesigningrequests/util/conditions.go
+++ b/pkg/controller/certificatesigningrequests/util/conditions.go
@@ -72,3 +72,12 @@ func CertificateSigningRequestSetFailed(csr *certificatesv1.CertificateSigningRe
 	logf.V(logf.InfoLevel).Infof("Setting lastTransitionTime for CertificateSigningRequest %s/%s condition Failed to %v",
 		csr.Namespace, csr.Name, nowTime.Time)
 }
+
+func certificateSigningRequestGetCondition(csr *certificatesv1.CertificateSigningRequest, condType certificatesv1.RequestConditionType) *certificatesv1.CertificateSigningRequestCondition {
+	for _, cond := range csr.Status.Conditions {
+		if cond.Type == condType {
+			return &cond
+		}
+	}
+	return nil
+}

--- a/pkg/controller/certificatesigningrequests/util/conditions_test.go
+++ b/pkg/controller/certificatesigningrequests/util/conditions_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	certificatesv1 "k8s.io/api/certificates/v1"
+)
+
+func Test_certificateSigningRequestGetCondition(t *testing.T) {
+	tests := map[string]struct {
+		conditions   []certificatesv1.CertificateSigningRequestCondition
+		condType     certificatesv1.RequestConditionType
+		expCondition *certificatesv1.CertificateSigningRequestCondition
+	}{
+		"if no conditions exist, return nil": {
+			conditions:   []certificatesv1.CertificateSigningRequestCondition{},
+			condType:     certificatesv1.RequestConditionType("a"),
+			expCondition: nil,
+		},
+		"if conditions exist but type doesn't match, return nil": {
+			conditions: []certificatesv1.CertificateSigningRequestCondition{
+				{Type: certificatesv1.RequestConditionType("a")},
+				{Type: certificatesv1.RequestConditionType("b")},
+			},
+			condType:     certificatesv1.RequestConditionType("c"),
+			expCondition: nil,
+		},
+		"if conditions exist and type matches, return condition": {
+			conditions: []certificatesv1.CertificateSigningRequestCondition{
+				{Type: certificatesv1.RequestConditionType("a")},
+				{Type: certificatesv1.RequestConditionType("b")},
+				{Type: certificatesv1.RequestConditionType("c")},
+			},
+			condType:     certificatesv1.RequestConditionType("c"),
+			expCondition: &certificatesv1.CertificateSigningRequestCondition{Type: certificatesv1.RequestConditionType("c")},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotCondition := certificateSigningRequestGetCondition(&certificatesv1.CertificateSigningRequest{
+				Status: certificatesv1.CertificateSigningRequestStatus{
+					Conditions: test.conditions,
+				},
+			}, test.condType)
+			assert.Equal(t, test.expCondition, gotCondition)
+		})
+	}
+}

--- a/pkg/controller/certificatesigningrequests/vault/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/vault/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/certificates/v1:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",


### PR DESCRIPTION
Branched from #4773 which should be merged first.

This PR implements Server Side Apply for CertificateSigningRequest controllers when the `SeverSideApply` Feature Gate (default `disabled`) is enabled.

Where `UpdateStatus` was previously, a new func are used to check for this feature gate.

See  https://github.com/jetstack/cert-manager/pull/4758 for more details and design.

---

```release-note
ServerSideApply: The feature gate `ServerSideApply=true` configures the certificatesigningrequest controllers to use Kubernetes Server Side Apply on CertificateRequest resources. 
```

/milestone v1.8
/kind feature