### PR TITLE
add acmeHttp01SolverImage

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
           - --leader-election-retry-period={{ .retryPeriod }}
           {{- end }}
           {{- end }}
+          {{- if .Values.acmeHttp01SolverImage.enabled }}
+          - --acme-http01-solver-image={{ .Values.acmeHttp01SolverImage.image }}:{{ .Values.acmeHttp01SolverImage.tag | default .Chart.AppVersion }}
+          {{- end }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -410,6 +410,12 @@ webhook:
       - ipBlock:
           cidr: 0.0.0.0/0
 
+acmeHttp01SolverImage:
+  # when enabled the default image will be used from cert-manager
+  enabled: false
+  image: quay.io/jetstack/cert-manager-acmesolver
+  # tag:
+
 cainjector:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
### Pull Request Motivation

When using a custom registy the [`values.yaml`](https://github.com/cert-manager/cert-manager/blob/068c5f08703aa31f48346657343424b73f722fe0/deploy/charts/cert-manager/values.yaml#L59) will allow to specify a custom image (e.g. selfhosted registry).
But the acmesolver can not be specified itself.
When there is a registry without connection to internet (and thus to quay.io) the pull of the image will fail.

To be able to specify the image for the acmesolver pod I've extended the chart

Also see the problem described in discussion #4949.

If you prefer other naming in values than suggested `acmeHttp01SolverImage` feel free to suggest another key.

### Kind

feature

### Release Note

```release-note
Adding support for specify custom acme HTTP01 solverimage in Helm chart.
```
