### PR TITLE
trim leading ./ from release archives created by Make

### DIFF
--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -31,6 +31,7 @@ bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/release/cert-manager-cmctl
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
@@ -59,6 +60,7 @@ bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/release/cert-manager-cmct
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
@@ -95,6 +97,7 @@ bin/release/cert-manager-cmctl-windows-amd64.tar.gz: bin/cmctl/cmctl-windows-amd
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl.exe
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
@@ -137,6 +140,7 @@ bin/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz bin/release/cer
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
@@ -165,6 +169,7 @@ bin/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz bin/release/ce
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
@@ -201,6 +206,7 @@ bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz: bin/kubectl-
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager.exe
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 

--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -31,7 +31,7 @@ bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/release/cert-manager-cmctl
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json: bin/metadata/cert-manager-cmctl-linux-%.tar.gz.metadata.json: bin/release/cert-manager-cmctl-linux-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
@@ -59,7 +59,7 @@ bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/release/cert-manager-cmct
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json: bin/metadata/cert-manager-cmctl-darwin-%.tar.gz.metadata.json: bin/release/cert-manager-cmctl-darwin-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
@@ -95,7 +95,7 @@ bin/release/cert-manager-cmctl-windows-amd64.tar.gz: bin/cmctl/cmctl-windows-amd
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl.exe
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json: bin/release/cert-manager-cmctl-windows-amd64.tar.gz hack/artifact-metadata.template.json | bin/metadata
@@ -137,7 +137,7 @@ bin/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz bin/release/cer
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json: bin/metadata/cert-manager-kubectl-cert_manager-linux-%.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
@@ -165,7 +165,7 @@ bin/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz bin/release/ce
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json: bin/metadata/cert-manager-kubectl-cert_manager-darwin-%.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
@@ -201,7 +201,7 @@ bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz: bin/kubectl-
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager.exe
 	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
-	tar czf $@ -C $(TARDIR) .
+	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
 bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz hack/artifact-metadata.template.json | bin/metadata

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -35,7 +35,8 @@ bin/release/cert-manager-manifests.tar.gz: bin/cert-manager-$(RELEASE_VERSION).t
 	mkdir -p bin/scratch/manifests/deploy/manifests/
 	cp bin/cert-manager-$(RELEASE_VERSION).tgz bin/cert-manager-$(RELEASE_VERSION).tgz.prov bin/scratch/manifests/deploy/chart/
 	cp bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml bin/scratch/manifests/deploy/manifests/
-	tar czf $@ -C bin/scratch/manifests .
+	# removes leading ./ from archived paths
+	find bin/scratch/manifests -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C bin/scratch/manifests -T -
 	rm -rf bin/scratch/manifests
 
 # This metadata blob is constructed slightly differently and doesn't use hack/artifact-metadata.template.json directly;


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes #5027 

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

/kind bug

These changes are compatible with BSD and GNU `find`, `sed` and `tar`

```console
# before
$ tar ztv -f bin/release/cert-manager-manifests.tar.gz
drwxr-xr-x  0 joakim staff       0 Apr 14 10:47 ./
drwxr-xr-x  0 joakim staff       0 Apr 14 10:47 ./deploy/
drwxr-xr-x  0 joakim staff       0 Apr 14 10:47 ./deploy/chart/
drwxr-xr-x  0 joakim staff       0 Apr 14 10:47 ./deploy/manifests/
-rw-r--r--  0 joakim staff  372226 Apr 14 10:47 ./deploy/manifests/cert-manager.crds.yaml
-rw-r--r--  0 joakim staff  407270 Apr 14 10:47 ./deploy/manifests/cert-manager.yaml
-rw-r--r--  0 joakim staff   62172 Apr 14 10:47 ./deploy/chart/cert-manager-v1.8.0-18-g25b3786e5dbbfd.tgz
-rw-r--r--  0 joakim staff    1746 Apr 14 10:47 ./deploy/chart/cert-manager-v1.8.0-18-g25b3786e5dbbfd.tgz.prov

# after
$ tar ztv -f bin/release/cert-manager-manifests.tar.gz
drwxr-xr-x  0 joakim staff       0 Apr 14 10:55 deploy/
drwxr-xr-x  0 joakim staff       0 Apr 14 10:55 deploy/chart/
drwxr-xr-x  0 joakim staff       0 Apr 14 10:55 deploy/manifests/
-rw-r--r--  0 joakim staff  372226 Apr 14 10:55 deploy/manifests/cert-manager.crds.yaml
-rw-r--r--  0 joakim staff  407270 Apr 14 10:55 deploy/manifests/cert-manager.yaml
-rw-r--r--  0 joakim staff   62171 Apr 14 10:55 deploy/chart/cert-manager-v1.8.0-18-g25b3786e5dbbfd.tgz
-rw-r--r--  0 joakim staff    1746 Apr 14 10:55 deploy/chart/cert-manager-v1.8.0-18-g25b3786e5dbbfd.tgz.prov
```

<!--

Pick a kind which best describes your PR from the following list:

	bug

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixed release artefact archives generated by Make to strip leading `./` from paths. Behaviour is now same as v1.7 and earlier
```
