### PR TITLE
make: in CI, copy binaries from "bin/downloaded" to "bin/tools"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SHELL := /bin/bash
 .DELETE_ON_ERROR:
 .SUFFIXES:
 
-SOURCES := $(shell find . -type f -name "*.go")
+SOURCES := $(shell find . -type f -name "*.go" -not -path "./bin/*" -not -path "./make/*")
 
 GOFLAGS := -ldflags '-w -s' -trimpath
 

--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -1,6 +1,6 @@
-CMCTL_GOFLAGS=$(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"'
+CMCTL_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"'
 
-KUBECTL_PLUGIN_GOFLAGS=$(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"'
+KUBECTL_PLUGIN_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"'
 
 bin/cmctl:
 	@mkdir -p $@

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -58,7 +58,7 @@ bin/cert-manager-$(RELEASE_VERSION).tgz.prov: bin/cert-manager-$(RELEASE_VERSION
 ifeq ($(strip $(CMREL_KEY)),)
 	$(error Trying to sign helm chart but CMREL_KEY is empty)
 endif
-	cd $(dir $<) && $(CMREL) sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
+	cd $(dir $<) && bin/tools/cmrel sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
 
 bin/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | bin/helm/cert-manager/templates
 	cp -f $^ $@
@@ -85,7 +85,7 @@ bin/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml
 	@# https://mikefarah.gitbook.io/yq/operators/string-operators#string-blocks-bash-and-newlines
 	@# we set a bash variable called SIGNKEY_ANNOTATION using read, and then use that bash variable in yq
 	IFS= read -rd '' SIGNKEY_ANNOTATION < <(cat deploy/charts/cert-manager/signkey_annotation.txt) ; \
-		SIGNKEY_ANNOTATION=$$SIGNKEY_ANNOTATION $(YQ) eval \
+		SIGNKEY_ANNOTATION=$$SIGNKEY_ANNOTATION bin/tools/yq eval \
 		'.annotations."artifacthub.io/signKey" = strenv(SIGNKEY_ANNOTATION) | .annotations."artifacthub.io/prerelease" = "$(IS_PRERELEASE)" | .version = "$(RELEASE_VERSION)" | .appVersion = "$(RELEASE_VERSION)"' \
 		$< > $@
 

--- a/make/release.mk
+++ b/make/release.mk
@@ -31,7 +31,7 @@ release: release-artifacts-signed
 #	cd $(dir $@) && sha256sum $(patsubst bin/%,%,$^) > $(notdir $@)
 
 #bin/SHA256SUMS.sig: bin/SHA256SUMS bin/tools/cosign
-#	$(COSIGN) sign-blob --key $(COSIGN_KEY) $< > $@
+#	bin/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@
 
 # Takes all metadata files in bin/metadata and combines them into one.
 


### PR DESCRIPTION
This is to work around the fact that binaries in hostPath-mounted directories cannot be executed even if the permissions are correct. 

I also fixed how tool versions are handled when switching across branches. Previously, if you were switching back and forth between two versions of Go or Kind, the second time would not work. Thanks @munnerz for raising this issue in https://github.com/jetstack/testing/pull/651.

I also propose to remove all the env vars (HELM, COSIGN, CMREL, YQ, KUBECTL, KIND, CRANE, CLIENT_GEN, CONVERSION_GEN, CONTROLLER_GEN, DEEPCOPY_GEN, DEFAULTER_GEN, INFORMER_GEN, LISTER_GEN) since it makes it a bit clearer using e.g. `bin/tools/yq` as both the binary path and a prerequisite.

For example, in the following example, we are referring to cosign in two different ways: bin/tools/cosign and $(COSIGN):

```sh
bin/SHA256SUMS.sig: bin/SHA256SUMS bin/tools/cosign
	$(COSIGN) sign-blob --key $(COSIGN_KEY) $< > $@
```

A clearer way is to use `bin/tools/cosign` in both cases:


```sh
bin/SHA256SUMS.sig: bin/SHA256SUMS bin/tools/cosign
	bin/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@
```

/kind cleanup

```release-note
NONE
```
