### PR TITLE
cmctl x uninstall

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -61,6 +61,7 @@ filegroup(
         "//cmd/ctl/pkg/install:all-srcs",
         "//cmd/ctl/pkg/renew:all-srcs",
         "//cmd/ctl/pkg/status:all-srcs",
+        "//cmd/ctl/pkg/uninstall:all-srcs",
         "//cmd/ctl/pkg/upgrade:all-srcs",
         "//cmd/ctl/pkg/version:all-srcs",
     ],

--- a/cmd/ctl/pkg/experimental/experimental.go
+++ b/cmd/ctl/pkg/experimental/experimental.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/create"
 	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/create/certificatesigningrequest"
 	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/install"
+	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/uninstall"
 )
 
 func NewCmdExperimental(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.Command {
@@ -39,6 +40,7 @@ func NewCmdExperimental(ctx context.Context, ioStreams genericclioptions.IOStrea
 	create.AddCommand(certificatesigningrequest.NewCmdCreateCSR(ctx, ioStreams))
 	cmds.AddCommand(create)
 	cmds.AddCommand(install.NewCmdInstall(ctx, ioStreams))
+	cmds.AddCommand(uninstall.NewCmd(ctx, ioStreams))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/uninstall/BUILD.bazel
+++ b/cmd/ctl/pkg/uninstall/BUILD.bazel
@@ -2,16 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["experimental.go"],
-    importpath = "github.com/cert-manager/cert-manager/cmd/ctl/pkg/experimental",
+    srcs = ["uninstall.go"],
+    importpath = "github.com/cert-manager/cert-manager/cmd/ctl/pkg/uninstall",
     visibility = ["//visibility:public"],
     deps = [
-        "//cmd/ctl/pkg/create:go_default_library",
-        "//cmd/ctl/pkg/create/certificatesigningrequest:go_default_library",
-        "//cmd/ctl/pkg/install:go_default_library",
-        "//cmd/ctl/pkg/uninstall:go_default_library",
+        "//cmd/ctl/pkg/build:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@sh_helm_helm_v3//pkg/action:go_default_library",
+        "@sh_helm_helm_v3//pkg/cli:go_default_library",
+        "@sh_helm_helm_v3//pkg/release:go_default_library",
+        "@sh_helm_helm_v3//pkg/storage/driver:go_default_library",
     ],
 )
 

--- a/cmd/ctl/pkg/uninstall/uninstall.go
+++ b/cmd/ctl/pkg/uninstall/uninstall.go
@@ -39,9 +39,9 @@ type options struct {
 	client   *action.Uninstall
 	cfg      *action.Configuration
 
-	DisableHooks bool
-	DryRun       bool
-	Wait         bool
+	disableHooks bool
+	dryRun       bool
+	wait         bool
 
 	genericclioptions.IOStreams
 }
@@ -91,7 +91,7 @@ func NewCmd(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.C
 				return fmt.Errorf("run: %v", err)
 			}
 
-			if options.DryRun {
+			if options.dryRun {
 				fmt.Fprintf(ioStreams.Out, "%s", res.Release.Manifest)
 				return nil
 			}
@@ -116,9 +116,9 @@ func NewCmd(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.C
 	cmd.Flag("namespace").Value.Set(defaultCertManagerNamespace)
 
 	cmd.Flags().DurationVar(&options.client.Timeout, "timeout", 5*time.Minute, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
-	cmd.Flags().BoolVar(&options.Wait, "wait", true, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
-	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "simulate uninstall and output manifests to be deleted")
-	cmd.Flags().BoolVar(&options.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation (pre- and post-uninstall hooks)")
+	cmd.Flags().BoolVar(&options.wait, "wait", true, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
+	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "simulate uninstall and output manifests to be deleted")
+	cmd.Flags().BoolVar(&options.disableHooks, "no-hooks", false, "prevent hooks from running during uninstallation (pre- and post-uninstall hooks)")
 
 	return cmd
 }
@@ -132,9 +132,9 @@ func run(ctx context.Context, o options) (*release.UninstallReleaseResponse, err
 		return nil, fmt.Errorf("o.cfg.Init: %v", err)
 	}
 
-	o.client.DisableHooks = o.DisableHooks
-	o.client.DryRun = o.DryRun
-	o.client.Wait = o.Wait
+	o.client.DisableHooks = o.disableHooks
+	o.client.DryRun = o.dryRun
+	o.client.Wait = o.wait
 
 	res, err := o.client.Run(releaseName)
 

--- a/cmd/ctl/pkg/uninstall/uninstall.go
+++ b/cmd/ctl/pkg/uninstall/uninstall.go
@@ -20,17 +20,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"helm.sh/helm/v3/pkg/storage/driver"
 	"log"
 	"os"
 	"time"
 
-	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/build"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/build"
 )
 
 type options struct {

--- a/cmd/ctl/pkg/uninstall/uninstall.go
+++ b/cmd/ctl/pkg/uninstall/uninstall.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uninstall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"log"
+	"os"
+	"time"
+
+	"github.com/cert-manager/cert-manager/cmd/ctl/pkg/build"
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type options struct {
+	settings *cli.EnvSettings
+	client   *action.Uninstall
+	cfg      *action.Configuration
+
+	DisableHooks bool
+	DryRun       bool
+	Wait         bool
+
+	genericclioptions.IOStreams
+}
+
+const (
+	defaultCertManagerNamespace = "cert-manager"
+	releaseName                 = "cert-manager"
+)
+
+func description() string {
+	return build.WithTemplate(`This command uninstalls cert-manager. It uses the Helm libraries to do so.
+
+It assumes cert-manager has been installed with this CLI.
+
+Most of the features supported by 'helm uninstall' are also supported by this command.
+
+Some example uses:
+	$ {{.BuildName}} x uninstall
+or
+	$ {{.BuildName}} x uninstall --namespace my-cert-manager
+or
+	$ {{.BuildName}} x uninstall --dry-run
+or
+	$ {{.BuildName}} x uninstall --no-hooks
+`)
+}
+
+func NewCmd(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	settings := cli.New()
+	cfg := new(action.Configuration)
+
+	options := options{
+		settings: settings,
+		cfg:      cfg,
+		client:   action.NewUninstall(cfg),
+
+		IOStreams: ioStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall cert-manager",
+		Long:  description(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res, err := run(ctx, options)
+			if err != nil {
+				return fmt.Errorf("run: %v", err)
+			}
+
+			if options.DryRun {
+				fmt.Fprintf(ioStreams.Out, "%s", res.Release.Manifest)
+				return nil
+			}
+
+			return nil
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	settings.AddFlags(cmd.Flags())
+
+	// The Helm cli.New function does not provide an easy way to
+	// override the default of the namespace flag.
+	// See https://github.com/helm/helm/issues/9790
+	//
+	// set the default value shown in the usage message.
+	cmd.Flag("namespace").DefValue = defaultCertManagerNamespace
+
+	// The returned error is ignored because
+	// pflag.stringValue.Set always returns a nil.
+	cmd.Flag("namespace").Value.Set(defaultCertManagerNamespace)
+
+	cmd.Flags().DurationVar(&options.client.Timeout, "timeout", 5*time.Minute, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
+	cmd.Flags().BoolVar(&options.Wait, "wait", true, "if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout")
+	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "simulate uninstall and output manifests to be deleted")
+	cmd.Flags().BoolVar(&options.DisableHooks, "no-hooks", false, "prevent hooks from running during uninstallation (pre- and post-uninstall hooks)")
+
+	return cmd
+}
+
+// run assumes cert-manager was installed as a Helm release named cert-manager.
+// this is not configurable to avoid uninstalling non-cert-manager releases.
+func run(ctx context.Context, o options) (*release.UninstallReleaseResponse, error) {
+	log.SetFlags(0) // disable prefixing logs with timestamps.
+
+	if err := o.cfg.Init(o.settings.RESTClientGetter(), o.settings.Namespace(), os.Getenv("HELM_DRIVER"), log.Printf); err != nil {
+		return nil, fmt.Errorf("o.cfg.Init: %v", err)
+	}
+
+	o.client.DisableHooks = o.DisableHooks
+	o.client.DryRun = o.DryRun
+	o.client.Wait = o.Wait
+
+	res, err := o.client.Run(releaseName)
+
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		log.Fatalf("release %v not found in namespace %v, did you use the correct namespace?", releaseName, o.settings.Namespace())
+	}
+
+	return res, nil
+}

--- a/cmd/ctl/pkg/uninstall/uninstall.go
+++ b/cmd/ctl/pkg/uninstall/uninstall.go
@@ -52,9 +52,9 @@ const (
 )
 
 func description() string {
-	return build.WithTemplate(`This command uninstalls cert-manager. It uses the Helm libraries to do so.
+	return build.WithTemplate(`This command uninstalls any Helm-managed release of cert-manager.
 
-It assumes cert-manager has been installed with this CLI.
+The CRDs will be deleted if you installed cert-manager with the option --set CRDs=true.
 
 Most of the features supported by 'helm uninstall' are also supported by this command.
 


### PR DESCRIPTION
This PR adds an experimental `uninstall` command to `cmctl`.

The command attempts to uninstall a Helm release named `cert-manager` in the given namespace.

```console
$ bazel run //cmd/ctl -- x install -n my-custom-namespace
$ bazel run //cmd/ctl -- x uninstall
> release cert-manager not found in namespace cert-manager, did you use the correct namespace?
$ bazel run //cmd/ctl -- x uninstall -n my-custom-namespace
uninstall: Deleting cert-manager
Starting delete for "cert-manager" Service
Starting delete for "cert-manager-webhook" Service
Starting delete for "cert-manager-cainjector" Deployment
Starting delete for "cert-manager-webhook" Deployment
Starting delete for "cert-manager" Deployment
Starting delete for "cert-manager-webhook:dynamic-serving" RoleBinding
Starting delete for "cert-manager-cainjector:leaderelection" RoleBinding
Starting delete for "cert-manager:leaderelection" RoleBinding
Starting delete for "cert-manager-cainjector:leaderelection" Role
Starting delete for "cert-manager:leaderelection" Role
Starting delete for "cert-manager-webhook:dynamic-serving" Role
Starting delete for "cert-manager-controller-issuers" ClusterRoleBinding
Starting delete for "cert-manager-cainjector" ClusterRoleBinding
Starting delete for "cert-manager-controller-clusterissuers" ClusterRoleBinding
Starting delete for "cert-manager-controller-certificates" ClusterRoleBinding
Starting delete for "cert-manager-controller-approve:cert-manager-io" ClusterRoleBinding
Starting delete for "cert-manager-webhook:subjectaccessreviews" ClusterRoleBinding
Starting delete for "cert-manager-controller-certificatesigningrequests" ClusterRoleBinding
Starting delete for "cert-manager-controller-ingress-shim" ClusterRoleBinding
Starting delete for "cert-manager-controller-orders" ClusterRoleBinding
Starting delete for "cert-manager-controller-challenges" ClusterRoleBinding
Starting delete for "cert-manager-view" ClusterRole
Starting delete for "cert-manager-cainjector" ClusterRole
Starting delete for "cert-manager-controller-approve:cert-manager-io" ClusterRole
Starting delete for "cert-manager-webhook:subjectaccessreviews" ClusterRole
Starting delete for "cert-manager-controller-certificatesigningrequests" ClusterRole
Starting delete for "cert-manager-edit" ClusterRole
Starting delete for "cert-manager-controller-certificates" ClusterRole
Starting delete for "cert-manager-controller-clusterissuers" ClusterRole
Starting delete for "cert-manager-controller-challenges" ClusterRole
Starting delete for "cert-manager-controller-issuers" ClusterRole
Starting delete for "cert-manager-controller-orders" ClusterRole
Starting delete for "cert-manager-controller-ingress-shim" ClusterRole
Starting delete for "cert-manager-webhook" ConfigMap
Starting delete for "cert-manager-webhook" ServiceAccount
Starting delete for "cert-manager-cainjector" ServiceAccount
Starting delete for "cert-manager" ServiceAccount
Starting delete for "cert-manager-webhook" MutatingWebhookConfiguration
Starting delete for "cert-manager-webhook" ValidatingWebhookConfiguration
beginning wait for 39 resources to be deleted with timeout of 5m0s
purge requested for cert-manager
```

:tada:

### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/4626

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added a new experimental cmctl command: uninstall (#4626, @jahrlin)
```
