### PR TITLE
make: the AppVersion and AppGitCommit weren't set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,6 @@ SHELL := /bin/bash
 
 SOURCES := $(shell find . -type f -name "*.go" -not -path "./bin/*" -not -path "./make/*")
 
-GOFLAGS := -ldflags '-w -s' -trimpath
-
-## GOBUILDPROCS is passed to GOMAXPROCS when running go build; if you're running
-## make in parallel using "-jN" then you'll probably want to reduce the value
-## of GOBUILDPROCS or else you could end up running N parallel invocations of
-## go build, each of which will spin up as many threads as are available on your
-## system.
-GOBUILDPROCS ?=
-
 include make/git.mk
 include make/tools.mk
 include make/ci.mk
@@ -45,6 +36,17 @@ include make/manifests.mk
 include make/licenses.mk
 include make/e2e-setup.mk
 include make/help.mk
+
+## GOBUILDPROCS is passed to GOMAXPROCS when running go build; if you're running
+## make in parallel using "-jN" then you'll probably want to reduce the value
+## of GOBUILDPROCS or else you could end up running N parallel invocations of
+## go build, each of which will spin up as many threads as are available on your
+## system.
+GOBUILDPROCS ?=
+
+GOFLAGS := -trimpath -ldflags '-w -s \
+	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)'
 
 .PHONY: clean
 ## Remove the kind cluster and everything that was built. The downloaded images

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -334,7 +334,7 @@ e2e-setup-pebble: load-bin/downloaded/containers/$(CRI_ARCH)/pebble.tar bin/scra
 
 bin/downloaded/containers/$(CRI_ARCH)/samplewebhook/samplewebhook: make/config/samplewebhook/sample/main.go $(DEPENDS_ON_GO)
 	@mkdir -p $(dir $@)
-	GOOS=linux GOARCH=$(CRI_ARCH) $(GOBUILD) -o $@ $(GOFLAGS) make/config/samplewebhook/sample/main.go
+	GOOS=linux GOARCH=$(CRI_ARCH) $(GOBUILD) -o $@ make/config/samplewebhook/sample/main.go
 
 bin/downloaded/containers/$(CRI_ARCH)/samplewebhook.tar: bin/downloaded/containers/$(CRI_ARCH)/samplewebhook/samplewebhook make/config/samplewebhook/Containerfile.samplewebhook
 	@$(eval BASE := BASE_IMAGE_controller-linux-$(CRI_ARCH))

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -311,7 +311,7 @@ bin/downloaded/pebble-$(PEBBLE_COMMIT).tar.gz: | bin/downloaded
 bin/downloaded/containers/$(CRI_ARCH)/pebble/pebble: bin/downloaded/pebble-$(PEBBLE_COMMIT).tar.gz $(DEPENDS_ON_GO)
 	@mkdir -p $(dir $@)
 	tar xzf $< -C $(dir $@)
-	cd $(dir $@)pebble-$(PEBBLE_COMMIT) && GOOS=linux GOARCH=$(CRI_ARCH) CGO_ENABLED=$(CGO_ENABLED) GOMAXPROCS=$(GOBUILDPROCS) $(GOBUILD) -o $(CURDIR)/$@ ./cmd/pebble
+	cd $(dir $@)pebble-$(PEBBLE_COMMIT) && GOOS=linux GOARCH=$(CRI_ARCH) CGO_ENABLED=$(CGO_ENABLED) GOMAXPROCS=$(GOBUILDPROCS) $(GOBUILD) $(GOFLAGS) -o $(CURDIR)/$@ ./cmd/pebble
 
 bin/downloaded/containers/$(CRI_ARCH)/pebble.tar: bin/downloaded/containers/$(CRI_ARCH)/pebble/pebble make/config/pebble/Containerfile.pebble
 	@$(eval BASE := BASE_IMAGE_controller-linux-$(CRI_ARCH))
@@ -334,7 +334,7 @@ e2e-setup-pebble: load-bin/downloaded/containers/$(CRI_ARCH)/pebble.tar bin/scra
 
 bin/downloaded/containers/$(CRI_ARCH)/samplewebhook/samplewebhook: make/config/samplewebhook/sample/main.go $(DEPENDS_ON_GO)
 	@mkdir -p $(dir $@)
-	GOOS=linux GOARCH=$(CRI_ARCH) $(GOBUILD) -o $@ make/config/samplewebhook/sample/main.go
+	GOOS=linux GOARCH=$(CRI_ARCH) $(GOBUILD) -o $@ $(GOFLAGS) make/config/samplewebhook/sample/main.go
 
 bin/downloaded/containers/$(CRI_ARCH)/samplewebhook.tar: bin/downloaded/containers/$(CRI_ARCH)/samplewebhook/samplewebhook make/config/samplewebhook/Containerfile.samplewebhook
 	@$(eval BASE := BASE_IMAGE_controller-linux-$(CRI_ARCH))


### PR DESCRIPTION
| This PR is part of the effort 'moving away from Bazel' tracked in https://github.com/cert-manager/cert-manager/pull/4712 |
|--|

When checking how User-Agent headers would differ from v1.7.1 to v1.8.0, The User-Agent looked off:

    cert-manager-issuers/v1.8.0 (linux/amd64) cert-manager/

The ending "/" should be followed by the git commit hash. It seems like we forgot to port [what Bazel does](https://github.com/cert-manager/cert-manager/blob/068c5f08703aa31f48346657343424b73f722fe0/build/version.bzl#L25-L27) to fill AppVersion, AppGitCommit, and AppGitState. This commit adds this feature to the Makefile. The User-Agent should now look like this:

    cert-manager-issuers/v1.8.0 (linux/amd64) cert-manager/9dd5f6c85fde2c3ed58cd6c9e465bb5a4c1ca2b2
                 <----->
                This part depends
                on the component.


/cleanup

```release-note
NONE
```
