### PR TITLE
Challenge cleanup improvements

### DIFF
--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//test/unit/gen:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
         "@org_golang_x_crypto//acme:go_default_library",

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -69,7 +69,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	oldChal := ch
 	ch = ch.DeepCopy()
 
-	if ch.DeletionTimestamp != nil {
+	if !ch.DeletionTimestamp.IsZero() {
 		return c.handleFinalizer(ctx, ch)
 	}
 

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -19,6 +19,7 @@ package gen
 import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ChallengeModifier func(*cmacme.Challenge)
@@ -111,5 +112,11 @@ func SetChallengeProcessing(b bool) ChallengeModifier {
 func SetChallengeFinalizers(finalizers []string) ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Finalizers = finalizers
+	}
+}
+
+func SetChallengeDeletionTimestamp(ts metav1.Time) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.DeletionTimestamp = &ts
 	}
 }


### PR DESCRIPTION
I've added a test for the happy path of running cleanup when the Challenge has a DeletionTimestamp and the finalizer is present.

I'll try and improve things further in later PRs. Here are some of the problems I see:
- [ ] Challenge Finalizer is always removed, regardless of whether solver.cleanup succeeds
- [ ] Challenge Finalizer is assumed to be the only (first) finalizer (breaks if external controllers add their own finalizers)
- [ ] Duplicate code for calling  Update and UpdateStatus. These can both be called in the deferred function at the top of Sync function, so as to reduce the complexity of the addFinalizer and handleFinalizer functions and their tests. 

/kind cleanup

```release-note
NONE
```
