### PR TITLE
Make: cmctl and kubectl-cert_manager are using two -ldflags, the second -ldflags is cancelling the first one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,26 @@ SOURCES := $(call get-sources,cat -)
 ## of GOBUILDPROCS or else you could end up running N parallel invocations of
 ## go build, each of which will spin up as many threads as are available on your
 ## system.
+## @category Build
 GOBUILDPROCS ?=
 
 include make/git.mk
 
-GOFLAGS := -trimpath -ldflags '-w -s \
+## By default, we don't link Go binaries to the libc. In some case, you might
+## want to build libc-linked binaries, in which case you can set this to "1".
+## @category Build
+CGO_ENABLED ?= 0
+
+## Extra flags passed to 'go' when building. For example, use GOFLAGS=-v to turn on the
+## verbose output.
+## @category Build
+GOFLAGS := -trimpath
+
+## Extra linking flags passed to 'go' via '-ldflags' when building.
+## @category Build
+GOLDFLAGS := -w -s \
 	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
-    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)'
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)
 
 include make/tools.mk
 include make/ci.mk

--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -1,6 +1,6 @@
-CMCTL_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"'
+CMCTL_GOLDFLAGS := $(GOLDFLAGS) -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"
 
-KUBECTL_PLUGIN_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"'
+KUBECTL_PLUGIN_GOLDFLAGS := $(GOLDFLAGS) -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"
 
 $(BINDIR)/cmctl:
 	@mkdir -p $@
@@ -21,10 +21,10 @@ cmctl-linux-tarballs: $(BINDIR)/release/cert-manager-cmctl-linux-amd64.tar.gz $(
 cmctl-linux-metadata: $(BINDIR)/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json | $(BINDIR)/metadata
 
 $(BINDIR)/cmctl/cmctl-linux-amd64 $(BINDIR)/cmctl/cmctl-linux-arm64 $(BINDIR)/cmctl/cmctl-linux-s390x $(BINDIR)/cmctl/cmctl-linux-ppc64le: $(BINDIR)/cmctl/cmctl-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
-	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/cmctl/cmctl-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-cmctl-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-cmctl-linux-%.tar.gz: $(BINDIR)/cmctl/cmctl-linux-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
@@ -53,7 +53,7 @@ cmctl-darwin-tarballs: $(BINDIR)/release/cert-manager-cmctl-darwin-amd64.tar.gz 
 cmctl-darwin-metadata: $(BINDIR)/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json | $(BINDIR)/metadata
 
 $(BINDIR)/cmctl/cmctl-darwin-amd64 $(BINDIR)/cmctl/cmctl-darwin-arm64:  $(BINDIR)/cmctl/cmctl-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
-	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-cmctl-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-darwin-arm64.tar.gz: $(BINDIR)/release/cert-manager-cmctl-darwin-%.tar.gz:  $(BINDIR)/cmctl/cmctl-darwin-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
@@ -82,7 +82,7 @@ cmctl-windows-tarballs: $(BINDIR)/release/cert-manager-cmctl-windows-amd64.tar.g
 cmctl-windows-metadata: $(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json | $(BINDIR)/release
 
 $(BINDIR)/cmctl/cmctl-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-cmctl-windows-amd64.zip: $(BINDIR)/cmctl/cmctl-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
@@ -130,10 +130,10 @@ kubectl-cert_manager-linux-tarballs: $(BINDIR)/release/cert-manager-kubectl-cert
 kubectl-cert_manager-linux-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json | $(BINDIR)/metadata
 
 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-s390x $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
-	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
@@ -162,7 +162,7 @@ kubectl-cert_manager-darwin-tarballs: $(BINDIR)/release/cert-manager-kubectl-cer
 kubectl-cert_manager-darwin-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json | $(BINDIR)/metadata
 
 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64:  $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
-	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz: $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz:  $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
@@ -191,7 +191,7 @@ kubectl-cert_manager-windows-tarballs: $(BINDIR)/release/cert-manager-kubectl-ce
 kubectl-cert_manager-windows-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json | $(BINDIR)/release
 
 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 $(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.zip: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
 	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))

--- a/make/server.mk
+++ b/make/server.mk
@@ -8,70 +8,70 @@ $(BINDIR)/server:
 controller: $(BINDIR)/server/controller-linux-amd64 $(BINDIR)/server/controller-linux-arm64 $(BINDIR)/server/controller-linux-s390x $(BINDIR)/server/controller-linux-ppc64le $(BINDIR)/server/controller-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
 $(BINDIR)/server/controller-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 $(BINDIR)/server/controller-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 $(BINDIR)/server/controller-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 $(BINDIR)/server/controller-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 $(BINDIR)/server/controller-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 .PHONY: acmesolver
 acmesolver: $(BINDIR)/server/acmesolver-linux-amd64 $(BINDIR)/server/acmesolver-linux-arm64 $(BINDIR)/server/acmesolver-linux-s390x $(BINDIR)/server/acmesolver-linux-ppc64le $(BINDIR)/server/acmesolver-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
 $(BINDIR)/server/acmesolver-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 $(BINDIR)/server/acmesolver-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 $(BINDIR)/server/acmesolver-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 $(BINDIR)/server/acmesolver-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 $(BINDIR)/server/acmesolver-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 .PHONY: webhook
 webhook: $(BINDIR)/server/webhook-linux-amd64 $(BINDIR)/server/webhook-linux-arm64 $(BINDIR)/server/webhook-linux-s390x $(BINDIR)/server/webhook-linux-ppc64le $(BINDIR)/server/webhook-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
 $(BINDIR)/server/webhook-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 $(BINDIR)/server/webhook-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 $(BINDIR)/server/webhook-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 $(BINDIR)/server/webhook-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 $(BINDIR)/server/webhook-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 .PHONY: cainjector
 cainjector: $(BINDIR)/server/cainjector-linux-amd64 $(BINDIR)/server/cainjector-linux-arm64 $(BINDIR)/server/cainjector-linux-s390x $(BINDIR)/server/cainjector-linux-ppc64le $(BINDIR)/server/cainjector-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
 $(BINDIR)/server/cainjector-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 $(BINDIR)/server/cainjector-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 $(BINDIR)/server/cainjector-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 $(BINDIR)/server/cainjector-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 $(BINDIR)/server/cainjector-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -68,7 +68,6 @@ tools: $(BINDIR)/tools/helm $(BINDIR)/tools/kubectl $(BINDIR)/tools/kind $(BINDI
 ######
 
 GO = go
-CGO_ENABLED ?= 0
 
 # DEPENDS_ON_GO is a target that is set as an order-only prerequisite in
 # any target that calls $(GO), e.g.:


### PR DESCRIPTION
I also took the opportunity to document the three most important "build" variables in "make help".

Fixes #5020 

/kind bug

```release-note
`cmctl` and `kubectl cert-manager` now report their actual versions instead of "canary", fixing issue [#5020](https://github.com/cert-manager/cert-manager/issues/5020)
```
