### PR TITLE
Remove timeouts in acme logging middleware

### DIFF
--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -18,17 +18,12 @@ package middleware
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/crypto/acme"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/client"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-)
-
-const (
-	timeout = time.Second * 10
 )
 
 func NewLogger(baseCl client.Interface) client.Interface {
@@ -49,17 +44,11 @@ var _ client.Interface = &Logger{}
 func (l *Logger) AuthorizeOrder(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling AuthorizeOrder")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.AuthorizeOrder(ctx, id, opt...)
 }
 
 func (l *Logger) GetOrder(ctx context.Context, url string) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetOrder")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.GetOrder(ctx, url)
 }
@@ -67,17 +56,11 @@ func (l *Logger) GetOrder(ctx context.Context, url string) (*acme.Order, error) 
 func (l *Logger) FetchCert(ctx context.Context, url string, bundle bool) ([][]byte, error) {
 	l.log.V(logf.TraceLevel).Info("Calling FetchCert")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.FetchCert(ctx, url, bundle)
 }
 
 func (l *Logger) ListCertAlternates(ctx context.Context, url string) ([]string, error) {
 	l.log.V(logf.TraceLevel).Info("Calling ListCertAlternates")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.ListCertAlternates(ctx, url)
 }
@@ -85,17 +68,11 @@ func (l *Logger) ListCertAlternates(ctx context.Context, url string) ([]string, 
 func (l *Logger) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling WaitOrder")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.WaitOrder(ctx, url)
 }
 
 func (l *Logger) CreateOrderCert(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error) {
 	l.log.V(logf.TraceLevel).Info("Calling CreateOrderCert")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.CreateOrderCert(ctx, finalizeURL, csr, bundle)
 }
@@ -103,17 +80,11 @@ func (l *Logger) CreateOrderCert(ctx context.Context, finalizeURL string, csr []
 func (l *Logger) Accept(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Accept")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.Accept(ctx, chal)
 }
 
 func (l *Logger) GetChallenge(ctx context.Context, url string) (*acme.Challenge, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetChallenge")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.GetChallenge(ctx, url)
 }
@@ -121,17 +92,11 @@ func (l *Logger) GetChallenge(ctx context.Context, url string) (*acme.Challenge,
 func (l *Logger) GetAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetAuthorization")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.GetAuthorization(ctx, url)
 }
 
 func (l *Logger) WaitAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	l.log.V(logf.TraceLevel).Info("Calling WaitAuthorization")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.WaitAuthorization(ctx, url)
 }
@@ -139,45 +104,35 @@ func (l *Logger) WaitAuthorization(ctx context.Context, url string) (*acme.Autho
 func (l *Logger) Register(ctx context.Context, a *acme.Account, prompt func(tosURL string) bool) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Register")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.Register(ctx, a, prompt)
 }
 
 func (l *Logger) GetReg(ctx context.Context, url string) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetReg")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.GetReg(ctx, url)
 }
 
 func (l *Logger) HTTP01ChallengeResponse(token string) (string, error) {
 	l.log.V(logf.TraceLevel).Info("Calling HTTP01ChallengeResponse")
+
 	return l.baseCl.HTTP01ChallengeResponse(token)
 }
 
 func (l *Logger) DNS01ChallengeRecord(token string) (string, error) {
 	l.log.V(logf.TraceLevel).Info("Calling DNS01ChallengeRecord")
+
 	return l.baseCl.DNS01ChallengeRecord(token)
 }
 
 func (l *Logger) Discover(ctx context.Context) (acme.Directory, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Discover")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	return l.baseCl.Discover(ctx)
 }
 
 func (l *Logger) UpdateReg(ctx context.Context, a *acme.Account) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling UpdateReg")
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	return l.baseCl.UpdateReg(ctx, a)
 }


### PR DESCRIPTION
### Pull Request Motivation

Logging middleware probably isn't the place for this in any case, but more broadly there's little need to add additional timeouts here; there's an argument for having the logging itself have a timeout, but these timeouts don't achieve that in any case.

This was spotted in [this comment](https://github.com/cert-manager/cert-manager/pull/5157#issuecomment-1148866215) and this PR should be merged before #5157 can be merged.

### Kind

/kind cleanup

### Release Note

```release-note
Removes context timeouts imposed by ACME logging middleware
```
