### PR TITLE
Remove auditsinks permissions from ca-injector as it is no longer supported

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -29,9 +29,6 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["auditregistration.k8s.io"]
-    resources: ["auditsinks"]
-    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/kind cleanup
/milestone v1.8

AuditSinks was an alpha feature in Kubernetes, and was added as a supported ca-injector target https://github.com/jetstack/cert-manager/pull/2027

This alpha feature was removed from Kubernetes, as well as cert-manager.

This PR just removes the permissions that were forgotten about when the feature was removed.

```release-note
NONE
```
