### PR TITLE
Don't use --force option to install addons with helm

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -181,7 +181,6 @@ e2e-setup-certmanager: bin/cert-manager.tgz $(foreach bin,controller acmesolver 
 	@$(eval TAG = $(shell tar xfO bin/containers/cert-manager-controller-linux-$(CRI_ARCH).tar manifest.json | jq '.[0].RepoTags[0]' -r | cut -d: -f2))
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--create-namespace \
 		--wait \
 		--namespace cert-manager \
@@ -220,7 +219,6 @@ e2e-setup-haproxyingress: $(call image-tar,haproxyingress) load-$(call image-tar
 	bin/tools/kubectl apply -f make/config/haproxy/manifests.yaml >/dev/null
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--namespace haproxy-ingress \
 		--create-namespace \
@@ -261,7 +259,6 @@ e2e-setup-ingressnginxprev1: $(call image-tar,ingressnginxprev1) load-$(call ima
 	bin/tools/helm repo add ingress-nginx --force-update https://kubernetes.github.io/ingress-nginx >/dev/null
 	bin/tools/Helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--version 3.40.0 \
 		--namespace ingress-nginx \
@@ -291,7 +288,6 @@ e2e-setup-ingressnginxpostv1: $(call image-tar,ingressnginxpostv1) load-$(call i
 	bin/tools/helm repo add ingress-nginx --force-update https://kubernetes.github.io/ingress-nginx >/dev/null
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--version 4.0.10 \
 		--namespace ingress-nginx \
@@ -313,7 +309,6 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 	bin/tools/helm repo add kyverno --force-update https://kyverno.github.io/kyverno/ >/dev/null
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--namespace kyverno \
 		--create-namespace \
@@ -350,7 +345,6 @@ bin/downloaded/containers/$(CRI_ARCH)/pebble.tar: bin/downloaded/containers/$(CR
 e2e-setup-pebble: load-bin/downloaded/containers/$(CRI_ARCH)/pebble.tar bin/scratch/kind-exists bin/tools/helm
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--namespace pebble \
 		--create-namespace \
@@ -373,7 +367,6 @@ bin/downloaded/containers/$(CRI_ARCH)/samplewebhook.tar: bin/downloaded/containe
 e2e-setup-samplewebhook: load-bin/downloaded/containers/$(CRI_ARCH)/samplewebhook.tar e2e-setup-certmanager bin/scratch/kind-exists bin/tools/helm
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--wait \
 		--namespace samplewebhook \
 		--create-namespace \
@@ -406,7 +399,6 @@ e2e-setup-traefik: load-$(call image-tar,traefik) make/config/traefik/traefik-va
 	bin/tools/helm repo add traefik --force-update https://helm.traefik.io/traefik >/dev/null
 	bin/tools/helm upgrade \
 		--install \
-		--force \
 		--version 10.1.1 \
 		--create-namespace \
 		--namespace traefik \


### PR DESCRIPTION



<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

We have a number of e2e tests that use the make targets that are failing at setup stage from which we don't get logs at the moment https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-e2e-v1-20

When I run the setup steps locally, I see a number of errors, one of which appears to be because of `--force` option that was added to `helm upgrade` command recently https://github.com/irbekrm/cert-manager/commit/3405edf821961bb0bc601ec9bd4381fb8ce3b24f

This appears to have known issues on older versions of Kubernetes as it errors out on repeated runs of the command, see i.e https://github.com/helm/helm/issues/7516 and is likely one of the causes for test failures.

To reproduce the issue locally and see the fix:

1. Run `make e2e-setup-kind K8S_VERSION=1.20`
2. Run `make -j e2e-setup`
3. Observe that the above command errors with
```
...
Error from server (BadRequest): error when creating "STDIN": Service in version "v1" cannot be handled as a Service: v1.Service.Spec: v1.ServiceSpec.ClusterIP: ReadString: expects " or n, but found 0, error found in #10 byte of ...|usterIP":0.14,"ports|..., bigger context ...|namespace":"projectcontour"},"spec":{"clusterIP":0.14,"ports":[{"name":"http","port":80,"protocol":"|...
```
and similar.

4. Observe that the same commands don't error when ran from this branch



<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->


<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
