### PR TITLE
Rework USERS doc

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -1,21 +1,25 @@
-# cert-manager users
+# cert-manager Users
 
-This is the list of organizations and individual users that publicly that they are using cert-manager.
+We love hearing about it when people use and enjoy cert-manager!
 
-Please send PRs to add or remove your organizations/users! We would love to let you share your cert-manager story with the world.
+## Organization Users
 
-The list of organizations that have publicly shared the usage of cert-manager:
+Please feel free to send PRs to add your org to the list, or to reach out to a maintainer with your details; they'll gladly add you!
+We'd love for you to share your cert-manager story with the world!
 
 | Organization | Usage | Links |
-| :--- | :--- | :--- |
-| [<img src="https://www.acoss.fr/files/Logos/logo_acoss.png" alt="Acoss" width="100"> ](https://www.acoss.fr/) | Securing ingresses | |
-| [<img src="https://static.atomist.com/logo/atomist-color-lockup-horiz-small.png" alt="Atomist" width="100"> ](https://atomist.com/) | Securing ingresses | [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/) |
-| [<img src="https://raw.githubusercontent.com/cert-manager/website/master/assets/icons/jetstack.svg" alt="Jetstack text" width="100"> ](https://jetstack.io) | Securing MySQL inside Kubernetes | [blog](https://blog.jetstack.io/blog/securing-mysql-with-cert-manager/)  |
+| :----------: | :---: | :---: |
+| [<img src="https://static.atomist.com/logo/atomist-color-lockup-horiz-small.png" alt="Atomist" width="100"> ](https://atomist.com/) | Securing ingresses | [Kubernetes, ingress-nginx, cert-manager &amp; external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/) |
+| [<img src="https://raw.githubusercontent.com/cert-manager/website/50afb0436bc0e72d7d27cc4b1c0195d029a9704b/assets/icons/jetstack.svg" alt="Jetstack text" width="100"> ](https://jetstack.io) | Securing MySQL inside Kubernetes | [Blog](https://blog.jetstack.io/blog/securing-mysql-with-cert-manager/)  |
 | [<img src="https://media.jfrog.com/wp-content/uploads/2017/12/20133032/Jfrog-Logo.svg" alt="JFrog" width="100"> ](https://jfrog.com/) | Securing ingresses |  |
+| [<img src="https://www.urssaf.org/files/Logos/logo_urssaforg.png" width="100" alt="Urssaf Caisse nationale"> ](https://urssaf.org) | Securing ingresses | |
 
-The list of individual users that have publicly shared the usage of cert-manager.
+## Individuals
 
-| user | Usage | Links |
-| :--- | :--- | :--- |
-| [Maartje Eyskens](https://github.com/meyskens) | Securing ingresses |  | 
-| [Noah Kantrowitz](https://github.com/coderanger) | Many things | [Lessons Learned From Two Years Of Kubernetes](https://coderanger.net/lessons-learned/) |
+As an open source project we welcome all kinds of users; please feel free to raise a PR to add yourself to the list.
+Plus, if you've written something about cert-manager throw in a link too for others to enjoy!
+
+| Name | GitHub | Usage | Links |
+| :--: | :----: | :---: | :---: |
+| Maartje Eyskens | [@meyskens](https://github.com/meyskens)     | Securing ingresses |  |
+| Noah Kantrowitz | [@coderanger](https://github.com/coderanger) | Many things!       | [Lessons Learned From Two Years Of Kubernetes](https://coderanger.net/lessons-learned/) |


### PR DESCRIPTION
- Renames Acoss -> Urssaf Caisse nationale
- Uses a commit SHA rather than a branch for jetstack logo
- Rewords things + fixes typos / grammar errors

/kind documentation

```release-note
NONE
```
