### PR TITLE
Make: faster "make all-containers" and rebuild on commit change

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,0 @@
-bin/*
-bazel*
-
-!bin/server/**
-!bin/cmctl/cmctl-linux-*
-!bin/scratch/cert-manager.license
-!bin/scratch/cert-manager.licenses_notice

--- a/hack/containers/Containerfile.acmesolver
+++ b/hack/containers/Containerfile.acmesolver
@@ -4,14 +4,9 @@ FROM $BASE_IMAGE
 
 USER 1000
 
-ARG BINARY_PATH
-ARG LICENSE_PATH
-ARG LICENSES_PATH
-
-COPY $BINARY_PATH /app/cmd/acmesolver/acmesolver
-
-COPY $LICENSE_PATH /licenses/LICENSE
-COPY $LICENSES_PATH /licenses/LICENSES
+COPY acmesolver /app/cmd/acmesolver/acmesolver
+COPY cert-manager.license /licenses/LICENSE
+COPY cert-manager.licenses_notice /licenses/LICENSES
 
 ENTRYPOINT ["/app/cmd/acmesolver/acmesolver"]
 

--- a/hack/containers/Containerfile.cainjector
+++ b/hack/containers/Containerfile.cainjector
@@ -4,14 +4,9 @@ FROM $BASE_IMAGE
 
 USER 1000
 
-ARG BINARY_PATH
-ARG LICENSE_PATH
-ARG LICENSES_PATH
-
-COPY $BINARY_PATH /app/cmd/cainjector/cainjector
-
-COPY $LICENSE_PATH /licenses/LICENSE
-COPY $LICENSES_PATH /licenses/LICENSES
+COPY cainjector /app/cmd/cainjector/cainjector
+COPY cert-manager.license /licenses/LICENSE
+COPY cert-manager.licenses_notice /licenses/LICENSES
 
 ENTRYPOINT ["/app/cmd/cainjector/cainjector"]
 

--- a/hack/containers/Containerfile.controller
+++ b/hack/containers/Containerfile.controller
@@ -4,14 +4,9 @@ FROM $BASE_IMAGE
 
 USER 1000
 
-ARG BINARY_PATH
-ARG LICENSE_PATH
-ARG LICENSES_PATH
-
-COPY $BINARY_PATH /app/cmd/controller/controller
-
-COPY $LICENSE_PATH /licenses/LICENSE
-COPY $LICENSES_PATH /licenses/LICENSES
+COPY controller /app/cmd/controller/controller
+COPY cert-manager.license /licenses/LICENSE
+COPY cert-manager.licenses_notice /licenses/LICENSES
 
 ENTRYPOINT ["/app/cmd/controller/controller"]
 

--- a/hack/containers/Containerfile.ctl
+++ b/hack/containers/Containerfile.ctl
@@ -4,14 +4,9 @@ FROM $BASE_IMAGE
 
 USER 1000
 
-ARG BINARY_PATH
-ARG LICENSE_PATH
-ARG LICENSES_PATH
-
-COPY $BINARY_PATH /app/cmd/ctl/ctl
-
-COPY $LICENSE_PATH /licenses/LICENSE
-COPY $LICENSES_PATH /licenses/LICENSES
+COPY ctl /app/cmd/ctl/ctl
+COPY cert-manager.license /licenses/LICENSE
+COPY cert-manager.licenses_notice /licenses/LICENSES
 
 ENTRYPOINT ["/app/cmd/ctl/ctl"]
 

--- a/hack/containers/Containerfile.webhook
+++ b/hack/containers/Containerfile.webhook
@@ -4,14 +4,9 @@ FROM $BASE_IMAGE
 
 USER 1000
 
-ARG BINARY_PATH
-ARG LICENSE_PATH
-ARG LICENSES_PATH
-
-COPY $BINARY_PATH /app/cmd/webhook/webhook
-
-COPY $LICENSE_PATH /licenses/LICENSE
-COPY $LICENSES_PATH /licenses/LICENSES
+COPY webhook /app/cmd/webhook/webhook
+COPY cert-manager.license /licenses/LICENSE
+COPY cert-manager.licenses_notice /licenses/LICENSES
 
 ENTRYPOINT ["/app/cmd/webhook/webhook"]
 

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -40,79 +40,83 @@ all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-ma
 .PHONY: cert-manager-controller-linux
 cert-manager-controller-linux: bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz
 
-bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
+bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-controller-linux-%
 	$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
-	$(eval BASE := $(BASE_IMAGE_$(notdir $<)))
+	$(eval BASE := BASE_IMAGE_$(notdir $<))
+	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	@cp $< $(CONTEXT_DIR)/controller
+	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.controller \
-		--build-arg BASE_IMAGE=$(BASE) \
-		--build-arg BINARY_PATH=$< \
-		--build-arg LICENSE_PATH=bin/scratch/cert-manager.license \
-		--build-arg LICENSES_PATH=bin/scratch/cert-manager.licenses_notice \
+		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		.
+		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-webhook-linux
 cert-manager-webhook-linux: bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz
 
-bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
+bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-webhook-linux-%
 	$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
+	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	@cp $< $(CONTEXT_DIR)/webhook
+	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.webhook \
 		--build-arg BASE_IMAGE=$($(BASE)) \
-		--build-arg BINARY_PATH=$< \
-		--build-arg LICENSE_PATH=bin/scratch/cert-manager.license \
-		--build-arg LICENSES_PATH=bin/scratch/cert-manager.licenses_notice \
 		-t $(TAG) \
-		.
+		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-cainjector-linux
 cert-manager-cainjector-linux: bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
+bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-cainjector-linux-%
 	$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
+	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	@cp $< $(CONTEXT_DIR)/cainjector
+	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.cainjector \
 		--build-arg BASE_IMAGE=$($(BASE)) \
-		--build-arg BINARY_PATH=$< \
-		--build-arg LICENSE_PATH=bin/scratch/cert-manager.license \
-		--build-arg LICENSES_PATH=bin/scratch/cert-manager.licenses_notice \
 		-t $(TAG) \
-		.
+		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-acmesolver-linux
 cert-manager-acmesolver-linux: bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
+bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-acmesolver-linux-%
 	$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
+	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	@cp $< $(CONTEXT_DIR)/acmesolver
+	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.acmesolver \
 		--build-arg BASE_IMAGE=$($(BASE)) \
-		--build-arg BINARY_PATH=$< \
-		--build-arg LICENSE_PATH=bin/scratch/cert-manager.license \
-		--build-arg LICENSES_PATH=bin/scratch/cert-manager.licenses_notice \
 		-t $(TAG) \
-		.
+		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-ctl-linux
 cert-manager-ctl-linux: bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz
 
-bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
+bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-ctl-linux-%
 	$(eval TAG := cert-manager-ctl-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
+	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	@cp $< $(CONTEXT_DIR)/ctl
+	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.ctl \
 		--build-arg BASE_IMAGE=$($(BASE)) \
-		--build-arg BINARY_PATH=$< \
-		--build-arg LICENSE_PATH=bin/scratch/cert-manager.license \
-		--build-arg LICENSES_PATH=bin/scratch/cert-manager.licenses_notice \
 		-t $(TAG) \
-		.
+		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
+
+
+$(foreach arch,amd64 arm64 s390x ppc64le arm,$(foreach bin,controller acmesolver cainjector webhook ctl, bin/scratch/containers/cert-manager-$(bin)-linux-$(arch))):
+	@mkdir -p $@

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -1,6 +1,9 @@
 # set to "DYNAMIC" to use a dynamic base image
 BASE_IMAGE_TYPE:=STATIC
 
+ARCHS = amd64 arm64 s390x ppc64le arm
+BINS = controller acmesolver cainjector webhook ctl
+
 BASE_IMAGE_controller-linux-amd64:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_amd64)
 BASE_IMAGE_controller-linux-arm64:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_arm64)
 BASE_IMAGE_controller-linux-s390x:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_s390x)
@@ -37,87 +40,72 @@ all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-ma
 .PHONY: cert-manager-controller-linux
 cert-manager-controller-linux: bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz
 
-bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-controller-linux-%
+bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/scratch/build-context/cert-manager-controller-linux-%/controller hack/containers/Containerfile.controller bin/scratch/build-context/cert-manager-controller-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-controller-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
-	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
-	@cp $< $(CONTEXT_DIR)/controller
-	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
+	$(eval BASE := BASE_IMAGE_controller-linux-$*)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.controller \
 		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		$(CONTEXT_DIR)
+		$(dir $<)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-webhook-linux
 cert-manager-webhook-linux: bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz
 
-bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-webhook-linux-%
+bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/scratch/build-context/cert-manager-webhook-linux-%/webhook hack/containers/Containerfile.webhook bin/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
-	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
-	@cp $< $(CONTEXT_DIR)/webhook
-	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
+	$(eval BASE := BASE_IMAGE_webhook-linux-$*)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.webhook \
 		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		$(CONTEXT_DIR)
+		$(dir $<)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-cainjector-linux
 cert-manager-cainjector-linux: bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-cainjector-linux-%
+bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/scratch/build-context/cert-manager-cainjector-linux-%/cainjector hack/containers/Containerfile.cainjector bin/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
-	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
-	@cp $< $(CONTEXT_DIR)/cainjector
-	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
+	$(eval BASE := BASE_IMAGE_cainjector-linux-$*)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.cainjector \
 		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		$(CONTEXT_DIR)
+		$(dir $<)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-acmesolver-linux
 cert-manager-acmesolver-linux: bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-acmesolver-linux-%
+bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/scratch/build-context/cert-manager-acmesolver-linux-%/acmesolver hack/containers/Containerfile.acmesolver bin/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
-	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
-	@cp $< $(CONTEXT_DIR)/acmesolver
-	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
+	$(eval BASE := BASE_IMAGE_acmesolver-linux-$*)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.acmesolver \
 		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		$(CONTEXT_DIR)
+		$(dir $<)
 	$(CTR) save $(TAG) | gzip > $@
 
 .PHONY: cert-manager-ctl-linux
 cert-manager-ctl-linux: bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz
 
-bin/containers/cert-manager-ctl-linux-amd64.tar.gz: bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-ctl-linux-%
+$(foreach arch,$(ARCHS),bin/containers/cert-manager-ctl-linux-$(arch).tar.gz): bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/scratch/build-context/cert-manager-ctl-linux-%/ctl hack/containers/Containerfile.ctl bin/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-ctl-$*:$(RELEASE_VERSION))
-	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
-	@cp $< $(CONTEXT_DIR)/ctl
-	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
+	$(eval BASE := BASE_IMAGE_cmctl-linux-$*)
 	$(CTR) build --quiet \
 		-f hack/containers/Containerfile.ctl \
 		--build-arg BASE_IMAGE=$($(BASE)) \
 		-t $(TAG) \
-		$(CONTEXT_DIR)
+		$(dir $<)
 	$(CTR) save $(TAG) | gzip > $@
 
-ARCHS = amd64 arm64 s390x ppc64le arm
-BINS = controller acmesolver cainjector webhook ctl
+bin/containers:
+	@mkdir -p $@
 
-# When running "docker build .", the "build context" was getting too big (1.6 GB
+# When running "docker build .", the "build context" was getting too big (1.1 GB
 # when all binaries for all archs are built). Even with a very strict
 # .dockerignore, each "docker build" command would last for more than 10 seconds
 # each due to the copying happening. To avoid that, we set a different folder
@@ -126,5 +114,14 @@ BINS = controller acmesolver cainjector webhook ctl
 $(foreach arch,$(ARCHS),$(foreach bin,$(BINS), bin/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@
 
-bin/containers:
-	@mkdir -p $@
+bin/scratch/build-context/cert-manager-%/cert-manager.license: bin/scratch/cert-manager.license | bin/scratch/build-context/cert-manager-%
+	@cp $< $@
+
+bin/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: bin/scratch/cert-manager.licenses_notice | bin/scratch/build-context/cert-manager-%
+	@cp $< $@
+
+bin/scratch/build-context/cert-manager-%/controller bin/scratch/build-context/cert-manager-%/acmesolver bin/scratch/build-context/cert-manager-%/cainjector bin/scratch/build-context/cert-manager-%/webhook: bin/server/% | bin/scratch/build-context/cert-manager-%
+	@cp $< $@
+
+bin/scratch/build-context/cert-manager-ctl-%/ctl: bin/cmctl/cmctl-% | bin/scratch/build-context/cert-manager-ctl-%
+	@cp $< $@

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -31,9 +31,6 @@ BASE_IMAGE_cmctl-linux-s390x:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_s390x)
 BASE_IMAGE_cmctl-linux-ppc64le:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_ppc64le)
 BASE_IMAGE_cmctl-linux-arm:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_arm)
 
-bin/containers:
-	@mkdir -p $@
-
 .PHONY: all-containers
 all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-manager-acmesolver-linux cert-manager-cainjector-linux cert-manager-ctl-linux
 
@@ -117,6 +114,8 @@ bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-c
 		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
+bin/containers:
+	@mkdir -p $@
 
 $(foreach arch,amd64 arm64 s390x ppc64le arm,$(foreach bin,controller acmesolver cainjector webhook ctl, bin/scratch/containers/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -37,10 +37,10 @@ all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-ma
 .PHONY: cert-manager-controller-linux
 cert-manager-controller-linux: bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz
 
-bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-controller-linux-%
+bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-controller-linux-%
 	$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
 	@cp $< $(CONTEXT_DIR)/controller
 	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
@@ -53,10 +53,10 @@ bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-webhook-linux
 cert-manager-webhook-linux: bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz
 
-bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-webhook-linux-%
+bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-webhook-linux-%
 	$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
 	@cp $< $(CONTEXT_DIR)/webhook
 	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
@@ -69,10 +69,10 @@ bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manag
 .PHONY: cert-manager-cainjector-linux
 cert-manager-cainjector-linux: bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-cainjector-linux-%
+bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-cainjector-linux-%
 	$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
 	@cp $< $(CONTEXT_DIR)/cainjector
 	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
@@ -85,10 +85,10 @@ bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-acmesolver-linux
 cert-manager-acmesolver-linux: bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-acmesolver-linux-%
+bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-acmesolver-linux-%
 	$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
 	@cp $< $(CONTEXT_DIR)/acmesolver
 	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
@@ -101,10 +101,10 @@ bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-ctl-linux
 cert-manager-ctl-linux: bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz
 
-bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/containers/cert-manager-ctl-linux-%
+bin/containers/cert-manager-ctl-linux-amd64.tar.gz: bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers bin/scratch/build-context/cert-manager-ctl-linux-%
 	$(eval TAG := cert-manager-ctl-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
-	$(eval CONTEXT_DIR := bin/scratch/containers/$(notdir $(@:%.tar.gz=%)))
+	$(eval CONTEXT_DIR := bin/scratch/build-context/$(notdir $(@:%.tar.gz=%)))
 	@cp $< $(CONTEXT_DIR)/ctl
 	@cp bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice $(CONTEXT_DIR)
 	$(CTR) build --quiet \
@@ -114,8 +114,17 @@ bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-c
 		$(CONTEXT_DIR)
 	$(CTR) save $(TAG) | gzip > $@
 
-bin/containers:
+ARCHS = amd64 arm64 s390x ppc64le arm
+BINS = controller acmesolver cainjector webhook ctl
+
+# When running "docker build .", the "build context" was getting too big (1.6 GB
+# when all binaries for all archs are built). Even with a very strict
+# .dockerignore, each "docker build" command would last for more than 10 seconds
+# each due to the copying happening. To avoid that, we set a different folder
+# for each "docker build" command, which reduces the copying to ~50 MB per
+# "docker build".
+$(foreach arch,$(ARCHS),$(foreach bin,$(BINS), bin/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@
 
-$(foreach arch,amd64 arm64 s390x ppc64le arm,$(foreach bin,controller acmesolver cainjector webhook ctl, bin/scratch/containers/cert-manager-$(bin)-linux-$(arch))):
+bin/containers:
 	@mkdir -p $@

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -40,7 +40,7 @@ all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-ma
 .PHONY: cert-manager-controller-linux
 cert-manager-controller-linux: bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz
 
-bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice | bin/containers
+bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz: bin/containers/cert-manager-controller-linux-%.tar.gz: bin/server/controller-linux-% hack/containers/Containerfile.controller bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
 	$(eval BASE := $(BASE_IMAGE_$(notdir $<)))
 	$(CTR) build --quiet \
@@ -56,7 +56,7 @@ bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-webhook-linux
 cert-manager-webhook-linux: bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz
 
-bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice | bin/containers
+bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz: bin/containers/cert-manager-webhook-linux-%.tar.gz: bin/server/webhook-linux-% hack/containers/Containerfile.webhook bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
 	$(CTR) build --quiet \
@@ -72,7 +72,7 @@ bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manag
 .PHONY: cert-manager-cainjector-linux
 cert-manager-cainjector-linux: bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice | bin/containers
+bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz: bin/containers/cert-manager-cainjector-linux-%.tar.gz: bin/server/cainjector-linux-% hack/containers/Containerfile.cainjector bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
 	$(CTR) build --quiet \
@@ -88,7 +88,7 @@ bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-acmesolver-linux
 cert-manager-acmesolver-linux: bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice | bin/containers
+bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz: bin/server/acmesolver-linux-% hack/containers/Containerfile.acmesolver bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
 	$(CTR) build --quiet \
@@ -104,7 +104,7 @@ bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-ma
 .PHONY: cert-manager-ctl-linux
 cert-manager-ctl-linux: bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz
 
-bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice | bin/containers
+bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz: bin/containers/cert-manager-ctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% hack/containers/Containerfile.ctl bin/scratch/cert-manager.license bin/scratch/cert-manager.licenses_notice bin/release-version | bin/containers
 	$(eval TAG := cert-manager-ctl-$*:$(RELEASE_VERSION))
 	$(eval BASE := BASE_IMAGE_$(notdir $<))
 	$(CTR) build --quiet \

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -111,17 +111,22 @@ bin/containers:
 # each due to the copying happening. To avoid that, we set a different folder
 # for each "docker build" command, which reduces the copying to ~50 MB per
 # "docker build".
+#
+# Note that we can't use symlinks in the build context. In order to avoid the
+# cost of multiple copies of the same binary, we use hard links which shouldn't
+# be a problem since the bin/ folder is entirely managed by make.
+
 $(foreach arch,$(ARCHS),$(foreach bin,$(BINS), bin/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@
 
 bin/scratch/build-context/cert-manager-%/cert-manager.license: bin/scratch/cert-manager.license | bin/scratch/build-context/cert-manager-%
-	@cp $< $@
+	@ln -f $< $@
 
 bin/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: bin/scratch/cert-manager.licenses_notice | bin/scratch/build-context/cert-manager-%
-	@cp $< $@
+	@ln -f $< $@
 
 bin/scratch/build-context/cert-manager-%/controller bin/scratch/build-context/cert-manager-%/acmesolver bin/scratch/build-context/cert-manager-%/cainjector bin/scratch/build-context/cert-manager-%/webhook: bin/server/% | bin/scratch/build-context/cert-manager-%
-	@cp $< $@
+	@ln -f $< $@
 
 bin/scratch/build-context/cert-manager-ctl-%/ctl: bin/cmctl/cmctl-% | bin/scratch/build-context/cert-manager-ctl-%
-	@cp $< $@
+	@ln -f $< $@

--- a/make/git.mk
+++ b/make/git.mk
@@ -27,10 +27,10 @@ bin/scratch/git/upstream-tags.txt: | bin/scratch/git
 		grep -v "v1.2.0-alpha.1" > $@
 
 # The file "release-version" gets updated whenever git describe --tags changes. This is
-# used by the bin/containers/*.tar.gz targets to make sure the containers, which use the
-# "git describe --tags" string as their tag, get rebuilt whenever you check out a different
-# commit. If we didn't do this, the Helm chart bin/cert-manager-*.tgz would refer to an
-# image tag that doesn't exist in bin/containers/*.tar.gz.
+# used by the bin/containers/*.tar.gz targets to make sure that the containers, which use
+# the output of "git describe --tags" as their tag, get rebuilt whenever you check out a
+# different commit. If we didn't do this, the Helm chart bin/cert-manager-*.tgz would refer
+# to an image tag that doesn't exist in bin/containers/*.tar.gz.
 bin/release-version: | bin
 	@test "$(RELEASE_VERSION)" == "$$(cat "$@" 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
 

--- a/make/git.mk
+++ b/make/git.mk
@@ -26,5 +26,8 @@ bin/scratch/git/upstream-tags.txt: | bin/scratch/git
 		sed -n '/v1.0.0/,$$p' | \
 		grep -v "v1.2.0-alpha.1" > $@
 
+bin/release-version: | bin
+	@test "$(RELEASE_VERSION)" == "$$(cat "$@" 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
+
 bin/scratch/git:
 	@mkdir -p $@

--- a/make/git.mk
+++ b/make/git.mk
@@ -26,6 +26,11 @@ bin/scratch/git/upstream-tags.txt: | bin/scratch/git
 		sed -n '/v1.0.0/,$$p' | \
 		grep -v "v1.2.0-alpha.1" > $@
 
+# The file "release-version" gets updated whenever git describe --tags changes. This is
+# used by the bin/containers/*.tar.gz targets to make sure the containers, which use the
+# "git describe --tags" string as their tag, get rebuilt whenever you check out a different
+# commit. If we didn't do this, the Helm chart bin/cert-manager-*.tgz would refer to an
+# image tag that doesn't exist in bin/containers/*.tar.gz.
 bin/release-version: | bin
 	@test "$(RELEASE_VERSION)" == "$$(cat "$@" 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
 

--- a/make/git.mk
+++ b/make/git.mk
@@ -26,13 +26,21 @@ bin/scratch/git/upstream-tags.txt: | bin/scratch/git
 		sed -n '/v1.0.0/,$$p' | \
 		grep -v "v1.2.0-alpha.1" > $@
 
-# The file "release-version" gets updated whenever git describe --tags changes. This is
-# used by the bin/containers/*.tar.gz targets to make sure that the containers, which use
-# the output of "git describe --tags" as their tag, get rebuilt whenever you check out a
-# different commit. If we didn't do this, the Helm chart bin/cert-manager-*.tgz would refer
-# to an image tag that doesn't exist in bin/containers/*.tar.gz.
-bin/release-version: | bin
-	@test "$(RELEASE_VERSION)" == "$$(cat "$@" 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
+# The file "release-version" gets updated whenever git describe --tags changes.
+# This is used by the bin/containers/*.tar.gz targets to make sure that the
+# containers, which use the output of "git describe --tags" as their tag, get
+# rebuilt whenever you check out a different commit. If we didn't do this, the
+# Helm chart bin/cert-manager-*.tgz would refer to an image tag that doesn't
+# exist in bin/containers/*.tar.gz.
+#
+# We use FORCE instead of .PHONY because this is a real file that can be used as
+# a prerequisite. If we were to use .PHONY, then the file's timestamp would not
+# be used to check whether targets should be rebuilt, and they would get
+# constantly rebuilt.
+bin/release-version: FORCE | bin
+	@test "$(RELEASE_VERSION)" == "$(shell cat $@ 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
+
+FORCE:
 
 bin/scratch/git:
 	@mkdir -p $@


### PR DESCRIPTION
| This PR is part of the effort 'moving away from Bazel' tracked in #4712 |
|--|

Previously, we had one `.dockerignore` that would do its best to only have the binaries and licenses copied into the Docker (or nerdctl, or buildah). Unfortunately, that meant it had to copy all of bin/server and bin/cmctl, which could become quite large (I measured 1.1 GB).

Instead of relying on a single .dockerignore file, we copy the licenses and binaries into a "scratch context" directory. The downside is that all the binaries are in two different places (bin/server and bin/scratch/containers). Note that we can't use symlinks because Docker won't dereference them.

I also added a target `bin/release-version` so that container images get rebuilt when a different commit is checked out. When switching branches, the Go files may not change. But since the images contain the commit hash, e.g.:

    cert-manager-controller-amd64:v1.7.0-beta.0-142-gfc0819af6

It is surprising when trying to deploy to Kind: the git commit that is checked out does not match the commit hash of the image.

To avoid confusion that may occur when someone deploys the chart, e.g., `bin/cert-manager-v1.7.0-beta.0-141-geccd68253.tgz`, I made sure the images, e.g., `bin/containers/cert-manager-ctl-linux-amd64.tar.gz` get rebuilt whenever the current git hash changes (change branches, new commit...). That relies on the new target `bin/release-version` that gets updated only when the checked out commit changes.

/kind cleanup

```release-note
NONE
```
