### PR TITLE
Always save e2e test logs

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -415,7 +415,7 @@ e2e-setup-traefik: load-$(call image-tar,traefik) make/config/traefik/traefik-va
 e2e-setup-vault: load-$(call image-tar,vaultretagged) bin/scratch/kind-exists bin/tools/helm
 
 # Exported because it needs to flow down to make/e2e.sh.
-export ARTIFACTS ?= bin/artifacts
+export ARTIFACTS ?= $(shell pwd)/bin/artifacts
 
 .PHONY: kind-logs
 kind-logs: bin/scratch/kind-exists bin/tools/kind


### PR DESCRIPTION
This PR ensures that logs from e2e tests are always saved, by default to ./bin/artifacts
I think that anyone who runs e2e tests locally wants to see the logs if their tests fail without putting in too much effort to figure out how to do that and/or having to re-run the tests.

This should not change the behaviour when tests are run in CI where the `ARTIFACTS` env var should currently be used to determine the location of logs ([here](https://github.com/jetstack/testing/blob/master/images/bazelbuild/coalesce.py#L85))


```release-note
NONE
```

/kind cleanup

Signed-off-by: irbekrm <irbekrm@gmail.com>
