### PR TITLE
docs: improve featureGates Helm chart value documentation

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -89,7 +89,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod |
-| `featureGates` | Comma-separated list of feature gates to enable on the controller pod | `` |
+| `featureGates` | Set of comma-separated key=value pairs that describe feature gates on the controller. Some feature gates may also have to be enabled on other components, and can be set supplying the `feature-gate` flag to `<component>.extraArgs` | `` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
 | `extraEnv` | Optional environment variables for cert-manager | `[]` |
 | `serviceAccount.create` | If `true`, create a new service account | `true` |


### PR DESCRIPTION
When trying to enable the `AdditionalCertificateOutputFormats` feature gate (Helm installation), I found the chart documentation a bit sparse and somehow misleading. This PR is an attempt to improve this.

/kind documentation
/area deploy
/cc @jakexks 

```release-note
NONE
```
