### PR TITLE
Increase margin of error in an otherwise unsound test

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -58,19 +58,25 @@ func Test_afterFunc(t *testing.T) {
 		assert.InDelta(t, expected, runtime.NumGoroutine(), 100)
 	})
 
-	t.Run("f is called after 100 milliseconds", func(t *testing.T) {
+	t.Run("f is called after roughly 100 milliseconds", func(t *testing.T) {
 		var end time.Time
 		wait := make(chan struct{})
 
 		start := time.Now()
 
-		afterFunc(clock.RealClock{}, 100*time.Millisecond, func() {
+		expectedDuration := 100 * time.Millisecond
+
+		afterFunc(clock.RealClock{}, expectedDuration, func() {
 			end = time.Now()
 			close(wait)
 		})
 
 		<-wait
-		assert.InDelta(t, 100*time.Millisecond, end.Sub(start), float64(1*time.Millisecond))
+
+		elapsed := end.Sub(start)
+
+		assert.InDelta(t, expectedDuration, elapsed, float64(500*time.Millisecond))
+		assert.GreaterOrEqual(t, elapsed, expectedDuration)
 	})
 }
 


### PR DESCRIPTION
This test can easily fail on a heavily loaded machine, such as one running many tests in parallel or a weaker developer laptop.

1. The afterFunc could be delayed _massively_ on a heavily loaded machine, such as one running a lot of tests in parallel.
2. Requiring an accuracy of 1ms seems like a flake waiting to happen (it was such a flake which inspired this PR)
3. When we write code which uses this scheduler, we can't even safely assume the afterFunc will _ever_ be run, let alone run within a 1ms margin of time error.

Put simply, as implemented this test is more of a test of how loaded the test server is than a test of any functionality.

By increasing the allowable delta hugely, we keep this test as a sanity check but basically remove the chance of a flake. The test essentially becomes "does afterFunc work, generally?".

/kind cleanup

```release-note
NONE
```
