### PR TITLE
Fix etcd flags

### DIFF
--- a/make/config/kind/config_etcd_no_fsync.yaml
+++ b/make/config/kind/config_etcd_no_fsync.yaml
@@ -11,13 +11,13 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
+    apiVersion: kubeadm.k8s.io/v1beta3
     kind: ClusterConfiguration
     metadata:
       name: config
     etcd:
       local:
         extraArgs:
-          unsafe-no-fsync: "True"
+          unsafe-no-fsync: "true"
 nodes:
   - role: control-plane


### PR DESCRIPTION
This PR ensures that `--unsafe-no-fsync` flag is actually passed to etcd as part of creating kind cluster for running e2e tests.

It appears that etcd flags are not passed when using `v1beta2` kubeadm ClusterConfiguration resource, see https://github.com/kubernetes-sigs/kind/issues/1839

To verify the bug:

1. Run ` kind create cluster --config make/config/kind/config_etcd_no_fsync.yaml` against current master
2. Run `kubectl get po -n kube-system etcd-kind-control-plane  -oyaml` and verify that the flag is not passed

To verify the fix repeat the same steps from this PR and check that the flag is set


```release-note
NONE
```

/kind cleanup
