### PR TITLE
add validation for certificate.spec.privateKey.rotationPolicy

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -190,6 +190,9 @@ spec:
                     rotationPolicy:
                       description: RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.
                       type: string
+                      enum:
+                        - Never
+                        - Always
                     size:
                       description: Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.
                       type: integer

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -212,6 +212,7 @@ type CertificatePrivateKey struct {
 	// will be generated whenever a re-issuance occurs.
 	// Default is 'Never' for backward compatibility.
 	// +optional
+	// +kubebuilder:validation:Enum=Never;Always
 	RotationPolicy PrivateKeyRotationPolicy `json:"rotationPolicy,omitempty"`
 
 	// The private key cryptography standards (PKCS) encoding for this

--- a/test/integration/validation/BUILD.bazel
+++ b/test/integration/validation/BUILD.bazel
@@ -16,7 +16,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["certificaterequest_test.go"],
+    srcs = [
+        "certificate_test.go",
+        "certificaterequest_test.go",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",

--- a/test/integration/validation/certificate_test.go
+++ b/test/integration/validation/certificate_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/cert-manager/pkg/api"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/integration/framework"
+)
+
+var certificateGVK = schema.GroupVersionKind{
+	Group:   "cert-manager.io",
+	Version: "v1",
+	Kind:    "Certificate",
+}
+
+func TestValidationCertificate(t *testing.T) {
+	tests := map[string]struct {
+		input       runtime.Object
+		errorSuffix string
+		expectError bool
+	}{
+		"Happy path returns no errors": {
+			input: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testing",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName: "testing-tls",
+					DNSNames:   []string{"myhostname.com"},
+					Usages:     []cmapi.KeyUsage{},
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "letsencrypt-staging",
+					},
+					PrivateKey: &cmapi.CertificatePrivateKey{
+						RotationPolicy: "Always",
+					},
+				},
+			},
+			expectError: false,
+		},
+		"Bad value for certificate.spec.privateKey.rotationPolicy returns error": {
+			input: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testing",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName: "testing-tls",
+					DNSNames:   []string{"myhostname.com"},
+					Usages:     []cmapi.KeyUsage{},
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "letsencrypt-staging",
+					},
+					PrivateKey: &cmapi.CertificatePrivateKey{
+						RotationPolicy: "Alway!",
+					},
+				},
+			},
+			errorSuffix: "supported values: \"Never\", \"Always\"",
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cert := test.input.(*cmapi.Certificate)
+			cert.SetGroupVersionKind(certificateGVK)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+			defer cancel()
+
+			config, stop := framework.RunControlPlane(t, ctx)
+			defer stop()
+
+			framework.WaitForOpenAPIResourcesToBeLoaded(t, ctx, config, certificateGVK)
+
+			cl, err := client.New(config, client.Options{Scheme: api.Scheme})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = cl.Create(ctx, cert)
+
+			if test.expectError {
+				if err == nil {
+					t.Error("expected an error, got nil")
+				}
+
+				if !strings.HasSuffix(err.Error(), test.errorSuffix) {
+					t.Errorf("expected error with suffix \"%v\", got error: \"%v\"", test.errorSuffix, err)
+				}
+			}
+
+			if !test.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>

Fixes #4898

```sh
cat <<EOF | kubectl apply -f -
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: testing
  namespace: testing
spec:
  secretName: testing-tls
  privateKey:
    rotationPolicy: Alway
  issuerRef:
    name: letsencrypt-staging
  dnsNames:
  - 'myhostname.com'
EOF
The Certificate "testing" is invalid: spec.privateKey.rotationPolicy: Unsupported value: "Alway": supported values: "Never", "Always"
```

/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added kube validation for certificate.spec.privateKey.rotationPolicy. Valid options are Never, Always. Existing Certificate resources with incorrect values needs to be updated. (#4898, @jahrlin)
```
