### PR TITLE
Change name of `bin` dir to `_bin` and make it configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # For details on some of these "prelude" settings, see:
 # https://clarkgrubb.com/makefile-style-guide
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 .SHELLFLAGS := -uo pipefail -c
 .DEFAULT_GOAL := help
 .DELETE_ON_ERROR:

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,7 @@ clean:
 .PHONY: clean-all
 clean-all: clean
 	rm -rf $(BINDIR)/
+
+# FORCE is a helper target to force a file to be rebuilt whenever its
+# target is invoked.
+FORCE:

--- a/hack/build/.kazelcfg.json
+++ b/hack/build/.kazelcfg.json
@@ -1,4 +1,5 @@
 {
   "GoPrefix": "github.com/cert-manager/cert-manager",
-  "AddSourcesRules": true
+  "AddSourcesRules": true,
+  "SkippedPaths": ["_bin"]
 }

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -42,6 +42,7 @@ fi
 
 set -o xtrace
 "$gazelle" fix \
+  --exclude=_bin \
   --external=external \
   --go_naming_convention=go_default_library
 

--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -33,9 +33,7 @@ common_flags=""
 
 echo "+++ running goimports" >&2
 
-# find all directories except bin which contain go files, and output them on a single line
-
-godirs=$(find . -not \( -path "./bin/*" -prune \) -name "*.go" | cut -d'/' -f2 | sort | uniq | tr '\n' ' ')
+godirs=$(make --silent print-source-dirs)
 
 output=$($goimports $common_flags -l $godirs)
 

--- a/internal/test/paths/paths.go
+++ b/internal/test/paths/paths.go
@@ -32,7 +32,9 @@ var (
 
 	// BinDir is the filesystem path of the bin directory which is populated using
 	// Makefile commands
-	BinDir = filepath.Join(ModuleRootDir, "bin")
+	// TODO: the BINDIR is configurable in make but is hardcoded here. It might be nice
+	// to detect the BINDIR here (`make print-bindir`?)
+	BinDir = filepath.Join(ModuleRootDir, "_bin")
 
 	// BinToolsDir is the filesystem path of the bin/tools directory which can for
 	// example be populated by `make -f make/Makefile integration-test-tools`.

--- a/make/README.md
+++ b/make/README.md
@@ -13,7 +13,7 @@ should just work, so long as the versions you have installed are roughly
 compatible.
 
 If you are running into issues with your host-installed tools, you can
-have them downloaded in `bin/tools` with the command:
+have them downloaded in `$(BINDIR)/tools` with the command:
 
 ```sh
 # With "-j8", the tools are downloaded in parallel.
@@ -24,7 +24,7 @@ To setup your shell to use the tools, run the following from the root of
 the repository:
 
 ```sh
-export PATH="$PWD/bin/tools:$PATH"
+export PATH="$PWD/$(BINDIR)/tools:$PATH"
 ```
 
 > **Tip:** this change of PATH won't persist between shell sessions. To get

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -8,11 +8,11 @@ __PYTHON := python3
 ci-presubmit: verify-imports verify-errexit verify-boilerplate
 
 .PHONY: verify-imports
-verify-imports: bin/tools/goimports
+verify-imports: $(BINDIR)/tools/goimports
 	./hack/verify-goimports.sh $<
 
 .PHONY: verify-chart
-verify-chart: bin/cert-manager-$(RELEASE_VERSION).tgz
+verify-chart: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
 	DOCKER=$(CTR) ./hack/verify-chart-version.sh $<
 
 .PHONY: verify-errexit

--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -98,6 +98,9 @@ if printenv K8S_VERSION >/dev/null && [ -n "$K8S_VERSION" ]; then
   k8s_version="$K8S_VERSION"
 fi
 
+# TODO(SgtCoDFish): Using "KIND_IMAGE_FULL_*" here breaks podman, which doesn't support using both tags and digests
+# when referring to an image. We should avoid using FULL where possible.
+
 case "$k8s_version" in
 1.18*) image=$KIND_IMAGE_FULL_K8S_118 ;;
 1.19*) image=$KIND_IMAGE_FULL_K8S_119 ;;

--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -2,40 +2,40 @@ CMCTL_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/c
 
 KUBECTL_PLUGIN_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"'
 
-bin/cmctl:
+$(BINDIR)/cmctl:
 	@mkdir -p $@
 
-bin/kubectl-cert_manager:
+$(BINDIR)/kubectl-cert_manager:
 	@mkdir -p $@
 
 .PHONY: cmctl
-cmctl: cmctl-linux cmctl-linux-tarballs cmctl-linux-metadata cmctl-darwin cmctl-darwin-tarballs cmctl-darwin-metadata cmctl-windows cmctl-windows-tarballs cmctl-windows-metadata | bin/cmctl
+cmctl: cmctl-linux cmctl-linux-tarballs cmctl-linux-metadata cmctl-darwin cmctl-darwin-tarballs cmctl-darwin-metadata cmctl-windows cmctl-windows-tarballs cmctl-windows-metadata | $(BINDIR)/cmctl
 
 .PHONY: cmctl-linux
-cmctl-linux: bin/cmctl/cmctl-linux-amd64 bin/cmctl/cmctl-linux-arm64 bin/cmctl/cmctl-linux-s390x bin/cmctl/cmctl-linux-ppc64le bin/cmctl/cmctl-linux-arm | bin/cmctl
+cmctl-linux: $(BINDIR)/cmctl/cmctl-linux-amd64 $(BINDIR)/cmctl/cmctl-linux-arm64 $(BINDIR)/cmctl/cmctl-linux-s390x $(BINDIR)/cmctl/cmctl-linux-ppc64le $(BINDIR)/cmctl/cmctl-linux-arm | $(BINDIR)/cmctl
 
 .PHONY: cmctl-linux-tarballs
-cmctl-linux-tarballs: bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/release/cert-manager-cmctl-linux-arm64.tar.gz bin/release/cert-manager-cmctl-linux-s390x.tar.gz bin/release/cert-manager-cmctl-linux-ppc64le.tar.gz bin/release/cert-manager-cmctl-linux-arm.tar.gz | bin/release
+cmctl-linux-tarballs: $(BINDIR)/release/cert-manager-cmctl-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm.tar.gz | $(BINDIR)/release
 
 .PHONY: cmctl-linux-metadata
-cmctl-linux-metadata: bin/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json | bin/metadata
+cmctl-linux-metadata: $(BINDIR)/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json | $(BINDIR)/metadata
 
-bin/cmctl/cmctl-linux-amd64 bin/cmctl/cmctl-linux-arm64 bin/cmctl/cmctl-linux-s390x bin/cmctl/cmctl-linux-ppc64le: bin/cmctl/cmctl-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
+$(BINDIR)/cmctl/cmctl-linux-amd64 $(BINDIR)/cmctl/cmctl-linux-arm64 $(BINDIR)/cmctl/cmctl-linux-s390x $(BINDIR)/cmctl/cmctl-linux-ppc64le: $(BINDIR)/cmctl/cmctl-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
 	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
 
-bin/cmctl/cmctl-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
+$(BINDIR)/cmctl/cmctl-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/release/cert-manager-cmctl-linux-arm64.tar.gz bin/release/cert-manager-cmctl-linux-s390x.tar.gz bin/release/cert-manager-cmctl-linux-ppc64le.tar.gz bin/release/cert-manager-cmctl-linux-arm.tar.gz: bin/release/cert-manager-cmctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-cmctl-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-cmctl-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-cmctl-linux-%.tar.gz: $(BINDIR)/cmctl/cmctl-linux-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json: bin/metadata/cert-manager-cmctl-linux-%.tar.gz.metadata.json: bin/release/cert-manager-cmctl-linux-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-cmctl-linux-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-cmctl-linux-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "linux" \
@@ -44,27 +44,27 @@ bin/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json bin/metadata/ce
 		hack/artifact-metadata.template.json > $@
 
 .PHONY: cmctl-darwin
-cmctl-darwin: bin/cmctl/cmctl-darwin-amd64 bin/cmctl/cmctl-darwin-arm64 | bin/cmctl
+cmctl-darwin: $(BINDIR)/cmctl/cmctl-darwin-amd64 $(BINDIR)/cmctl/cmctl-darwin-arm64 | $(BINDIR)/cmctl
 
 .PHONY: cmctl-darwin-tarballs
-cmctl-darwin-tarballs: bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/release/cert-manager-cmctl-darwin-arm64.tar.gz | bin/release
+cmctl-darwin-tarballs: $(BINDIR)/release/cert-manager-cmctl-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-darwin-arm64.tar.gz | $(BINDIR)/release
 
 .PHONY: cmctl-darwin-metadata
-cmctl-darwin-metadata: bin/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json | bin/metadata
+cmctl-darwin-metadata: $(BINDIR)/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json | $(BINDIR)/metadata
 
-bin/cmctl/cmctl-darwin-amd64 bin/cmctl/cmctl-darwin-arm64:  bin/cmctl/cmctl-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
+$(BINDIR)/cmctl/cmctl-darwin-amd64 $(BINDIR)/cmctl/cmctl-darwin-arm64:  $(BINDIR)/cmctl/cmctl-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
 	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/release/cert-manager-cmctl-darwin-arm64.tar.gz: bin/release/cert-manager-cmctl-darwin-%.tar.gz:  bin/cmctl/cmctl-darwin-% bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-cmctl-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-darwin-arm64.tar.gz: $(BINDIR)/release/cert-manager-cmctl-darwin-%.tar.gz:  $(BINDIR)/cmctl/cmctl-darwin-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json: bin/metadata/cert-manager-cmctl-darwin-%.tar.gz.metadata.json: bin/release/cert-manager-cmctl-darwin-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-cmctl-darwin-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-cmctl-darwin-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "darwin" \
@@ -73,35 +73,35 @@ bin/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json bin/metadata/c
 		hack/artifact-metadata.template.json > $@
 
 .PHONY: cmctl-windows
-cmctl-windows: bin/cmctl/cmctl-windows-amd64.exe | bin/cmctl
+cmctl-windows: $(BINDIR)/cmctl/cmctl-windows-amd64.exe | $(BINDIR)/cmctl
 
 .PHONY: cmctl-windows-tarballs
-cmctl-windows-tarballs: bin/release/cert-manager-cmctl-windows-amd64.tar.gz bin/release/cert-manager-cmctl-windows-amd64.zip | bin/release
+cmctl-windows-tarballs: $(BINDIR)/release/cert-manager-cmctl-windows-amd64.tar.gz $(BINDIR)/release/cert-manager-cmctl-windows-amd64.zip | $(BINDIR)/release
 
 .PHONY: cmctl-windows-metadata
-cmctl-windows-metadata: bin/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json | bin/release
+cmctl-windows-metadata: $(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json | $(BINDIR)/release
 
-bin/cmctl/cmctl-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
+$(BINDIR)/cmctl/cmctl-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/cmctl
 	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-cmctl-windows-amd64.zip: bin/cmctl/cmctl-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-cmctl-windows-amd64.zip: $(BINDIR)/cmctl/cmctl-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl.exe
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	pushd $(TARDIR) && zip -r $(notdir $@) . && popd && mv $(TARDIR)/$(notdir $@) $@
 	rm -rf $(TARDIR)
 
-bin/release/cert-manager-cmctl-windows-amd64.tar.gz: bin/cmctl/cmctl-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-cmctl-windows-amd64.tar.gz: $(BINDIR)/cmctl/cmctl-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/cmctl.exe
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json: bin/release/cert-manager-cmctl-windows-amd64.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-cmctl-windows-amd64.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "windows" \
@@ -109,7 +109,7 @@ bin/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json: bin/release/
 		'.name = $$name | .sha256 = $$sha256 | .os = $$os | .architecture = $$architecture' \
 		hack/artifact-metadata.template.json > $@
 
-bin/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json: bin/release/cert-manager-cmctl-windows-amd64.zip hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json: $(BINDIR)/release/cert-manager-cmctl-windows-amd64.zip hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "windows" \
@@ -118,33 +118,33 @@ bin/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json: bin/release/cer
 		hack/artifact-metadata.template.json > $@
 
 .PHONY: kubectl-cert_manager
-kubectl-cert_manager: kubectl-cert_manager-linux kubectl-cert_manager-linux-tarballs kubectl-cert_manager-linux-metadata kubectl-cert_manager-darwin kubectl-cert_manager-darwin-tarballs kubectl-cert_manager-darwin-metadata kubectl-cert_manager-windows kubectl-cert_manager-windows-tarballs kubectl-cert_manager-windows-metadata | bin/kubectl-cert_manager
+kubectl-cert_manager: kubectl-cert_manager-linux kubectl-cert_manager-linux-tarballs kubectl-cert_manager-linux-metadata kubectl-cert_manager-darwin kubectl-cert_manager-darwin-tarballs kubectl-cert_manager-darwin-metadata kubectl-cert_manager-windows kubectl-cert_manager-windows-tarballs kubectl-cert_manager-windows-metadata | $(BINDIR)/kubectl-cert_manager
 
 .PHONY: kubectl-cert_manager-linux
-kubectl-cert_manager-linux: bin/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-s390x bin/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm | bin/kubectl-cert_manager
+kubectl-cert_manager-linux: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-s390x $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm | $(BINDIR)/kubectl-cert_manager
 
 .PHONY: kubectl-cert_manager-linux-tarballs
-kubectl-cert_manager-linux-tarballs: bin/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz | bin/release
+kubectl-cert_manager-linux-tarballs: $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz | $(BINDIR)/release
 
 .PHONY: kubectl-cert_manager-linux-metadata
-kubectl-cert_manager-linux-metadata: bin/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json | bin/metadata
+kubectl-cert_manager-linux-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json | $(BINDIR)/metadata
 
-bin/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-s390x bin/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le: bin/kubectl-cert_manager/kubectl-cert_manager-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
+$(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-s390x $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
 	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
 
-bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
+$(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz: bin/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz: bin/kubectl-cert_manager/kubectl-cert_manager-linux-% bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-linux-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json: bin/metadata/cert-manager-kubectl-cert_manager-linux-%.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-linux-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "linux" \
@@ -153,27 +153,27 @@ bin/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json 
 		hack/artifact-metadata.template.json > $@
 
 .PHONY: kubectl-cert_manager-darwin
-kubectl-cert_manager-darwin: bin/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64 | bin/kubectl-cert_manager
+kubectl-cert_manager-darwin: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64 | $(BINDIR)/kubectl-cert_manager
 
 .PHONY: kubectl-cert_manager-darwin-tarballs
-kubectl-cert_manager-darwin-tarballs: bin/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz | bin/release
+kubectl-cert_manager-darwin-tarballs: $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz | $(BINDIR)/release
 
 .PHONY: kubectl-cert_manager-darwin-metadata
-kubectl-cert_manager-darwin-metadata: bin/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json | bin/metadata
+kubectl-cert_manager-darwin-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json | $(BINDIR)/metadata
 
-bin/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64:  bin/kubectl-cert_manager/kubectl-cert_manager-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
+$(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64:  $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
 	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz: bin/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz:  bin/kubectl-cert_manager/kubectl-cert_manager-darwin-% bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz: $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz:  $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-darwin-% $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json: bin/metadata/cert-manager-kubectl-cert_manager-darwin-%.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-darwin-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "darwin" \
@@ -182,35 +182,35 @@ bin/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json
 		hack/artifact-metadata.template.json > $@
 
 .PHONY: kubectl-cert_manager-windows
-kubectl-cert_manager-windows: bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe | bin/kubectl-cert_manager
+kubectl-cert_manager-windows: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe | $(BINDIR)/kubectl-cert_manager
 
 .PHONY: kubectl-cert_manager-windows-tarballs
-kubectl-cert_manager-windows-tarballs: bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-windows-amd64.zip | bin/release
+kubectl-cert_manager-windows-tarballs: $(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz $(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.zip | $(BINDIR)/release
 
 .PHONY: kubectl-cert_manager-windows-metadata
-kubectl-cert_manager-windows-metadata: bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json | bin/release
+kubectl-cert_manager-windows-metadata: $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json | $(BINDIR)/release
 
-bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
+$(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/kubectl-cert_manager
 	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
 
-bin/release/cert-manager-kubectl-cert_manager-windows-amd64.zip: bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.zip: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager.exe
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	pushd $(TARDIR) && zip -r $(notdir $@) . && popd && mv $(TARDIR)/$(notdir $@) $@
 	rm -rf $(TARDIR)
 
-bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz: bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
-	@$(eval TARDIR := bin/scratch/$(notdir $@))
+$(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz: $(BINDIR)/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch $(BINDIR)/release
+	@$(eval TARDIR := $(BINDIR)/scratch/$(notdir $@))
 	mkdir -p $(TARDIR)
 	cp $< $(TARDIR)/kubectl-cert_manager.exe
-	cp bin/scratch/cert-manager.license $(TARDIR)/LICENSE
+	cp $(BINDIR)/scratch/cert-manager.license $(TARDIR)/LICENSE
 	# removes leading ./ from archived paths
 	find $(TARDIR) -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(TARDIR) -T -
 	rm -rf $(TARDIR)
 
-bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json: bin/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "windows" \
@@ -218,7 +218,7 @@ bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.jso
 		'.name = $$name | .sha256 = $$sha256 | .os = $$os | .architecture = $$architecture' \
 		hack/artifact-metadata.template.json > $@
 
-bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json: bin/release/cert-manager-kubectl-cert_manager-windows-amd64.zip hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json: $(BINDIR)/release/cert-manager-kubectl-cert_manager-windows-amd64.zip hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "windows" \

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -38,9 +38,9 @@ BASE_IMAGE_cmctl-linux-arm:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_arm)
 all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-manager-acmesolver-linux cert-manager-cainjector-linux cert-manager-ctl-linux
 
 .PHONY: cert-manager-controller-linux
-cert-manager-controller-linux: bin/containers/cert-manager-controller-linux-amd64.tar.gz bin/containers/cert-manager-controller-linux-arm64.tar.gz bin/containers/cert-manager-controller-linux-s390x.tar.gz bin/containers/cert-manager-controller-linux-ppc64le.tar.gz bin/containers/cert-manager-controller-linux-arm.tar.gz
+cert-manager-controller-linux: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-arm.tar.gz
 
-bin/containers/cert-manager-controller-linux-amd64.tar bin/containers/cert-manager-controller-linux-arm64.tar bin/containers/cert-manager-controller-linux-s390x.tar bin/containers/cert-manager-controller-linux-ppc64le.tar bin/containers/cert-manager-controller-linux-arm.tar: bin/containers/cert-manager-controller-linux-%.tar: bin/scratch/build-context/cert-manager-controller-linux-%/controller hack/containers/Containerfile.controller bin/scratch/build-context/cert-manager-controller-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-controller-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
+$(BINDIR)/containers/cert-manager-controller-linux-amd64.tar $(BINDIR)/containers/cert-manager-controller-linux-arm64.tar $(BINDIR)/containers/cert-manager-controller-linux-s390x.tar $(BINDIR)/containers/cert-manager-controller-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-controller-linux-arm.tar: $(BINDIR)/containers/cert-manager-controller-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/controller hack/containers/Containerfile.controller $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
 	@$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_controller-linux-$*)
 	$(CTR) build --quiet \
@@ -51,9 +51,9 @@ bin/containers/cert-manager-controller-linux-amd64.tar bin/containers/cert-manag
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-webhook-linux
-cert-manager-webhook-linux: bin/containers/cert-manager-webhook-linux-amd64.tar.gz bin/containers/cert-manager-webhook-linux-arm64.tar.gz bin/containers/cert-manager-webhook-linux-s390x.tar.gz bin/containers/cert-manager-webhook-linux-ppc64le.tar.gz bin/containers/cert-manager-webhook-linux-arm.tar.gz
+cert-manager-webhook-linux: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-arm.tar.gz
 
-bin/containers/cert-manager-webhook-linux-amd64.tar bin/containers/cert-manager-webhook-linux-arm64.tar bin/containers/cert-manager-webhook-linux-s390x.tar bin/containers/cert-manager-webhook-linux-ppc64le.tar bin/containers/cert-manager-webhook-linux-arm.tar: bin/containers/cert-manager-webhook-linux-%.tar: bin/scratch/build-context/cert-manager-webhook-linux-%/webhook hack/containers/Containerfile.webhook bin/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
+$(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar $(BINDIR)/containers/cert-manager-webhook-linux-arm64.tar $(BINDIR)/containers/cert-manager-webhook-linux-s390x.tar $(BINDIR)/containers/cert-manager-webhook-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-webhook-linux-arm.tar: $(BINDIR)/containers/cert-manager-webhook-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/webhook hack/containers/Containerfile.webhook $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
 	@$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_webhook-linux-$*)
 	$(CTR) build --quiet \
@@ -64,9 +64,9 @@ bin/containers/cert-manager-webhook-linux-amd64.tar bin/containers/cert-manager-
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-cainjector-linux
-cert-manager-cainjector-linux: bin/containers/cert-manager-cainjector-linux-amd64.tar.gz bin/containers/cert-manager-cainjector-linux-arm64.tar.gz bin/containers/cert-manager-cainjector-linux-s390x.tar.gz bin/containers/cert-manager-cainjector-linux-ppc64le.tar.gz bin/containers/cert-manager-cainjector-linux-arm.tar.gz
+cert-manager-cainjector-linux: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-bin/containers/cert-manager-cainjector-linux-amd64.tar bin/containers/cert-manager-cainjector-linux-arm64.tar bin/containers/cert-manager-cainjector-linux-s390x.tar bin/containers/cert-manager-cainjector-linux-ppc64le.tar bin/containers/cert-manager-cainjector-linux-arm.tar: bin/containers/cert-manager-cainjector-linux-%.tar: bin/scratch/build-context/cert-manager-cainjector-linux-%/cainjector hack/containers/Containerfile.cainjector bin/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
+$(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar $(BINDIR)/containers/cert-manager-cainjector-linux-arm64.tar $(BINDIR)/containers/cert-manager-cainjector-linux-s390x.tar $(BINDIR)/containers/cert-manager-cainjector-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-cainjector-linux-arm.tar: $(BINDIR)/containers/cert-manager-cainjector-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cainjector hack/containers/Containerfile.cainjector $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
 	@$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_cainjector-linux-$*)
 	$(CTR) build --quiet \
@@ -77,9 +77,9 @@ bin/containers/cert-manager-cainjector-linux-amd64.tar bin/containers/cert-manag
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-acmesolver-linux
-cert-manager-acmesolver-linux: bin/containers/cert-manager-acmesolver-linux-amd64.tar.gz bin/containers/cert-manager-acmesolver-linux-arm64.tar.gz bin/containers/cert-manager-acmesolver-linux-s390x.tar.gz bin/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz bin/containers/cert-manager-acmesolver-linux-arm.tar.gz
+cert-manager-acmesolver-linux: $(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-bin/containers/cert-manager-acmesolver-linux-amd64.tar bin/containers/cert-manager-acmesolver-linux-arm64.tar bin/containers/cert-manager-acmesolver-linux-s390x.tar bin/containers/cert-manager-acmesolver-linux-ppc64le.tar bin/containers/cert-manager-acmesolver-linux-arm.tar: bin/containers/cert-manager-acmesolver-linux-%.tar: bin/scratch/build-context/cert-manager-acmesolver-linux-%/acmesolver hack/containers/Containerfile.acmesolver bin/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
+$(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-arm64.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-s390x.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-arm.tar: $(BINDIR)/containers/cert-manager-acmesolver-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/acmesolver hack/containers/Containerfile.acmesolver $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
 	@$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_acmesolver-linux-$*)
 	$(CTR) build --quiet \
@@ -90,9 +90,9 @@ bin/containers/cert-manager-acmesolver-linux-amd64.tar bin/containers/cert-manag
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-ctl-linux
-cert-manager-ctl-linux: bin/containers/cert-manager-ctl-linux-amd64.tar.gz bin/containers/cert-manager-ctl-linux-arm64.tar.gz bin/containers/cert-manager-ctl-linux-s390x.tar.gz bin/containers/cert-manager-ctl-linux-ppc64le.tar.gz bin/containers/cert-manager-ctl-linux-arm.tar.gz
+cert-manager-ctl-linux: $(BINDIR)/containers/cert-manager-ctl-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-ctl-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-ctl-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-ctl-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-ctl-linux-arm.tar.gz
 
-$(foreach arch,$(ARCHS),bin/containers/cert-manager-ctl-linux-$(arch).tar): bin/containers/cert-manager-ctl-linux-%.tar: bin/scratch/build-context/cert-manager-ctl-linux-%/ctl hack/containers/Containerfile.ctl bin/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.license bin/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.licenses_notice bin/release-version | bin/containers
+$(foreach arch,$(ARCHS),$(BINDIR)/containers/cert-manager-ctl-linux-$(arch).tar): $(BINDIR)/containers/cert-manager-ctl-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-ctl-linux-%/ctl hack/containers/Containerfile.ctl $(BINDIR)/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-ctl-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
 	@$(eval TAG := cert-manager-ctl-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_cmctl-linux-$*)
 	$(CTR) build --quiet \
@@ -105,10 +105,10 @@ $(foreach arch,$(ARCHS),bin/containers/cert-manager-ctl-linux-$(arch).tar): bin/
 # At first, we used .INTERMEDIATE to remove the intermediate .tar files.
 # But it meant "make install" would always have to rebuild
 # the tar files.
-bin/containers/cert-manager-%.tar.gz: bin/containers/cert-manager-%.tar
+$(BINDIR)/containers/cert-manager-%.tar.gz: $(BINDIR)/containers/cert-manager-%.tar
 	gzip -c $< > $@
 
-bin/containers:
+$(BINDIR)/containers:
 	@mkdir -p $@
 
 # When running "docker build .", the "build context" was getting too big (1.1 GB
@@ -120,19 +120,19 @@ bin/containers:
 #
 # Note that we can't use symlinks in the build context. In order to avoid the
 # cost of multiple copies of the same binary, we use hard links which shouldn't
-# be a problem since the bin/ folder is entirely managed by make.
+# be a problem since the $(BINDIR)/ folder is entirely managed by make.
 
-$(foreach arch,$(ARCHS),$(foreach bin,$(BINS), bin/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
+$(foreach arch,$(ARCHS),$(foreach bin,$(BINS), $(BINDIR)/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@
 
-bin/scratch/build-context/cert-manager-%/cert-manager.license: bin/scratch/cert-manager.license | bin/scratch/build-context/cert-manager-%
+$(BINDIR)/scratch/build-context/cert-manager-%/cert-manager.license: $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch/build-context/cert-manager-%
 	@ln -f $< $@
 
-bin/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: bin/scratch/cert-manager.licenses_notice | bin/scratch/build-context/cert-manager-%
+$(BINDIR)/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: $(BINDIR)/scratch/cert-manager.licenses_notice | $(BINDIR)/scratch/build-context/cert-manager-%
 	@ln -f $< $@
 
-bin/scratch/build-context/cert-manager-%/controller bin/scratch/build-context/cert-manager-%/acmesolver bin/scratch/build-context/cert-manager-%/cainjector bin/scratch/build-context/cert-manager-%/webhook: bin/server/% | bin/scratch/build-context/cert-manager-%
+$(BINDIR)/scratch/build-context/cert-manager-%/controller $(BINDIR)/scratch/build-context/cert-manager-%/acmesolver $(BINDIR)/scratch/build-context/cert-manager-%/cainjector $(BINDIR)/scratch/build-context/cert-manager-%/webhook: $(BINDIR)/server/% | $(BINDIR)/scratch/build-context/cert-manager-%
 	@ln -f $< $@
 
-bin/scratch/build-context/cert-manager-ctl-%/ctl: bin/cmctl/cmctl-% | bin/scratch/build-context/cert-manager-ctl-%
+$(BINDIR)/scratch/build-context/cert-manager-ctl-%/ctl: $(BINDIR)/cmctl/cmctl-% | $(BINDIR)/scratch/build-context/cert-manager-ctl-%
 	@ln -f $< $@

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 The cert-manager Authors.
+# Copyright 2022 The cert-manager Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ source "$here/config/lib.sh"
 cd "$here/.." || exit 1
 set -e
 
-ARTIFACTS=${ARTIFACTS:-$(pwd)/bin/artifacts}
+_default_bindir=$(make print-bindir)
+
+BINDIR=${BINDIR:-$_default_bindir}
+ARTIFACTS=${ARTIFACTS:-$(pwd)/$BINDIR/artifacts}
 
 # Why do we only run 20 tests concurrently? Because we have noticed that
 # many tests start timing out when the Prow pod gets overloaded. We are
@@ -103,7 +106,7 @@ Environment variables:
       to $feature_gates
   ${green}ARTIFACTS${end}
       The path to a directory where the JUnit XML files will be stored. By
-      default, the JUnit XML files are saved to ./bin/artifacts
+      default, the JUnit XML files are saved to ./$BINDIR/artifacts
 
 Details:
   Imagine you got the following failure:

--- a/make/git.mk
+++ b/make/git.mk
@@ -40,7 +40,5 @@ $(BINDIR)/scratch/git/upstream-tags.txt: | $(BINDIR)/scratch/git
 $(BINDIR)/release-version: FORCE | $(BINDIR)
 	@test "$(RELEASE_VERSION)" == "$(shell cat $@ 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
 
-FORCE:
-
 $(BINDIR)/scratch/git:
 	@mkdir -p $@

--- a/make/git.mk
+++ b/make/git.mk
@@ -19,7 +19,7 @@ gitver:
 # duplicate CRD resources (2 CRDs with the same name) which in turn can cause problems
 # with the versionchecker test.
 # Open question: how do we decide when to refresh this target?
-bin/scratch/git/upstream-tags.txt: | bin/scratch/git
+$(BINDIR)/scratch/git/upstream-tags.txt: | $(BINDIR)/scratch/git
 	git ls-remote --tags --refs https://github.com/cert-manager/cert-manager.git | \
 		awk '{print $$2;}' | \
 		sed 's/refs\/tags\///' | \
@@ -27,20 +27,20 @@ bin/scratch/git/upstream-tags.txt: | bin/scratch/git
 		grep -v "v1.2.0-alpha.1" > $@
 
 # The file "release-version" gets updated whenever git describe --tags changes.
-# This is used by the bin/containers/*.tar.gz targets to make sure that the
+# This is used by the $(BINDIR)/containers/*.tar.gz targets to make sure that the
 # containers, which use the output of "git describe --tags" as their tag, get
 # rebuilt whenever you check out a different commit. If we didn't do this, the
-# Helm chart bin/cert-manager-*.tgz would refer to an image tag that doesn't
-# exist in bin/containers/*.tar.gz.
+# Helm chart $(BINDIR)/cert-manager-*.tgz would refer to an image tag that doesn't
+# exist in $(BINDIR)/containers/*.tar.gz.
 #
 # We use FORCE instead of .PHONY because this is a real file that can be used as
 # a prerequisite. If we were to use .PHONY, then the file's timestamp would not
 # be used to check whether targets should be rebuilt, and they would get
 # constantly rebuilt.
-bin/release-version: FORCE | bin
+$(BINDIR)/release-version: FORCE | $(BINDIR)
 	@test "$(RELEASE_VERSION)" == "$(shell cat $@ 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
 
 FORCE:
 
-bin/scratch/git:
+$(BINDIR)/scratch/git:
 	@mkdir -p $@

--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -6,18 +6,18 @@ LICENSE_YEAR=2021
 
 # Creates the boilerplate header for YAML files, assumed to be the same as the one in
 # shell scripts (hence the use of boilerplate.sh.txt)
-bin/scratch/license.yaml: hack/boilerplate/boilerplate.sh.txt | bin/scratch
+$(BINDIR)/scratch/license.yaml: hack/boilerplate/boilerplate.sh.txt | $(BINDIR)/scratch
 	sed -e "s/YEAR/$(LICENSE_YEAR)/g" < $< > $@
 
 # The references LICENSES file is 1.4MB at the time of writing. Bundling it into every container image
 # seems wasteful in terms of bytes stored and bytes transferred on the wire just to add a file
 # which presumably nobody will ever read or care about. Instead, just add a little footnote pointing
 # to the cert-manager repo in case anybody actually decides that they care.
-bin/scratch/license-footnote.yaml: | bin/scratch
+$(BINDIR)/scratch/license-footnote.yaml: | $(BINDIR)/scratch
 	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GITCOMMIT)/LICENSES" > $@
 
-bin/scratch/cert-manager.license: bin/scratch/license.yaml bin/scratch/license-footnote.yaml | bin/scratch
+$(BINDIR)/scratch/cert-manager.license: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
 	cat $^ > $@
 
-bin/scratch/cert-manager.licenses_notice: bin/scratch/license-footnote.yaml | bin/scratch
+$(BINDIR)/scratch/cert-manager.licenses_notice: $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
 	cp $< $@

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,9 +1,9 @@
-HELM_CMD=./bin/tools/helm
+HELM_CMD=./$(BINDIR)/tools/helm
 
 ALLCRDS=deploy/crds/crd-certificaterequests.yaml deploy/crds/crd-certificates.yaml deploy/crds/crd-challenges.yaml deploy/crds/crd-clusterissuers.yaml deploy/crds/crd-issuers.yaml deploy/crds/crd-orders.yaml
 
 HELM_TEMPLATE_SOURCES=$(wildcard deploy/charts/cert-manager/templates/*.yaml)
-HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,bin/helm/cert-manager/templates/%,$(HELM_TEMPLATE_SOURCES))
+HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,$(BINDIR)/helm/cert-manager/templates/%,$(HELM_TEMPLATE_SOURCES))
 
 ####################
 # Friendly Targets #
@@ -12,16 +12,16 @@ HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,bin/helm
 # These targets provide friendly names for the various manifests / charts we build
 
 .PHONY: helm-chart
-helm-chart: bin/cert-manager-$(RELEASE_VERSION).tgz
+helm-chart: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
 
-bin/cert-manager.tgz: bin/cert-manager-$(RELEASE_VERSION).tgz
+$(BINDIR)/cert-manager.tgz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
 	@ln -s -f $(notdir $<) $@
 
 .PHONY: helm-chart-signature
-helm-chart-signature: bin/cert-manager-$(RELEASE_VERSION).tgz.prov
+helm-chart-signature: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov
 
 .PHONY: static-manifests
-static-manifests: bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml
+static-manifests: $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml
 
 ###################
 # Release Targets #
@@ -31,7 +31,7 @@ static-manifests: bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml
 ## Build YAML manifests and helm charts (but not the helm chart signature)
 ##
 ## @category Release
-release-manifests: bin/scratch/cert-manager-manifests-unsigned.tar.gz
+release-manifests: $(BINDIR)/scratch/cert-manager-manifests-unsigned.tar.gz
 
 .PHONY: release-manifests-signed
 ## Build YAML manifests and helm charts including the helm chart signature
@@ -40,29 +40,29 @@ release-manifests: bin/scratch/cert-manager-manifests-unsigned.tar.gz
 ## Prefer `make release-manifests` locally.
 ##
 ## @category Release
-release-manifests-signed: bin/release/cert-manager-manifests.tar.gz bin/metadata/cert-manager-manifests.tar.gz.metadata.json
+release-manifests-signed: $(BINDIR)/release/cert-manager-manifests.tar.gz $(BINDIR)/metadata/cert-manager-manifests.tar.gz.metadata.json
 
-bin/release/cert-manager-manifests.tar.gz: bin/cert-manager-$(RELEASE_VERSION).tgz bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml bin/cert-manager-$(RELEASE_VERSION).tgz.prov | bin/scratch/manifests bin/release
-	mkdir -p bin/scratch/manifests/deploy/chart/
-	mkdir -p bin/scratch/manifests/deploy/manifests/
-	cp bin/cert-manager-$(RELEASE_VERSION).tgz bin/cert-manager-$(RELEASE_VERSION).tgz.prov bin/scratch/manifests/deploy/chart/
-	cp bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml bin/scratch/manifests/deploy/manifests/
+$(BINDIR)/release/cert-manager-manifests.tar.gz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov | $(BINDIR)/scratch/manifests $(BINDIR)/release
+	mkdir -p $(BINDIR)/scratch/manifests/deploy/chart/
+	mkdir -p $(BINDIR)/scratch/manifests/deploy/manifests/
+	cp $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov $(BINDIR)/scratch/manifests/deploy/chart/
+	cp $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/scratch/manifests/deploy/manifests/
 	# removes leading ./ from archived paths
-	find bin/scratch/manifests -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C bin/scratch/manifests -T -
-	rm -rf bin/scratch/manifests
+	find $(BINDIR)/scratch/manifests -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(BINDIR)/scratch/manifests -T -
+	rm -rf $(BINDIR)/scratch/manifests
 
-bin/scratch/cert-manager-manifests-unsigned.tar.gz: bin/cert-manager-$(RELEASE_VERSION).tgz bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml | bin/scratch/manifests
-	mkdir -p bin/scratch/manifests/deploy/chart/
-	mkdir -p bin/scratch/manifests/deploy/manifests/
-	cp bin/cert-manager-$(RELEASE_VERSION).tgz bin/scratch/manifests/deploy/chart/
-	cp bin/yaml/cert-manager.crds.yaml bin/yaml/cert-manager.yaml bin/scratch/manifests/deploy/manifests/
+$(BINDIR)/scratch/cert-manager-manifests-unsigned.tar.gz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml | $(BINDIR)/scratch/manifests
+	mkdir -p $(BINDIR)/scratch/manifests/deploy/chart/
+	mkdir -p $(BINDIR)/scratch/manifests/deploy/manifests/
+	cp $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/scratch/manifests/deploy/chart/
+	cp $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/scratch/manifests/deploy/manifests/
 	# removes leading ./ from archived paths
-	find bin/scratch/manifests -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C bin/scratch/manifests -T -
-	rm -rf bin/scratch/manifests
+	find $(BINDIR)/scratch/manifests -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(BINDIR)/scratch/manifests -T -
+	rm -rf $(BINDIR)/scratch/manifests
 
 # This metadata blob is constructed slightly differently and doesn't use hack/artifact-metadata.template.json directly;
 # this is because the bazel staged releases didn't include an "os" or "architecture" field for this artifact
-bin/metadata/cert-manager-manifests.tar.gz.metadata.json: bin/release/cert-manager-manifests.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-manifests.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-manifests.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq -n --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		'.name = $$name | .sha256 = $$sha256' > $@
@@ -73,41 +73,41 @@ bin/metadata/cert-manager-manifests.tar.gz.metadata.json: bin/release/cert-manag
 
 # These targets provide for building and signing the cert-manager helm chart.
 
-bin/cert-manager-$(RELEASE_VERSION).tgz: bin/helm/cert-manager/README.md bin/helm/cert-manager/Chart.yaml bin/helm/cert-manager/values.yaml $(HELM_TEMPLATE_TARGETS) bin/helm/cert-manager/templates/NOTES.txt bin/helm/cert-manager/templates/_helpers.tpl bin/helm/cert-manager/templates/crds.yaml bin/tools/helm | bin/helm/cert-manager
-	$(HELM_CMD) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./bin/helm/cert-manager
+$(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz: $(BINDIR)/helm/cert-manager/README.md $(BINDIR)/helm/cert-manager/Chart.yaml $(BINDIR)/helm/cert-manager/values.yaml $(HELM_TEMPLATE_TARGETS) $(BINDIR)/helm/cert-manager/templates/NOTES.txt $(BINDIR)/helm/cert-manager/templates/_helpers.tpl $(BINDIR)/helm/cert-manager/templates/crds.yaml $(BINDIR)/tools/helm | $(BINDIR)/helm/cert-manager
+	$(HELM_CMD) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./$(BINDIR)/helm/cert-manager
 
-bin/cert-manager-$(RELEASE_VERSION).tgz.prov: bin/cert-manager-$(RELEASE_VERSION).tgz | bin/helm/cert-manager bin/tools/cmrel
+$(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz | $(BINDIR)/helm/cert-manager $(BINDIR)/tools/cmrel
 ifeq ($(strip $(CMREL_KEY)),)
 	$(error Trying to sign helm chart but CMREL_KEY is empty)
 endif
 	cd $(dir $<) && $(CMREL) sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
 
-bin/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | bin/helm/cert-manager/templates
+$(BINDIR)/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | $(BINDIR)/helm/cert-manager/templates
 	cp -f $^ $@
 
-bin/helm/cert-manager/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | bin/helm/cert-manager/templates
+$(BINDIR)/helm/cert-manager/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | $(BINDIR)/helm/cert-manager/templates
 	cp $< $@
 
-bin/helm/cert-manager/templates/NOTES.txt: deploy/charts/cert-manager/templates/NOTES.txt | bin/helm/cert-manager/templates
+$(BINDIR)/helm/cert-manager/templates/NOTES.txt: deploy/charts/cert-manager/templates/NOTES.txt | $(BINDIR)/helm/cert-manager/templates
 	cp $< $@
 
-bin/helm/cert-manager/templates/crds.yaml: bin/scratch/yaml/cert-manager-crd-templates.yaml | bin/helm/cert-manager/templates
+$(BINDIR)/helm/cert-manager/templates/crds.yaml: $(BINDIR)/scratch/yaml/cert-manager-crd-templates.yaml | $(BINDIR)/helm/cert-manager/templates
 	echo '{{- if .Values.installCRDs }}' > $@
 	cat $< >> $@
 	echo '{{- end }}' >> $@
 
-bin/helm/cert-manager/values.yaml: deploy/charts/cert-manager/values.yaml | bin/helm/cert-manager
+$(BINDIR)/helm/cert-manager/values.yaml: deploy/charts/cert-manager/values.yaml | $(BINDIR)/helm/cert-manager
 	cp $< $@
 
-bin/helm/cert-manager/README.md: deploy/charts/cert-manager/README.template.md | bin/helm/cert-manager
+$(BINDIR)/helm/cert-manager/README.md: deploy/charts/cert-manager/README.template.md | $(BINDIR)/helm/cert-manager
 	sed -e "s:{{RELEASE_VERSION}}:$(RELEASE_VERSION):g" < $< > $@
 
-bin/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml deploy/charts/cert-manager/signkey_annotation.txt bin/tools/yq | bin/helm/cert-manager
+$(BINDIR)/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml deploy/charts/cert-manager/signkey_annotation.txt $(BINDIR)/tools/yq | $(BINDIR)/helm/cert-manager
 	@# this horrible mess is taken from the YQ manual's example of multiline string blocks from a file:
 	@# https://mikefarah.gitbook.io/yq/operators/string-operators#string-blocks-bash-and-newlines
 	@# we set a bash variable called SIGNKEY_ANNOTATION using read, and then use that bash variable in yq
 	IFS= read -rd '' SIGNKEY_ANNOTATION < <(cat deploy/charts/cert-manager/signkey_annotation.txt) ; \
-		SIGNKEY_ANNOTATION=$$SIGNKEY_ANNOTATION bin/tools/yq eval \
+		SIGNKEY_ANNOTATION=$$SIGNKEY_ANNOTATION $(BINDIR)/tools/yq eval \
 		'.annotations."artifacthub.io/signKey" = strenv(SIGNKEY_ANNOTATION) | .annotations."artifacthub.io/prerelease" = "$(IS_PRERELEASE)" | .version = "$(RELEASE_VERSION)" | .appVersion = "$(RELEASE_VERSION)"' \
 		$< > $@
 
@@ -119,12 +119,12 @@ bin/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml
 # They use `helm template` to create a single static YAML manifest containing all resources
 # with templating completed, and then concatenate with the cert-manager namespace and the CRDs.
 
-bin/yaml/cert-manager.yaml: bin/scratch/license.yaml deploy/manifests/namespace.yaml bin/scratch/yaml/cert-manager.crds.unlicensed.yaml bin/scratch/yaml/cert-manager-static-resources.yaml | bin/yaml
+$(BINDIR)/yaml/cert-manager.yaml: $(BINDIR)/scratch/license.yaml deploy/manifests/namespace.yaml $(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml $(BINDIR)/scratch/yaml/cert-manager-static-resources.yaml | $(BINDIR)/yaml
 	@# NB: filter-out removes the license (the first dependency, $<) from the YAML concatenation
 	./hack/concat-yaml.sh $(filter-out $<, $^) | cat $< - > $@
 
 # Renders all resources except the namespace and the CRDs
-bin/scratch/yaml/cert-manager-static-resources.yaml: bin/cert-manager-$(RELEASE_VERSION).tgz bin/tools/helm | bin/scratch/yaml
+$(BINDIR)/scratch/yaml/cert-manager-static-resources.yaml: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/tools/helm | $(BINDIR)/scratch/yaml
 	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM_CMD) template --api-versions="" --namespace=cert-manager --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
@@ -137,43 +137,43 @@ bin/scratch/yaml/cert-manager-static-resources.yaml: bin/cert-manager-$(RELEASE_
 # to create a single YAML file containing all CRDS with the templating completed
 
 # CRDs with a license
-bin/yaml/cert-manager.crds.yaml: bin/scratch/license.yaml bin/scratch/yaml/cert-manager.crds.unlicensed.yaml | bin/yaml
+$(BINDIR)/yaml/cert-manager.crds.yaml: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml | $(BINDIR)/yaml
 	cat $^ > $@
 
-bin/scratch/yaml/cert-manager.crds.unlicensed.yaml: bin/scratch/cert-manager-crds/cert-manager-$(RELEASE_VERSION).tgz bin/tools/helm | bin/scratch/yaml
+$(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml: $(BINDIR)/scratch/cert-manager-crds/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/tools/helm | $(BINDIR)/scratch/yaml
 	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM_CMD) template --api-versions="" --namespace=cert-manager --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
 
-bin/scratch/cert-manager-crds/cert-manager-$(RELEASE_VERSION).tgz: bin/helm/cert-manager-crds/templates/_helpers.tpl bin/helm/cert-manager-crds/templates/crd-templates.yaml bin/helm/cert-manager-crds/README.md bin/helm/cert-manager-crds/Chart.yaml bin/helm/cert-manager-crds/values.yaml bin/tools/helm | bin/scratch
-	$(HELM_CMD) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./bin/helm/cert-manager-crds
+$(BINDIR)/scratch/cert-manager-crds/cert-manager-$(RELEASE_VERSION).tgz: $(BINDIR)/helm/cert-manager-crds/templates/_helpers.tpl $(BINDIR)/helm/cert-manager-crds/templates/crd-templates.yaml $(BINDIR)/helm/cert-manager-crds/README.md $(BINDIR)/helm/cert-manager-crds/Chart.yaml $(BINDIR)/helm/cert-manager-crds/values.yaml $(BINDIR)/tools/helm | $(BINDIR)/scratch
+	$(HELM_CMD) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./$(BINDIR)/helm/cert-manager-crds
 
 # create a temporary chart containing the cert-manager CRDs in order to use helm's
 # templating engine to create usable CRDs for static installation
-bin/helm/cert-manager-crds/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml | bin/helm/cert-manager-crds
+$(BINDIR)/helm/cert-manager-crds/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml | $(BINDIR)/helm/cert-manager-crds
 	sed -e "s:{{IS_PRERELEASE}}:$(IS_PRERELEASE):g" \
 		-e "s:{{RELEASE_VERSION}}:$(RELEASE_VERSION):g" < $< > $@
 
-bin/helm/cert-manager-crds/README.md: | bin/helm/cert-manager-crds
+$(BINDIR)/helm/cert-manager-crds/README.md: | $(BINDIR)/helm/cert-manager-crds
 	@echo "This chart is a cert-manager build artifact, do not use" > $@
 
-bin/helm/cert-manager-crds/values.yaml: deploy/charts/cert-manager/values.yaml | bin/helm/cert-manager
+$(BINDIR)/helm/cert-manager-crds/values.yaml: deploy/charts/cert-manager/values.yaml | $(BINDIR)/helm/cert-manager
 	cp $< $@
 
-bin/helm/cert-manager-crds/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | bin/helm/cert-manager-crds/templates
+$(BINDIR)/helm/cert-manager-crds/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | $(BINDIR)/helm/cert-manager-crds/templates
 	cp $< $@
 
-bin/helm/cert-manager-crds/templates/crd-templates.yaml: bin/scratch/yaml/cert-manager-crd-templates.yaml | bin/helm/cert-manager-crds/templates
+$(BINDIR)/helm/cert-manager-crds/templates/crd-templates.yaml: $(BINDIR)/scratch/yaml/cert-manager-crd-templates.yaml | $(BINDIR)/helm/cert-manager-crds/templates
 	cp $< $@
 
 # Create a single file containing all CRDs before they've been templated.
-bin/scratch/yaml/cert-manager-crd-templates.yaml: $(ALLCRDS) | bin/scratch/yaml
+$(BINDIR)/scratch/yaml/cert-manager-crd-templates.yaml: $(ALLCRDS) | $(BINDIR)/scratch/yaml
 	./hack/concat-yaml.sh $^ > $@
 
 .PHONY: templated-crds
-templated-crds: bin/yaml/templated-crds/crd-challenges.templated.yaml bin/yaml/templated-crds/crd-orders.templated.yaml bin/yaml/templated-crds/crd-certificaterequests.templated.yaml bin/yaml/templated-crds/crd-clusterissuers.templated.yaml bin/yaml/templated-crds/crd-issuers.templated.yaml bin/yaml/templated-crds/crd-certificates.templated.yaml
+templated-crds: $(BINDIR)/yaml/templated-crds/crd-challenges.templated.yaml $(BINDIR)/yaml/templated-crds/crd-orders.templated.yaml $(BINDIR)/yaml/templated-crds/crd-certificaterequests.templated.yaml $(BINDIR)/yaml/templated-crds/crd-clusterissuers.templated.yaml $(BINDIR)/yaml/templated-crds/crd-issuers.templated.yaml $(BINDIR)/yaml/templated-crds/crd-certificates.templated.yaml
 
-bin/yaml/templated-crds/crd-challenges.templated.yaml bin/yaml/templated-crds/crd-orders.templated.yaml bin/yaml/templated-crds/crd-certificaterequests.templated.yaml bin/yaml/templated-crds/crd-clusterissuers.templated.yaml bin/yaml/templated-crds/crd-issuers.templated.yaml bin/yaml/templated-crds/crd-certificates.templated.yaml: bin/yaml/templated-crds/crd-%.templated.yaml: bin/yaml/cert-manager.yaml $(DEPENDS_ON_GO) | bin/yaml/templated-crds
+$(BINDIR)/yaml/templated-crds/crd-challenges.templated.yaml $(BINDIR)/yaml/templated-crds/crd-orders.templated.yaml $(BINDIR)/yaml/templated-crds/crd-certificaterequests.templated.yaml $(BINDIR)/yaml/templated-crds/crd-clusterissuers.templated.yaml $(BINDIR)/yaml/templated-crds/crd-issuers.templated.yaml $(BINDIR)/yaml/templated-crds/crd-certificates.templated.yaml: $(BINDIR)/yaml/templated-crds/crd-%.templated.yaml: $(BINDIR)/yaml/cert-manager.yaml $(DEPENDS_ON_GO) | $(BINDIR)/yaml/templated-crds
 	$(GO) run hack/extractcrd/main.go $< $* > $@
 
 ###############
@@ -182,26 +182,26 @@ bin/yaml/templated-crds/crd-challenges.templated.yaml bin/yaml/templated-crds/cr
 
 # These targets are trivial, to ensure that dirs exist
 
-bin/yaml:
+$(BINDIR)/yaml:
 	@mkdir -p $@
 
-bin/helm/cert-manager:
+$(BINDIR)/helm/cert-manager:
 	@mkdir -p $@
 
-bin/helm/cert-manager/templates:
+$(BINDIR)/helm/cert-manager/templates:
 	@mkdir -p $@
 
-bin/helm/cert-manager-crds:
+$(BINDIR)/helm/cert-manager-crds:
 	@mkdir -p $@
 
-bin/helm/cert-manager-crds/templates:
+$(BINDIR)/helm/cert-manager-crds/templates:
 	@mkdir -p $@
 
-bin/scratch/yaml:
+$(BINDIR)/scratch/yaml:
 	@mkdir -p $@
 
-bin/scratch/manifests:
+$(BINDIR)/scratch/manifests:
 	@mkdir -p $@
 
-bin/yaml/templated-crds:
+$(BINDIR)/yaml/templated-crds:
 	@mkdir -p $@

--- a/make/release.mk
+++ b/make/release.mk
@@ -52,15 +52,6 @@ ifeq ($(strip $(RELEASE_TARGET_BUCKET)),)
 endif
 	./$(BINDIR)/tools/rclone copyto ./$(BINDIR)/release :gcs:$(RELEASE_TARGET_BUCKET)/stage/gcb/release/$(RELEASE_VERSION)
 
-# Example of how we can generate a SHA256SUMS file and sign it using cosign
-#$(BINDIR)/SHA256SUMS: $(wildcard ...)
-#	@# The patsubst means "all dependencies, but with "$(BINDIR)/" trimmed off the beginning
-#	@# We cd into bin so that SHA256SUMS file doesn't have a prefix of `bin` on everything
-#	cd $(dir $@) && sha256sum $(patsubst $(BINDIR)/%,%,$^) > $(notdir $@)
-
-#$(BINDIR)/SHA256SUMS.sig: $(BINDIR)/SHA256SUMS $(BINDIR)/tools/cosign
-#	$(BINDIR)/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@
-
 # Takes all metadata files in $(BINDIR)/metadata and combines them into one.
 
 $(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDIR)/release
@@ -116,3 +107,12 @@ forcetime: | $(BINDIR)
 
 $(BINDIR)/release $(BINDIR)/metadata:
 	@mkdir -p $@
+
+# Example of how we can generate a SHA256SUMS file and sign it using cosign
+#$(BINDIR)/SHA256SUMS: $(wildcard ...)
+#	@# The patsubst means "all dependencies, but with "$(BINDIR)/" trimmed off the beginning
+#	@# We cd into bin so that SHA256SUMS file doesn't have a prefix of `bin` on everything
+#	cd $(dir $@) && sha256sum $(patsubst $(BINDIR)/%,%,$^) > $(notdir $@)
+
+#$(BINDIR)/SHA256SUMS.sig: $(BINDIR)/SHA256SUMS $(BINDIR)/tools/cosign
+#	$(BINDIR)/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@

--- a/make/release.mk
+++ b/make/release.mk
@@ -39,31 +39,31 @@ release-artifacts-signed: release-artifacts release-manifests-signed
 ##
 ## @category Release
 release: release-artifacts-signed
-	$(MAKE) --no-print-directory bin/release/metadata.json
+	$(MAKE) --no-print-directory $(BINDIR)/release/metadata.json
 
 .PHONY: upload-release
 ## Create a complete release and then upload it to a target GCS bucket specified by
 ## RELEASE_TARGET_BUCKET
 ##
 ## @category Release
-upload-release: release | bin/tools/rclone
+upload-release: release | $(BINDIR)/tools/rclone
 ifeq ($(strip $(RELEASE_TARGET_BUCKET)),)
 	$(error Trying to upload-release but RELEASE_TARGET_BUCKET is empty)
 endif
-	./bin/tools/rclone copyto ./bin/release :gcs:$(RELEASE_TARGET_BUCKET)/stage/gcb/release/$(RELEASE_VERSION)
+	./$(BINDIR)/tools/rclone copyto ./$(BINDIR)/release :gcs:$(RELEASE_TARGET_BUCKET)/stage/gcb/release/$(RELEASE_VERSION)
 
 # Example of how we can generate a SHA256SUMS file and sign it using cosign
-#bin/SHA256SUMS: $(wildcard ...)
-#	@# The patsubst means "all dependencies, but with "bin/" trimmed off the beginning
+#$(BINDIR)/SHA256SUMS: $(wildcard ...)
+#	@# The patsubst means "all dependencies, but with "$(BINDIR)/" trimmed off the beginning
 #	@# We cd into bin so that SHA256SUMS file doesn't have a prefix of `bin` on everything
-#	cd $(dir $@) && sha256sum $(patsubst bin/%,%,$^) > $(notdir $@)
+#	cd $(dir $@) && sha256sum $(patsubst $(BINDIR)/%,%,$^) > $(notdir $@)
 
-#bin/SHA256SUMS.sig: bin/SHA256SUMS bin/tools/cosign
-#	bin/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@
+#$(BINDIR)/SHA256SUMS.sig: $(BINDIR)/SHA256SUMS $(BINDIR)/tools/cosign
+#	$(BINDIR)/tools/cosign sign-blob --key $(COSIGN_KEY) $< > $@
 
-# Takes all metadata files in bin/metadata and combines them into one.
+# Takes all metadata files in $(BINDIR)/metadata and combines them into one.
 
-bin/release/metadata.json: $(wildcard bin/metadata/*.json) | bin/release
+$(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDIR)/release
 	jq -n \
 		--arg releaseVersion "$(RELEASE_VERSION)" \
 		--arg buildSource "make" \
@@ -74,12 +74,12 @@ bin/release/metadata.json: $(wildcard bin/metadata/*.json) | bin/release
 release-containers: release-container-bundles release-container-metadata
 
 .PHONY: release-container-bundles
-release-container-bundles: bin/release/cert-manager-server-linux-amd64.tar.gz bin/release/cert-manager-server-linux-arm64.tar.gz bin/release/cert-manager-server-linux-s390x.tar.gz bin/release/cert-manager-server-linux-ppc64le.tar.gz bin/release/cert-manager-server-linux-arm.tar.gz
+release-container-bundles: $(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-server-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-server-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm.tar.gz
 
-bin/release/cert-manager-server-linux-amd64.tar.gz bin/release/cert-manager-server-linux-arm64.tar.gz bin/release/cert-manager-server-linux-s390x.tar.gz bin/release/cert-manager-server-linux-ppc64le.tar.gz bin/release/cert-manager-server-linux-arm.tar.gz: bin/release/cert-manager-server-linux-%.tar.gz: bin/containers/cert-manager-acmesolver-linux-%.tar.gz bin/containers/cert-manager-cainjector-linux-%.tar.gz bin/containers/cert-manager-controller-linux-%.tar.gz bin/containers/cert-manager-webhook-linux-%.tar.gz bin/containers/cert-manager-ctl-linux-%.tar.gz bin/scratch/cert-manager.license | bin/release bin/scratch
+$(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-server-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-server-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-server-linux-%.tar.gz: $(BINDIR)/containers/cert-manager-acmesolver-linux-%.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-%.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-%.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-%.tar.gz $(BINDIR)/containers/cert-manager-ctl-linux-%.tar.gz $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/release $(BINDIR)/scratch
 	@# use basename twice to strip both "tar" and "gz"
 	@$(eval CTR_BASENAME := $(basename $(basename $(notdir $@))))
-	@$(eval CTR_SCRATCHDIR := bin/scratch/release-container-bundle/$(CTR_BASENAME))
+	@$(eval CTR_SCRATCHDIR := $(BINDIR)/scratch/release-container-bundle/$(CTR_BASENAME))
 	mkdir -p $(CTR_SCRATCHDIR)/server/images
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/version
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/acmesolver.docker_tag
@@ -87,20 +87,20 @@ bin/release/cert-manager-server-linux-amd64.tar.gz bin/release/cert-manager-serv
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/controller.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/webhook.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/ctl.docker_tag
-	cp bin/scratch/cert-manager.license $(CTR_SCRATCHDIR)/LICENSES
-	gunzip -c bin/containers/cert-manager-acmesolver-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/acmesolver.tar
-	gunzip -c bin/containers/cert-manager-cainjector-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/cainjector.tar
-	gunzip -c bin/containers/cert-manager-controller-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/controller.tar
-	gunzip -c bin/containers/cert-manager-webhook-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/webhook.tar
-	gunzip -c bin/containers/cert-manager-ctl-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/ctl.tar
+	cp $(BINDIR)/scratch/cert-manager.license $(CTR_SCRATCHDIR)/LICENSES
+	gunzip -c $(BINDIR)/containers/cert-manager-acmesolver-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/acmesolver.tar
+	gunzip -c $(BINDIR)/containers/cert-manager-cainjector-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/cainjector.tar
+	gunzip -c $(BINDIR)/containers/cert-manager-controller-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/controller.tar
+	gunzip -c $(BINDIR)/containers/cert-manager-webhook-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/webhook.tar
+	gunzip -c $(BINDIR)/containers/cert-manager-ctl-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/ctl.tar
 	chmod -R 755 $(CTR_SCRATCHDIR)/server/images/*
-	tar czf $@ -C bin/scratch/release-container-bundle $(CTR_BASENAME)
+	tar czf $@ -C $(BINDIR)/scratch/release-container-bundle $(CTR_BASENAME)
 	rm -rf $(CTR_SCRATCHDIR)
 
 .PHONY: release-container-metadata
-release-container-metadata: bin/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json
+release-container-metadata: $(BINDIR)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json
 
-bin/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json: bin/metadata/cert-manager-server-linux-%.tar.gz.metadata.json: bin/release/cert-manager-server-linux-%.tar.gz hack/artifact-metadata.template.json | bin/metadata
+$(BINDIR)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-server-linux-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-server-linux-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "linux" \
@@ -111,8 +111,8 @@ bin/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json bin/metadata/c
 # This target allows us to set all the modified times for all files in bin to the same time, which
 # is similar to what bazel does. We might not want this, and it's not currently used.
 .PHONY: forcetime
-forcetime: | bin
-	find bin | xargs touch -d "2000-01-01 00:00:00" -
+forcetime: | $(BINDIR)
+	find $(BINDIR) | xargs touch -d "2000-01-01 00:00:00" -
 
-bin/release bin/metadata:
+$(BINDIR)/release $(BINDIR)/metadata:
 	@mkdir -p $@

--- a/make/server.mk
+++ b/make/server.mk
@@ -1,77 +1,77 @@
 .PHONY: server-binaries
 server-binaries: controller acmesolver webhook cainjector
 
-bin/server:
+$(BINDIR)/server:
 	@mkdir -p $@
 
 .PHONY: controller
-controller: bin/server/controller-linux-amd64 bin/server/controller-linux-arm64 bin/server/controller-linux-s390x bin/server/controller-linux-ppc64le bin/server/controller-linux-arm $(DEPENDS_ON_GO) | bin/server
+controller: $(BINDIR)/server/controller-linux-amd64 $(BINDIR)/server/controller-linux-arm64 $(BINDIR)/server/controller-linux-s390x $(BINDIR)/server/controller-linux-ppc64le $(BINDIR)/server/controller-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
-bin/server/controller-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/controller-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
 
-bin/server/controller-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/controller-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
 
-bin/server/controller-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/controller-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
 
-bin/server/controller-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/controller-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
 
-bin/server/controller-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/controller-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
 
 .PHONY: acmesolver
-acmesolver: bin/server/acmesolver-linux-amd64 bin/server/acmesolver-linux-arm64 bin/server/acmesolver-linux-s390x bin/server/acmesolver-linux-ppc64le bin/server/acmesolver-linux-arm $(DEPENDS_ON_GO) | bin/server
+acmesolver: $(BINDIR)/server/acmesolver-linux-amd64 $(BINDIR)/server/acmesolver-linux-arm64 $(BINDIR)/server/acmesolver-linux-s390x $(BINDIR)/server/acmesolver-linux-ppc64le $(BINDIR)/server/acmesolver-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
-bin/server/acmesolver-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/acmesolver-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
 
-bin/server/acmesolver-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/acmesolver-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
 
-bin/server/acmesolver-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/acmesolver-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
 
-bin/server/acmesolver-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/acmesolver-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
 
-bin/server/acmesolver-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/acmesolver-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
 
 .PHONY: webhook
-webhook: bin/server/webhook-linux-amd64 bin/server/webhook-linux-arm64 bin/server/webhook-linux-s390x bin/server/webhook-linux-ppc64le bin/server/webhook-linux-arm $(DEPENDS_ON_GO) | bin/server
+webhook: $(BINDIR)/server/webhook-linux-amd64 $(BINDIR)/server/webhook-linux-arm64 $(BINDIR)/server/webhook-linux-s390x $(BINDIR)/server/webhook-linux-ppc64le $(BINDIR)/server/webhook-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
-bin/server/webhook-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/webhook-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
 
-bin/server/webhook-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/webhook-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
 
-bin/server/webhook-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/webhook-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
 
-bin/server/webhook-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/webhook-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
 
-bin/server/webhook-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/webhook-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
 
 .PHONY: cainjector
-cainjector: bin/server/cainjector-linux-amd64 bin/server/cainjector-linux-arm64 bin/server/cainjector-linux-s390x bin/server/cainjector-linux-ppc64le bin/server/cainjector-linux-arm $(DEPENDS_ON_GO) | bin/server
+cainjector: $(BINDIR)/server/cainjector-linux-amd64 $(BINDIR)/server/cainjector-linux-arm64 $(BINDIR)/server/cainjector-linux-s390x $(BINDIR)/server/cainjector-linux-ppc64le $(BINDIR)/server/cainjector-linux-arm $(DEPENDS_ON_GO) | $(BINDIR)/server
 
-bin/server/cainjector-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/cainjector-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
 
-bin/server/cainjector-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/cainjector-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
 
-bin/server/cainjector-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/cainjector-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
 
-bin/server/cainjector-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/cainjector-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
 
-bin/server/cainjector-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
+$(BINDIR)/server/cainjector-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | $(BINDIR)/server
 	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,4 +1,4 @@
-export KUBEBUILDER_ASSETS=$(PWD)/bin/tools
+export KUBEBUILDER_ASSETS=$(PWD)/$(BINDIR)/tools
 
 # WHAT can be used to control which unit tests are run by "make test"; defaults to running all
 # tests except e2e tests (which require more significant setup)
@@ -12,7 +12,7 @@ WHAT ?= ./pkg/... ./cmd/... ./internal/... ./test/...
 ##   make test WHAT=./pkg/...
 ##
 ## @category Development
-test: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin/tools/kubectl bin/tools/kube-apiserver
+test: setup-integration-tests $(BINDIR)/tools/gotestsum $(BINDIR)/tools/etcd $(BINDIR)/tools/kubectl $(BINDIR)/tools/kube-apiserver
 	$(GOTESTSUM) -- $(WHAT)
 
 .PHONY: test-ci
@@ -24,7 +24,7 @@ test: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin/tools/kubec
 ## issues with dashboards and UIs.
 ##
 ## @category CI
-test-ci: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin/tools/kubectl bin/tools/kube-apiserver
+test-ci: setup-integration-tests $(BINDIR)/tools/gotestsum $(BINDIR)/tools/etcd $(BINDIR)/tools/kubectl $(BINDIR)/tools/kube-apiserver
 	@# Fuzz tests are hidden from JUnit output because they can break dashboards.
 	@# They look like this:
 	@# <testcase classname="internal/controller/certificates" name="Test_serializeApplyStatus/fuzz_8358"></testcase>
@@ -39,12 +39,12 @@ test-ci: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin/tools/ku
 ## or an apiserver.
 ##
 ## @category Development
-unit-test: bin/tools/gotestsum
+unit-test: $(BINDIR)/tools/gotestsum
 	$(GOTESTSUM) ./cmd/... ./pkg/... ./internal/...
 
 .PHONY: setup-integration-tests
 setup-integration-tests: test/integration/versionchecker/testdata/test_manifests.tar templated-crds
-	@$(eval GIT_TAGS_FILE := bin/scratch/git/upstream-tags.txt)
+	@$(eval GIT_TAGS_FILE := $(BINDIR)/scratch/git/upstream-tags.txt)
 	@echo -e "\033[0;33mLatest known tag for integration tests is $(shell tail -1 $(GIT_TAGS_FILE)); if that seems out-of-date,\npull latest tags, run 'rm $(GIT_TAGS_FILE)' and retest\033[0m"
 
 .PHONY: integration-test
@@ -53,7 +53,7 @@ setup-integration-tests: test/integration/versionchecker/testdata/test_manifests
 ## require a full Kubernetes cluster.
 ##
 ## @category Development
-integration-test: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin/tools/kubectl bin/tools/kube-apiserver
+integration-test: setup-integration-tests $(BINDIR)/tools/gotestsum $(BINDIR)/tools/etcd $(BINDIR)/tools/kubectl $(BINDIR)/tools/kube-apiserver
 	$(GOTESTSUM) ./test/...
 
 .PHONY: e2e
@@ -68,36 +68,36 @@ integration-test: setup-integration-tests bin/tools/gotestsum bin/tools/etcd bin
 ## For more information about GINKGO_FOCUS, see "make/e2e.sh --help".
 ##
 ## @category Development
-e2e: bin/scratch/kind-exists bin/tools/kubectl bin/tools/ginkgo
+e2e: $(BINDIR)/scratch/kind-exists $(BINDIR)/tools/kubectl $(BINDIR)/tools/ginkgo
 	make/e2e.sh
 
 .PHONY: e2e-ci
 e2e-ci: e2e-setup-kind e2e-setup
 	$(MAKE) --no-print-directory e2e FLAKE_ATTEMPTS=2 K8S_VERSION="$(K8S_VERSION)" || ($(MAKE) kind-logs && exit 1)
 
-test/integration/versionchecker/testdata/test_manifests.tar: bin/scratch/oldcrds.tar bin/yaml/cert-manager.yaml
+test/integration/versionchecker/testdata/test_manifests.tar: $(BINDIR)/scratch/oldcrds.tar $(BINDIR)/yaml/cert-manager.yaml
 	@# Remove the temp files if they exist
-	rm -f bin/scratch/versionchecker-test-manifests.tar bin/scratch/$(RELEASE_VERSION).yaml
+	rm -f $(BINDIR)/scratch/versionchecker-test-manifests.tar $(BINDIR)/scratch/$(RELEASE_VERSION).yaml
 	@# Copy the old CRDs tar and append the currentl release version to it
-	cp bin/scratch/oldcrds.tar bin/scratch/versionchecker-test-manifests.tar
-	cp bin/yaml/cert-manager.yaml bin/scratch/$(RELEASE_VERSION).yaml
-	tar --append -f bin/scratch/versionchecker-test-manifests.tar -C bin/scratch ./$(RELEASE_VERSION).yaml
-	cp bin/scratch/versionchecker-test-manifests.tar $@
+	cp $(BINDIR)/scratch/oldcrds.tar $(BINDIR)/scratch/versionchecker-test-manifests.tar
+	cp $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/scratch/$(RELEASE_VERSION).yaml
+	tar --append -f $(BINDIR)/scratch/versionchecker-test-manifests.tar -C $(BINDIR)/scratch ./$(RELEASE_VERSION).yaml
+	cp $(BINDIR)/scratch/versionchecker-test-manifests.tar $@
 
-bin/scratch/oldcrds.tar: bin/scratch/git/upstream-tags.txt | bin/scratch/oldcrds
+$(BINDIR)/scratch/oldcrds.tar: $(BINDIR)/scratch/git/upstream-tags.txt | $(BINDIR)/scratch/oldcrds
 	@# First, download the CRDs for all releases listed in upstream-tags.txt
-	<bin/scratch/git/upstream-tags.txt xargs -I% -P5 \
+	<$(BINDIR)/scratch/git/upstream-tags.txt xargs -I% -P5 \
 		./hack/fetch-old-crd.sh \
 		"https://github.com/cert-manager/cert-manager/releases/download/%/cert-manager.yaml" \
-		bin/scratch/oldcrds/%.yaml
+		$(BINDIR)/scratch/oldcrds/%.yaml
 	@# Next, tar up the old CRDs together
-	tar cf $@ -C bin/scratch/oldcrds .
+	tar cf $@ -C $(BINDIR)/scratch/oldcrds .
 
-bin/scratch/oldcrds:
+$(BINDIR)/scratch/oldcrds:
 	@mkdir -p $@
 
-bin/test:
+$(BINDIR)/test:
 	@mkdir -p $@
 
-bin/testlogs:
+$(BINDIR)/testlogs:
 	@mkdir -p $@

--- a/make/util.mk
+++ b/make/util.mk
@@ -1,0 +1,20 @@
+# Utility helper function to "get every go file in all except binary / make dirs"
+# The first argument $(1) defines the commands which the find output are piped into
+# Note that the "-not \( ... -prune \)" syntax is important here, if a little trickier to
+# understand. It causes find to prune entire search branches and not search inside the path.
+# If we used "-not -path X" instead, find would _still look inside X_.
+define get-sources
+$(shell find . -not \( -path "./$(BINDIR)/*" -prune \) -not \( -path "./bin/*" -prune \) -not \( -path "./make/*" -prune \) -name "*.go" | $(1))
+endef
+
+.PHONY: print-bindir
+print-bindir:
+	@echo $(BINDIR)
+
+.PHONY: print-sources
+print-sources:
+	@echo $(SOURCES)
+
+.PHONY: print-source-dirs
+print-source-dirs:
+	@echo $(call get-sources,cut -d'/' -f2 | sort | uniq | tr '\n' ' ')


### PR DESCRIPTION
### Pull Request Motivation

As per [this doc](https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns):

> Directory and file names that begin with "." or "_" are ignored by the go tool, as are directories named "testdata". 

We never want any go files inside `bin` to add dependencies for our go.mod - nor do we want them to be scanned by anything. By making the whole dir ignored by go, we avoid a class of issues where the go tooling might consider files under `bin` to be part of the project.

To achieve this, we change manual uses of `bin` to `$(BINDIR)`, so it's easier to change permanently or temporarily in the future.

After this PR merges we should immediately merge https://github.com/jetstack/testing/pull/699 which will re-enable download cacheing in CI.

### Kind

/kind feature

### Release Note

```release-note
Change default build dir from "bin" to "_bin"
```
