### PR TITLE
support user.bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,6 @@
 build --workspace_status_command hack/build/print-workspace-status.sh
 # Show timestamps with each bazel message
 build --show_timestamps
+
+# import per-user options
+try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bazel-*
 _artifacts/
 /vendor/
 bin/
+user.bazelrc


### PR DESCRIPTION
Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>

This PR allows developers to use a `user.bazelrc` at the root of the workspace to configure bazel without affecting other users' environments.

In my case, I want to prevent "spontaneous" protobuf recompilations which are caused by changes to `PATH` so I use the following config. Theoretically the last 2 lines should be enough

```bash
$ cat user.bazelrc

build --action_env=PATH="/usr/local/bin:/Users/joakim/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin"
run --action_env=PATH="/usr/local/bin:/Users/joakim/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin"

build --incompatible_strict_action_env
run --incompatible_strict_action_env
```

More:
https://docs.bazel.build/versions/main/guide.html#imports

```release-note
NONE
```