### PR TITLE
WIP: configurable context timeout

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -271,6 +271,8 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 
 		Namespace: opts.Namespace,
 
+		ContextTimeout: opts.ContextTimeout,
+
 		Clock:   clock.RealClock{},
 		Metrics: metrics.New(log, clock.RealClock{}),
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -113,6 +113,9 @@ type ControllerOptions struct {
 
 	DNS01CheckRetryPeriod time.Duration
 
+	// Max context lifetime.
+	ContextTimeout time.Duration
+
 	// Annotations copied Certificate -> CertificateRequest,
 	// CertificateRequest -> Order. Slice of string literals that are
 	// treated as prefixes for annotation keys.
@@ -143,6 +146,8 @@ const (
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+
+	defaultContextTimeout = 10 * time.Second
 )
 
 var (
@@ -241,6 +246,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
+		ContextTimeout:                    defaultContextTimeout,
 		EnablePprof:                       cmdutil.DefaultEnableProfiling,
 		PprofAddress:                      cmdutil.DefaultProfilerAddr,
 	}
@@ -349,6 +355,11 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.DNS01CheckRetryPeriod, "dns01-check-retry-period", defaultDNS01CheckRetryPeriod, ""+
 		"The duration the controller should wait between checking if a ACME dns entry exists."+
 		"This should be a valid duration string, for example 180s or 1h")
+
+  fs.DurationVar(&s.ContextTimeout, "context-timeout", defaultContextTimeout, ""+
+    "The duration a Controller Context is kept alive. "+
+		"Can be changed if context timeouts occure due to slow responding ACME api."+
+		"This should be a valid duration string, for example 10s or 1m")
 
 	fs.StringVar(&s.MetricsListenAddress, "metrics-listen-address", defaultPrometheusMetricsServerAddress, ""+
 		"The host and port that the metrics endpoint should listen on.")

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -18,6 +18,7 @@ package clusterissuers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,9 @@ type controller struct {
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
+
+	// ContextTimeout is the duration the controllers context is kept alive
+	contextTimeout time.Duration
 }
 
 // Register registers and constructs the controller using the provided context.
@@ -97,6 +101,10 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
 	c.clusterResourceNamespace = ctx.IssuerOptions.ClusterResourceNamespace
+	c.contextTimeout = time.Second * 10
+	if ctx.ContextTimeout > 0 {
+			c.contextTimeout = ctx.ContextTimeout
+	}
 
 	return c.queue, mustSync, nil
 }

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -18,7 +18,6 @@ package clusterissuers
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -42,7 +41,7 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.ClusterIssuer) (err er
 	log := logf.FromContext(ctx)
 
 	// allow a maximum of 10s
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, c.contextTimeout)
 	defer cancel()
 
 	issuerCopy := iss.DeepCopy()

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -131,6 +131,9 @@ type ContextOptions struct {
 	// Metrics is used for exposing Prometheus metrics across the controllers
 	Metrics *metrics.Metrics
 
+	// ContextTimeout is the duration the controllers context is kept alive
+	ContextTimeout time.Duration
+
 	IssuerOptions
 	ACMEOptions
 	IngressShimOptions

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -18,6 +18,7 @@ package issuers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +58,9 @@ type controller struct {
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
+
+	// ContextTimeout is the duration the controllers context is kept alive
+	contextTimeout time.Duration
 }
 
 // Register registers and constructs the controller using the provided context.
@@ -92,6 +96,11 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.cmClient = ctx.CMClient
 	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
+
+	c.contextTimeout = time.Second * 10
+	if ctx.ContextTimeout > 0 {
+			c.contextTimeout = ctx.ContextTimeout
+	}
 
 	return c.queue, mustSync, nil
 }

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -18,7 +18,6 @@ package issuers
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -42,7 +41,7 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 	log := logf.FromContext(ctx)
 
 	// allow a maximum of 10s
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, c.contextTimeout)
 	defer cancel()
 
 	issuerCopy := iss.DeepCopy()


### PR DESCRIPTION
### Pull Request Motivation

The initial issue is slow responding ZeroSSL ACME api. So most of the time cert-manager is not able to register.

```
cert-manager/controller/clusterissuers "msg"="failed to register an ACME account" "error"="context deadline exceeded"
```

The root cause is already reported to ZeroSSL support but overall the fixed value context timeout of 10 seconds is not ideal when it come to edge-clusters with not reliable or slow connection.

This PR should:
- fix #5080 
- fix cert-manager/website#583

Question to maintainer: Should this be back-ported to previous versions?

### Kind

feature

### Release Note

```release-note
Added context-timeout flag for controller to support slow responding ACME apis
```
