### PR TITLE
Switch leader election to use Lease objects

### DIFF
--- a/cmd/cainjector/app/BUILD.bazel
+++ b/cmd/cainjector/app/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_client_go//plugin/pkg/client/auth:go_default_library",
+        "@io_k8s_client_go//tools/leaderelection/resourcelock:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],

--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	cmdutil "github.com/cert-manager/cert-manager/cmd/util"
@@ -141,6 +142,7 @@ func (o InjectorControllerOptions) RunInjectorController(ctx context.Context) er
 		LeaderElectionNamespace:       o.LeaderElectionNamespace,
 		LeaderElectionID:              "cert-manager-cainjector-leader-election",
 		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 		LeaseDuration:                 &o.LeaseDuration,
 		RenewDeadline:                 &o.RenewDeadline,
 		RetryPeriod:                   &o.RetryPeriod,

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -326,15 +326,15 @@ func startLeaderElection(ctx context.Context, opts *options.ControllerOptions, l
 		return fmt.Errorf("error getting hostname: %v", err)
 	}
 
-	// Set up Multilock for leader election. This Multilock is here for the
-	// transitionary period from configmaps to leases see
-	// https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
 	lockName := "cert-manager-controller"
 	lc := resourcelock.ResourceLockConfig{
 		Identity:      id + "-external-cert-manager-controller",
 		EventRecorder: recorder,
 	}
-	ml, err := resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
+
+	// We only support leases for leader election. Previously we supported ConfigMap & Lease objects for leader
+	// election.
+	ml, err := resourcelock.New(resourcelock.LeasesResourceLock,
 		opts.LeaderElectionNamespace,
 		lockName,
 		leaderElectionClient.CoreV1(),

--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -68,14 +68,6 @@ rules:
   #   see cmd/cainjector/start.go#L113
   # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
   #   see cmd/cainjector/start.go#L137
-  # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
-    verbs: ["get", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -11,15 +11,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
 rules:
-  # Used for leader election by the controller
-  # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["cert-manager-controller"]
-    verbs: ["get", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     resourceNames: ["cert-manager-controller"]


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

#3766 

### Kind

/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Previously, cert-manager supported both ConfigMap & Lease objects for leader election. This change modifies
the leader-election code to now solely use Lease objects. Existing ConfigMap resources used for leader election
will remain and need deleting manually.

This change means that you cannot upgrade to the version containing this change from cert-manager 1.3.
```
