### PR TITLE
Delete mask

### DIFF
--- a/logo/logo.svg
+++ b/logo/logo.svg
@@ -128,7 +128,6 @@
        id="Text"
        transform="translate(-528.23,-113.97)">
       <g
-         mask="url(#mask-2)"
          id="g3878">
         <g
            id="Text_and_detail"


### PR DESCRIPTION
Firefox does not like a mask reference to a nonexistent mask

Here's the rough before (w/ some coloring):
![image](https://user-images.githubusercontent.com/2119212/166965456-6accea83-bfa7-48cd-87d1-c9b3dea6e7e6.png)

And the rough after:
![image](https://user-images.githubusercontent.com/2119212/166965488-8dfd86a2-9a5c-4459-a60e-bbc72ad4d037.png)

Firefox 100.0 (64-bit) on macOS Big Sur 11.6.5 (20G527) (amd64)