### PR TITLE
make: GOFLAGS missing when building cmctl and kubectl_cert-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,19 @@ SHELL := /bin/bash
 
 SOURCES := $(shell find . -type f -name "*.go" -not -path "./bin/*" -not -path "./make/*")
 
+## GOBUILDPROCS is passed to GOMAXPROCS when running go build; if you're running
+## make in parallel using "-jN" then you'll probably want to reduce the value
+## of GOBUILDPROCS or else you could end up running N parallel invocations of
+## go build, each of which will spin up as many threads as are available on your
+## system.
+GOBUILDPROCS ?=
+
 include make/git.mk
+
+GOFLAGS := -trimpath -ldflags '-w -s \
+	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)'
+
 include make/tools.mk
 include make/ci.mk
 include make/test.mk
@@ -36,17 +48,6 @@ include make/manifests.mk
 include make/licenses.mk
 include make/e2e-setup.mk
 include make/help.mk
-
-## GOBUILDPROCS is passed to GOMAXPROCS when running go build; if you're running
-## make in parallel using "-jN" then you'll probably want to reduce the value
-## of GOBUILDPROCS or else you could end up running N parallel invocations of
-## go build, each of which will spin up as many threads as are available on your
-## system.
-GOBUILDPROCS ?=
-
-GOFLAGS := -trimpath -ldflags '-w -s \
-	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
-    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)'
 
 .PHONY: clean
 ## Remove the kind cluster and everything that was built. The downloaded images


### PR DESCRIPTION
The GOFLAGS make variable was set after "include make/cmctl.mk", leading to the warning:

    Makefile:34: warning: undefined variable 'RELEASE_VERSION'
    Makefile:34: warning: undefined variable 'GITCOMMIT'

~I also fixed the warning `warning: undefined variable 'CI'` that was caused by referencing a make variable that may not exist. Note that `ifdef CI` didn't seem to work when running:~

```sh
CI=true make e2e-setup -j8
```

~I haven't investigated why, and fell back to using `printenv CI`.~

/kind cleanup
```release-note
NONE
```
