### PR TITLE
Revert "Use Apply instead of Update to modify resources in tests"

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -15570,6 +15570,64 @@ SOFTWARE.
 
 
 ================================================================================
+= vendor/github.com/segmentio/asm licensed under: =
+
+MIT License
+
+Copyright (c) 2021 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+= vendor/github.com/segmentio/asm/LICENSE ca1c7e031ab736c26f94ee4439ab227f
+================================================================================
+
+
+================================================================================
+= vendor/github.com/segmentio/encoding licensed under: =
+
+MIT License
+
+Copyright (c) 2019 Segment.io, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+= vendor/github.com/segmentio/encoding/LICENSE 6f71e571802c25d02519c1deef1785d8
+================================================================================
+
+
+================================================================================
 = vendor/github.com/sergi/go-diff licensed under: =
 
 Copyright (c) 2012-2016 The go-diff Authors. All rights reserved.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/pavel-v-chernykh/keystore-go/v4 v4.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
+	github.com/segmentio/encoding v0.3.3
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
@@ -178,6 +179,7 @@ require (
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1163,6 +1163,10 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.3.3 h1:VG1HceOLwHkSDdkxshlu9pD4FftWkScmHc8RDQ+w9uM=
+github.com/segmentio/encoding v0.3.3/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -1581,6 +1585,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -3410,6 +3410,22 @@ def go_repositories():
         sum = "h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=",
         version = "v0.9.1",
     )
+    go_repository(
+        name = "com_github_segmentio_asm",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/segmentio/asm",
+        sum = "h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=",
+        version = "v1.1.3",
+    )
+    go_repository(
+        name = "com_github_segmentio_encoding",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/segmentio/encoding",
+        sum = "h1:VG1HceOLwHkSDdkxshlu9pD4FftWkScmHc8RDQ+w9uM=",
+        version = "v0.3.3",
+    )
 
     go_repository(
         name = "com_github_sergi_go_diff",

--- a/internal/controller/certificaterequests/apply.go
+++ b/internal/controller/certificaterequests/apply.go
@@ -78,8 +78,6 @@ func serializeApply(req *cmapi.CertificateRequest) ([]byte, error) {
 		Spec:       *req.Spec.DeepCopy(),
 		Status:     cmapi.CertificateRequestStatus{},
 	}
-	// When using the apply operation you cannot have managedFields in the object that is being applied
-	// https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
 	req.ObjectMeta.ManagedFields = nil
 
 	reqData, err := json.Marshal(req)

--- a/internal/controller/challenges/apply.go
+++ b/internal/controller/challenges/apply.go
@@ -73,10 +73,7 @@ func serializeApply(challenge *cmacme.Challenge) ([]byte, error) {
 		ObjectMeta: *challenge.ObjectMeta.DeepCopy(),
 		Spec:       *challenge.Spec.DeepCopy(),
 	}
-	// When using the apply operation you cannot have managedFields in the object that is being applied
-	// https://kubernetes.io/docs/reference/using-api/server-side-apply/#apply-and-update
 	ch.ManagedFields = nil
-
 	challengeData, err := json.Marshal(ch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal challenge object: %w", err)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -135,7 +135,7 @@ func SyncFnFor(
 		for _, crt := range updateCrts {
 
 			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-				_, err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
+				err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            crt.Name,
 						Namespace:       crt.Namespace,

--- a/test/e2e/suite/approval/BUILD.bazel
+++ b/test/e2e/suite/approval/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/approval",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/controller/certificaterequests:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/approval/approval.go
+++ b/test/e2e/suite/approval/approval.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -46,8 +45,6 @@ import (
 // have the correct RBAC permissions.
 var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	f := framework.NewDefaultFramework("approval-certificaterequests")
-
-	const fieldManager = "e2e-test-field-manager"
 
 	var (
 		sa       *corev1.ServiceAccount
@@ -85,7 +82,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 					Resources: []string{"certificaterequests"},
 				},
 				{
-					Verbs:     []string{"patch"},
+					Verbs:     []string{"update"},
 					APIGroups: []string{"cert-manager.io"},
 					Resources: []string{"certificaterequests/status"},
 				},
@@ -179,14 +176,14 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	It("attempting to approve a certificate request without the approve permission should error", func() {
 		approvedCR := request.DeepCopy()
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err := internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err := saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("attempting to deny a certificate request without the approve permission should error", func() {
 		approvedCR := request.DeepCopy()
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err := internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err := saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -198,7 +195,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -208,7 +205,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -221,7 +218,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -232,7 +229,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -245,7 +242,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -256,7 +253,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -267,7 +264,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -278,7 +275,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, approvedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), approvedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -291,7 +288,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -302,7 +299,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -313,7 +310,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -324,7 +321,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(context.TODO(), request.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
-		err = internalcertificaterequests.ApplyStatus(context.Background(), saclient, fieldManager, deniedCR)
+		_, err = saclient.CertmanagerV1().CertificateRequests(f.Namespace.Name).UpdateStatus(context.TODO(), deniedCR, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/test/e2e/suite/approval/userinfo.go
+++ b/test/e2e/suite/approval/userinfo.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/cert-manager/cert-manager/pkg/util"
@@ -42,8 +41,6 @@ import (
 // correctly, and they cannot be modified.
 var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 	f := framework.NewDefaultFramework("userinfo-certificaterequests")
-
-	var fieldManager = "e2e-test-field-manager"
 
 	It("should appropriately create set UserInfo of CertificateRequests, and reject changes", func() {
 		var (
@@ -76,7 +73,7 @@ var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 		By("Should error when attempting to update UserInfo fields")
 		cr.Spec.Username = "abc"
 		cr.Spec.UID = "123"
-		_, err = internalcertificaterequests.Apply(context.Background(), f.CertManagerClientSet, fieldManager, cr)
+		cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Update(context.TODO(), cr, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/test/e2e/suite/certificates/BUILD.bazel
+++ b/test/e2e/suite/certificates/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/certificates",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/controller/certificates:go_default_library",
         "//internal/controller/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",

--- a/test/e2e/suite/certificates/secrettemplate.go
+++ b/test/e2e/suite/certificates/secrettemplate.go
@@ -19,7 +19,6 @@ package certificates
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -30,7 +29,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
-	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/test/e2e/framework"
@@ -43,19 +41,17 @@ import (
 // Certificate's target Secret, and is reconciled on modify events.
 var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	const (
-		issuerName   = "certificate-secret-template"
-		secretName   = "test-secret-template"
-		fieldManager = "e2e-test-field-manager"
+		issuerName = "certificate-secret-template"
+		secretName = "test-secret-template"
 	)
 
 	f := framework.NewDefaultFramework("certificates-secret-template")
 
-	createCertificate := func(f *framework.Framework, secretTemplate *cmapi.CertificateSecretTemplate, fieldManager string) *cmapi.Certificate {
-		certName := fmt.Sprintf("test-secret-template-%d", time.Now().Unix())
+	createCertificate := func(f *framework.Framework, secretTemplate *cmapi.CertificateSecretTemplate) *cmapi.Certificate {
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      certName,
-				Namespace: f.Namespace.Name,
+				GenerateName: "test-secret-template-",
+				Namespace:    f.Namespace.Name,
 			},
 			Spec: cmapi.CertificateSpec{
 				CommonName: "test",
@@ -71,9 +67,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 
 		By("creating Certificate with SecretTemplate")
 
-		// We use PATCH to create the certificate to make it easier to
-		// PATCH (SSA) later changes to the same certificate object
-		crt, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.Background(), crt, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*30)
@@ -100,7 +94,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	})
 
 	It("should not remove Annotations and Labels which have been added by a third party and not present in the SecretTemplate", func() {
-		createCertificate(f, &cmapi.CertificateSecretTemplate{Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"}}, fieldManager)
+		createCertificate(f, &cmapi.CertificateSecretTemplate{Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"}})
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -110,11 +104,11 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Labels).To(HaveKeyWithValue("abc", "123"))
 
 		By("add Annotation to Secret which should not be removed")
-		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		applyConfig = applyConfig.WithAnnotations(map[string]string{"random": "annotation"})
 
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
+		secret.Annotations["random"] = "annotation"
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string]string {
@@ -125,11 +119,11 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Annotations).To(HaveKeyWithValue("random", "annotation"))
 
 		By("add Label to Secret which should not be removed")
-
-		applyConfig, err = applycorev1.ExtractSecret(secret, fieldManager)
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		applyConfig = applyConfig.WithLabels(map[string]string{"random": "label"})
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
+
+		secret.Labels["random"] = "label"
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string]string {
@@ -143,7 +137,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"foo": "bar", "bar": "foo"},
 			Labels:      map[string]string{"abc": "123", "def": "456"},
-		}, fieldManager)
+		})
 
 		By("ensure Secret has correct Labels and Annotations with SecretTemplate")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -154,12 +148,13 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Labels).To(HaveKeyWithValue("def", "456"))
 
 		By("adding Annotations and Labels to SecretTemplate should appear on the Secret")
+
 		crt.Spec.SecretTemplate.Annotations["random"] = "annotation"
 		crt.Spec.SecretTemplate.Annotations["another"] = "random annotation"
 		crt.Spec.SecretTemplate.Labels["hello"] = "world"
 		crt.Spec.SecretTemplate.Labels["random"] = "label"
 
-		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -190,7 +185,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		delete(crt.Spec.SecretTemplate.Labels, "abc")
 		delete(crt.Spec.SecretTemplate.Labels, "another")
 
-		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -208,7 +203,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"foo": "bar", "bar": "foo"},
 			Labels:      map[string]string{"abc": "123", "def": "456"},
-		}, fieldManager)
+		})
 
 		By("ensure Secret has correct Labels and Annotations with SecretTemplate")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -226,7 +221,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt.Spec.SecretTemplate.Labels["abc"] = "098"
 		crt.Spec.SecretTemplate.Labels["def"] = "555"
 
-		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -242,27 +237,38 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 	It("should add cert-manager manager to existing Annotation and Labels fields which are added to SecretTemplate, should not be removed if they are removed by the third party", func() {
 		By("Secret Annotations and Labels should not be removed if the field still hold a field manager")
 
-		crt := createCertificate(f, nil, fieldManager)
+		crt := createCertificate(f, nil)
 
 		By("add Labels and Annotations to the Secret that are not owned by cert-manager")
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		applyconfig, err := applycorev1.ExtractSecret(secret, fieldManager)
+		if secret.Annotations == nil {
+			secret.Annotations = make(map[string]string)
+		}
+		if secret.Labels == nil {
+			secret.Labels = make(map[string]string)
+		}
+		secret.Annotations["an-annotation"] = "bar"
+		secret.Annotations["another-annotation"] = "def"
+		secret.Labels["abc"] = "123"
+		secret.Labels["foo"] = "bar"
+
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		annots := map[string]string{
-			"an-annotation":      "bar",
-			"another-annotation": "def",
-		}
-		labels := map[string]string{
-			"abc": "123",
-			"foo": "bar",
-		}
-		applyconfig = applyconfig.WithAnnotations(annots)
-		applyconfig = applyconfig.WithLabels(labels)
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyconfig, metav1.ApplyOptions{FieldManager: fieldManager})
-		Expect(err).ToNot(HaveOccurred())
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue("an-annotation", "bar"))
+		Expect(secret.Annotations).To(HaveKeyWithValue("another-annotation", "def"))
+		Expect(secret.Labels).To(HaveKeyWithValue("abc", "123"))
+		Expect(secret.Labels).To(HaveKeyWithValue("foo", "bar"))
+
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(),
+			applycorev1.Secret(secret.Name, secret.Namespace).
+				WithAnnotations(secret.Annotations).
+				WithLabels(secret.Labels),
+			metav1.ApplyOptions{FieldManager: "e2e-test-client"})
 
 		By("expect those Annotations and Labels to be present on the Secret")
 		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -278,7 +284,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 			Labels:      map[string]string{"abc": "123", "foo": "bar"},
 		}
 
-		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("waiting for those Annotation and Labels on the Secret to contain managed fields from cert-manager")
@@ -355,7 +361,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 			applycorev1.Secret(secret.Name, secret.Namespace).
 				WithAnnotations(make(map[string]string)).
 				WithLabels(make(map[string]string)),
-			metav1.ApplyOptions{FieldManager: fieldManager})
+			metav1.ApplyOptions{FieldManager: "e2e-test-client"})
 
 		Consistently(func() map[string]string {
 			secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -371,14 +377,12 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123"},
 			Labels:      map[string]string{"foo": "bar"},
-		}, fieldManager)
+		})
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		applyConfig, err := applycorev1.ExtractSecret(secret, fieldManager)
-		Expect(err).NotTo(HaveOccurred())
-		applyConfig = applyConfig.WithData(map[string][]byte{"random-key": []byte("hello-world")})
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(), applyConfig, metav1.ApplyOptions{FieldManager: fieldManager})
+		secret.Data["random-key"] = []byte("hello-world")
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(func() map[string][]byte {
@@ -392,11 +396,11 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123"},
 			Labels:      map[string]string{"foo": "bar"},
-		}, fieldManager)
+		})
 		crt.Spec.SecretTemplate.Annotations["abc"] = "456"
 		crt.Spec.SecretTemplate.Labels["foo"] = "foo"
 
-		_, err := internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {
@@ -416,7 +420,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		crt := createCertificate(f, &cmapi.CertificateSecretTemplate{
 			Annotations: map[string]string{"abc": "123", "def": "456"},
 			Labels:      map[string]string{"foo": "bar", "label": "hello-world"},
-		}, fieldManager)
+		})
 
 		var (
 			secret *corev1.Secret
@@ -433,7 +437,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 
 		crt.Spec.SecretTemplate = nil
 
-		_, err = internalcertificates.Apply(context.Background(), f.CertManagerClientSet, fieldManager, crt)
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(context.Background(), crt, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() map[string]string {

--- a/test/e2e/suite/conformance/certificates/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/conformance/certificates",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/controller/certificates:go_default_library",
         "//internal/controller/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
@@ -27,6 +26,8 @@ go_library(
         "@io_k8s_api//networking/v1:go_default_library",
         "@io_k8s_api//networking/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/serving/BUILD.bazel
+++ b/test/e2e/suite/serving/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/serving",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/controller/certificates:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
@@ -20,6 +19,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_kube_aggregator//pkg/apis/apiregistration/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],

--- a/test/integration/acme/BUILD.bazel
+++ b/test/integration/acme/BUILD.bazel
@@ -4,7 +4,6 @@ go_test(
     name = "go_default_test",
     srcs = ["orders_controller_test.go"],
     deps = [
-        "//internal/controller/challenges:go_default_library",
         "//pkg/acme/accounts/test:go_default_library",
         "//pkg/acme/client:go_default_library",
         "//pkg/apis/acme/v1:go_default_library",

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
-	internalchallenges "github.com/cert-manager/cert-manager/internal/controller/challenges"
 	accountstest "github.com/cert-manager/cert-manager/pkg/acme/accounts/test"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -57,7 +56,6 @@ func TestAcmeOrdersController(t *testing.T) {
 		testName      string = "acmetest"
 		challengeType string = "dns-01"
 		authType      string = "dns"
-		fieldManager  string = "integration-test-field-manager"
 	)
 
 	// Initial ACME authorization to be returned by GetAuthorization.
@@ -237,7 +235,7 @@ func TestAcmeOrdersController(t *testing.T) {
 	// Set the Challenge state to valid- the status of the ACME order remains 'pending'.
 	chal = chal.DeepCopy()
 	chal.Status.State = cmacme.Valid
-	_, err = internalchallenges.ApplyStatus(ctx, cmCl, fieldManager, chal)
+	_, err = cmCl.AcmeV1().Challenges(testName).UpdateStatus(ctx, chal, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -10,8 +10,6 @@ go_test(
         "trigger_controller_test.go",
     ],
     deps = [
-        "//internal/controller/certificaterequests:go_default_library",
-        "//internal/controller/certificates:go_default_library",
         "//internal/controller/certificates/policies:go_default_library",
         "//internal/webhook/feature:go_default_library",
         "//pkg/api/util:go_default_library",
@@ -31,6 +29,7 @@ go_test(
         "//test/integration/framework:go_default_library",
         "//test/unit/crypto:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_segmentio_encoding//json:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	fakeclock "k8s.io/utils/clock/testing"
 
-	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -113,7 +112,6 @@ func TestMetricsController(t *testing.T) {
 		crtName         = "testcrt"
 		namespace       = "testns"
 		metricsEndpoint = fmt.Sprintf("http://%s/metrics", server.Addr)
-		fieldManager    = "integration-test-field-manager"
 
 		lastErr error
 	)
@@ -206,8 +204,7 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	crt.Status.RenewalTime = &metav1.Time{
 		Time: time.Unix(100, 0),
 	}
-
-	err = internalcertificates.ApplyStatus(ctx, cmClient, fieldManager, crt)
+	_, err = cmClient.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
-	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -69,10 +68,9 @@ func TestRevisionManagerController(t *testing.T) {
 	defer stopController()
 
 	var (
-		crtName      = "testcrt"
-		namespace    = "testns"
-		secretName   = "test-crt-tls"
-		fieldManager = "integration-test-field-manager"
+		crtName    = "testcrt"
+		namespace  = "testns"
+		secretName = "test-crt-tls"
 	)
 
 	// Create Namespace
@@ -99,7 +97,7 @@ func TestRevisionManagerController(t *testing.T) {
 	// Set Certificate to Ready
 	apiutil.SetCertificateCondition(crt, crt.Generation,
 		cmapi.CertificateConditionReady, cmmeta.ConditionTrue, "Issued", "integration test")
-	err = internalcertificates.ApplyStatus(ctx, cmCl, fieldManager, crt)
+	crt, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -22,13 +22,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/segmentio/encoding/json"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 	fakeclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
 
-	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -228,7 +230,6 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 	namespace := "testns"
 	secretName := "example"
 	certName := "testcrt"
-	fieldManager := "integration-test-field-manager"
 
 	failedIssuanceAttempts := 7
 	backoffPeriod := time.Hour * 32
@@ -283,7 +284,7 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 	apiutil.SetCertificateCondition(cert, 1, cmapi.CertificateConditionIssuing, cmmeta.ConditionFalse, "", "")
 	cert.Status.FailedIssuanceAttempts = &failedIssuanceAttempts
 	cert.Status.LastFailureTime = &metaNow
-	err = internalcertificates.ApplyStatus(ctx, cmCl, fieldManager, cert)
+	cert, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, cert, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,9 +390,30 @@ func selfSignCertificateWithNotBeforeAfter(t *testing.T, pkData []byte, spec *cm
 // triggered on certificate events.
 func applyTestCondition(t *testing.T, ctx context.Context, cert *cmapi.Certificate, client cmclient.Interface) {
 	t.Helper()
-	message := fmt.Sprintf("Test-%s", time.Now().Truncate(time.Second))
-	apiutil.SetCertificateCondition(cert, cert.Generation, cmapi.CertificateConditionType("Test"), cmmeta.ConditionUnknown, "Test", message)
-	err := internalcertificates.ApplyStatus(ctx, client, "test", cert)
+	testCond := cmapi.CertificateCondition{
+		Type:    cmapi.CertificateConditionType("Test"),
+		Reason:  "TestTwo",
+		Message: fmt.Sprintf("Test-%s", time.Now().Truncate(time.Second).String()),
+		Status:  cmmeta.ConditionUnknown,
+	}
+	// Patch instead of update as there might be conflicts here due to
+	// trigger controller picking up the cert and adding Issuing condition
+	// in between.
+	statusUpdate := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: cert.Name, Namespace: cert.Namespace},
+		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+		Status: cmapi.CertificateStatus{
+			Conditions: []cmapi.CertificateCondition{testCond},
+		},
+	}
+	statusUpdateJson, err := json.Marshal(statusUpdate)
+	if err != nil {
+		t.Errorf("failed to marshal cert data: %v", err)
+	}
+	_, err = client.CertmanagerV1().Certificates(cert.Namespace).Patch(
+		ctx, cert.Name, types.ApplyPatchType, statusUpdateJson, metav1.PatchOptions{FieldManager: "test", Force: pointer.Bool(true)},
+		"status",
+	)
 	if err != nil {
 		t.Fatalf("Failed to apply test condition: %v", err)
 	}


### PR DESCRIPTION

Reverts cert-manager/cert-manager#5077

As this seem to still have resource conflicts, see https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1651567807840999


```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
