### PR TITLE
Add controller_requeue_count metric

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,8 +159,12 @@ func (c *controller) worker(ctx context.Context) {
 			if err != nil {
 				if strings.Contains(err.Error(), genericregistry.OptimisticLockErrorMsg) {
 					log.Info("re-queuing item due to optimistic locking on resource", "error", err.Error())
+					// These errors are not counted towards the controllerSyncErrorCount metric on purpose
+					// as they will go way with
+					// https://github.com/cert-manager/cert-manager/blob/master/design/20220118.server-side-apply.md
 				} else {
 					log.Error(err, "re-queuing item due to error processing")
+					c.metrics.IncrementSyncErrorCount(c.name)
 				}
 
 				c.queue.AddRateLimited(obj)


### PR DESCRIPTION
### Pull Request Motivation
This adds more visibility to potential issues ranging from things like connection problems to the API or webhooks to possible hard errors.

For context, please see #4956

### Kind
/kind feature


### Release Note
```release-note
Introducing a new metric `controller_sync_error_count` counting the number of errors during sync() of a controller.
```
