### PR TITLE
Added certificate owner ref field

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cert-manager/cert-manager/controller-binary/app/options"
 	config "github.com/cert-manager/cert-manager/internal/apis/config/controller"
 	cmdutil "github.com/cert-manager/cert-manager/internal/cmd/util"
+	"github.com/cert-manager/cert-manager/cmd/controller/app/options"
 	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cert-manager/cert-manager/controller-binary/app/options"
 	config "github.com/cert-manager/cert-manager/internal/apis/config/controller"
 	cmdutil "github.com/cert-manager/cert-manager/internal/cmd/util"
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/controller"
@@ -319,8 +320,9 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 		},
 
 		CertificateOptions: controller.CertificateOptions{
-			EnableOwnerRef:           opts.EnableCertificateOwnerRef,
-			CopiedAnnotationPrefixes: opts.CopiedAnnotationPrefixes,
+			EnableOwnerRef:             opts.EnableCertificateOwnerRef,
+			DefaultSecretCleanupPolicy: certmanager.CleanupPolicy(opts.DefaultSecretCleanupPolicy),
+			CopiedAnnotationPrefixes:   opts.CopiedAnnotationPrefixes,
 		},
 	})
 	if err != nil {

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -39,6 +39,7 @@ import (
 	cmdutil "github.com/cert-manager/cert-manager/internal/cmd/util"
 	"github.com/cert-manager/cert-manager/cmd/controller/app/options"
 	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
+	cmdutil "github.com/cert-manager/cert-manager/internal/cmd/util"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/controller"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -117,6 +117,7 @@ serviceAccount:
 # automountServiceAccountToken: true
 
 # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
+# This flag is deprecated, please use --default-secret-cleanup-policy instead.
 enableCertificateOwnerRef: false
 
 # Used to configure options for the controller pod.

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -78,6 +78,12 @@ spec:
                         enum:
                           - DER
                           - CombinedPEM
+                cleanupPolicy:
+                  description: CleanupPolicy is when this field is set to `OnDelete`, the owner reference is always created on the Secret resource and the secret will be automatically removed when the certificate resource is deleted. When this field is set to `Never`, the owner reference is never created on the Secret resource and the secret will not be automatically removed when the certificate resource is deleted. If the value of this field is unset this field "inherits" the value of the flag `--default-secret-cleanup-policy`.
+                  type: string
+                  enum:
+                    - Never
+                    - OnDelete
                 commonName:
                   description: "Requested common name X509 certificate subject attribute. More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6 NOTE: TLS clients will ignore this value when any subject alternative name is set (see https://tools.ietf.org/html/rfc6125#section-6.4.4). \n Should have a length of 64 characters or fewer to avoid generating invalid CSRs. Cannot be set if the `literalSubject` field is set."
                   type: string

--- a/internal/apis/certmanager/types.go
+++ b/internal/apis/certmanager/types.go
@@ -212,3 +212,11 @@ const (
 	UsageMicrosoftSGC      KeyUsage = "microsoft sgc"
 	UsageNetscapeSGC       KeyUsage = "netscape sgc"
 )
+
+// +kubebuilder:validation:Enum=Never;OnDelete
+type CleanupPolicy string
+
+const (
+	CleanupPolicyNever    CleanupPolicy = "Never"
+	CleanupPolicyOnDelete CleanupPolicy = "OnDelete"
+)

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -236,6 +236,16 @@ type CertificateSpec struct {
 	// `--feature-gates=AdditionalCertificateOutputFormats=true` option set on both
 	// the controller and webhook components.
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat
+
+	// CleanupPolicy is when this field is set to `OnDelete`, the owner reference
+	// is always created on the Secret resource and the secret will be
+	// automatically removed when the certificate resource is deleted.
+	// When this field is set to `Never`, the owner reference is never created
+	// on the Secret resource and the secret will not be automatically removed
+	// when the certificate resource is deleted.
+	// If the value of this field is unset this field "inherits" the value of
+	// the flag `--default-secret-cleanup-policy`.
+	CleanupPolicy CleanupPolicy `json:"cleanupPolicy,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -845,6 +845,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 
@@ -878,6 +879,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]v1.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -19,6 +19,7 @@ package v1alpha2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
@@ -223,6 +224,16 @@ type CertificateSpec struct {
 	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
+
+	// CleanupPolicy is when this field is set to `OnDelete`, the owner reference
+	// is always created on the Secret resource and the secret will be
+	// automatically removed when the certificate resource is deleted.
+	// When this field is set to `Never`, the owner reference is never created
+	// on the Secret resource and the secret will not be automatically removed
+	// when the certificate resource is deleted.
+	// If the value of this field is unset this field "inherits" the value of
+	// the flag `--default-secret-cleanup-policy`.
+	CleanupPolicy certmanager.CleanupPolicy `json:"cleanupPolicy,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -845,6 +845,7 @@ func autoConvert_v1alpha2_CertificateSpec_To_certmanager_CertificateSpec(in *Cer
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 
@@ -894,6 +895,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -19,6 +19,7 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
@@ -221,6 +222,16 @@ type CertificateSpec struct {
 	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
+
+	// CleanupPolicy is when this field is set to `OnDelete`, the owner reference
+	// is always created on the Secret resource and the secret will be
+	// automatically removed when the certificate resource is deleted.
+	// When this field is set to `Never`, the owner reference is never created
+	// on the Secret resource and the secret will not be automatically removed
+	// when the certificate resource is deleted.
+	// If the value of this field is unset this field "inherits" the value of
+	// the flag `--default-secret-cleanup-policy`.
+	CleanupPolicy certmanager.CleanupPolicy `json:"cleanupPolicy,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -844,6 +844,7 @@ func autoConvert_v1alpha3_CertificateSpec_To_certmanager_CertificateSpec(in *Cer
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 
@@ -893,6 +894,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *cer
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
@@ -198,6 +199,16 @@ type CertificateSpec struct {
 	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
+
+	// CleanupPolicy is when this field is set to `OnDelete`, the owner reference
+	// is always created on the Secret resource and the secret will be
+	// automatically removed when the certificate resource is deleted.
+	// When this field is set to `Never`, the owner reference is never created
+	// on the Secret resource and the secret will not be automatically removed
+	// when the certificate resource is deleted.
+	// If the value of this field is unset this field "inherits" the value of
+	// the flag `--default-secret-cleanup-policy`.
+	CleanupPolicy certmanager.CleanupPolicy `json:"cleanupPolicy,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -843,6 +843,7 @@ func autoConvert_v1beta1_CertificateSpec_To_certmanager_CertificateSpec(in *Cert
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 
@@ -881,6 +882,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1beta1_CertificateSpec(in *cert
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
+	out.CleanupPolicy = certmanager.CleanupPolicy(in.CleanupPolicy)
 	return nil
 }
 

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 	"sigs.k8s.io/structured-merge-diff/v4/value"
 
-	cmmeta "github.com/cert-manager/cert-manager/internal/apis/meta"
 	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
+	cmmeta "github.com/cert-manager/cert-manager/internal/apis/meta"
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"

--- a/internal/controller/certificates/policies/policies.go
+++ b/internal/controller/certificates/policies/policies.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -100,7 +101,7 @@ func NewReadinessPolicyChain(c clock.Clock) Chain {
 // NewSecretPostIssuancePolicyChain includes policy checks that are to be
 // performed _after_ issuance has been successful, testing for the presence and
 // correctness of metadata and output formats of Certificate's Secrets.
-func NewSecretPostIssuancePolicyChain(ownerRefEnabled bool, fieldManager string) Chain {
+func NewSecretPostIssuancePolicyChain(ownerRefEnabled bool, defaultSecretCleanupPolicy certmanager.CleanupPolicy, fieldManager string) Chain {
 	return Chain{
 		SecretBaseLabelsMismatch,                                             // Make sure the managed labels have the correct values
 		SecretCertificateDetailsAnnotationsMismatch,                          // Make sure the managed certificate details annotations have the correct values
@@ -109,7 +110,7 @@ func NewSecretPostIssuancePolicyChain(ownerRefEnabled bool, fieldManager string)
 		SecretSecretTemplateManagedFieldsMismatch(fieldManager),              // Make sure the only the expected template labels and annotations exist
 		SecretAdditionalOutputFormatsMismatch,
 		SecretAdditionalOutputFormatsManagedFieldsMismatch(fieldManager),
-		SecretOwnerReferenceMismatch(ownerRefEnabled),
+		SecretOwnerReferenceMismatch(ownerRefEnabled,defaultSecretCleanupPolicy),
 		SecretOwnerReferenceManagedFieldMismatch(ownerRefEnabled, fieldManager),
 
 		SecretKeystoreFormatMismatch,

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -19,6 +19,7 @@ package v1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
@@ -263,6 +264,16 @@ type CertificateSpec struct {
 	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
+
+	// CleanupPolicy is when this field is set to `OnDelete`, the owner reference
+	// is always created on the Secret resource and the secret will be
+	// automatically removed when the certificate resource is deleted.
+	// When this field is set to `Never`, the owner reference is never created
+	// on the Secret resource and the secret will not be automatically removed
+	// when the certificate resource is deleted.
+	// If the value of this field is unset this field "inherits" the value of
+	// the flag `--default-secret-cleanup-policy`.
+	CleanupPolicy certmanager.CleanupPolicy `json:"cleanupPolicy,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -141,8 +141,8 @@ func NewController(
 		secretsUpdateData:        secretsManager.UpdateData,
 		postIssuancePolicyChain: policies.NewSecretPostIssuancePolicyChain(
 			ctx.CertificateOptions.EnableOwnerRef,
-			ctx.FieldManager,
 			ctx.DefaultSecretCleanupPolicy,
+			ctx.FieldManager,
 		),
 		fieldManager:         ctx.FieldManager,
 		localTemporarySigner: pki.GenerateLocallySignedTemporaryCertificate,

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -128,6 +128,7 @@ func NewController(
 	secretsManager := internal.NewSecretsManager(
 		ctx.Client.CoreV1(), secretsInformer.Lister(),
 		ctx.FieldManager, ctx.CertificateOptions.EnableOwnerRef,
+		ctx.DefaultSecretCleanupPolicy,
 	)
 
 	return &controller{
@@ -141,6 +142,7 @@ func NewController(
 		postIssuancePolicyChain: policies.NewSecretPostIssuancePolicyChain(
 			ctx.CertificateOptions.EnableOwnerRef,
 			ctx.FieldManager,
+			ctx.DefaultSecretCleanupPolicy,
 		),
 		fieldManager:         ctx.FieldManager,
 		localTemporarySigner: pki.GenerateLocallySignedTemporaryCertificate,

--- a/pkg/controller/certificates/issuing/secret_manager_test.go
+++ b/pkg/controller/certificates/issuing/secret_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -62,6 +63,9 @@ func Test_ensureSecretData(t *testing.T) {
 
 		// enableOwnerRef is passed to the post issuance policy checks.
 		enableOwnerRef bool
+
+		// enableOwnerRef is passed to the post issuance policy checks.
+		defaultSecretCleanupPolicy certmanager.CleanupPolicy
 	}{
 		"if 'key' is empty, should do nothing and not error": {
 			expectedAction: false,
@@ -1178,7 +1182,7 @@ func Test_ensureSecretData(t *testing.T) {
 				actionCalled = true
 				return nil
 			}
-			w.postIssuancePolicyChain = policies.NewSecretPostIssuancePolicyChain(test.enableOwnerRef, fieldManager)
+			w.postIssuancePolicyChain = policies.NewSecretPostIssuancePolicyChain(test.enableOwnerRef, test.defaultSecretCleanupPolicy, fieldManager)
 
 			// Start the informers and begin processing updates.
 			builder.Start()

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -45,6 +45,7 @@ import (
 	gwscheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 	gwinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
@@ -220,6 +221,9 @@ type CertificateOptions struct {
 	// EnableOwnerRef controls whether the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
+	// defaultSecretCleanupPolicy controls whether the certificate is configured as an owner of
+	// secret where the effective TLS certificate is stored.
+	DefaultSecretCleanupPolicy certmanager.CleanupPolicy
 	// CopiedAnnotationPrefixes defines which annotations should be copied
 	// Certificate -> CertificateRequest, CertificateRequest -> Order.
 	CopiedAnnotationPrefixes []string

--- a/test/integration/certificates/cleanup_policy_test.go
+++ b/test/integration/certificates/cleanup_policy_test.go
@@ -56,18 +56,17 @@ func Test_CleanupPolicyChange(t *testing.T) {
 	defer stopFn()
 
 	kubeClient, factory, cmClient, cmFactory := framework.NewClients(t, config)
-	controllerOptions := controllerpkg.CertificateOptions{
-		EnableOwnerRef:             false,
-		DefaultSecretCleanupPolicy: certmanager.CleanupPolicyNever,
-	}
 	controllerContext := controllerpkg.Context{
 		Client:                    kubeClient,
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmClient,
 		SharedInformerFactory:     cmFactory,
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
-			CertificateOptions: controllerOptions,
+			Clock: clock.RealClock{},
+			CertificateOptions: controllerpkg.CertificateOptions{
+				EnableOwnerRef:             false,
+				DefaultSecretCleanupPolicy: certmanager.CleanupPolicyNever,
+			},
 		},
 		Recorder:     framework.NewEventRecorder(t),
 		FieldManager: fieldManager,
@@ -142,7 +141,7 @@ func Test_CleanupPolicyChange(t *testing.T) {
 	stopControllerNoOwnerRef()
 	kubeClient, factory, cmClient, cmFactory = framework.NewClients(t, config)
 	stopControllerNoOwnerRef = nil
-	controllerOptions.DefaultSecretCleanupPolicy = certmanager.CleanupPolicyOnDelete
+	controllerContext.DefaultSecretCleanupPolicy = certmanager.CleanupPolicyOnDelete
 	ctrl, queue, mustSync = issuing.NewController(logf.Log, &controllerContext)
 	c = controllerpkg.NewController(ctx, fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
 	stopControllerOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)

--- a/test/integration/certificates/cleanup_policy_test.go
+++ b/test/integration/certificates/cleanup_policy_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/issuing"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/test/integration/framework"
+	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+// Test_CleanupPolicyChange tests change state of issuerRef on created Secret
+// when certificate cleanupPolicy is changed.
+
+func Test_CleanupPolicyChange(t *testing.T) {
+	const (
+		fieldManager = "cert-manager-cleanup-policy-test"
+	)
+
+	t.Log("starting controller with default secret cleanup policy set to Never")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
+
+	kubeClient, factory, cmClient, cmFactory := framework.NewClients(t, config)
+	controllerOptions := controllerpkg.CertificateOptions{
+		EnableOwnerRef:             false,
+		DefaultSecretCleanupPolicy: certmanager.CleanupPolicyNever,
+	}
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient, cmClient,
+		factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
+		controllerOptions, fieldManager,
+	)
+	c := controllerpkg.NewController(ctx, fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
+	stopControllerNoOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer func() {
+		if stopControllerNoOwnerRef != nil {
+			stopControllerNoOwnerRef()
+		}
+	}()
+
+	t.Log("creating a Secret and Certificate which does not need issuance")
+	ns, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "owner-reference-test"}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	crt := gen.Certificate("owner-reference-test",
+		gen.SetCertificateNamespace(ns.Name),
+		gen.SetCertificateCommonName("my-common-name"),
+		gen.SetCertificateDNSNames("example.com", "foo.example.com"),
+		gen.SetCertificateIPs("1.2.3.4", "5.6.7.8"),
+		gen.SetCertificateURIs("spiffe://hello.world"),
+		gen.SetCertificateKeyAlgorithm(cmapi.RSAKeyAlgorithm),
+		gen.SetCertificateKeySize(2048),
+		gen.SetCertificateSecretName("cert-manager-issuing-test-secret"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "testissuer", Group: "foo.io", Kind: "Issuer"}),
+	)
+	bundle := testcrypto.MustCreateCryptoBundle(t, crt, &clock.RealClock{})
+	secret, err := kubeClient.CoreV1().Secrets(ns.Name).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: crt.Spec.SecretName},
+		Data: map[string][]byte{
+			"ca.crt":  bundle.CertBytes,
+			"tls.crt": bundle.CertBytes,
+			"tls.key": bundle.PrivateKeyBytes,
+		},
+	}, metav1.CreateOptions{FieldManager: fieldManager})
+	require.NoError(t, err)
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Create(ctx, crt, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("ensure Certificate does not gain Issuing condition")
+	require.Never(t, func() bool {
+		crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Get(ctx, crt.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue})
+	}, time.Second*3, time.Millisecond*10, "expected Certificate to not gain Issuing condition")
+
+	t.Log("change Certificate cleanupPolicy to onDelete")
+	crt.Spec.CleanupPolicy = certmanager.CleanupPolicyOnDelete
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Update(ctx, crt, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		secret, err = kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		fmt.Println(secret.OwnerReferences)
+		return apiequality.Semantic.DeepEqual(secret.OwnerReferences, []metav1.OwnerReference{*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate"))})
+	}, time.Second*10, time.Millisecond*10, "expected Secret to have owner reference to Certificate added: %#+v", secret.OwnerReferences)
+
+	t.Log("change Certificate cleanupPolicy to Never")
+	crt.Spec.CleanupPolicy = certmanager.CleanupPolicyNever
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Update(ctx, crt, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		secret, err = kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return len(secret.OwnerReferences) == 0
+	}, time.Second*10, time.Millisecond*10, "expected Secret cannot have owner reference to Certificate")
+
+	t.Log("restarting controller with default secret cleanup policy set to OnDelete")
+	stopControllerNoOwnerRef()
+	kubeClient, factory, cmClient, cmFactory = framework.NewClients(t, config)
+	stopControllerNoOwnerRef = nil
+	controllerOptions.DefaultSecretCleanupPolicy = certmanager.CleanupPolicyOnDelete
+	ctrl, queue, mustSync = issuing.NewController(logf.Log, kubeClient, cmClient,
+		factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
+		controllerOptions, fieldManager,
+	)
+	c = controllerpkg.NewController(ctx, fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
+	stopControllerOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopControllerOwnerRef()
+
+	t.Log("remove Certificate cleanupPolicy")
+	crt.Spec.CleanupPolicy = ""
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Update(ctx, crt, metav1.UpdateOptions{})
+
+	t.Log("waiting for owner reference to be set")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		secret, err = kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return apiequality.Semantic.DeepEqual(secret.OwnerReferences, []metav1.OwnerReference{*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate"))})
+	}, time.Second*10, time.Millisecond*10, "expected Secret to have owner reference to Certificate added: %#+v", secret.OwnerReferences)
+
+	t.Log("change Certificate cleanupPolicy to Never")
+	crt.Spec.CleanupPolicy = certmanager.CleanupPolicyNever
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Update(ctx, crt, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		secret, err = kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return len(secret.OwnerReferences) == 0
+	}, time.Second*10, time.Millisecond*10, "expected Secret cannot have owner reference to Certificate")
+
+	t.Log("change Certificate cleanupPolicy to onDelete")
+	crt.Spec.CleanupPolicy = certmanager.CleanupPolicyOnDelete
+	crt, err = cmClient.CertmanagerV1().Certificates(ns.Name).Update(ctx, crt, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		secret, err = kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		fmt.Println(secret.OwnerReferences)
+		return apiequality.Semantic.DeepEqual(secret.OwnerReferences, []metav1.OwnerReference{*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate"))})
+	}, time.Second*10, time.Millisecond*10, "expected Secret to have owner reference to Certificate added: %#+v", secret.OwnerReferences)
+
+}

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
 	"github.com/cert-manager/cert-manager/integration-tests/framework"
 	"github.com/cert-manager/cert-manager/internal/webhook/feature"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -49,7 +51,6 @@ import (
 	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 // TestIssuingController performs a basic test to ensure that the issuing
@@ -983,7 +984,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 // is removed again when disabled.
 // Also ensures that changes to the Secret which modify the owner reference,
 // are reverted or corrected if needed by the issuing controller.
-func Test_IssuingController_OwnerRefernece(t *testing.T) {
+func Test_IssuingController_OwnerReference(t *testing.T) {
 	const (
 		fieldManager = "cert-manager-issuing-test"
 	)

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -276,5 +277,11 @@ func SetCertificateRevisionHistoryLimit(limit int32) CertificateModifier {
 func SetCertificateAdditionalOutputFormats(additionalOutputFormats ...v1.CertificateAdditionalOutputFormat) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		crt.Spec.AdditionalOutputFormats = additionalOutputFormats
+	}
+}
+
+func SetCertificateCleanupPolicy(cleanupPolicy certmanager.CleanupPolicy) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.CleanupPolicy = cleanupPolicy
 	}
 }


### PR DESCRIPTION
| ✨ Design document: https://github.com/cert-manager/cert-manager/pull/5324 |
|-|

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
The cert-manager has the ability to set the owner reference field in generated secrets. We can enable this option globally by setting the `--enable-certificate-owner-ref` cli flag.
We want to configure it in more detail, at the certificate level. So we add a new field to the certificate CRD, `cleanupPolicy`. 
When this field is set to `Delete`, the owner reference is always created on the Secret resource and the secret will be automatically removed when the certificate resource is deleted. 
When this field is set to `Never`, the owner reference is never created on the Secret resource and the secret will not be automatically removed when the certificate resource is deleted.
Also, we add cli flag `--default-secret-cleanup-policy` to set default policy for certificates if certificate CRD field `cleanupPolicy` is not set.
`--enable-certificate-owner-ref` cli flag is declared as deprecated but takes precedence over `--default-secret-cleanup-policy` for backward compatibility.

This option is useful if the cluster contains both prod environments, where secrets should not be deleted, and development environments, where secrets should be deleted all the time.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

feature

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added new field `cleanupPolicy` to Certificate CRD.
Added new cli flag `--default-secret-cleanup-policy`.
`--enable-certificate-owner-ref` cli flag is declared as deprecated.
```
