### PR TITLE
WIP: Only remove the cleanup finalizer if the cleanup succeeds

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -29,6 +29,7 @@ import (
 
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
+	"github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -79,6 +80,8 @@ type controller struct {
 	// objectUpdater implements the updateObject function which is used to save
 	// changes to the Challenge.Status and Challenge.Finalizers
 	objectUpdater
+
+	cmClient versioned.Interface
 }
 
 func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
@@ -152,7 +155,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// Construct an objectUpdater which is used to save changes to the Challenge
 	// object, either using Update or using Patch + Server Side Apply.
 	c.objectUpdater = newObjectUpdater(ctx.CMClient, ctx.FieldManager)
-
+	c.cmClient = ctx.CMClient
 	return c.queue, mustSync, nil
 }
 

--- a/pkg/controller/acmechallenges/finalizer.go
+++ b/pkg/controller/acmechallenges/finalizer.go
@@ -17,9 +17,14 @@ limitations under the License.
 package acmechallenges
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
+	"context"
 
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/cert-manager/cert-manager/pkg/acme"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 // Functions for adding and checking the cleanup finalizer of a challenge.
@@ -29,7 +34,40 @@ import (
 // deployed ("presented") resources and if successful, removes this finalizer
 // allowing the garbage collector to remove the challenge.
 
-// finalizerRequired returns true if the finalizer is not found on the challenge.
-func finalizerRequired(ch *cmacme.Challenge) bool {
-	return !sets.NewString(ch.Finalizers...).Has(cmacme.ACMEFinalizer)
+// addCleanupFinalizer adds the cleanup finalizer if it is not already present,
+// and returns true if the finalizer is added.
+func addCleanupFinalizer(ch *cmacme.Challenge) bool {
+	if controllerutil.ContainsFinalizer(ch, cmacme.ACMEFinalizer) {
+		return false
+	}
+	controllerutil.AddFinalizer(ch, cmacme.ACMEFinalizer)
+	return true
+}
+
+// challengeFinished returns true if either the DeletionTimestamp is set or the
+// challenge is in a "final" state
+func challengeFinished(ch *cmacme.Challenge) bool {
+	if !ch.DeletionTimestamp.IsZero() {
+		return true
+	}
+	if acme.IsFinalState(ch.Status.State) {
+		return true
+	}
+	return false
+}
+
+// handleCleanup invokes solver.Cleanup if the finalizer is present and removes
+// the cleanup finalizer if that succeeds.
+// And if cleanup is skipped or succeeds it resets the Presented and Processing
+// fields to false.
+func handleCleanup(ctx context.Context, solver solver, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error {
+	if controllerutil.ContainsFinalizer(ch, cmacme.ACMEFinalizer) {
+		if err := solver.CleanUp(ctx, issuer, ch); err != nil {
+			return errors.WithMessage(err, "Error cleaning up challenge")
+		}
+		controllerutil.RemoveFinalizer(ch, cmacme.ACMEFinalizer)
+	}
+	ch.Status.Presented = false
+	ch.Status.Processing = false
+	return nil
 }

--- a/pkg/controller/acmechallenges/finalizer_test.go
+++ b/pkg/controller/acmechallenges/finalizer_test.go
@@ -17,35 +17,43 @@ limitations under the License.
 package acmechallenges
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func Test_finalizerRequired(t *testing.T) {
+func TestAddCleanupFinalizer(t *testing.T) {
 	tests := []struct {
 		name       string
 		finalizers []string
 		want       bool
 	}{
+		// Add the finalizer if empty
 		{
 			name:       "no-finalizers",
-			finalizers: nil,
+			finalizers: []string{},
 			want:       true,
 		},
+		// Noop if the finalizer is the only one
 		{
 			name:       "only-native-finalizer",
 			finalizers: []string{cmacme.ACMEFinalizer},
 			want:       false,
 		},
+		// Noop if the finalizer is one of many
 		{
 			name:       "some-foreign-finalizers",
 			finalizers: []string{"f1", "f2", cmacme.ACMEFinalizer, "f3"},
 			want:       false,
 		},
+		// Add the finalizer if there are only other finalizers
 		{
 			name:       "only-foreign-finalizers",
 			finalizers: []string{"f1", "f2", "f3"},
@@ -54,13 +62,128 @@ func Test_finalizerRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ch := gen.Challenge("example", gen.SetChallengeFinalizers(tt.finalizers))
+			chOriginal := ch.DeepCopy()
+			added := addCleanupFinalizer(ch)
+
+			assert.Equal(t, tt.want, added)
+			if added {
+				assert.Equal(t, cmacme.ACMEFinalizer, ch.Finalizers[len(ch.Finalizers)-1], "The finalizer should be added at the end")
+				assert.Equal(t, chOriginal.Finalizers, ch.Finalizers[:len(ch.Finalizers)-1], "The original finalizers should not be changed or re-ordered")
+			} else {
+				assert.Equal(t, chOriginal.Finalizers, ch.Finalizers, "The finalizers should not be changed if the desired finalizer is already present")
+			}
 			assert.Equal(
 				t,
-				tt.want,
-				finalizerRequired(
-					gen.Challenge("example", gen.SetChallengeFinalizers(tt.finalizers)),
-				),
+				gen.ChallengeFrom(chOriginal, gen.SetChallengeFinalizers(nil)),
+				gen.ChallengeFrom(ch, gen.SetChallengeFinalizers(nil)),
+				"Only the finalizers field should ever change",
 			)
+		})
+	}
+}
+
+func TestChallengeFinished(t *testing.T) {
+	tests := []struct {
+		name      string
+		challenge *cmacme.Challenge
+		result    bool
+	}{
+		// If challenge is deleted attempt to cleanup
+		{
+			name: "deleted",
+			challenge: gen.Challenge("c1",
+				gen.SetChallengeDeletionTimestamp(metav1.Now()),
+			),
+			result: true,
+		},
+		// If challenge is in a finished state, attempt to cleanup
+		{
+			name: "final-state",
+			challenge: gen.Challenge("c1",
+				gen.SetChallengeState(cmacme.Invalid),
+			),
+			result: true,
+		},
+		// If challenge is deleted and in a finished state, attempt to cleanup
+		{
+			name: "deleted-and-final-state",
+			challenge: gen.Challenge("c1",
+				gen.SetChallengeDeletionTimestamp(metav1.Now()),
+				gen.SetChallengeState(cmacme.Invalid),
+			),
+			result: true,
+		},
+		// If the challenge is neither deleted nor finished, skip the cleanup
+		{
+			name:      "not-finished",
+			challenge: gen.Challenge("c1"),
+			result:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.result, challengeFinished(tt.challenge))
+		})
+	}
+}
+
+func TestHandleCleanup(t *testing.T) {
+	simulatedCleanupError := errors.New("simulated-cleanup-error")
+	tests := []struct {
+		name         string
+		mods         []gen.ChallengeModifier
+		cleanupError error
+		errorMessage string
+	}{
+		// Invoke solver.Cleanup if the finalizer is present and remove the
+		// finalizer and reset the status fields if it succeeds
+		{
+			name: "success-with-cleanup",
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{cmacme.ACMEFinalizer}),
+			},
+		},
+		// Skip the solver.Cleanup when the finalizer absent, but reset the
+		// status fields if it succeeds
+		{
+			name:         "success-skip-cleanup",
+			cleanupError: simulatedCleanupError,
+		},
+		// Return the solver.Cleanup error if it fails and do not remove the
+		// finalizer nor update he status fields.
+		{
+			name: "cleanup-error",
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{cmacme.ACMEFinalizer}),
+			},
+			cleanupError: simulatedCleanupError,
+			errorMessage: "Error cleaning up challenge: simulated-cleanup-error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			solver := &fakeSolver{
+				fakeCleanUp: func(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error {
+					return tt.cleanupError
+				},
+			}
+			issuer := gen.Issuer("issuer1")
+			ch := gen.Challenge("challenge1", append(tt.mods, gen.SetChallengeProcessing(true), gen.SetChallengePresented(true))...)
+			chOriginal := ch.DeepCopy()
+			err := handleCleanup(ctx, solver, issuer, ch)
+			if tt.errorMessage == "" {
+				assert.NoError(t, err)
+				assert.NotContains(t, ch.Finalizers, cmacme.ACMEFinalizer, "The finalizer should be removed if cleanup succeeded")
+				assert.False(t, ch.Status.Processing)
+				assert.False(t, ch.Status.Presented)
+			} else {
+				assert.EqualError(t, err, tt.errorMessage)
+				assert.Equal(t, chOriginal, ch, "The challenge should be unchanged if the cleanup failed")
+				assert.True(t, ch.Status.Processing)
+				assert.True(t, ch.Status.Presented)
+			}
 		})
 	}
 }

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/cert-manager/cert-manager/pkg/acme"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -32,7 +33,9 @@ import (
 )
 
 var (
-	orderGvk = cmacme.SchemeGroupVersion.WithKind("Order")
+	orderGvk         = cmacme.SchemeGroupVersion.WithKind("Order")
+	issuerGvk        = cmapi.SchemeGroupVersion.WithKind("Issuer")
+	clusterIssuerGvk = cmapi.SchemeGroupVersion.WithKind("ClusterIssuer")
 )
 
 // buildPartialRequiredChallenges builds partial required ACME challenges by
@@ -73,12 +76,26 @@ func buildPartialChallenge(ctx context.Context, issuer cmapi.GenericIssuer, o *c
 	if err != nil {
 		return nil, err
 	}
+	issuerOwnerRef := metav1.OwnerReference{
+		APIVersion:         issuerGvk.GroupVersion().String(),
+		Kind:               issuerGvk.Kind,
+		Name:               issuer.GetName(),
+		UID:                issuer.GetUID(),
+		BlockOwnerDeletion: pointer.Bool(true),
+	}
+
+	if _, ok := issuer.(*cmapi.ClusterIssuer); ok {
+		issuerOwnerRef.Kind = clusterIssuerGvk.Kind
+	}
 
 	return &cmacme.Challenge{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            chName,
-			Namespace:       o.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(o, orderGvk)},
+			Name:      chName,
+			Namespace: o.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(o, orderGvk),
+				issuerOwnerRef,
+			},
 		},
 		Spec: *chSpec,
 	}, nil


### PR DESCRIPTION
This addresses two problems:
 * The finalizer was being removed unconditionally, regardless of whether solver.Cleanup succeeds
 * The finalizer was assumed to be the first in the list of finalizers, potentially resulting in the removal of foreign finalizers and resulting in the cleanup finalizer never being removed.
 * solver.Cleanup was invoked inconsistently from two different places, in handleFinalizer and in an `acme.IsFinalState` block, but in the former, the Status.Processing and Status.Presented fields were not being reset and in the latter case, the finalizer wasn't being removed if the cleanup succeeded.

Part of:
 * #3640
/kind cleanup

```release-note
NONE
```
