### PR TITLE
Gateway API: with v1alpha2, the labels have become optional

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -375,12 +375,12 @@ spec:
                           type: object
                           properties:
                             labels:
-                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
                               type: object
                               additionalProperties:
                                 type: string
                             parentRefs:
-                              description: ParentRefs define the Gateways that the HTTP-01 challenges will be solvable through. See https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
                               type: array
                               items:
                                 description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -375,7 +375,7 @@ spec:
                           type: object
                           properties:
                             labels:
-                              description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
+                              description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                               type: object
                               additionalProperties:
                                 type: string

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -410,12 +410,12 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
                                     type: object
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: ParentRefs define the Gateways that the HTTP-01 challenges will be solvable through. See https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -410,7 +410,7 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -412,12 +412,12 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
                                     type: object
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: ParentRefs define the Gateways that the HTTP-01 challenges will be solvable through. See https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -412,7 +412,7 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: Custom labels that you want the HTTPRoutes created by cert-manager for solving HTTP-01 challenges. Back when cert-manager supported v1alpha1, this field was used when creating the solver's HTTPRoute, and used to be how the HTTPRoute was matched to a Gateway. Since v1alpha2, the HTTPRoute is matched to a Gateway using the field parentRefs on the HTTPRoute.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -229,11 +229,18 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType
 
-	// The labels that cert-manager will use when creating the temporary
-	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
-	// must match the label selector of at least one Gateway.
+	// Custom labels that you want the HTTPRoutes created by cert-manager
+	// for solving HTTP-01 challenges. Back when cert-manager supported
+	// v1alpha1, this field was used when creating the solver's HTTPRoute,
+	// and used to be how the HTTPRoute was matched to a Gateway. Since
+	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
+	// parentRefs on the HTTPRoute.
 	Labels map[string]string
 
+	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+	// cert-manager needs to know which parentRefs should be used when creating
+	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
+	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
 	ParentRefs []gwapi.ParentRef
 }
 

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -229,12 +229,9 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType
 
-	// Custom labels that you want the HTTPRoutes created by cert-manager
-	// for solving HTTP-01 challenges. Back when cert-manager supported
-	// v1alpha1, this field was used when creating the solver's HTTPRoute,
-	// and used to be how the HTTPRoute was matched to a Gateway. Since
-	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
-	// parentRefs on the HTTPRoute.
+	// Custom labels that will be applied to HTTPRoutes created by cert-manager
+	// while solving HTTP-01 challenges.
+	// +optional
 	Labels map[string]string
 
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.

--- a/internal/apis/acme/v1alpha2/types_issuer.go
+++ b/internal/apis/acme/v1alpha2/types_issuer.go
@@ -252,12 +252,19 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The labels that cert-manager will use when creating the temporary
-	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
-	// must match the label selector of at least one Gateway.
-	Labels map[string]string `json:"labels,omitempty"`
+	// Custom labels that you want the HTTPRoutes created by cert-manager
+	// for solving HTTP-01 challenges. Back when cert-manager supported
+	// v1alpha1, this field was used when creating the solver's HTTPRoute,
+	// and used to be how the HTTPRoute was matched to a Gateway. Since
+	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
+	// parentRefs on the HTTPRoute.
+	Labels map[string]string
 
-	ParentRefs []gwapi.ParentRef `json:"parentRefs,omitempty"`
+	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+	// cert-manager needs to know which parentRefs should be used when creating
+	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
+	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+	ParentRefs []gwapi.ParentRef
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {

--- a/internal/apis/acme/v1alpha2/types_issuer.go
+++ b/internal/apis/acme/v1alpha2/types_issuer.go
@@ -252,12 +252,9 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// Custom labels that you want the HTTPRoutes created by cert-manager
-	// for solving HTTP-01 challenges. Back when cert-manager supported
-	// v1alpha1, this field was used when creating the solver's HTTPRoute,
-	// and used to be how the HTTPRoute was matched to a Gateway. Since
-	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
-	// parentRefs on the HTTPRoute.
+	// Custom labels that will be applied to HTTPRoutes created by cert-manager
+	// while solving HTTP-01 challenges.
+	// +optional
 	Labels map[string]string
 
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.

--- a/internal/apis/acme/v1alpha3/types_issuer.go
+++ b/internal/apis/acme/v1alpha3/types_issuer.go
@@ -252,12 +252,19 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The labels that cert-manager will use when creating the temporary
-	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
-	// must match the label selector of at least one Gateway.
-	Labels map[string]string `json:"labels,omitempty"`
+	// Custom labels that you want the HTTPRoutes created by cert-manager
+	// for solving HTTP-01 challenges. Back when cert-manager supported
+	// v1alpha1, this field was used when creating the solver's HTTPRoute,
+	// and used to be how the HTTPRoute was matched to a Gateway. Since
+	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
+	// parentRefs on the HTTPRoute.
+	Labels map[string]string
 
-	ParentRefs []gwapi.ParentRef `json:"parentRefs,omitempty"`
+	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+	// cert-manager needs to know which parentRefs should be used when creating
+	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
+	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+	ParentRefs []gwapi.ParentRef
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {

--- a/internal/apis/acme/v1alpha3/types_issuer.go
+++ b/internal/apis/acme/v1alpha3/types_issuer.go
@@ -252,12 +252,9 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// Custom labels that you want the HTTPRoutes created by cert-manager
-	// for solving HTTP-01 challenges. Back when cert-manager supported
-	// v1alpha1, this field was used when creating the solver's HTTPRoute,
-	// and used to be how the HTTPRoute was matched to a Gateway. Since
-	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
-	// parentRefs on the HTTPRoute.
+	// Custom labels that will be applied to HTTPRoutes created by cert-manager
+	// while solving HTTP-01 challenges.
+	// +optional
 	Labels map[string]string
 
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.

--- a/internal/apis/acme/v1beta1/types_issuer.go
+++ b/internal/apis/acme/v1beta1/types_issuer.go
@@ -251,11 +251,18 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The labels that cert-manager will use when creating the temporary
-	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
-	// must match the label selector of at least one Gateway.
+	// Custom labels that you want the HTTPRoutes created by cert-manager
+	// for solving HTTP-01 challenges. Back when cert-manager supported
+	// v1alpha1, this field was used when creating the solver's HTTPRoute,
+	// and used to be how the HTTPRoute was matched to a Gateway. Since
+	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
+	// parentRefs on the HTTPRoute.
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+	// cert-manager needs to know which parentRefs should be used when creating
+	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
+	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
 	ParentRefs []gwapi.ParentRef `json:"parentRefs,omitempty"`
 }
 

--- a/internal/apis/acme/v1beta1/types_issuer.go
+++ b/internal/apis/acme/v1beta1/types_issuer.go
@@ -251,12 +251,9 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// Custom labels that you want the HTTPRoutes created by cert-manager
-	// for solving HTTP-01 challenges. Back when cert-manager supported
-	// v1alpha1, this field was used when creating the solver's HTTPRoute,
-	// and used to be how the HTTPRoute was matched to a Gateway. Since
-	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
-	// parentRefs on the HTTPRoute.
+	// Custom labels that will be applied to HTTPRoutes created by cert-manager
+	// while solving HTTP-01 challenges.
+	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.

--- a/internal/apis/certmanager/validation/BUILD.bazel
+++ b/internal/apis/certmanager/validation/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
         "@io_k8s_component_base//featuregate/testing:go_default_library",
+        "@io_k8s_sigs_gateway_api//apis/v1alpha2:go_default_library",
     ],
 )
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -196,9 +196,6 @@ func ValidateACMEIssuerChallengeSolverHTTP01IngressConfig(ingress *cmacme.ACMECh
 func ValidateACMEIssuerChallengeSolverHTTP01GatewayConfig(gateway *cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
-	if len(gateway.Labels) == 0 {
-		el = append(el, field.Required(fldPath.Child("labels"), `labels must be set`))
-	}
 	switch gateway.ServiceType {
 	case "", corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort:
 	default:

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -201,6 +201,9 @@ func ValidateACMEIssuerChallengeSolverHTTP01GatewayConfig(gateway *cmacme.ACMECh
 	default:
 		el = append(el, field.Invalid(fldPath.Child("serviceType"), gateway.ServiceType, `must be empty, "ClusterIP" or "NodePort"`))
 	}
+	if len(gateway.ParentRefs) == 0 {
+		el = append(el, field.Required(fldPath.Child("parentRefs"), `at least 1 parentRef is required`))
+	}
 	return el
 }
 

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"reflect"
+	gwapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -244,8 +245,10 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 					{
 						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
-								Labels: map[string]string{
-									"key": "value",
+								ParentRefs: []gwapi.ParentRef{
+									{
+										Name: "blah",
+									},
 								},
 							},
 						},
@@ -268,8 +271,8 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Required(
-					fldPath.Child("solvers").Index(0).Child("http01", "gateway").Child("labels"),
-					"labels must be set",
+					fldPath.Child("solvers").Index(0).Child("http01", "gateway").Child("parentRefs"),
+					"at least 1 parentRef is required",
 				),
 			},
 		},
@@ -285,6 +288,11 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
 								Labels: map[string]string{
 									"a": "b",
+								},
+								ParentRefs: []gwapi.ParentRef{
+									{
+										Name: "blah",
+									},
 								},
 							},
 						},

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -18,13 +18,13 @@ package validation
 
 import (
 	"reflect"
-	gwapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	gwapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
 	cmapi "github.com/cert-manager/cert-manager/internal/apis/certmanager"

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -255,13 +255,17 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The labels that cert-manager will use when creating the temporary
-	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
-	// must match the label selector of at least one Gateway.
+	// Custom labels that you want the HTTPRoutes created by cert-manager
+	// for solving HTTP-01 challenges. Back when cert-manager supported
+	// v1alpha1, this field was used when creating the solver's HTTPRoute,
+	// and used to be how the HTTPRoute was matched to a Gateway. Since
+	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
+	// parentRefs on the HTTPRoute.
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// ParentRefs define the Gateways that the HTTP-01 challenges will be
-	// solvable through. See
+	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+	// cert-manager needs to know which parentRefs should be used when creating
+	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
 	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
 	ParentRefs []gwapi.ParentRef `json:"parentRefs,omitempty"`
 }

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -255,12 +255,9 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// Custom labels that you want the HTTPRoutes created by cert-manager
-	// for solving HTTP-01 challenges. Back when cert-manager supported
-	// v1alpha1, this field was used when creating the solver's HTTPRoute,
-	// and used to be how the HTTPRoute was matched to a Gateway. Since
-	// v1alpha2, the HTTPRoute is matched to a Gateway using the field
-	// parentRefs on the HTTPRoute.
+	// Custom labels that will be applied to HTTPRoutes created by cert-manager
+	// while solving HTTP-01 challenges.
+	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.


### PR DESCRIPTION
Previously, in v1alpha1, an HTTPRoute was matched to a Gateway using the label selectors present on the Gateways. For example, with the following Gateway:

```yaml
  apiVersion: networking.x-k8s.io/v1alpha1
  kind: Gateway
  metadata:
    name: acmesolver
  spec:
    listeners:
      - protocol: HTTP
        port: 80
        routes:
          kind: HTTPRoute
          selector:
            matchLabels:
              app: foo
```

You would have to use the following labels on the HTTPRoute in order to get the above Gateway to be used:

```yaml
  apiVersion: networking.x-k8s.io/v1alpha1
  kind: HTTPRoute
  metadata:
    labels:
      app: foo
```

With v1alpha2, the label selectors have been dropped. Instead, the HTTPRoute has to give a direct reference to the Gateway:

```yaml
    apiVersion: gateway.networking.k8s.io/v1alpha2
    kind: HTTPRoute
    spec:
      parentRefs:
        - kind: Gateway
          name: acmesolver
          namespace: traefik
```

This means that the "labels" field on the `gatewayHTTPRoute` solver is now optional:

```yaml
    apiVersion: cert-manager.io/v1
    kind: Issuer
    spec:
      acme:
        solvers:
          - http01:
              gatewayHTTPRoute:
                labels:              # This field is
                  app: test          # now optional.
                parentRefs:
                  - kind: Gateway
                    name: acmesolver
```

/kind feature


```release-note
Gateway API: with v1alpha2, the field `labels` on the gatewayHTTPRoute solver is now optional.
```
