### PR TITLE
Use Apply instead of Update to modify resources in tests

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -15570,64 +15570,6 @@ SOFTWARE.
 
 
 ================================================================================
-= vendor/github.com/segmentio/asm licensed under: =
-
-MIT License
-
-Copyright (c) 2021 Segment
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-= vendor/github.com/segmentio/asm/LICENSE ca1c7e031ab736c26f94ee4439ab227f
-================================================================================
-
-
-================================================================================
-= vendor/github.com/segmentio/encoding licensed under: =
-
-MIT License
-
-Copyright (c) 2019 Segment.io, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-= vendor/github.com/segmentio/encoding/LICENSE 6f71e571802c25d02519c1deef1785d8
-================================================================================
-
-
-================================================================================
 = vendor/github.com/sergi/go-diff licensed under: =
 
 Copyright (c) 2012-2016 The go-diff Authors. All rights reserved.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/pavel-v-chernykh/keystore-go/v4 v4.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/segmentio/encoding v0.3.3
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
@@ -179,7 +178,6 @@ require (
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1163,10 +1163,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
-github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
-github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
-github.com/segmentio/encoding v0.3.3 h1:VG1HceOLwHkSDdkxshlu9pD4FftWkScmHc8RDQ+w9uM=
-github.com/segmentio/encoding v0.3.3/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -1585,7 +1581,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -3410,22 +3410,6 @@ def go_repositories():
         sum = "h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=",
         version = "v0.9.1",
     )
-    go_repository(
-        name = "com_github_segmentio_asm",
-        build_file_generation = "on",
-        build_file_proto_mode = "disable",
-        importpath = "github.com/segmentio/asm",
-        sum = "h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=",
-        version = "v1.1.3",
-    )
-    go_repository(
-        name = "com_github_segmentio_encoding",
-        build_file_generation = "on",
-        build_file_proto_mode = "disable",
-        importpath = "github.com/segmentio/encoding",
-        sum = "h1:VG1HceOLwHkSDdkxshlu9pD4FftWkScmHc8RDQ+w9uM=",
-        version = "v0.3.3",
-    )
 
     go_repository(
         name = "com_github_sergi_go_diff",

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -78,6 +78,8 @@ func serializeApply(req *cmapi.CertificateRequest) ([]byte, error) {
 		Spec:       *req.Spec.DeepCopy(),
 		Status:     cmapi.CertificateRequestStatus{},
 	}
+	// When using the apply operation you cannot have managedFields in the object that is being applied
+	// https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
 	req.ObjectMeta.ManagedFields = nil
 
 	reqData, err := json.Marshal(req)

--- a/internal/controller/certificates/apply.go
+++ b/internal/controller/certificates/apply.go
@@ -35,18 +35,16 @@ import (
 // The given fieldManager is will be used as the FieldManager in the Apply
 // call.
 // Always sets Force Apply to true.
-func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, crt *cmapi.Certificate) error {
+func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, crt *cmapi.Certificate) (*cmapi.Certificate, error) {
 	crtData, err := serializeApply(crt)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = cl.CertmanagerV1().Certificates(crt.Namespace).Patch(
+	return cl.CertmanagerV1().Certificates(crt.Namespace).Patch(
 		ctx, crt.Name, apitypes.ApplyPatchType, crtData,
 		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager},
 	)
-
-	return err
 }
 
 // ApplyStatus will make a Patch API call with the given client to the

--- a/internal/controller/certificates/apply.go
+++ b/internal/controller/certificates/apply.go
@@ -77,6 +77,9 @@ func serializeApply(crt *cmapi.Certificate) ([]byte, error) {
 		Spec:       *crt.Spec.DeepCopy(),
 		Status:     cmapi.CertificateStatus{},
 	}
+	// When using the apply operation you cannot have managedFields in the object that is being applied
+	// https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
+	crt.ObjectMeta.ManagedFields = nil
 	crtData, err := json.Marshal(crt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal certificate object: %w", err)

--- a/internal/controller/challenges/apply.go
+++ b/internal/controller/challenges/apply.go
@@ -73,7 +73,10 @@ func serializeApply(challenge *cmacme.Challenge) ([]byte, error) {
 		ObjectMeta: *challenge.ObjectMeta.DeepCopy(),
 		Spec:       *challenge.Spec.DeepCopy(),
 	}
+	// When using the apply operation you cannot have managedFields in the object that is being applied
+	// https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
 	ch.ManagedFields = nil
+
 	challengeData, err := json.Marshal(ch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal challenge object: %w", err)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -135,7 +135,7 @@ func SyncFnFor(
 		for _, crt := range updateCrts {
 
 			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-				err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
+				_, err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            crt.Name,
 						Namespace:       crt.Namespace,

--- a/test/e2e/suite/approval/BUILD.bazel
+++ b/test/e2e/suite/approval/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/approval",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/approval/approval.go
+++ b/test/e2e/suite/approval/approval.go
@@ -47,6 +47,8 @@ import (
 var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	f := framework.NewDefaultFramework("approval-certificaterequests")
 
+	const fieldManager = "e2e-test-field-manager"
+
 	var (
 		sa       *corev1.ServiceAccount
 		saclient clientset.Interface
@@ -55,8 +57,6 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		crd       *crdapi.CustomResourceDefinition
 		crdclient crdclientset.Interface
 		group     string
-
-		fieldManager = "e2e-test-field-manager"
 	)
 
 	JustBeforeEach(func() {

--- a/test/e2e/suite/approval/userinfo.go
+++ b/test/e2e/suite/approval/userinfo.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/cert-manager/cert-manager/pkg/util"
@@ -41,6 +42,8 @@ import (
 // correctly, and they cannot be modified.
 var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 	f := framework.NewDefaultFramework("userinfo-certificaterequests")
+
+	var fieldManager = "e2e-test-field-manager"
 
 	It("should appropriately create set UserInfo of CertificateRequests, and reject changes", func() {
 		var (
@@ -73,7 +76,7 @@ var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 		By("Should error when attempting to update UserInfo fields")
 		cr.Spec.Username = "abc"
 		cr.Spec.UID = "123"
-		cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Update(context.TODO(), cr, metav1.UpdateOptions{})
+		_, err = internalcertificaterequests.Apply(context.Background(), f.CertManagerClientSet, fieldManager, cr)
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/test/e2e/suite/certificates/BUILD.bazel
+++ b/test/e2e/suite/certificates/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/certificates",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificates:go_default_library",
         "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -20,15 +20,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/pem"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -44,17 +47,20 @@ import (
 // events.
 var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFormats", func() {
 	const (
-		issuerName = "certificate-additional-output-formats"
-		secretName = "test-additional-output-formats"
+		issuerName   = "certificate-additional-output-formats"
+		secretName   = "test-additional-output-formats"
+		fieldManager = "e2-test-field-manager"
 	)
 
 	createCertificate := func(f *framework.Framework, aof []cmapi.CertificateAdditionalOutputFormat) *cmapi.Certificate {
 		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
+		// This should be a sufficiently unique and descriptive name
+		certName := fmt.Sprintf("test-additional-output-formats-%d", time.Now().Unix())
 
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-additional-output-formats-",
-				Namespace:    f.Namespace.Name,
+				Name:      certName,
+				Namespace: f.Namespace.Name,
 			},
 			Spec: cmapi.CertificateSpec{
 				CommonName: "test",
@@ -68,7 +74,9 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		}
 
 		By("creating Certificate with AdditionalOutputFormats")
-		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.Background(), crt, metav1.CreateOptions{})
+		// We use PATCH to create the certificate to make it easier to
+		// PATCH (SSA) later changes to the same certificate object
+		crt, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Minute*2)
 		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
@@ -108,11 +116,17 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		secret.Data["random-1"] = []byte("data-1")
-		secret.Data["random-2"] = []byte("data-2")
-		secret.Data["tls-combined.pem"] = []byte("data-3")
-		secret.Data["key.der"] = []byte("data-4")
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		Expect(err).ToNot(HaveOccurred())
+		data := map[string][]byte{
+			"random-1":         []byte("data-1"),
+			"random-2":         []byte("data-2"),
+			"tls-combined.pem": []byte("data-3"),
+			"key.der":          []byte("data-4"),
+		}
+
+		applyConfig = applyConfig.WithData(data)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string][]byte {
@@ -147,7 +161,9 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 
 		By("add Combined PEM to Certificate's Additional Output Formats")
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}}
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has correct Combined PEM additional output formats")
 		Eventually(func() map[string][]byte {
@@ -165,7 +181,8 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}, {Type: "DER"}}
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has correct Combined PEM and DER additional output formats")
 		Eventually(func() map[string][]byte {
@@ -184,7 +201,8 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "DER"}}
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has correct DER additional output formats")
 		Eventually(func() map[string][]byte {
@@ -202,7 +220,8 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = nil
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has no additional output formats")
 		Eventually(func() map[string][]byte {
@@ -234,9 +253,15 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		}))
 
 		By("changing the values of additional output format keys, should have that value reverted to the correct value")
-		secret.Data["tls-combined.pem"] = []byte("random-1")
-		secret.Data["key.der"] = []byte("random-2")
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyconfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		Expect(err).NotTo(HaveOccurred())
+		data := map[string][]byte{
+			"tls-combined.pem": []byte("random-1"),
+			"key.der":          []byte("random-2"),
+		}
+
+		applyconfig = applyconfig.WithData(data)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyconfig, metav1.ApplyOptions{FieldManager: fieldManager, Force: true})
 		Expect(err).NotTo(HaveOccurred())
 		By("wait for those values to be reverted on the Secret")
 		Eventually(func() map[string][]byte {
@@ -275,9 +300,9 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "e2e-testing", "Renewing for AdditionalOutputFormat e2e test")
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).UpdateStatus(context.Background(), crt, metav1.UpdateOptions{})
+		err = internalcertificates.ApplyStatus(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
-		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Minute*2)
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Minute*2)
 		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
 
 		By("ensuring additional output formats reflect the new private key and certificate")
@@ -307,16 +332,22 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crtPEM := secret.Data["tls.crt"]
 		pkPEM := secret.Data["tls.key"]
 		block, _ := pem.Decode(pkPEM)
-		secret.Data["tls-combined.pem"] = append(append(pkPEM, '\n'), crtPEM...)
-		secret.Data["key.der"] = block.Bytes
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		Expect(err).NotTo(HaveOccurred())
+		data := map[string][]byte{
+			"tls-combined.pem": append(append(pkPEM, '\n'), crtPEM...),
+			"key.der":          block.Bytes,
+		}
+		applyConfig = applyConfig.WithData(data)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("add additional output formats to Certificate")
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}, {Type: "DER"}}
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("wait for cert-manager to assigned ownership to the additional output format fields")
@@ -348,7 +379,8 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = nil
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("observe secret maintain the additional output format keys and values since they are owned by a third party")

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -161,7 +161,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 
 		By("add Combined PEM to Certificate's Additional Output Formats")
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}}
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -181,7 +180,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}, {Type: "DER"}}
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has correct Combined PEM and DER additional output formats")
@@ -201,7 +199,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "DER"}}
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has correct DER additional output formats")
@@ -220,7 +217,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = nil
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 		By("ensure Secret has no additional output formats")
@@ -346,7 +342,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = []cmapi.CertificateAdditionalOutputFormat{{Type: "CombinedPEM"}, {Type: "DER"}}
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -379,7 +374,6 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(context.Background(), crt.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		crt.Spec.AdditionalOutputFormats = nil
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/certificates/secrettemplate.go
+++ b/test/e2e/suite/certificates/secrettemplate.go
@@ -19,6 +19,7 @@ package certificates
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/test/e2e/framework"
@@ -41,17 +43,19 @@ import (
 // Certificate's target Secret, and is reconciled on modify events.
 var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	const (
-		issuerName = "certificate-secret-template"
-		secretName = "test-secret-template"
+		issuerName   = "certificate-secret-template"
+		secretName   = "test-secret-template"
+		fieldManager = "e2e-test-field-manager"
 	)
 
 	f := framework.NewDefaultFramework("certificates-secret-template")
 
-	createCertificate := func(f *framework.Framework, secretTemplate *cmapi.CertificateSecretTemplate) *cmapi.Certificate {
+	createCertificate := func(f *framework.Framework, secretTemplate *cmapi.CertificateSecretTemplate, fieldManager string) *cmapi.Certificate {
+		certName := fmt.Sprintf("test-secret-template-%d", time.Now().Unix())
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-secret-template-",
-				Namespace:    f.Namespace.Name,
+				Name:      certName,
+				Namespace: f.Namespace.Name,
 			},
 			Spec: cmapi.CertificateSpec{
 				CommonName: "test",
@@ -67,7 +71,9 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 
 		By("creating Certificate with SecretTemplate")
 
-		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.Background(), crt, metav1.CreateOptions{})
+		// We use PATCH to create the certificate to make it easier to
+		// PATCH (SSA) later changes to the same certificate object
+		crt, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*30)
@@ -94,7 +100,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	})
 
 	It("should not remove Annotations and Labels which have been added by a third party and not present in the SecretTemplate", func() {
-		createCertificate(f, &cmapi.CertificateSecretTemplate{Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"}})
+		createCertificate(f, &cmapi.CertificateSecretTemplate{Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"}}, fieldManager)
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -104,11 +110,11 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Labels).To(HaveKeyWithValue("abc", "123"))
 
 		By("add Annotation to Secret which should not be removed")
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
 		Expect(err).NotTo(HaveOccurred())
+		applyConfig = applyConfig.WithAnnotations(map[string]string{"random": "annotation"})
 
-		secret.Annotations["random"] = "annotation"
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string]string {
@@ -119,11 +125,11 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Annotations).To(HaveKeyWithValue("random", "annotation"))
 
 		By("add Label to Secret which should not be removed")
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
 
-		secret.Labels["random"] = "label"
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyConfig, err = applycorev1.ExtractSecret(secret, fieldManager)
+		Expect(err).NotTo(HaveOccurred())
+		applyConfig = applyConfig.WithLabels(map[string]string{"random": "label"})
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string]string {
@@ -137,7 +143,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"foo": "bar", "bar": "foo"},
 			Labels:      map[string]string{"abc": "123", "def": "456"},
-		})
+		}, fieldManager)
 
 		By("ensure Secret has correct Labels and Annotations with SecretTemplate")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -148,13 +154,13 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Labels).To(HaveKeyWithValue("def", "456"))
 
 		By("adding Annotations and Labels to SecretTemplate should appear on the Secret")
-
 		crt.Spec.SecretTemplate.Annotations["random"] = "annotation"
 		crt.Spec.SecretTemplate.Annotations["another"] = "random annotation"
 		crt.Spec.SecretTemplate.Labels["hello"] = "world"
 		crt.Spec.SecretTemplate.Labels["random"] = "label"
 
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -185,7 +191,8 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		delete(crt.Spec.SecretTemplate.Labels, "abc")
 		delete(crt.Spec.SecretTemplate.Labels, "another")
 
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -203,7 +210,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"foo": "bar", "bar": "foo"},
 			Labels:      map[string]string{"abc": "123", "def": "456"},
-		})
+		}, fieldManager)
 
 		By("ensure Secret has correct Labels and Annotations with SecretTemplate")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -221,7 +228,8 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt.Spec.SecretTemplate.Labels["abc"] = "098"
 		crt.Spec.SecretTemplate.Labels["def"] = "555"
 
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -237,38 +245,27 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	It("should add cert-manager manager to existing Annotation and Labels fields which are added to SecretTemplate, should not be removed if they are removed by the third party", func() {
 		By("Secret Annotations and Labels should not be removed if the field still hold a field manager")
 
-		crt := createCertificate(f, nil)
+		crt := createCertificate(f, nil, fieldManager)
 
 		By("add Labels and Annotations to the Secret that are not owned by cert-manager")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		if secret.Annotations == nil {
-			secret.Annotations = make(map[string]string)
-		}
-		if secret.Labels == nil {
-			secret.Labels = make(map[string]string)
-		}
-		secret.Annotations["an-annotation"] = "bar"
-		secret.Annotations["another-annotation"] = "def"
-		secret.Labels["abc"] = "123"
-		secret.Labels["foo"] = "bar"
-
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyconfig, err := applycorev1.ExtractSecret(secret, fieldManager)
 		Expect(err).NotTo(HaveOccurred())
 
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(secret.Annotations).To(HaveKeyWithValue("an-annotation", "bar"))
-		Expect(secret.Annotations).To(HaveKeyWithValue("another-annotation", "def"))
-		Expect(secret.Labels).To(HaveKeyWithValue("abc", "123"))
-		Expect(secret.Labels).To(HaveKeyWithValue("foo", "bar"))
-
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(),
-			applycorev1.Secret(secret.Name, secret.Namespace).
-				WithAnnotations(secret.Annotations).
-				WithLabels(secret.Labels),
-			metav1.ApplyOptions{FieldManager: "e2e-test-client"})
+		annots := map[string]string{
+			"an-annotation":      "bar",
+			"another-annotation": "def",
+		}
+		labels := map[string]string{
+			"abc": "123",
+			"foo": "bar",
+		}
+		applyconfig = applyconfig.WithAnnotations(annots)
+		applyconfig = applyconfig.WithLabels(labels)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyconfig, metav1.ApplyOptions{FieldManager: fieldManager})
+		Expect(err).ToNot(HaveOccurred())
 
 		By("expect those Annotations and Labels to be present on the Secret")
 		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -284,7 +281,8 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 			Labels:      map[string]string{"abc": "123", "foo": "bar"},
 		}
 
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("waiting for those Annotation and Labels on the Secret to contain managed fields from cert-manager")
@@ -361,7 +359,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 			applycorev1.Secret(secret.Name, secret.Namespace).
 				WithAnnotations(make(map[string]string)).
 				WithLabels(make(map[string]string)),
-			metav1.ApplyOptions{FieldManager: "e2e-test-client"})
+			metav1.ApplyOptions{FieldManager: fieldManager})
 
 		Consistently(func() map[string]string {
 			secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -377,12 +375,14 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123"},
 			Labels:      map[string]string{"foo": "bar"},
-		})
+		}, fieldManager)
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		secret.Data["random-key"] = []byte("hello-world")
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		Expect(err).NotTo(HaveOccurred())
+		applyConfig = applyConfig.WithData(map[string][]byte{"random-key": []byte("hello-world")})
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string][]byte {
@@ -396,11 +396,12 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123"},
 			Labels:      map[string]string{"foo": "bar"},
-		})
+		}, fieldManager)
 		crt.Spec.SecretTemplate.Annotations["abc"] = "456"
 		crt.Spec.SecretTemplate.Labels["foo"] = "foo"
 
-		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -420,7 +421,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123", "def": "456"},
 			Labels:      map[string]string{"foo": "bar", "label": "hello-world"},
-		})
+		}, fieldManager)
 
 		var (
 			secret *corev1.Secret
@@ -437,7 +438,8 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 
 		crt.Spec.SecretTemplate = nil
 
-		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
+		crt.ManagedFields = nil
+		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {

--- a/test/e2e/suite/certificates/secrettemplate.go
+++ b/test/e2e/suite/certificates/secrettemplate.go
@@ -159,7 +159,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt.Spec.SecretTemplate.Labels["hello"] = "world"
 		crt.Spec.SecretTemplate.Labels["random"] = "label"
 
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -191,7 +190,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		delete(crt.Spec.SecretTemplate.Labels, "abc")
 		delete(crt.Spec.SecretTemplate.Labels, "another")
 
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -228,7 +226,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt.Spec.SecretTemplate.Labels["abc"] = "098"
 		crt.Spec.SecretTemplate.Labels["def"] = "555"
 
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -281,7 +278,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 			Labels:      map[string]string{"abc": "123", "foo": "bar"},
 		}
 
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -400,7 +396,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt.Spec.SecretTemplate.Annotations["abc"] = "456"
 		crt.Spec.SecretTemplate.Labels["foo"] = "foo"
 
-		crt.ManagedFields = nil
 		_, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -438,7 +433,6 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 
 		crt.Spec.SecretTemplate = nil
 
-		crt.ManagedFields = nil
 		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/conformance/certificates/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/conformance/certificates",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificates:go_default_library",
         "//internal/controller/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
@@ -26,8 +27,6 @@ go_library(
         "@io_k8s_api//networking/v1:go_default_library",
         "@io_k8s_api//networking/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/types:go_default_library",
-        "@io_k8s_client_go//util/retry:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -49,9 +49,9 @@ func (s *Suite) Define() {
 	Describe("with issuer type "+s.Name, func() {
 		ctx := context.Background()
 		f := framework.NewDefaultFramework("certificates")
-
 		sharedIPAddress := "127.0.0.1"
-		fieldManager := "e2e-test-conformance"
+
+		const fieldManager = "e2e-test-conformance"
 
 		// Wrap this in a BeforeEach else flags will not have been parsed and
 		// f.Config will not be populated at the time that this code is run.
@@ -890,7 +890,6 @@ func (s *Suite) Define() {
 
 			testCertificate.Spec.DNSNames = append(testCertificate.Spec.DNSNames, newDNSName)
 
-			testCertificate.ManagedFields = nil
 			testCertificate, err = internalcertificates.Apply(ctx, f.Helper().CMClient, fieldManager, testCertificate)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/serving/BUILD.bazel
+++ b/test/e2e/suite/serving/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/serving",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/certificates:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
@@ -19,7 +20,6 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
-        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_kube_aggregator//pkg/apis/apiregistration/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -44,16 +44,17 @@ import (
 type injectableTest struct {
 	makeInjectable func(namePrefix string) client.Object
 	getCAs         func(runtime.Object) [][]byte
-	subject        string
 	disabled       string
 }
 
 var _ = framework.CertManagerDescribe("CA Injector", func() {
 	f := framework.NewDefaultFramework("ca-injector")
 
-	issuerName := "inject-cert-issuer"
-	secretName := "serving-certs-data"
-	fieldManger := "e2e-test-ca-injector"
+	const (
+		issuerName  = "inject-cert-issuer"
+		secretName  = "serving-certs-data"
+		fieldManger = "e2e-test-ca-injector"
+	)
 
 	injectorContext := func(subj string, test *injectableTest) {
 		Context("for "+subj+"s", func() {
@@ -157,7 +158,6 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 
 				cert.Spec.DNSNames = append(cert.Spec.DNSNames, "something.com")
 
-				cert.ManagedFields = nil
 				cert, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManger, cert)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -29,9 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -53,6 +53,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 
 	issuerName := "inject-cert-issuer"
 	secretName := "serving-certs-data"
+	fieldManger := "e2e-test-ca-injector"
 
 	injectorContext := func(subj string, test *injectableTest) {
 		Context("for "+subj+"s", func() {
@@ -153,22 +154,14 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				injectable, cert := generalSetup(test.makeInjectable("changed"))
 
 				By("changing the name of the corresponding secret in the cert")
-				retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, cert)
-					if err != nil {
-						return err
-					}
 
-					cert.Spec.DNSNames = append(cert.Spec.DNSNames, "something.com")
+				cert.Spec.DNSNames = append(cert.Spec.DNSNames, "something.com")
 
-					err = f.CRClient.Update(context.Background(), cert)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
+				cert.ManagedFields = nil
+				cert, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManger, cert)
+				Expect(err).ToNot(HaveOccurred())
 
-				cert, err := f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*2)
+				cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*2)
 				Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become updated")
 
 				By("grabbing the new secret")

--- a/test/integration/acme/BUILD.bazel
+++ b/test/integration/acme/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["orders_controller_test.go"],
     deps = [
+        "//internal/controller/challenges:go_default_library",
         "//pkg/acme/accounts/test:go_default_library",
         "//pkg/acme/client:go_default_library",
         "//pkg/apis/acme/v1:go_default_library",

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
+	internalchallenges "github.com/cert-manager/cert-manager/internal/controller/challenges"
 	accountstest "github.com/cert-manager/cert-manager/pkg/acme/accounts/test"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -56,6 +57,7 @@ func TestAcmeOrdersController(t *testing.T) {
 		testName      string = "acmetest"
 		challengeType string = "dns-01"
 		authType      string = "dns"
+		fieldManager  string = "integration-test-field-manager"
 	)
 
 	// Initial ACME authorization to be returned by GetAuthorization.
@@ -235,7 +237,7 @@ func TestAcmeOrdersController(t *testing.T) {
 	// Set the Challenge state to valid- the status of the ACME order remains 'pending'.
 	chal = chal.DeepCopy()
 	chal.Status.State = cmacme.Valid
-	_, err = cmCl.AcmeV1().Challenges(testName).UpdateStatus(ctx, chal, metav1.UpdateOptions{})
+	_, err = internalchallenges.ApplyStatus(ctx, cmCl, fieldManager, chal)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -10,6 +10,8 @@ go_test(
         "trigger_controller_test.go",
     ],
     deps = [
+        "//internal/controller/certificaterequests:go_default_library",
+        "//internal/controller/certificates:go_default_library",
         "//internal/controller/certificates/policies:go_default_library",
         "//internal/webhook/feature:go_default_library",
         "//pkg/api/util:go_default_library",
@@ -29,7 +31,6 @@ go_test(
         "//test/integration/framework:go_default_library",
         "//test/unit/crypto:go_default_library",
         "//test/unit/gen:go_default_library",
-        "@com_github_segmentio_encoding//json:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -656,7 +656,6 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	annotations := map[string]string{"annotation-1": "abc", "annotation-2": "123"}
 	labels := map[string]string{"labels-1": "abc", "labels-2": "123"}
 	crt = gen.CertificateFrom(crt, gen.SetCertificateSecretTemplate(annotations, labels))
-	crt.ManagedFields = nil
 	crt, err = internalcertificates.Apply(ctx, cmCl, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)
@@ -687,7 +686,6 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 
 	// Remove labels and annotations from the SecretTemplate.
 	crt.Spec.SecretTemplate = nil
-	crt.ManagedFields = nil
 	crt, err = internalcertificates.Apply(ctx, cmCl, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)
@@ -896,7 +894,6 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		cmapi.CertificateAdditionalOutputFormat{Type: "CombinedPEM"},
 		cmapi.CertificateAdditionalOutputFormat{Type: "DER"},
 	))
-	crt.ManagedFields = nil
 	crt, err = internalcertificates.Apply(ctx, cmCl, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)
@@ -924,7 +921,6 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 
 	// Remove AdditionalOutputFormats
 	crt.Spec.AdditionalOutputFormats = nil
-	crt.ManagedFields = nil
 	crt, err = internalcertificates.Apply(ctx, cmCl, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -112,6 +113,7 @@ func TestMetricsController(t *testing.T) {
 		crtName         = "testcrt"
 		namespace       = "testns"
 		metricsEndpoint = fmt.Sprintf("http://%s/metrics", server.Addr)
+		fieldManager    = "integration-test-field-manager"
 
 		lastErr error
 	)
@@ -204,7 +206,8 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	crt.Status.RenewalTime = &metav1.Time{
 		Time: time.Unix(100, 0),
 	}
-	_, err = cmClient.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+
+	err = internalcertificates.ApplyStatus(ctx, cmClient, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -68,9 +69,10 @@ func TestRevisionManagerController(t *testing.T) {
 	defer stopController()
 
 	var (
-		crtName    = "testcrt"
-		namespace  = "testns"
-		secretName = "test-crt-tls"
+		crtName      = "testcrt"
+		namespace    = "testns"
+		secretName   = "test-crt-tls"
+		fieldManager = "integration-test-field-manager"
 	)
 
 	// Create Namespace
@@ -97,7 +99,7 @@ func TestRevisionManagerController(t *testing.T) {
 	// Set Certificate to Ready
 	apiutil.SetCertificateCondition(crt, crt.Generation,
 		cmapi.CertificateConditionReady, cmmeta.ConditionTrue, "Issued", "integration test")
-	crt, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+	err = internalcertificates.ApplyStatus(ctx, cmCl, fieldManager, crt)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR attempts to fix resource update conflicts in e2e and integration tests (such as [this](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5050/pull-cert-manager-make-e2e-v1-23/1516326073632034816)) by making updates to test resources via server-side apply instead of `Update`/`UpdateStatus`.

- For core resources (`Secret`s) I used client-go's applyconfigurations](https://github.com/kubernetes/client-go/tree/master/applyconfigurations) that seems like really nice functionality

- For our own resource types I used the same functionality that [Josh wrote for server-side apply](https://github.com/cert-manager/cert-manager/tree/master/internal/controller) in controller code

- In cases where fields are being removed from test resources I needed to change resource creation from `Create` to server-side apply too as a manager cannot remove fields that it has applied via a different operation https://github.com/kubernetes/kubernetes/issues/99003

- This PR changes _all_  `Update`/`UpdateStatus` operations in tests to server-side apply. Not in all cases there actually is a posibility of conflicts, but I think it's preferable to do it in the same way everywhere and ultimately server-side apply seems to be the future, so probably good for us getting used to using it.


```release-note
NONE
```
/kind cleanup
