### PR TITLE
Path Traversal vulnerability 

### DIFF
--- a/hack/extractcrd/main.go
+++ b/hack/extractcrd/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	filename := os.Args[1]
 	wantedCRDName := strings.ToLower(os.Args[2])
-
+//rawYAMLBytes, err := os.ReadFile(filename)
 	rawYAMLBytes, err := os.ReadFile(filename)
 	if err != nil {
 		logger.Printf("failed to read %q: %s", filename, err)


### PR DESCRIPTION
Unsanitized input from a CLI argument flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
Fix analysis:-

// Commands
switch os.Args[1] {
case "build":
  err := buildCommand.Parse(os.Args[2:])
// Read the given file
bytes, err := ioutil.ReadFile(file)
if err != nil {
  log.Errorf(err)

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
