### PR TITLE
Use absolute path of cmrel

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -58,7 +58,7 @@ bin/cert-manager-$(RELEASE_VERSION).tgz.prov: bin/cert-manager-$(RELEASE_VERSION
 ifeq ($(strip $(CMREL_KEY)),)
 	$(error Trying to sign helm chart but CMREL_KEY is empty)
 endif
-	cd $(dir $<) && bin/tools/cmrel sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
+	cd $(dir $<) && $(CMREL) sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
 
 bin/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | bin/helm/cert-manager/templates
 	cp -f $^ $@

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -10,6 +10,10 @@ export PATH := $(PWD)/bin/tools:$(PATH)
 
 CTR=docker
 
+# We have a variable for cmrel since one of the targets which uses it
+# requires an absolute path to the tool.
+CMREL=$(PWD)/bin/tools/cmrel
+
 HELM_VERSION=3.8.0
 KUBECTL_VERSION=1.22.1
 KIND_VERSION=0.11.1


### PR DESCRIPTION
### Pull Request Motivation

Fixes the breakage created by #4988

Part of the migration to make: #4712 

### Kind

/kind bug

### Release Note

```release-note
NONE
```
