### PR TITLE
explicitly mount service-account-token in deployment

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -42,6 +42,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cainjector.serviceAccountName" . }}
+      {{- if hasKey .Values.cainjector "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.cainjector.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -41,6 +41,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}
+      {{- if hasKey .Values.webhook "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.webhook.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -87,6 +87,9 @@ serviceAccount:
   # labels: {}
   automountServiceAccountToken: true
 
+# Automounting API credentials for a particular pod
+# automountServiceAccountToken: true
+
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
 extraArgs: []
@@ -332,6 +335,9 @@ webhook:
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true
 
+  # Automounting API credentials for a particular pod
+  # automountServiceAccountToken: true
+
   # The port that the webhook should listen on for requests.
   # In GKE private clusters, by default kubernetes apiservers are allowed to
   # talk to the cluster nodes only on 443 and 10250. so configuring
@@ -441,6 +447,9 @@ cainjector:
     # Optional additional labels to add to the cainjector's ServiceAccount
     # labels: {}
     automountServiceAccountToken: true
+
+  # Automounting API credentials for a particular pod
+  # automountServiceAccountToken: true
 
 # This startupapicheck is a Helm post-install hook that waits for the webhook
 # endpoints to become available.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Our environment has some restrictions on service-accounts: We're not allowed to use automountServiceAccountToken=true as default for a service-account but have to explicit enable the service-account-mount in each deployment.
It would be nice, if you could merge that change to make Reloader usable in such einvironments.

Here link to K8s issue
https://github.com/kubernetes/kubernetes/issues/57601

### Kind

design

### Release Note

```release-note
Implementation for https://github.com/kubernetes/kubernetes/issues/57601
```
