### PR TITLE
Ensure that Venafi client for CSRs gets initialized with metrics

### DIFF
--- a/pkg/controller/certificatesigningrequests/venafi/venafi.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi.go
@@ -81,6 +81,7 @@ func NewVenafi(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 		recorder:      ctx.Recorder,
 		clientBuilder: venaficlient.New,
 		fieldManager:  ctx.FieldManager,
+		metrics:       ctx.Metrics,
 	}
 }
 


### PR DESCRIPTION
certificate signing request e2e tests with Venafi TPP/Cloud issuers [are now failing](https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-venafi), it appears because the Venafi client is not initialized with metrics.

The functionality with the new Venafi metric was added in https://github.com/cert-manager/cert-manager/pull/5053 which has not been released yet.

We're not running the Venafi tests together with the rest of the e2e tests and looking at https://github.com/cert-manager/cert-manager/pull/5053 I think we didn't run the Venafi tests for that PR, so this issue was not caught.

I've ssh-ed to test pod and saw that there was a nil pointer exception:
```
I0516 15:56:27.317893       1 logs.go:59] vCert: Got 200 OK status for POST https://venafi-tpp.platform-ops.jetstack.net/vedsdk/certificates/checkpolicy
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x15acbc2]

goroutine 639 [running]:
github.com/cert-manager/cert-manager/pkg/metrics.(*Metrics).ObserveVenafiRequestDuration(0xc000e9f440, 0x96e8701, {0xc001504820, 0x224fd60, 0x1d})
	github.com/cert-manager/cert-manager/pkg/metrics/venafi.go:25 +0x22
github.com/cert-manager/cert-manager/pkg/issuer/venafi/client.instrumentedConnector.ReadZoneConfiguration({{0x7f9b2fcf1ac8, 0xc000e9f440}, 0x0, 0xc0003a5638})
	github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/instrumentedvenaficlient.go:51 +0x12a
github.com/cert-manager/cert-manager/pkg/issuer/venafi/client.(*Venafi).buildVReq(0xc0003a5668, {0xc000f50000, 0x393, 0x393}, 0x40d407, {0x0, 0x0, 0x0})
	github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/request.go:81 +0x6f
github.com/cert-manager/cert-manager/pkg/issuer/venafi/client.(*Venafi).RequestCertificate(0xc00119eba0, {0xc000f50000, 0x227d873, 0x2d}, 0xc0001d1340, {0x0, 0xc000652120, 0x2667cc0})
	github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/request.go:48 +0x28
github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/venafi.(*Venafi).Sign(0xc00042dab0, {0x2603218, 0xc000df2000}, 0xc00000af00, {0x2667cc0, 0xc0001d1340})
	github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/venafi/venafi.go:145 +0x72a
github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests.(*Controller).Sync(0xc0007ae460, {0x2603218, 0xc000df2000}, 0xc0005b49d0)
	github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/sync.go:163 +0xbe2
github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests.(*Controller).ProcessItem(0xc0007ae460, {0x2603170, 0xc00061a140}, {0xc000fa8300, 0x15})
	github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/controller.go:218 +0x165
github.com/cert-manager/cert-manager/pkg/controller.(*controller).worker.func1(0xc000b54f30, {0x1debcc0, 0xc000f016b0}, 0xc000fa1f78, {{0x2626940, 0xc000b582d0}, 0x0}, {0x2603170, 0xc00061a140})
	github.com/cert-manager/cert-manager/pkg/controller/controller.go:158 +0x2bb
github.com/cert-manager/cert-manager/pkg/controller.(*controller).worker(0xc000b54f30, {0x2603170, 0xc00061a140})
	github.com/cert-manager/cert-manager/pkg/controller/controller.go:175 +0xbf
github.com/cert-manager/cert-manager/pkg/controller.(*controller).Run.func1()
	github.com/cert-manager/cert-manager/pkg/controller/controller.go:113 +0x65
created by github.com/cert-manager/cert-manager/pkg/controller.(*controller).Run
	github.com/cert-manager/cert-manager/pkg/controller/controller.go:111 +0x176

```


```release-note
NONE
```

/kind bug

Signed-off-by: irbekrm <irbekrm@gmail.com>
