### PR TITLE
Use Kubernetes CSR spec.expirationSeconds to express cert duration

### DIFF
--- a/cmd/ctl/pkg/create/certificatesigningrequest/certificatesigningrequest.go
+++ b/cmd/ctl/pkg/create/certificatesigningrequest/certificatesigningrequest.go
@@ -372,7 +372,10 @@ func buildCertificateSigningRequest(crt *cmapi.Certificate, pk []byte, crName, s
 	}
 	csr.Annotations[experimentalapi.CertificateSigningRequestIsCAAnnotationKey] = strconv.FormatBool(crt.Spec.IsCA)
 	if crt.Spec.Duration != nil {
-		csr.Annotations[experimentalapi.CertificateSigningRequestDurationAnnotationKey] = crt.Spec.Duration.Duration.String()
+		duration := crt.Spec.Duration.Duration
+		csr.Annotations[experimentalapi.CertificateSigningRequestDurationAnnotationKey] = duration.String()
+		seconds := int32(duration.Seconds())  // technically this could overflow but I do not think it matters
+		csr.Spec.ExpirationSeconds = &seconds // if this is less than 600, the API server will fail the request
 	}
 
 	return csr, nil

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -732,6 +732,41 @@ func TestSign(t *testing.T) {
 				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
 			},
 		},
+		"when the CertificateSigningRequest has the expiration seconds field set, it should appear as notAfter on the signed certificate": {
+			csr: gen.CertificateSigningRequest("csr-1",
+				gen.AddCertificateSigningRequestAnnotations(map[string]string{
+					"experimental.cert-manager.io/private-key-secret-name": "test-secret",
+				}),
+				gen.SetCertificateSigningRequestSignerName("issuers.cert-manager.io/default-unit-test-ns.issuer-1"),
+				gen.SetCertificateSigningRequestExpirationSeconds(444),
+				gen.SetCertificateSigningRequestRequest(csrBundle.csrPEM),
+			),
+			issuer: baseIssuer,
+			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
+				// Although there is less than 1µs between the time.Now
+				// call made by the certificate template func (in the "pki"
+				// package) and the time.Now below, rounding or truncating
+				// will always end up with a flaky test. This is due to the
+				// rounding made to the notAfter value when serializing the
+				// certificate to ASN.1 [1].
+				//
+				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
+				//
+				// So instead of using a truncation or rounding in order to
+				// check the time, we use a delta of 2 seconds. One entire
+				// second is totally overkill since, as detailed above, the
+				// delay is probably less than a microsecond. But that will
+				// do for now!
+				//
+				// Note that we do have a plan to fix this. We want to be
+				// injecting a time (instead of time.Now) to the template
+				// functions. This work is being tracked in this issue:
+				// https://github.com/cert-manager/cert-manager/issues/3738
+				expectNotAfter := time.Now().UTC().Add(444 * time.Second)
+				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
+				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+			},
+		},
 		"when the CertificateSigningRequest has the isCA field set, it should appear on the signed certificate": {
 			csr: gen.CertificateSigningRequest("csr-1",
 				gen.AddCertificateSigningRequestAnnotations(map[string]string{

--- a/pkg/util/pki/kube_test.go
+++ b/pkg/util/pki/kube_test.go
@@ -131,6 +131,73 @@ func TestGenerateTemplateFromCertificateSigningRequest(t *testing.T) {
 				DNSNames: []string{"example.com", "foo.example.com"},
 			},
 		},
+		"a CSR with expiration seconds that is valid should return a valid *x509.Certificate": {
+			csr: gen.CertificateSigningRequest("",
+				gen.SetCertificateSigningRequestExpirationSeconds(999),
+				gen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{
+					certificatesv1.UsageAny,
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageCRLSign,
+					certificatesv1.UsageCodeSigning,
+					certificatesv1.UsageContentCommitment,
+				}),
+				gen.SetCertificateSigningRequestIsCA(false),
+				gen.SetCertificateSigningRequestRequest(csr),
+			),
+			expCertificate: &x509.Certificate{
+				Version:               2,
+				BasicConstraintsValid: true,
+				SerialNumber:          nil,
+				PublicKeyAlgorithm:    x509.RSA,
+				PublicKey:             pk.Public(),
+				IsCA:                  false,
+				Subject: pkix.Name{
+					CommonName: "example.com",
+				},
+				NotBefore: time.Now(),
+				NotAfter:  time.Now().Add(999 * time.Second),
+				KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign | x509.KeyUsageContentCommitment,
+				ExtKeyUsage: []x509.ExtKeyUsage{
+					x509.ExtKeyUsageAny,
+					x509.ExtKeyUsageCodeSigning,
+				},
+				DNSNames: []string{"example.com", "foo.example.com"},
+			},
+		},
+		"a CSR with expiration seconds and duration annotation should prefer the annotation duration": {
+			csr: gen.CertificateSigningRequest("",
+				gen.SetCertificateSigningRequestExpirationSeconds(999),
+				gen.SetCertificateSigningRequestDuration("777s"),
+				gen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{
+					certificatesv1.UsageAny,
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageCRLSign,
+					certificatesv1.UsageCodeSigning,
+					certificatesv1.UsageContentCommitment,
+				}),
+				gen.SetCertificateSigningRequestIsCA(false),
+				gen.SetCertificateSigningRequestRequest(csr),
+			),
+			expCertificate: &x509.Certificate{
+				Version:               2,
+				BasicConstraintsValid: true,
+				SerialNumber:          nil,
+				PublicKeyAlgorithm:    x509.RSA,
+				PublicKey:             pk.Public(),
+				IsCA:                  false,
+				Subject: pkix.Name{
+					CommonName: "example.com",
+				},
+				NotBefore: time.Now(),
+				NotAfter:  time.Now().Add(777 * time.Second),
+				KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign | x509.KeyUsageContentCommitment,
+				ExtKeyUsage: []x509.ExtKeyUsage{
+					x509.ExtKeyUsageAny,
+					x509.ExtKeyUsageCodeSigning,
+				},
+				DNSNames: []string{"example.com", "foo.example.com"},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
+++ b/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
@@ -194,8 +194,12 @@ func ExpectValidDuration(csr *certificatesv1.CertificateSigningRequest, _ crypto
 	var expectedDuration time.Duration
 	durationString, ok := csr.Annotations[experimentalapi.CertificateSigningRequestDurationAnnotationKey]
 	if !ok {
-		// If duration wasn't requested, then we match against the default.
-		expectedDuration = cmapi.DefaultCertificateDuration
+		if csr.Spec.ExpirationSeconds != nil {
+			expectedDuration = time.Duration(*csr.Spec.ExpirationSeconds) * time.Second
+		} else {
+			// If duration wasn't requested, then we match against the default.
+			expectedDuration = cmapi.DefaultCertificateDuration
+		}
 	} else {
 		expectedDuration, err = time.ParseDuration(durationString)
 		if err != nil {

--- a/test/e2e/suite/conformance/certificatesigningrequests/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificatesigningrequests/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/test/unit/gen/certificatesigningrequest.go
+++ b/test/unit/gen/certificatesigningrequest.go
@@ -95,6 +95,12 @@ func SetCertificateSigningRequestSignerName(signerName string) CertificateSignin
 	}
 }
 
+func SetCertificateSigningRequestExpirationSeconds(seconds int32) CertificateSigningRequestModifier {
+	return func(csr *certificatesv1.CertificateSigningRequest) {
+		csr.Spec.ExpirationSeconds = &seconds
+	}
+}
+
 func SetCertificateSigningRequestDuration(duration string) CertificateSigningRequestModifier {
 	return AddCertificateSigningRequestAnnotations(map[string]string{
 		experimentalapi.CertificateSigningRequestDurationAnnotationKey: duration,


### PR DESCRIPTION
### Pull Request Motivation

This change adds the ability to express certificate duration using
the Kubernetes CSR spec.expirationSeconds field alongside the existing
approach of using the experimental.cert-manager.io/request-duration
annotation.  Both approaches are supported as the expirationSeconds
field requires Kubernetes v1.22+.

Signed-off-by: Monis Khan <mok@vmware.com>

### Kind

/kind feature

### Release Note

```release-note
Signers now honor Kubernetes CSR duration expressed via the spec.expirationSeconds field.
```