### PR TITLE
Change controller context rate limiter test to ensure they are the same pointer

### DIFF
--- a/pkg/controller/context_test.go
+++ b/pkg/controller/context_test.go
@@ -38,5 +38,5 @@ func Test_NewContextFactory(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NotNil(t, ctx1.RESTConfig.RateLimiter)
-	assert.Equal(t, ctx1.RESTConfig.RateLimiter, ctx2.RESTConfig.RateLimiter)
+	assert.Same(t, ctx1.RESTConfig.RateLimiter, ctx2.RESTConfig.RateLimiter)
 }


### PR DESCRIPTION
Assert these variables are the same pointer rather than value. This is a stronger test to ensure that the rate limiter is shared between controller contexts.

/milestone v1.8
/kind cleanup

```release-note
NONE
```
