### PR TITLE
#3898 add pod disruption budgets

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-pdb.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.cainjector.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cainjector.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  {{ toYaml .Values.podDisruptionBudget }}
+  selector:
+    matchLabels:
+      app: cainjector
+      app.kubernetes.io/component: cainjector
+      app.kubernetes.io/instance: certmanager
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/pdb.yaml
+++ b/deploy/charts/cert-manager/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  {{ toYaml .Values.podDisruptionBudget }}
+  selector:
+    matchLabels:
+      app: cert-manager
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: certmanager
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-pdb.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webhook.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "webhook.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  {{ toYaml .Values.podDisruptionBudget }}
+  selector:
+    matchLabels:
+      app: webhook
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: certmanager
+{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -45,6 +45,9 @@ installCRDs: false
 
 replicaCount: 1
 
+podDisruptionBudget: {}
+  # minAvailable: 1
+
 strategy: {}
   # type: RollingUpdate
   # rollingUpdate:
@@ -247,6 +250,8 @@ webhook:
     #   - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
+  podDisruptionBudget: {}
+    # minAvailable: 1
 
   # Optional additional annotations to add to the webhook Deployment
   # deploymentAnnotations: {}
@@ -383,7 +388,9 @@ cainjector:
     #   - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
-
+  
+  podDisruptionBudget: {}
+    # minAvailable: 1
 
   # Optional additional annotations to add to the cainjector Deployment
   # deploymentAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Raymond Phua <raymond.phua@infosupport.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR should fix the request in the following issue: https://github.com/cert-manager/cert-manager/issues/3898

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind
Feature

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Support added for PodDisruptionBudgets
```
