### PR TITLE
Reverts additional check for whether Prometheus APIs exist before creating ServiceMonitor

### DIFF
--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
As discussed in our standup and on https://github.com/cert-manager/cert-manager/pull/4844 this PR reverts the check for whether Prometheus monitoring API exists before creating `ServiceMonitor` to avoid introducing a dependency ordering which does not fit GitOps installers model.

I am planning to backport this to 1.8 and release a patch release with this revert and Go patch version bump to reduce scanner spam for folks who run those https://github.com/cert-manager/cert-manager/issues/5161


```release-note
Reverts additional check for ServiceMonitor
```

/kind cleanup
