### PR TITLE
Parse and distribute feature gates in devel script

### DIFF
--- a/cmd/cainjector/app/BUILD.bazel
+++ b/cmd/cainjector/app/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller/cainjector:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//pkg/util/profiling:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/cainjector"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
 
@@ -88,6 +89,8 @@ func (o *InjectorControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&o.EnablePprof, "enable-profiling", cmdutil.DefaultEnableProfiling, "Enable profiling for cainjector")
 	fs.StringVar(&o.PprofAddr, "profiler-address", cmdutil.DefaultProfilerAddr, "Address of the Go profiler (pprof) if enabled. This should never be exposed on a public interface.")
+
+	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 }
 
 // NewInjectorControllerOptions returns a new InjectorControllerOptions

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -115,3 +115,24 @@ export_logs() {
   echo "Exporting cluster logs to artifacts..."
   "${SCRIPT_ROOT}/cluster/export-logs.sh"
 }
+
+# join_by joins a list of strings by a string.
+# e.g. `join_by , a b c` -> `a,b,c`
+join_by() {
+  local d=${1-} f=${2-}
+  if shift 2; then
+    printf %s "$f" "${@/#/$d}"
+  fi
+}
+
+registered_feature_gates_for() {
+  declare -a FEATURE_GATES_SUPPORTED=($1)
+  FEATURE_GATES="$2"
+  declare -a FEATURE_GATES_TO_RUN=()
+  for val in ${FEATURE_GATES//,/ }; do
+    if [[ "${FEATURE_GATES_SUPPORTED[*]}" =~ "${val%=*}" ]]; then
+      FEATURE_GATES_TO_RUN+=($val)
+    fi
+  done
+  join_by , ${FEATURE_GATES_TO_RUN[@]}
+}

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -125,6 +125,9 @@ join_by() {
   fi
 }
 
+# registered_feature_gates_for returns the subset of supported of feature gates
+# from the given enabled features. Supported features is the first argument,
+# features that are enabled is second.
 registered_feature_gates_for() {
   declare -a FEATURE_GATES_SUPPORTED=($1)
   FEATURE_GATES="$2"

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
         "//internal/apis/certmanager:all-srcs",
         "//internal/apis/config/webhook:all-srcs",
         "//internal/apis/meta:all-srcs",
+        "//internal/cainjector/feature:all-srcs",
         "//internal/controller/certificates:all-srcs",
         "//internal/controller/feature:all-srcs",
         "//internal/ingress:all-srcs",

--- a/internal/cainjector/feature/BUILD.bazel
+++ b/internal/cainjector/feature/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["features.go"],
+    importpath = "github.com/jetstack/cert-manager/internal/cainjector/feature",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//pkg/util/feature:go_default_library",
+        "@io_k8s_component_base//featuregate:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/internal/cainjector/feature/BUILD.bazel
+++ b/internal/cainjector/feature/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["features.go"],
-    importpath = "github.com/jetstack/cert-manager/internal/cainjector/feature",
+    importpath = "github.com/cert-manager/cert-manager/internal/cainjector/feature",
     visibility = ["//:__subpackages__"],
     deps = [
         "//pkg/util/feature:go_default_library",

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -19,7 +19,7 @@ package feature
 import (
 	"k8s.io/component-base/featuregate"
 
-	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 const (
@@ -40,5 +40,5 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 // To check whether a feature is enabled, use:
 //   utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
-// Where utilfeature is github.com/jetstack/cert-manager/pkg/util/feature.
+// Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"k8s.io/component-base/featuregate"
+
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
+)
+
+const (
+// FeatureName will enable XYZ feature.
+// Fill this section out with additional details about the feature.
+//
+// Owner (responsible for graduating feature through to GA): @username
+// Alpha: vX.Y
+// Beta: ...
+//FeatureName featuregate.Feature = "FeatureName"
+)
+
+func init() {
+	utilfeature.DefaultMutableFeatureGate.Add(cainjectorFeatureGates)
+}
+
+// cainjectorFeatureGates defines all feature gates for the cainjector component.
+// To add a new feature, define a key for it above and add it here.
+// To check whether a feature is enabled, use:
+//   utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
+// Where utilfeature is github.com/jetstack/cert-manager/pkg/util/feature.
+var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}


### PR DESCRIPTION
This PR adds the feature gates flag to cainjector (currently empty).

All feature gates passed to the cert-manager install scripts (via `FEATURE_GATES` env var), are parsed and given to each component that supports each particular feature. This simplifies setting feature gates during an install for both CI and developers, as only the component that supports that feature gate will have it applied, and not cause the component to error during start.

/assign @munnerz 
/kind cleanup
/milestone v1.8

```release-note
NONE
```
