### PR TITLE
WIP: Refactor the challenge "present" step

### DIFF
--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "checks.go",
         "controller.go",
+        "present.go",
         "sync.go",
     ],
     importpath = "github.com/cert-manager/cert-manager/pkg/controller/acmechallenges",
@@ -47,6 +48,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "controller_test.go",
+        "present_test.go",
         "sync_test.go",
     ],
     embed = [":go_default_library"],
@@ -62,9 +64,11 @@ go_test(
         "//pkg/controller/test:go_default_library",
         "//pkg/issuer:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_client_go//tools/record:go_default_library",
         "@org_golang_x_crypto//acme:go_default_library",
     ],
 )

--- a/pkg/controller/acmechallenges/present.go
+++ b/pkg/controller/acmechallenges/present.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acmechallenges
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+const (
+	reasonPresentError = "PresentError"
+	reasonPresented    = "Presented"
+)
+
+// presentStep "presents" (aka deploys) the resources needed for a Challenge.
+// E.g. DNS records or Ingress configuration.
+type presentStep struct {
+	ch       *cmacme.Challenge
+	solver   solver
+	issuer   cmapi.GenericIssuer
+	recorder record.EventRecorder
+}
+
+// Required checks the Challenge status to see whether this step has already been run.
+func (o *presentStep) Required() bool {
+	return !o.ch.Status.Presented
+}
+
+// Run invokes solver.Present and updates the Challenge.Status with the success
+// or failure of that operation.
+func (o *presentStep) Run(ctx context.Context) error {
+	if err := o.solver.Present(ctx, o.issuer, o.ch); err != nil {
+		o.recorder.Eventf(o.ch, corev1.EventTypeWarning, reasonPresentError, "Error presenting challenge: %v", err)
+		o.ch.Status.Reason = err.Error()
+		return err
+	}
+	o.ch.Status.Reason = ""
+	o.ch.Status.Presented = true
+	o.recorder.Eventf(o.ch, corev1.EventTypeNormal, reasonPresented, "Presented challenge using %s challenge mechanism", o.ch.Spec.Type)
+	return nil
+}

--- a/pkg/controller/acmechallenges/present_test.go
+++ b/pkg/controller/acmechallenges/present_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acmechallenges
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/record"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func Test_presentStep_Required(t *testing.T) {
+	tests := []struct {
+		name      string
+		presented bool
+		want      bool
+	}{
+		{
+			name:      "not-required-if-presented",
+			presented: true,
+			want:      false,
+		},
+		{
+			name:      "required-if-not-presented",
+			presented: false,
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		ch := gen.Challenge("example", gen.SetChallengePresented(tt.presented))
+		t.Run(tt.name, func(t *testing.T) {
+			o := &presentStep{
+				ch: ch,
+			}
+			assert.Equal(t, tt.want, o.Required())
+		})
+	}
+}
+
+func Test_presentStep_Run(t *testing.T) {
+	simulatedError := errors.New("simulated error")
+	tests := []struct {
+		name               string
+		solverPresentError error
+		wantErr            error
+	}{
+		{
+			name:               "present-succeeds",
+			solverPresentError: nil,
+			wantErr:            nil,
+		},
+		{
+			name:               "present-fails",
+			solverPresentError: simulatedError,
+			wantErr:            simulatedError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedChallenge := gen.Challenge("example",
+				gen.SetChallengePresented(false),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+				gen.SetChallengeReason("existing-reason-which-should-be-overwritten"))
+			suppliedChallenge := expectedChallenge.DeepCopy()
+
+			expectedIssuer := gen.Issuer("example")
+			suppliedIssuer := expectedIssuer.DeepCopy()
+			recorder := record.NewFakeRecorder(1)
+
+			o := &presentStep{
+				ch: suppliedChallenge,
+				solver: &fakeSolver{
+					fakePresent: func(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error {
+						assert.Equal(t, expectedIssuer, issuer,
+							"the issuer assigned to the step should be supplied to solver.Present unmodified")
+						assert.Equal(t, expectedChallenge, ch,
+							"the challenge assigned to the step should be supplied to solver.Present unmodified")
+						return tt.solverPresentError
+					},
+				},
+				issuer:   suppliedIssuer,
+				recorder: recorder,
+			}
+			actualErr := o.Run(context.TODO())
+			assert.Equal(t, tt.wantErr, actualErr, "unexpected error")
+			assert.Equal(t, expectedIssuer, suppliedIssuer, "the issuer assigned to the step should not be modified")
+			assert.Equal(
+				t,
+				gen.ChallengeFrom(expectedChallenge,
+					gen.SetChallengePresented(true),
+					gen.SetChallengeReason("")),
+				gen.ChallengeFrom(suppliedChallenge,
+					gen.SetChallengePresented(true),
+					gen.SetChallengeReason("")),
+				"only Status.Presented and Status.Reason should be modified",
+			)
+			actualEvent := <-recorder.Events
+			assert.Empty(t, recorder.Events, "only one event should be recorded")
+			if tt.solverPresentError == nil {
+				assert.True(t, suppliedChallenge.Status.Presented,
+					"status.presented should be true if solver.Present succeeds")
+				assert.Empty(t, suppliedChallenge.Status.Reason,
+					"status.reason should be empty if solver.Present succeeds")
+				assert.Equal(t, "Normal Presented Presented challenge using HTTP-01 challenge mechanism", actualEvent,
+					"A Normal event should be recorded if solver.Present succeeds")
+			} else {
+				assert.False(t, suppliedChallenge.Status.Presented,
+					"status.presented should be false if solver.Present fails")
+				assert.Equal(t, actualErr.Error(), suppliedChallenge.Status.Reason,
+					"status.reason should be the error message returned by  solver.Present if it fails")
+				assert.Equal(t, fmt.Sprintf("Warning PresentError Error presenting challenge: %s", tt.solverPresentError), actualEvent,
+					"A Warning event should be recorded if solver.Present fails")
+			}
+		})
+	}
+}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -194,6 +194,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengeURL("testurl"),
 					gen.SetChallengeState(cmacme.Pending),
 					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeReason("error-from-a-previous-failed-call-to-present"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
@@ -205,7 +206,7 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.SetChallengeState(cmacme.Pending),
 							gen.SetChallengePresented(true),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
-							gen.SetChallengeReason("Waiting for HTTP-01 challenge propagation: some error"),
+							gen.SetChallengeReason(""),
 						))),
 				},
 				ExpectedEvents: []string{


### PR DESCRIPTION
 * Return after updating the status in an effort to perform one change per reconcile.
 * Always update the status.reason field so as to clear any previous error
   message.
 * Add more unit-tests for this step.

```release-note
NONE
```
