### PR TITLE
Bump Go 1.17.1 --> 1.17.8 to fix CVEs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//hack/build:nogo_vet",
-    version = "1.17.1",
+    version = "1.17.8",
 )
 
 ## Load gazelle and dependencies


### PR DESCRIPTION
### Pull Request Motivation
Bumping golang to `1.17.8` to fix Go CVE security vulnerabilities in https://github.com/cert-manager/cert-manager/issues/4951.

Fixes issue: https://github.com/cert-manager/cert-manager/issues/4951

### Kind
bug

### Release Note
```release-note
NONE
```

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>