### PR TITLE
Require Gateway API feature gate for Gateway API tests. Add a helper func

### DIFF
--- a/test/e2e/framework/BUILD.bazel
+++ b/test/e2e/framework/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_component_base//featuregate:go_default_library",
         "@io_k8s_kube_aggregator//pkg/apis/apiregistration/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_gateway_api//apis/v1alpha1:go_default_library",

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/featuregate"
 
 	. "github.com/cert-manager/cert-manager/test/e2e/framework/log"
 )
@@ -48,6 +49,12 @@ func Skipf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	Logf("INFO", msg)
 	Skip(nowStamp() + ": " + msg)
+}
+
+func RequireFeatureGate(f *Framework, featureSet featuregate.FeatureGate, gate featuregate.Feature) {
+	if !featureSet.Enabled(gate) {
+		Skipf("feature gate %q is not enabled, skipping test", gate)
+	}
 }
 
 // TODO: move this function into a different package

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -49,9 +49,7 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 	)
 
 	createCertificate := func(f *framework.Framework, aof []cmapi.CertificateAdditionalOutputFormat) *cmapi.Certificate {
-		if !utilfeature.DefaultFeatureGate.Enabled(feature.AdditionalCertificateOutputFormats) {
-			framework.Skipf("feature gate %q is not enabled, skipping test", feature.AdditionalCertificateOutputFormats)
-		}
+		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
 
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
@@ -299,9 +297,7 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 
 	It("if a third party set additional output formats, they then get added to the Certificate, when they are removed again they should persist as they are still owned by a third party", func() {
 		// This e2e test requires that the ServerSideApply feature gate is enabled.
-		if !utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-			framework.Skipf("feature gate %q is not enabled, skipping test", feature.ServerSideApply)
-		}
+		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ServerSideApply)
 
 		crt := createCertificate(f, nil)
 

--- a/test/e2e/suite/conformance/certificates/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/BUILD.bazel
@@ -9,9 +9,11 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/conformance/certificates",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/helper/featureset:go_default_library",

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -23,15 +23,16 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/util"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/e2e/framework"
 	"github.com/cert-manager/cert-manager/test/e2e/framework/helper/featureset"
@@ -69,6 +70,7 @@ func (s *Suite) Define() {
 				sharedIPAddress = f.Config.Addons.ACMEServer.IngressIP
 			case "Gateway":
 				sharedIPAddress = f.Config.Addons.ACMEServer.GatewayIP
+				framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
 			}
 		})
 

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -786,6 +786,8 @@ func (s *Suite) Define() {
 		})
 
 		s.it(f, "Creating a Gateway with annotations for issuerRef and other Certificate fields", func(issuerRef cmmeta.ObjectReference) {
+			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
+
 			name := "testcert-gateway"
 			secretName := "testcert-gateway-tls"
 			domain := e2eutil.RandomSubdomain(s.DomainSuffix)

--- a/test/e2e/suite/conformance/certificatesigningrequests/suite.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/suite.go
@@ -109,10 +109,7 @@ func (s *Suite) it(f *framework.Framework, name string, fn func(string), require
 		return
 	}
 	It(name, func() {
-		if !utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalCertificateSigningRequestControllers) {
-			framework.Skipf("skipping CertificateSigningRequest controller test since FEATURE_GATE %s is not enabled",
-				feature.ExperimentalCertificateSigningRequestControllers)
-		}
+		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
 
 		By("Creating an issuer resource")
 		signerName := s.CreateIssuerFunc(f)

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -129,9 +129,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		It("should be able to create a certificate with additional output formats", func() {
 			// Output formats is only enabled via this feature gate being enabled.
 			// Don't run test if the gate isn't enabled.
-			if !utilfeature.DefaultFeatureGate.Enabled(feature.AdditionalCertificateOutputFormats) {
-				framework.Skipf("feature gate %s is not enabled, skipping test", feature.AdditionalCertificateOutputFormats)
-			}
+			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
 
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 


### PR DESCRIPTION
e2e tests which do not have the Gateway API feature gate enabled are currently failing.

https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4792/pull-cert-manager-e2e-feature-gates-disabled/1492211977156562944

This PR adds a feature gate check for the Gateway API e2e tests, and also adds a helper function for checking whether to skip tests based on a feature gate not being enabled.


```release-note
NONE
```
