### PR TITLE
Goimports improvement / rclone tool install

### DIFF
--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -40,8 +40,8 @@ godirs=$(find . -not \( -path "./bin/*" -prune \) -name "*.go" | cut -d'/' -f2 |
 output=$($goimports $common_flags -l $godirs)
 
 if [ ! -z "${output}" ]; then
-    echo "${output}"
-    echo "+++ goimports failed; the following command may fix:" >&2
-    echo "+++ $goimports $common_flags -w $godirs" >&2
-    exit 1
+	echo "${output}" | sed "s/^/goimports: broken file: /"
+	echo "+++ goimports failed; the following command may fix:" >&2
+	echo "+++ $goimports $common_flags -w $godirs" >&2
+	exit 1
 fi


### PR DESCRIPTION
### Pull Request Motivation

1. Prefixes `goimports` output to make it clear what's going on when `goimports` fails
2. Adds install for `rclone` on different platforms. This'll be used in place of `gsutil` for uploading files to GCS.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
