### PR TITLE
Optional to aggregate cert-manager ClusterRoles to K8s default user-facing ClusterRoles

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -420,9 +420,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
+    {{- if .Values.global.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
@@ -444,8 +446,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
+    {{- if .Values.global.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -12,6 +12,8 @@ global:
   priorityClassName: ""
   rbac:
     create: true
+    # Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+    aggregateClusterRoles: true
 
   podSecurityPolicy:
     enabled: false


### PR DESCRIPTION
### Pull Request Motivation

It might not always be desirable to aggregate the -edit and -view ClusterRoles to the default user-facing roles. There should be an option to disable this, for example in order to adhere to a least privilege principle in a multi-tenant cluster setup.

Follow-up/enhancement of #902

### Kind

/kind feature

### Release Note

```release-note
Optional to aggregate cert-manager ClusterRoles to K8s default user-facing ClusterRoles (admin/edit/view)
```
