### PR TITLE
Added issuer_name, issuer_kind and issuer_group to prom metrics

### DIFF
--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -59,8 +59,11 @@ func (m *Metrics) updateCertificateExpiry(ctx context.Context, key string, crt *
 	}
 
 	m.certificateExpiryTimeSeconds.With(prometheus.Labels{
-		"name":      crt.Name,
-		"namespace": crt.Namespace}).Set(expiryTime)
+		"name":         crt.Name,
+		"namespace":    crt.Namespace,
+		"issuer_name":  crt.Spec.IssuerRef.Name,
+		"issuer_kind":  crt.Spec.IssuerRef.Kind,
+		"issuer_group": crt.Spec.IssuerRef.Group}).Set(expiryTime)
 }
 
 // updateCertificateRenewalTime updates the renew before duration of a certificate

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
-// certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renewal_timestamp_seconds{name, namespace}
+// certificate_expiration_timestamp_seconds{name, namespace, issue_name, issuer_kind, issuer_group}
+// certificate_renewal_timestamp_seconds{name, namespace, issue_name, issuer_kind, issuer_group}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
@@ -75,8 +75,11 @@ func (m *Metrics) updateCertificateRenewalTime(crt *cmapi.Certificate) {
 	}
 
 	m.certificateRenewalTimeSeconds.With(prometheus.Labels{
-		"name":      crt.Name,
-		"namespace": crt.Namespace}).Set(renewalTime)
+		"name":         crt.Name,
+		"namespace":    crt.Namespace,
+		"issuer_name":  crt.Spec.IssuerRef.Name,
+		"issuer_kind":  crt.Spec.IssuerRef.Kind,
+		"issuer_group": crt.Spec.IssuerRef.Group}).Set(renewalTime)
 
 }
 

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
-// certificate_expiration_timestamp_seconds{name, namespace, issue_name, issuer_kind, issuer_group}
-// certificate_renewal_timestamp_seconds{name, namespace, issue_name, issuer_kind, issuer_group}
+// certificate_expiration_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
+// certificate_renewal_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -70,7 +70,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -78,7 +78,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 
@@ -92,7 +92,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -100,7 +100,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 
@@ -121,7 +121,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 100
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 1
@@ -129,7 +129,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 		"certificate with expiry and status Unknown should give an expiry and Unknown status": {
@@ -149,7 +149,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 99999
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns",issuer="test-issuer"} 99999
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -157,7 +157,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns",issuer="test-issuer"} 0
 `,
 		},
 		"certificate with expiry and ready status and renew before": {
@@ -180,7 +180,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -188,7 +188,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 		},
 	}
@@ -302,9 +302,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt2",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 200
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 200
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {
@@ -313,9 +313,9 @@ func TestCertificateCache(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(m.certificateRenewalTimeSeconds,
 		strings.NewReader(renewalTimeMetadata+`
-        certmanager_certificate_renewal_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
-        certmanager_certificate_renewal_timestamp_seconds{name="crt2",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 200
-        certmanager_certificate_renewal_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 200
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_renewal_timestamp_seconds",
 	); err != nil {
@@ -339,8 +339,8 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -56,6 +56,11 @@ func TestCertificateMetrics(t *testing.T) {
 		"certificate with expiry and ready status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(2208988804, 0),
 				}),
@@ -65,7 +70,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -73,16 +78,21 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
 `,
 		},
 
 		"certificate with no expiry and no status should give an expiry of 0 and Unknown status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -90,13 +100,18 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
 `,
 		},
 
 		"certificate with expiry and status False should give an expiry and False status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(100, 0),
 				}),
@@ -106,7 +121,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 100
+	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 1
@@ -114,12 +129,17 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
 `,
 		},
 		"certificate with expiry and status Unknown should give an expiry and Unknown status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(99999, 0),
 				}),
@@ -129,7 +149,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 99999
+	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 99999
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -137,12 +157,17 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 0
 `,
 		},
 		"certificate with expiry and ready status and renew before": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(2208988804, 0),
 				}),
@@ -155,7 +180,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -163,7 +188,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 2.208988804e+09
 `,
 		},
 	}
@@ -201,6 +226,11 @@ func TestCertificateCache(t *testing.T) {
 
 	crt1 := gen.Certificate("crt1",
 		gen.SetCertificateUID("uid-1"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(100, 0),
 		}),
@@ -213,6 +243,11 @@ func TestCertificateCache(t *testing.T) {
 		}))
 	crt2 := gen.Certificate("crt2",
 		gen.SetCertificateUID("uid-2"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(200, 0),
 		}),
@@ -226,6 +261,11 @@ func TestCertificateCache(t *testing.T) {
 	)
 	crt3 := gen.Certificate("crt3",
 		gen.SetCertificateUID("uid-3"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(300, 0),
 		}),
@@ -262,9 +302,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt2",namespace="default-unit-test-ns"} 200
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
+        certmanager_certificate_expiration_timestamp_seconds{name="crt2",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 200
+        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {
@@ -273,9 +313,9 @@ func TestCertificateCache(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(m.certificateRenewalTimeSeconds,
 		strings.NewReader(renewalTimeMetadata+`
-        certmanager_certificate_renewal_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_renewal_timestamp_seconds{name="crt2",namespace="default-unit-test-ns"} 200
-        certmanager_certificate_renewal_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_renewal_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
+        certmanager_certificate_renewal_timestamp_seconds{name="crt2",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 200
+        certmanager_certificate_renewal_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
 `),
 		"certmanager_certificate_renewal_timestamp_seconds",
 	); err != nil {
@@ -299,8 +339,8 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 100
+        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns",issuer="test-issuer",issuer_kind="test-issuer-kind",issuer_group="test-issuer-group"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -149,7 +149,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns",issuer="test-issuer"} 99999
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 99999
 `,
 			expectedReady: `
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
@@ -157,7 +157,7 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns",issuer="test-issuer"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 		"certificate with expiry and ready status and renew before": {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
-// certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renewal_timestamp_seconds{name, namespace}
+// certificate_expiration_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
+// certificate_renewal_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -104,7 +104,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Name:      "certificate_expiration_timestamp_seconds",
 				Help:      "The date after which the certificate expires. Expressed as a Unix Epoch Time.",
 			},
-			[]string{"name", "namespace"},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
 
 		certificateRenewalTimeSeconds = prometheus.NewGaugeVec(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -113,7 +113,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Name:      "certificate_renewal_timestamp_seconds",
 				Help:      "The number of seconds before expiration time the certificate should renew.",
 			},
-			[]string{"name", "namespace"},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
 
 		certificateReadyStatus = prometheus.NewGaugeVec(

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -161,7 +161,7 @@ func TestMetricsController(t *testing.T) {
 
 	// Create Certificate
 	crt := gen.Certificate(crtName,
-		gen.SetCertificateIssuer(cmmeta.ObjectReference{Kind: "Issuer", Name: "test-issuer"}),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Kind: "Issuer", Name: "test-issuer", Group: "test-issuer-group"}),
 		gen.SetCertificateSecretName(crtName),
 		gen.SetCertificateCommonName(crtName),
 		gen.SetCertificateNamespace(namespace),
@@ -176,7 +176,7 @@ func TestMetricsController(t *testing.T) {
 	// Should expose that Certificate as unknown with no expiry
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
-certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="testns"} 0
+certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
@@ -184,7 +184,7 @@ certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 1
 # HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
-certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 0
+certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 ` + clockCounterMetric + clockGaugeMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
@@ -212,7 +212,7 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	// Should expose that Certificate as ready with expiry
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
-certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="testns"} 100
+certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
@@ -220,7 +220,7 @@ certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
-certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 100
+certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
 ` + clockCounterMetric + clockGaugeMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter


### PR DESCRIPTION
Closes #4454 
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
Feature request for inclusion of issuer name, kind and group in the ```certificate_expiration_timestamp_seconds``` metrics.
<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind
/kind feature
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add issuer_name, issuer_kind and issuer_group as labels to "certificate_expiration_timestamp_seconds" metric
```
