### PR TITLE
Bump patch version of Go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//hack/build:nogo_vet",
-    version = "1.17.8",
+    version = "1.17.11",
 )
 
 ## Load gazelle and dependencies

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -93,7 +93,7 @@ GOTEST=CGO_ENABLED=$(CGO_ENABLED) $(GO) test
 
 GOTESTSUM=CGO_ENABLED=$(CGO_ENABLED) ./bin/tools/gotestsum
 
-VENDORED_GO_VERSION := 1.17.8
+VENDORED_GO_VERSION := 1.17.11
 
 .PHONY: vendor-go
 ## By default, this Makefile uses the system's Go. You can use a "vendored"


### PR DESCRIPTION
This PR bumps Go 1.17.8 -> 1.17.11 to get latest security fixes.

(We are not aware of any of the security issues actually affecting cert-manager. See https://github.com/cert-manager/cert-manager/issues/5161 for context)

```release-note
Bumps Go 1.17.8 -> 1.17.11 to get latest security fixes
```

/kind cleanup
