### PR TITLE
[release-1.6] bump base image

### DIFF
--- a/build/images.bzl
+++ b/build/images.bzl
@@ -35,5 +35,5 @@ def define_base_images():
         name = "dynamic_base",
         registry = "gcr.io",
         repository = "distroless/base",
-        digest = "sha256:eaddb8ca70848a43fab351226d9549a571f68d9427c53356114fedd3711b5d73"
+        digest = "sha256:26bbe93b4e3bbc4846aab153fde35885d22dc3ff22f1166eb7935717d86c5c7e"
     )


### PR DESCRIPTION
### Pull Request Motivation

As reminded by #4033 - this is a manual cherry pick of the latest base image for release-1.6, since the latest-base-images script wasn't present there.

We don't need to cut a release for this, but it's worth having it backported in case we do release.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
