### PR TITLE
[release-1.6] Remove hardcoded cert from cmctl inspect secret unit tests

### DIFF
--- a/cmd/ctl/pkg/inspect/secret/BUILD.bazel
+++ b/cmd/ctl/pkg/inspect/secret/BUILD.bazel
@@ -50,6 +50,8 @@ go_test(
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )

--- a/cmd/ctl/pkg/inspect/secret/util_test.go
+++ b/cmd/ctl/pkg/inspect/secret/util_test.go
@@ -24,6 +24,24 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 )
 
+const testCertForFingerprinting = `-----BEGIN CERTIFICATE-----
+MIICljCCAhugAwIBAgIUNAQr779ga/BNXyCpK7ddFbjAK98wCgYIKoZIzj0EAwMw
+aTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNh
+biBGcmFuY2lzY28xHzAdBgNVBAoTFkludGVybmV0IFdpZGdldHMsIEluYy4xDDAK
+BgNVBAsTA1dXVzAeFw0yMTAyMjYxMDM1MDBaFw0yMjAyMjYxMDM1MDBaMDMxCzAJ
+BgNVBAYTAkdCMQ0wCwYDVQQKEwRjbmNmMRUwEwYDVQQLEwxjZXJ0LW1hbmFnZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATd5gWH2rkzWBGrr1jCR6JDB0dZOizZ
+jCt2gnzNfzZmEg3rqxPvIakfT1lsjL2HrQyBRMQGGZhj7RkN7/VUM+VUo4HWMIHT
+MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+DAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUCUEeUFyT7U3e6zP4q4VYEr2x0KcwHwYD
+VR0jBBgwFoAUFkKAaJ18Vg9xFx3K7d5b7HjoSSMwVAYDVR0RBE0wS4IRY2VydC1t
+YW5hZ2VyLnRlc3SBFHRlc3RAY2VydC1tYW5hZ2VyLmlvhwQKAAABhhpzcGlmZmU6
+Ly9jZXJ0LW1hbmFnZXIudGVzdDAKBggqhkjOPQQDAwNpADBmAjEA3Fv1aP+dBtBh
++DThW0QQO/Xl0CHQRKnJmJ8JjnleaMYFVdHf7dcf0ZeyOC26aUkdAjEA/fvxvhcz
+Dtj+gY2rewoeJv5Pslli+SEObUslRaVtUMGxwUbmPU2fKuZHWBfe2FfA
+-----END CERTIFICATE-----
+`
+
 func Test_fingerprintCert(t *testing.T) {
 	tests := []struct {
 		name string
@@ -32,7 +50,7 @@ func Test_fingerprintCert(t *testing.T) {
 	}{
 		{
 			name: "Fingerprint a valid cert",
-			cert: MustParseCertificate(t, testCert),
+			cert: MustParseCertificate(t, testCertForFingerprinting),
 			want: "FF:D0:A8:85:0B:A4:5A:E1:FC:55:40:E1:FC:07:09:F1:02:AE:B9:EB:28:C4:01:23:B9:4F:C8:FA:9B:EF:F4:C1",
 		},
 		{

--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -46,9 +46,9 @@ elif [[ "$K8S_VERSION" =~ 1\.19 ]] ; then
 elif [[ "$K8S_VERSION" =~ 1\.20 ]] ; then
   KIND_IMAGE_SHA="sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
 elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
-  KIND_IMAGE_SHA="sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+  KIND_IMAGE_SHA="sha256:0fda882e43d425622f045b492f8bd83c2e0b4984fc03e2e05ec101ca1a685fb7"
 elif [[ "$K8S_VERSION" =~ 1\.22 ]] ; then
-  KIND_IMAGE_SHA="sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047"
+  KIND_IMAGE_SHA="sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
 else
   echo "Unrecognised Kubernetes version '${K8S_VERSION}'! Aborting..."
   exit 1

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -74,6 +74,12 @@ func SetCertificateIPs(ips ...string) CertificateModifier {
 	}
 }
 
+func SetCertificateEmails(emails ...string) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.EmailAddresses = emails
+	}
+}
+
 func SetCertificateURIs(uris ...string) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		crt.Spec.URIs = uris


### PR DESCRIPTION
Cherry pick required manual intervention to fix imports.

This backports #4905 to release-1.6

Depends on https://github.com/jetstack/testing/pull/649 for test matrix fixes

Also updates a couple of kind image versions.

/kind bug

### Release Note

```release-note
Fixes an expired hardcoded certificate which broke unit tests
```
