### PR TITLE
Relax the validation on the default Issuer Kind for certificate-shim

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -358,11 +359,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *ControllerOptions) Validate() error {
-	switch o.DefaultIssuerKind {
-	case "Issuer":
-	case "ClusterIssuer":
-	default:
-		return fmt.Errorf("invalid default issuer kind: %v", o.DefaultIssuerKind)
+	if len(o.DefaultIssuerKind) == 0 {
+		return errors.New("the --default-issuer-kind flag must not be empty")
 	}
 
 	if o.KubernetesAPIBurst <= 0 {


### PR DESCRIPTION
### Pull Request Motivation

Fixes #4832 

I don't think we can apply any meaningful validation here, and it seems like a good feature to allow any other issuer `kind`s. Let me know what you all think.

### Kind

/kind feature

### Release Note

```release-note
External issuers may now be referenced as the default Issuer name / group / kind for the ingress-shim.
```
