### PR TITLE
Tweak release targets

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -103,7 +103,7 @@ bin/yaml/cert-manager.yaml: bin/scratch/license.yaml deploy/manifests/namespace.
 
 # Renders all resources except the namespace and the CRDs
 bin/scratch/yaml/cert-manager-static-resources.yaml: bin/cert-manager-$(RELEASE_VERSION).tgz bin/tools/helm | bin/scratch/yaml
-	# The sed command removes the first line but only if it matches "---", which helm adds
+	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM_CMD) template --api-versions="" --namespace=cert-manager --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
 
@@ -119,7 +119,7 @@ bin/yaml/cert-manager.crds.yaml: bin/scratch/license.yaml bin/scratch/yaml/cert-
 	cat $^ > $@
 
 bin/scratch/yaml/cert-manager.crds.unlicensed.yaml: bin/scratch/cert-manager-crds/cert-manager-$(RELEASE_VERSION).tgz bin/tools/helm | bin/scratch/yaml
-	# The sed command removes the first line but only if it matches "---", which helm adds
+	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM_CMD) template --api-versions="" --namespace=cert-manager --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
 

--- a/make/release.mk
+++ b/make/release.mk
@@ -8,19 +8,20 @@ CMREL_KEY ?=
 .PHONY: release-artifacts
 # Build all release artifacts which might be run or used locally, except
 # for anything signed.
-release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart static-manifests all-containers
+release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart release-container-bundles release-manifests
 
 .PHONY: release-artifacts-signed
 # Same as `release`, except it also signs the Helm chart. Requires CMREL_KEY
 # to be configured.
-release-artifacts-signed: release-artifacts helm-chart-signature
+release-artifacts-signed: release-artifacts
+	$(MAKE) --no-print-directory helm-chart-signature
 
 .PHONY: release
 ## Create a full release ready to be staged, including containers bundled for
 ## distribution. Requires CMREL_KEY to be configured.
 ##
 ## @category Release
-release: release-signed release-manifests release-containers
+release: release-artifacts-signed
 	$(MAKE) --no-print-directory bin/release/metadata.json
 
 # Example of how we can generate a SHA256SUMS file and sign it using cosign

--- a/make/release.mk
+++ b/make/release.mk
@@ -28,7 +28,7 @@ release: release-signed release-manifests release-containers
 #	@# The patsubst means "all dependencies, but with "bin/" trimmed off the beginning
 #	@# We cd into bin so that SHA256SUMS file doesn't have a prefix of `bin` on everything
 #	cd $(dir $@) && sha256sum $(patsubst bin/%,%,$^) > $(notdir $@)
-#
+
 #bin/SHA256SUMS.sig: bin/SHA256SUMS bin/tools/cosign
 #	$(COSIGN) sign-blob --key $(COSIGN_KEY) $< > $@
 

--- a/make/release.mk
+++ b/make/release.mk
@@ -5,17 +5,17 @@
 ## @category Release
 CMREL_KEY ?=
 
-.PHONY: release
+.PHONY: release-artifacts
 # Build all release artifacts which might be run or used locally, except
 # for anything signed.
 release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart static-manifests all-containers
 
-.PHONY: release-signed
+.PHONY: release-artifacts-signed
 # Same as `release`, except it also signs the Helm chart. Requires CMREL_KEY
 # to be configured.
 release-artifacts-signed: release-artifacts helm-chart-signature
 
-.PHONY: staged-release
+.PHONY: release
 ## Create a full release ready to be staged, including containers bundled for
 ## distribution. Requires CMREL_KEY to be configured.
 ##


### PR DESCRIPTION

### Pull Request Motivation

Part of #4712

Ensures that `make release` is a one-stop target for building _everything_, similar to how `make staged-release` was used in the original makefile flow in #4554  

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
