### PR TITLE
Fix `release-artifacts` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ bazel-*
 _artifacts/
 /vendor/
 bin/
+_bin/
+.bin/
 user.bazelrc
 *.bak

--- a/make/release.mk
+++ b/make/release.mk
@@ -7,21 +7,22 @@ CMREL_KEY ?=
 
 .PHONY: release-artifacts
 ## Build all release artifacts which might be run or used locally, except
-## for anything signed.
+## for anything which requires signing. Note that since the manifests bundle
+## requires signing, this command will not build the exact cert-manager-manifests.tar.gz
+## which would form part of a release, but will instead build an unsigned tarball.
 ##
 ## Useful to check that all binaries and manifests on all platforms can be
-## built without errors.
+## built without errors. Not useful for an actual release - instead, use `make release` for that.
 ##
 ## @category Release
 release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart release-containers release-manifests
 
 .PHONY: release-artifacts-signed
-# Same as `release`, except it also signs the Helm chart. Requires CMREL_KEY
+# Same as `release-artifacts`, except also signs the Helm chart. Requires CMREL_KEY
 # to be configured.
 # Note that this doesn't sign containers, since it's tricky to do that before
 # a release is staged. Instead we sign them after we push them to a registry.
-release-artifacts-signed: release-artifacts
-	$(MAKE) --no-print-directory helm-chart-signature
+release-artifacts-signed: release-artifacts release-manifests-signed
 
 .PHONY: release
 ## Create a complete release ready to be staged, including containers bundled for


### PR DESCRIPTION
### Pull Request Motivation

The intention of `make release-artifacts` was to build everything possible locally, ignoring signatures which most people won't want to do locally. As part of the development of the makefile workflow the signed helm chart image crept into the target which removed its usefulness.

This PR will ensure that that target only builds unsigned things.

(Also adds alternative namings for the `bin` directory to `.gitignore`, in preparation for #5130 )

### Kind

/kind bug

### Release Note

```release-note
Ensure that `make release-artifacts` only builds unsigned artifacts as intended
```
