### PR TITLE
Add URL for cert-manager website to chart + update logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 <p align="center">
   <img src="./logo/logo-small.png" height="256" width="256" alt="cert-manager project logo" />
 </p>
-<!-- note that the cert-manager logo in this repo is referred to in other README files in the cert-manager org;
+<!-- note that the cert-manager logo in this repo is referred to in other README files in the cert-manager org
+     as well as in Helm charts, etc.
      if you change its location or name, you'll need to update several other repos too! -->
 
 <p align="center"><a href="https://prow.build-infra.jetstack.net/?job=ci-cert-manager-bazel">

--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -6,7 +6,7 @@ appVersion: v0.1.0
 kubeVersion: ">= 1.19.0-0"
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
-icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo.png
+icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png
 keywords:
   - cert-manager
   - kube-lego
@@ -17,5 +17,6 @@ sources:
 maintainers:
   - name: cert-manager-maintainers
     email: cert-manager-maintainers@googlegroups.com
+    url: https://cert-manager.io
 annotations:
   artifacthub.io/prerelease: "{{IS_PRERELEASE}}"


### PR DESCRIPTION
The SHA for the logo is the latest master in my local checkout.

/kind cleanup

```release-note
NONE
```
