### PR TITLE
Server Side Apply: Adds support for Order controllers to use SSA with Feature Gate 

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -159,7 +159,7 @@ metadata:
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "challenges"]
     verbs: ["get", "list", "watch"]

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -17,6 +17,7 @@ filegroup(
         "//internal/controller/certificates:all-srcs",
         "//internal/controller/feature:all-srcs",
         "//internal/controller/issuers:all-srcs",
+        "//internal/controller/orders:all-srcs",
         "//internal/ingress:all-srcs",
         "//internal/plugin:all-srcs",
         "//internal/test/paths:all-srcs",

--- a/internal/controller/orders/BUILD.bazel
+++ b/internal/controller/orders/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apply.go"],
+    importpath = "github.com/cert-manager/cert-manager/internal/controller/orders",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//pkg/apis/acme/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apply_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/acme/v1:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/internal/controller/orders/OWNERS
+++ b/internal/controller/orders/OWNERS
@@ -1,4 +1,4 @@
 filters:
-  "^apply(_test)?\\.go$":
+  "apply(_test)?\\.go$":
     required_reviewers:
     - joshvanl

--- a/internal/controller/orders/OWNERS
+++ b/internal/controller/orders/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  "^apply(_test)?\\.go$":
+    required_reviewers:
+    - joshvanl

--- a/internal/controller/orders/apply.go
+++ b/internal/controller/orders/apply.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/controller/orders/apply.go
+++ b/internal/controller/orders/apply.go
@@ -21,12 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 )
 
 // ApplyStatus will make a Apply API call with the given client to the order's

--- a/internal/controller/orders/apply.go
+++ b/internal/controller/orders/apply.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+)
+
+// ApplyStatus will make a Apply API call with the given client to the order's
+// status sub-resource endpoint. All data in the given Order object is dropped;
+// expect for the name, namespace, and status object. The given fieldManager is
+// will be used as the FieldManager in the Apply call.
+// Always sets Force Apply to true.
+func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string, order *cmacme.Order) error {
+	orderData, err := serializeApplyStatus(order)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AcmeV1().Orders(order.Namespace).Patch(
+		ctx, order.Name, apitypes.ApplyPatchType, orderData,
+		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",
+	)
+
+	return err
+}
+
+// serializeApplyStatus converts the given Order object in JSON. Only the name,
+// namespace, and status field values will be copied and encoded into the
+// serialized slice. All other fields will be left at their zero value.
+// TypeMeta will be populated with the Kind "Order" and API Version
+// "acme.cert-manager.io/v1" respectively.
+func serializeApplyStatus(order *cmacme.Order) ([]byte, error) {
+	order = &cmacme.Order{
+		TypeMeta:   metav1.TypeMeta{Kind: cmacme.OrderKind, APIVersion: cmacme.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: order.Namespace, Name: order.Name},
+		Status:     order.Status,
+	}
+	orderData, err := json.Marshal(order)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal order object: %w", err)
+	}
+	return orderData, nil
+}

--- a/internal/controller/orders/apply_test.go
+++ b/internal/controller/orders/apply_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orders
 
 import (
+	"encoding/json"
 	"strconv"
 	"sync"
 	"testing"
@@ -51,6 +52,11 @@ func Test_serializeApplyStatus(t *testing.T) {
 					orderData, err := serializeApplyStatus(&order)
 					assert.NoError(t, err)
 					assert.Regexp(t, expReg, string(orderData))
+
+					// Test round trip preserves the status.
+					var rtOrder cmacme.Order
+					assert.NoError(t, json.Unmarshal(orderData, &rtOrder))
+					assert.Equal(t, order.Status, rtOrder.Status)
 
 					// String match on empty status.
 					order.Status = cmacme.OrderStatus{}

--- a/internal/controller/orders/apply_test.go
+++ b/internal/controller/orders/apply_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/controller/orders/apply_test.go
+++ b/internal/controller/orders/apply_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orders
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+)
+
+func Test_serializeApplyStatus(t *testing.T) {
+	const (
+		expReg   = `^{"kind":"Order","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"request":null,"issuerRef":{"name":""}},"status":{.*}$`
+		expEmpty = `{"kind":"Order","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"request":null,"issuerRef":{"name":""}},"status":{}}`
+		numJobs  = 10000
+	)
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	wg.Add(numJobs)
+	for i := 0; i < 3; i++ {
+		go func() {
+			for j := range jobs {
+				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
+					var order cmacme.Order
+					fuzz.New().NilChance(0.5).Fuzz(&order)
+					order.Name = "foo"
+					order.Namespace = "bar"
+
+					// Test regex with non-empty status.
+					orderData, err := serializeApplyStatus(&order)
+					assert.NoError(t, err)
+					assert.Regexp(t, expReg, string(orderData))
+
+					// String match on empty status.
+					order.Status = cmacme.OrderStatus{}
+					orderData, err = serializeApplyStatus(&order)
+					assert.NoError(t, err)
+					assert.Equal(t, expEmpty, string(orderData))
+
+					wg.Done()
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < numJobs; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+}

--- a/internal/controller/orders/apply_test.go
+++ b/internal/controller/orders/apply_test.go
@@ -24,7 +24,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
 
 func Test_serializeApplyStatus(t *testing.T) {

--- a/pkg/controller/acmeorders/BUILD.bazel
+++ b/pkg/controller/acmeorders/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/acmeorders",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/feature:go_default_library",
+        "//internal/controller/orders:go_default_library",
         "//pkg/acme:go_default_library",
         "//pkg/acme/accounts:go_default_library",
         "//pkg/acme/client:go_default_library",
@@ -26,6 +28,7 @@ go_library(
         "//pkg/issuer:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/scheduler:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -157,6 +157,7 @@ func NewController(
 		recorder:            recorder,
 		cmClient:            cmClient,
 		accountRegistry:     accountRegistry,
+		fieldManager:        fieldManager,
 	}, queue, mustSync
 
 }

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -63,6 +63,9 @@ type controller struct {
 	// clientset used to update cert-manager API resources
 	cmClient cmclient.Interface
 
+	// fieldManager is the manager name used for the Apply operations on Secrets.
+	fieldManager string
+
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
 	queue workqueue.RateLimitingInterface
@@ -84,6 +87,7 @@ func NewController(
 	recorder record.EventRecorder,
 	clock clock.Clock,
 	isNamespaced bool,
+	fieldManager string,
 ) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
 
 	// Create a queue used to queue up Orders to be processed.
@@ -217,6 +221,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.Recorder,
 		ctx.Clock,
 		isNamespaced,
+		ctx.FieldManager,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -59,9 +59,6 @@ type ACME struct {
 	acmeClientV cmacmeclientset.AcmeV1Interface
 	certClient  certificatesclient.CertificateSigningRequestInterface
 
-	// fieldManager is the manager name used for the Apply operations.
-	fieldManager string
-
 	recorder record.EventRecorder
 
 	copiedAnnotationPrefixes []string

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -65,6 +65,9 @@ type ACME struct {
 	recorder record.EventRecorder
 
 	copiedAnnotationPrefixes []string
+
+	// fieldManager is the manager name used for Create and Apply operations.
+	fieldManager string
 }
 
 func init() {
@@ -139,7 +142,7 @@ func (a *ACME) Sign(ctx context.Context, csr *certificatesv1.CertificateSigningR
 
 	order, err := a.orderLister.Orders(expectedOrder.Namespace).Get(expectedOrder.Name)
 	if apierrors.IsNotFound(err) {
-		_, err = a.acmeClientV.Orders(expectedOrder.Namespace).Create(ctx, expectedOrder, metav1.CreateOptions{})
+		_, err = a.acmeClientV.Orders(expectedOrder.Namespace).Create(ctx, expectedOrder, metav1.CreateOptions{FieldManager: a.fieldManager})
 		if err != nil {
 			// Failing to create the order here is most likely network related. We
 			// should backoff and keep trying.

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -128,6 +128,7 @@ func TestAcmeOrdersController(t *testing.T) {
 		framework.NewEventRecorder(t),
 		clock.RealClock{},
 		false,
+		"cert-manager-test",
 	)
 	c := controllerpkg.NewController(
 		ctx,


### PR DESCRIPTION
Branched from #4773 which should be merged first.

This PR implements Server Side Apply for the Order controller when the `SeverSideApply` Feature Gate (default `disabled`) is enabled.

Where `UpdateStatus` was previously, a new func are used to check for this feature gate.

See  https://github.com/jetstack/cert-manager/pull/4758 for more details and design.

---

```release-note
ServerSideApply: The feature gate `ServerSideApply=true` configures the order controller to use Kubernetes Server Side Apply on Order resources. 
```

/milestone v1.8
/kind feature