### PR TITLE
Remove OWNERS from helm chart

### DIFF
--- a/deploy/charts/cert-manager/OWNERS
+++ b/deploy/charts/cert-manager/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- munnerz
-- simonswine
-- kragniz
-reviewers:
-- munnerz
-- unguiculus
-- kragniz


### PR DESCRIPTION
### Pull Request Motivation

The helm chart OWNERS need not be different from the maintainers any more.

### Kind

/kind documentation

### Release Note

```release-note
NONE
```
