### PR TITLE
Add relabeling and metricRelabelings settings for ServiceMonitor.

### DIFF
--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -36,4 +36,13 @@ spec:
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
     honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
+{{- if .Values.prometheus.servicemonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.prometheus.servicemonitor.metricRelabelings | nindent 4 }}
+{{- end }}
+{{- if .Values.prometheus.servicemonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.prometheus.servicemonitor.relabelings | nindent 4 }}
+{{- end }}
+
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -171,6 +171,18 @@ prometheus:
     scrapeTimeout: 30s
     labels: {}
     honorLabels: false
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
Signed-off-by: lftgl <v.lftgl@gmail.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

With this PR I would like to create the possibility to apply relabeling settings and the ServiceMonitor resources.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

    <cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->
feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
relabelings and metricsRelabelings can be applied to resources: ServiceMonitor.
```


