### PR TITLE
Add EncodeUsagesInRequestAnnotationKey for certificate

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -39,6 +39,9 @@ const (
 	// Annotation key for certificate key usages.
 	UsagesAnnotationKey = "cert-manager.io/usages"
 
+	// Annotation key for certificate encodeUsagesInRequest.
+	EncodeUsagesInRequestAnnotationKey = "cert-manager.io/encode-usages-in-request"
+
 	// Annotation key the 'name' of the Issuer resource.
 	IssuerNameAnnotationKey = "cert-manager.io/issuer-name"
 

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -19,6 +19,7 @@ package shimhelper
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +44,7 @@ var (
 //       cert-manager.io/duration: 2160h
 //       cert-manager.io/renew-before: 1440h
 //       cert-manager.io/usages: "digital signature,key encipherment"
+//       cert-manager.io/encoded-usages-in-request: "false"
 //
 // is mapped to the following Certificate:
 //
@@ -54,6 +56,7 @@ var (
 //     usages:
 //       - digital signature
 //       - key encipherment
+//     encodedUsagesInRequest: false
 func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]string) error {
 	if crt == nil {
 		return errNilCertificate
@@ -92,5 +95,14 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		}
 		crt.Spec.Usages = newUsages
 	}
+
+	if encodeUsagesInRequest, found := ingLikeAnnotations[cmapi.EncodeUsagesInRequestAnnotationKey]; found {
+		flag, err := strconv.ParseBool(encodeUsagesInRequest)
+		if err != nil {
+			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.EncodeUsagesInRequestAnnotationKey, err)
+		}
+		crt.Spec.EncodeUsagesInRequest = &flag
+	}
+
 	return nil
 }

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -39,10 +39,11 @@ func Test_translateAnnotations(t *testing.T) {
 
 	validAnnotations := func() map[string]string {
 		return map[string]string{
-			cmapi.CommonNameAnnotationKey:  "www.example.com",
-			cmapi.DurationAnnotationKey:    "168h", // 1 week
-			cmapi.RenewBeforeAnnotationKey: "24h",
-			cmapi.UsagesAnnotationKey:      "server auth,signing",
+			cmapi.CommonNameAnnotationKey:            "www.example.com",
+			cmapi.DurationAnnotationKey:              "168h", // 1 week
+			cmapi.RenewBeforeAnnotationKey:           "24h",
+			cmapi.UsagesAnnotationKey:                "server auth,signing",
+			cmapi.EncodeUsagesInRequestAnnotationKey: "false",
 		}
 	}
 
@@ -55,6 +56,7 @@ func Test_translateAnnotations(t *testing.T) {
 				a.Equal(&metav1.Duration{Duration: time.Hour * 24 * 7}, crt.Spec.Duration)
 				a.Equal(&metav1.Duration{Duration: time.Hour * 24}, crt.Spec.RenewBefore)
 				a.Equal([]cmapi.KeyUsage{cmapi.UsageServerAuth, cmapi.UsageSigning}, crt.Spec.Usages)
+				a.Equal(false, *crt.Spec.EncodeUsagesInRequest)
 			},
 		},
 		"nil annotations": {


### PR DESCRIPTION
### Pull Request Motivation

We have integrated Cert Manager with GlobalSign ACME. Their backend requires `certificate.spec.encodeUsagesInRequest` explicitly to be `false` and `certificate.spec.usages` to be empty/unset. For example, this generates a CSR without the extended key usages (required by GlobalSign):

```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test
spec:
  encodeUsagesInRequest: false
  dnsNames:
  - test.example.com
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: globalsign-production
  secretName: globalsign-test
```

This does encode key usages in the CSR extensions (and therfore not accepted by GlobalSign).

```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test
spec:
  dnsNames:
  - test.example.com
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: globalsign-production
  secretName: globalsign-test
```

We also want to be able to control this with annotations on the Ingress object, like in this PR.

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add EncodeUsagesInRequestAnnotationKey for certificate
```
