### PR TITLE
Server Side Apply: Adds support for Challenge controllers to use SSA with Feature Gate

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -190,7 +190,7 @@ rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges", "challenges/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   # Used to watch challenge resources
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges"]

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -16,6 +16,7 @@ filegroup(
         "//internal/cainjector/feature:all-srcs",
         "//internal/controller/certificaterequests:all-srcs",
         "//internal/controller/certificates:all-srcs",
+        "//internal/controller/challenges:all-srcs",
         "//internal/controller/feature:all-srcs",
         "//internal/controller/issuers:all-srcs",
         "//internal/controller/orders:all-srcs",

--- a/internal/controller/challenges/BUILD.bazel
+++ b/internal/controller/challenges/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//pkg/apis/acme/v1:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
     ],
 )
 

--- a/internal/controller/challenges/BUILD.bazel
+++ b/internal/controller/challenges/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["apply.go"],
-    importpath = "github.com/jetstack/cert-manager/internal/controller/challenges",
+    importpath = "github.com/cert-manager/cert-manager/internal/controller/challenges",
     visibility = ["//:__subpackages__"],
     deps = [
         "//pkg/apis/acme/v1:go_default_library",

--- a/internal/controller/challenges/BUILD.bazel
+++ b/internal/controller/challenges/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apply.go"],
+    importpath = "github.com/jetstack/cert-manager/internal/controller/challenges",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//pkg/apis/acme/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apply_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/acme/v1:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/internal/controller/challenges/OWNERS
+++ b/internal/controller/challenges/OWNERS
@@ -1,4 +1,4 @@
 filters:
-  "^apply(_test)?\\.go$":
+  "apply(_test)?\\.go$":
     required_reviewers:
     - joshvanl

--- a/internal/controller/challenges/OWNERS
+++ b/internal/controller/challenges/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  "^apply(_test)?\\.go$":
+    required_reviewers:
+    - joshvanl

--- a/internal/controller/challenges/apply.go
+++ b/internal/controller/challenges/apply.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/controller/challenges/apply.go
+++ b/internal/controller/challenges/apply.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package challenges
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+)
+
+// Apply will make a Apply API call with the given client to the challenges
+// endpoint. All data in the given Challenges object is dropped; expect for the
+// name, namespace, and spec object. The given fieldManager is will be used as
+// the FieldManager in the Apply call.  Always sets Force Apply to true.
+func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, challenge *cmacme.Challenge) (*cmacme.Challenge, error) {
+	challengeData, err := serializeApply(challenge)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.AcmeV1().Challenges(challenge.Namespace).Patch(
+		ctx, challenge.Name, apitypes.ApplyPatchType, challengeData,
+		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager},
+	)
+}
+
+// ApplyStatus will make a Apply API call with the given client to the
+// challenges status sub-resource endpoint. All data in the given Challenges
+// object is dropped; expect for the name, namespace, and status object. The
+// given fieldManager is will be used as the FieldManager in the Apply call.
+// Always sets Force Apply to true.
+func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string, challenge *cmacme.Challenge) (*cmacme.Challenge, error) {
+	challengeData, err := serializeApplyStatus(challenge)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.AcmeV1().Challenges(challenge.Namespace).Patch(
+		ctx, challenge.Name, apitypes.ApplyPatchType, challengeData,
+		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",
+	)
+}
+
+// serializeApply converts the given Challenge object in JSON. Only the
+// name, namespace, and spec field values will be copied and encoded into the
+// serialized slice. All other fields will be left at their zero value.
+// TypeMeta will be populated with the Kind "Challenge" and API Version
+// "acme.cert-manager.io/v1" respectively.
+func serializeApply(challenge *cmacme.Challenge) ([]byte, error) {
+	challenge = &cmacme.Challenge{
+		TypeMeta:   metav1.TypeMeta{Kind: cmacme.ChallengeKind, APIVersion: cmacme.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: challenge.Namespace, Name: challenge.Name},
+		Spec:       challenge.Spec,
+	}
+	challengeData, err := json.Marshal(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal challenge object: %w", err)
+	}
+	return challengeData, nil
+}
+
+// serializeApplyStatus converts the given Challenge object in JSON. Only the
+// name, namespace, and status field values will be copied and encoded into the
+// serialized slice. All other fields will be left at their zero value.
+// TypeMeta will be populated with the Kind "Challenge" and API Version
+// "acme.cert-manager.io/v1" respectively.
+func serializeApplyStatus(challenge *cmacme.Challenge) ([]byte, error) {
+	challenge = &cmacme.Challenge{
+		TypeMeta:   metav1.TypeMeta{Kind: cmacme.ChallengeKind, APIVersion: cmacme.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: challenge.Namespace, Name: challenge.Name},
+		Status:     challenge.Status,
+	}
+	challengeData, err := json.Marshal(challenge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal challenge object: %w", err)
+	}
+	return challengeData, nil
+}

--- a/internal/controller/challenges/apply.go
+++ b/internal/controller/challenges/apply.go
@@ -73,7 +73,7 @@ func serializeApply(challenge *cmacme.Challenge) ([]byte, error) {
 		ObjectMeta: *challenge.ObjectMeta.DeepCopy(),
 		Spec:       *challenge.Spec.DeepCopy(),
 	}
-	challenge.ManagedFields = nil
+	ch.ManagedFields = nil
 	challengeData, err := json.Marshal(ch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal challenge object: %w", err)

--- a/internal/controller/challenges/apply_test.go
+++ b/internal/controller/challenges/apply_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@ limitations under the License.
 package challenges
 
 import (
+	"encoding/json"
 	"strconv"
 	"sync"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
@@ -45,7 +47,8 @@ func Test_serializeApply(t *testing.T) {
 					fuzz.New().NilChance(0.5).Funcs(
 						func(challenge *cmacme.Challenge, c fuzz.Continue) {
 							if challenge.Spec.Solver.DNS01 != nil && challenge.Spec.Solver.DNS01.Webhook != nil {
-								challenge.Spec.Solver.DNS01.Webhook.Config = nil
+								// Config can only hold data which originates from proper JSON.
+								challenge.Spec.Solver.DNS01.Webhook.Config = &apiextensionsv1.JSON{Raw: []byte(`{"some": {"json": "test"}, "string": 42}`)}
 							}
 						},
 					).Fuzz(&challenge)
@@ -54,6 +57,11 @@ func Test_serializeApply(t *testing.T) {
 					challengeData, err := serializeApply(&challenge)
 					assert.NoError(t, err, "%+#v", challenge)
 					assert.Regexp(t, expReg, string(challengeData))
+
+					// Test a roundtrip results in the same data.
+					var rtChallenge cmacme.Challenge
+					assert.NoError(t, json.Unmarshal(challengeData, &rtChallenge))
+					assert.Equal(t, challenge.Spec, rtChallenge.Spec)
 
 					wg.Done()
 				})
@@ -98,6 +106,11 @@ func Test_serializeApplyStatus(t *testing.T) {
 					challengeData, err = serializeApplyStatus(&challenge)
 					assert.NoError(t, err)
 					assert.Equal(t, expEmpty, string(challengeData))
+
+					// Test a roundtrip results in the same data.
+					var rtChallenge cmacme.Challenge
+					assert.NoError(t, json.Unmarshal(challengeData, &rtChallenge))
+					assert.Equal(t, challenge.Status, rtChallenge.Status)
 
 					wg.Done()
 				})

--- a/internal/controller/challenges/apply_test.go
+++ b/internal/controller/challenges/apply_test.go
@@ -24,7 +24,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
 
 func Test_serializeApply(t *testing.T) {

--- a/internal/controller/challenges/apply_test.go
+++ b/internal/controller/challenges/apply_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package challenges
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+)
+
+func Test_serializeApply(t *testing.T) {
+	const (
+		expReg  = `^{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{.*},"spec":{.*},"status":{"processing":false,"presented":false}}$`
+		numJobs = 10000
+	)
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	wg.Add(numJobs)
+	for i := 0; i < 3; i++ {
+		go func() {
+			for j := range jobs {
+				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
+					var challenge cmacme.Challenge
+					fuzz.New().NilChance(0.5).Funcs(
+						func(challenge *cmacme.Challenge, c fuzz.Continue) {
+							if challenge.Spec.Solver.DNS01 != nil && challenge.Spec.Solver.DNS01.Webhook != nil {
+								challenge.Spec.Solver.DNS01.Webhook.Config = nil
+							}
+						},
+					).Fuzz(&challenge)
+
+					// Test regex with non-empty status.
+					challengeData, err := serializeApply(&challenge)
+					assert.NoError(t, err, "%+#v", challenge)
+					assert.Regexp(t, expReg, string(challengeData))
+
+					wg.Done()
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < numJobs; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func Test_serializeApplyStatus(t *testing.T) {
+	const (
+		expReg   = `^{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"url":"","authorizationURL":"","dnsName":"","wildcard":false,"type":"","token":"","key":"","solver":{},"issuerRef":{"name":""}},"status":{.*}$`
+		expEmpty = `{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar","creationTimestamp":null},"spec":{"url":"","authorizationURL":"","dnsName":"","wildcard":false,"type":"","token":"","key":"","solver":{},"issuerRef":{"name":""}},"status":{"processing":false,"presented":false}}`
+		numJobs  = 10000
+	)
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	wg.Add(numJobs)
+	for i := 0; i < 3; i++ {
+		go func() {
+			for j := range jobs {
+				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
+					var challenge cmacme.Challenge
+					fuzz.New().NilChance(0.5).Fuzz(&challenge)
+					challenge.Name = "foo"
+					challenge.Namespace = "bar"
+
+					// Test regex with non-empty status.
+					challengeData, err := serializeApplyStatus(&challenge)
+					assert.NoError(t, err)
+					assert.Regexp(t, expReg, string(challengeData))
+
+					// String match on empty status.
+					challenge.Status = cmacme.ChallengeStatus{}
+					challengeData, err = serializeApplyStatus(&challenge)
+					assert.NoError(t, err)
+					assert.Equal(t, expEmpty, string(challengeData))
+
+					wg.Done()
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < numJobs; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+}

--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/acmechallenges",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/challenges:go_default_library",
         "//internal/controller/feature:go_default_library",
         "//internal/ingress:go_default_library",
         "//pkg/acme:go_default_library",

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -74,7 +74,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	}
 
 	defer func() {
-		if apiequality.Semantic.DeepEqual(oldChal.Status, ch.Status) && len(oldChal.Finalizers) == len(ch.Finalizers) {
+		if apiequality.Semantic.DeepEqual(oldChal.Status, ch.Status) {
 			return
 		}
 		if _, updateErr := c.updateStatusOrApply(ctx, ch); updateErr != nil {

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -73,7 +73,6 @@ func buildChallenge(ctx context.Context, cl acmecl.Interface, issuer cmapi.Gener
 			Name:            chName,
 			Namespace:       o.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(o, orderGvk)},
-			Finalizers:      []string{cmacme.ACMEFinalizer},
 		},
 		Spec: *chSpec,
 	}, nil

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -12,6 +12,7 @@ filegroup(
         "//test/integration/acme:all-srcs",
         "//test/integration/certificaterequests:all-srcs",
         "//test/integration/certificates:all-srcs",
+        "//test/integration/challenges:all-srcs",
         "//test/integration/conversion:all-srcs",
         "//test/integration/ctl:all-srcs",
         "//test/integration/framework:all-srcs",

--- a/test/integration/challenges/BUILD.bazel
+++ b/test/integration/challenges/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apply_test.go"],
+    deps = [
+        "//internal/controller/challenges:go_default_library",
+        "//pkg/apis/acme/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/challenges/apply_test.go
+++ b/test/integration/challenges/apply_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package challenges
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	internalchallenges "github.com/cert-manager/cert-manager/internal/controller/challenges"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/integration/framework"
+)
+
+// Test_Apply ensures that the Challenge Apply helpers can set both the
+// ObjectMeta/Spec and Status objects respectively.
+func Test_Apply(t *testing.T) {
+	const (
+		namespace = "test-apply"
+		name      = "test-apply"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	restConfig, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
+
+	kubeClient, _, cmClient, _ := framework.NewClients(t, restConfig)
+
+	t.Log("creating test Namespace")
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	ch := &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: cmacme.ChallengeSpec{
+			URL: "http://example.com", AuthorizationURL: "http://example.com/auth",
+			DNSName: "example.com", Wildcard: true,
+			Type: cmacme.ACMEChallengeTypeDNS01, Token: "1234", Key: "5678",
+			Solver: cmacme.ACMEChallengeSolver{},
+			IssuerRef: cmmeta.ObjectReference{
+				Name:  "issuer",
+				Kind:  "Issuer",
+				Group: "cert-manager.io",
+			},
+		},
+	}
+
+	t.Log("creating Challenge")
+	_, err = cmClient.AcmeV1().Challenges(namespace).Create(ctx, ch, metav1.CreateOptions{FieldManager: "cert-manager-test"})
+	assert.NoError(t, err)
+
+	t.Log("ensuring apply will can set annotations and labels")
+	_, err = internalchallenges.Apply(ctx, cmClient, "cert-manager-test", &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: name,
+			Annotations: map[string]string{"test-1": "abc", "test-2": "def"},
+			Labels:      map[string]string{"123": "456", "789": "abc"},
+		},
+		Spec: ch.Spec,
+	})
+	assert.NoError(t, err)
+	ch, err = cmClient.AcmeV1().Challenges(namespace).Get(ctx, name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"test-1": "abc", "test-2": "def"}, ch.Annotations, "annotations")
+	assert.Equal(t, map[string]string{"123": "456", "789": "abc"}, ch.Labels, "labels")
+
+	t.Log("ensuring apply can change status")
+	_, err = internalchallenges.ApplyStatus(ctx, cmClient, "cert-manager-test", &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: cmacme.ChallengeStatus{
+			Processing: true,
+			Presented:  true,
+			Reason:     "this is a reason",
+			State:      cmacme.State("errored"),
+		},
+	})
+	assert.NoError(t, err)
+	ch, err = cmClient.AcmeV1().Challenges(namespace).Get(ctx, name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, cmacme.ChallengeStatus{
+		Processing: true,
+		Presented:  true,
+		Reason:     "this is a reason",
+		State:      cmacme.State("errored"),
+	}, ch.Status)
+}


### PR DESCRIPTION
Branched from #4773 which should be merged first.

This PR implements Server Side Apply for the Challenge controller when the `SeverSideApply` Feature Gate (default `disabled`) is enabled.

Where `UpdateStatus` was previously, a new func are used to check for this feature gate.

See  https://github.com/jetstack/cert-manager/pull/4758 for more details and design.

---

```release-note
ServerSideApply: The feature gate `ServerSideApply=true` configures the challenges controller to use Kubernetes Server Side Apply on Challenge resources. 
Warning: if you upgrade to cert-manger v1.8 with `ServerSideApply=true`, do make sure there are no `Challenge` resources currently in the cluster. If there are some, you will need to manually delete them once they are in 'valid' state as cert-manager post-v1.8 with the SSA feature is not able to clean up `Challenge` CRs created pre-v1.8.
```

/milestone v1.8
/kind feature