### PR TITLE
add VerifyCredentials to Venafi issuers setup

### DIFF
--- a/pkg/issuer/venafi/client/BUILD.bazel
+++ b/pkg/issuer/venafi/client/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "@com_github_venafi_vcert_v4//:go_default_library",
         "@com_github_venafi_vcert_v4//pkg/certificate:go_default_library",
         "@com_github_venafi_vcert_v4//pkg/endpoint:go_default_library",
+        "@com_github_venafi_vcert_v4//pkg/venafi/cloud:go_default_library",
+        "@com_github_venafi_vcert_v4//pkg/venafi/tpp:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
     ],
 )

--- a/pkg/issuer/venafi/client/fake/venafi.go
+++ b/pkg/issuer/venafi/client/fake/venafi.go
@@ -29,6 +29,7 @@ type Venafi struct {
 	RequestCertificateFn    func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
 	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
 	ReadZoneConfigurationFn func() (*endpoint.ZoneConfiguration, error)
+	VerifyCredentialsFn     func() error
 }
 
 func (v *Venafi) Ping() error {
@@ -48,3 +49,12 @@ func (v *Venafi) ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error) {
 }
 
 func (v *Venafi) SetClient(endpoint.Connector) {}
+
+// VerifyCredentials will return VerifyCredentialsFn if set, otherwise nil.
+func (v *Venafi) VerifyCredentials() error {
+	if v.VerifyCredentialsFn != nil {
+		return v.VerifyCredentialsFn()
+	}
+
+	return nil
+}

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -23,6 +23,8 @@ import (
 	vcert "github.com/Venafi/vcert/v4"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/venafi/cloud"
+	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
 	"github.com/go-logr/logr"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
@@ -49,6 +51,7 @@ type Interface interface {
 	Ping() error
 	ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error)
 	SetClient(endpoint.Connector)
+	VerifyCredentials() error
 }
 
 // Venafi is a implementation of vcert library to manager certificates from TPP or Venafi Cloud
@@ -60,6 +63,9 @@ type Venafi struct {
 	secretsLister corelisters.SecretLister
 
 	vcertClient connector
+	tppClient   *tpp.Connector
+	cloudClient *cloud.Connector
+	config      *vcert.Config
 }
 
 // connector exposes a subset of the vcert Connector interface to make stubbing
@@ -86,12 +92,31 @@ func New(namespace string, secretsLister corelisters.SecretLister, issuer cmapi.
 		return nil, fmt.Errorf("error creating Venafi client: %s", err.Error())
 	}
 
+	var tppc *tpp.Connector
+	var cc *cloud.Connector
+
+	switch vcertClient.GetType() {
+	case endpoint.ConnectorTypeTPP:
+		c, ok := vcertClient.(*tpp.Connector)
+		if ok {
+			tppc = c
+		}
+	case endpoint.ConnectorTypeCloud:
+		c, ok := vcertClient.(*cloud.Connector)
+		if ok {
+			cc = c
+		}
+	}
+
 	instrumentedVCertClient := newInstumentedConnector(vcertClient, metrics, logger)
 
 	return &Venafi{
 		namespace:     namespace,
 		secretsLister: secretsLister,
 		vcertClient:   instrumentedVCertClient,
+		cloudClient:   cc,
+		tppClient:     tppc,
+		config:        cfg,
 	}, nil
 }
 
@@ -124,6 +149,14 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister corelisters.SecretLi
 				Password:    password,
 				AccessToken: accessToken,
 			},
+			// this is needed for local development when tunneling to the TPP server
+			//Client: &http.Client{
+			//	Transport: &http.Transport{
+			//		TLSClientConfig: &tls.Config{
+			//			Renegotiation: tls.RenegotiateOnceAsClient,
+			//		},
+			//	},
+			//},
 		}, nil
 	case venCfg.Cloud != nil:
 		cloud := venCfg.Cloud
@@ -164,4 +197,51 @@ func (v *Venafi) ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error) {
 
 func (v *Venafi) SetClient(client endpoint.Connector) {
 	v.vcertClient = client
+}
+
+// VerifyCredentials will remotely verify the credentials for the client, both for TPP and Cloud
+func (v *Venafi) VerifyCredentials() error {
+	switch {
+	case v.cloudClient != nil:
+		err := v.cloudClient.Authenticate(&endpoint.Authentication{
+			APIKey: v.config.Credentials.APIKey,
+		})
+
+		if err != nil {
+			return fmt.Errorf("cloudClient.Authenticate: %v", err)
+		}
+
+		return nil
+	case v.tppClient != nil:
+		if v.config.Credentials == nil {
+			return fmt.Errorf("credentials not configured")
+		}
+
+		if v.config.Credentials.AccessToken != "" {
+			_, err := v.tppClient.VerifyAccessToken(&endpoint.Authentication{
+				AccessToken: v.config.Credentials.AccessToken,
+			})
+
+			if err != nil {
+				return fmt.Errorf("tppClient.VerifyAccessToken: %v", err)
+			}
+
+			return nil
+		}
+
+		if v.config.Credentials.User != "" && v.config.Credentials.Password != "" {
+			err := v.tppClient.Authenticate(&endpoint.Authentication{
+				User:     v.config.Credentials.User,
+				Password: v.config.Credentials.Password,
+			})
+
+			if err != nil {
+				return fmt.Errorf("tppClient.Authenticate: %v", err)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("neither tppClient or cloudClient have been set")
 }

--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (v *Venafi) Setup(ctx context.Context) (err error) {
@@ -44,6 +45,11 @@ func (v *Venafi) Setup(ctx context.Context) (err error) {
 	err = client.Ping()
 	if err != nil {
 		return fmt.Errorf("error pinging Venafi API: %v", err)
+	}
+
+	err = client.VerifyCredentials()
+	if err != nil {
+		return fmt.Errorf("client.VerifyCredentials: %v", err)
 	}
 
 	// If it does not already have a 'ready' condition, we'll also log an event

--- a/pkg/issuer/venafi/setup_test.go
+++ b/pkg/issuer/venafi/setup_test.go
@@ -19,11 +19,13 @@ package venafi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/go-logr/logr"
 
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
-	"github.com/go-logr/logr"
 
 	corelisters "k8s.io/client-go/listers/core/v1"
 
@@ -62,6 +64,28 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
+	verifyCredentialsClient := func(string, corelisters.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+		return &internalvenafifake.Venafi{
+			PingFn: func() error {
+				return nil
+			},
+			VerifyCredentialsFn: func() error {
+				return nil
+			},
+		}, nil
+	}
+
+	failingVerifyCredentialsClient := func(string, corelisters.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+		return &internalvenafifake.Venafi{
+			PingFn: func() error {
+				return nil
+			},
+			VerifyCredentialsFn: func() error {
+				return fmt.Errorf("401 Unauthorized")
+			},
+		}, nil
+	}
+
 	tests := map[string]testSetupT{
 		"if client builder fails then should error": {
 			clientBuilder: failingClientBuilder,
@@ -96,6 +120,30 @@ func TestSetup(t *testing.T) {
 			},
 			expectedEvents: []string{
 				"Normal Ready Verified issuer with Venafi server",
+			},
+		},
+		"verifyCredentials happy path": {
+			clientBuilder: verifyCredentialsClient,
+			iss:           baseIssuer.DeepCopy(),
+			expectedErr:   false,
+			expectedCondition: &cmapi.IssuerCondition{
+				Message: "Venafi issuer started",
+				Reason:  "Venafi issuer started",
+				Status:  "True",
+			},
+			expectedEvents: []string{
+				"Normal Ready Verified issuer with Venafi server",
+			},
+		},
+
+		"if verifyCredentials returns an error we should set condition to False": {
+			clientBuilder: failingVerifyCredentialsClient,
+			iss:           baseIssuer.DeepCopy(),
+			expectedErr:   true,
+			expectedCondition: &cmapi.IssuerCondition{
+				Reason:  "ErrorSetup",
+				Message: "Failed to setup Venafi issuer: client.VerifyCredentials: 401 Unauthorized",
+				Status:  "False",
 			},
 		},
 	}

--- a/test/e2e/framework/addon/venafi/cloud.go
+++ b/test/e2e/framework/addon/venafi/cloud.go
@@ -136,3 +136,15 @@ func (t *CloudDetails) BuildClusterIssuer() *cmapi.ClusterIssuer {
 		},
 	}
 }
+
+// SetAPIKey sets the Secret data["apikey"] value
+func (v *VenafiCloud) SetAPIKey(token string) error {
+	v.createdSecret.Data["apikey"] = []byte(token)
+	s, err := v.Base.Details().KubeClient.CoreV1().Secrets(v.Namespace).Update(context.TODO(), v.createdSecret, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	v.createdSecret = s
+	return nil
+}

--- a/test/e2e/framework/addon/venafi/tpp.go
+++ b/test/e2e/framework/addon/venafi/tpp.go
@@ -144,3 +144,15 @@ func (t *TPPDetails) BuildClusterIssuer() *cmapi.ClusterIssuer {
 		},
 	}
 }
+
+// SetAccessToken sets the Secret data["access-token"] value
+func (v *VenafiTPP) SetAccessToken(token string) error {
+	v.createdSecret.Data["access-token"] = []byte(token)
+	s, err := v.Base.Details().KubeClient.CoreV1().Secrets(v.Namespace).Update(context.TODO(), v.createdSecret, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	v.createdSecret = s
+	return nil
+}

--- a/test/e2e/suite/issuers/venafi/BUILD.bazel
+++ b/test/e2e/suite/issuers/venafi/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["import.go"],
     importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/issuers/venafi",
     visibility = ["//visibility:public"],
-    deps = ["//test/e2e/suite/issuers/venafi/tpp:go_default_library"],
+    deps = [
+        "//test/e2e/suite/issuers/venafi/cloud:go_default_library",
+        "//test/e2e/suite/issuers/venafi/tpp:go_default_library",
+    ],
 )
 
 filegroup(
@@ -19,6 +22,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//test/e2e/suite/issuers/venafi/cloud:all-srcs",
         "//test/e2e/suite/issuers/venafi/tpp:all-srcs",
     ],
     tags = ["automanaged"],

--- a/test/e2e/suite/issuers/venafi/cloud/BUILD.bazel
+++ b/test/e2e/suite/issuers/venafi/cloud/BUILD.bazel
@@ -2,19 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "certificate.go",
-        "certificaterequest.go",
-        "doc.go",
-        "setup.go",
-    ],
-    importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/issuers/venafi/tpp",
-    tags = ["manual"],
+    srcs = ["setup.go"],
+    importpath = "github.com/cert-manager/cert-manager/test/e2e/suite/issuers/venafi/cloud",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/util:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon/venafi:go_default_library",
         "//test/e2e/util:go_default_library",

--- a/test/e2e/suite/issuers/venafi/cloud/setup.go
+++ b/test/e2e/suite/issuers/venafi/cloud/setup.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The cert-manager Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/e2e/framework"
+	vaddon "github.com/cert-manager/cert-manager/test/e2e/framework/addon/venafi"
+	"github.com/cert-manager/cert-manager/test/e2e/util"
+)
+
+func CloudDescribe(name string, body func()) bool {
+	return framework.CertManagerDescribe(name, body)
+}
+
+var _ = CloudDescribe("properly configured Venafi Cloud Issuer", func() {
+	f := framework.NewDefaultFramework("venafi-cloud-setup")
+
+	var (
+		issuer     *cmapi.Issuer
+		cloudAddon = &vaddon.VenafiCloud{}
+	)
+
+	BeforeEach(func() {
+		cloudAddon.Namespace = f.Namespace.Name
+	})
+
+	f.RequireAddon(cloudAddon)
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+	})
+
+	It("should set Ready=True accordingly", func() {
+		var err error
+		By("Creating a Venafi Cloud Issuer resource")
+		issuer = cloudAddon.Details().BuildIssuer()
+		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should set Ready=False with a bad access token", func() {
+		var err error
+		By("Creating a Venafi Cloud Issuer resource")
+		issuer = cloudAddon.Details().BuildIssuer()
+		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Changing the API key to something bad")
+		err = cloudAddon.SetAPIKey("this_is_a_bad_key")
+		Expect(err).NotTo(HaveOccurred())
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/e2e/suite/issuers/venafi/cloud/setup.go
+++ b/test/e2e/suite/issuers/venafi/cloud/setup.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The cert-manager Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/e2e/suite/issuers/venafi/import.go
+++ b/test/e2e/suite/issuers/venafi/import.go
@@ -17,5 +17,6 @@ limitations under the License.
 package venafi
 
 import (
+	_ "github.com/cert-manager/cert-manager/test/e2e/suite/issuers/venafi/cloud"
 	_ "github.com/cert-manager/cert-manager/test/e2e/suite/issuers/venafi/tpp"
 )

--- a/test/e2e/suite/issuers/venafi/tpp/setup.go
+++ b/test/e2e/suite/issuers/venafi/tpp/setup.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The cert-manager Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/e2e/suite/issuers/venafi/tpp/setup.go
+++ b/test/e2e/suite/issuers/venafi/tpp/setup.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The cert-manager Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpp
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/e2e/framework"
+	vaddon "github.com/cert-manager/cert-manager/test/e2e/framework/addon/venafi"
+	"github.com/cert-manager/cert-manager/test/e2e/util"
+)
+
+var _ = TPPDescribe("properly configured Venafi TPP Issuer", func() {
+	f := framework.NewDefaultFramework("venafi-tpp-setup")
+
+	var (
+		issuer   *cmapi.Issuer
+		tppAddon = &vaddon.VenafiTPP{}
+	)
+
+	BeforeEach(func() {
+		tppAddon.Namespace = f.Namespace.Name
+	})
+
+	f.RequireAddon(tppAddon)
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+	})
+
+	It("should set Ready=True accordingly", func() {
+		var err error
+		By("Creating a Venafi Issuer resource")
+		issuer = tppAddon.Details().BuildIssuer()
+		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should set Ready=False with a bad access token", func() {
+		var err error
+		By("Creating a Venafi Issuer resource")
+		issuer = tppAddon.Details().BuildIssuer()
+		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Changing the Access Token to something bad")
+		err = tppAddon.SetAccessToken("this_is_a_bad_token")
+		Expect(err).NotTo(HaveOccurred())
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuer.Name,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

Fixes #5154 

This is the first PR that fixes the immediate problem: a Venafi Issuer does not verify its access token or API key.

This PR changes the Venafi Issuer to remotely verify its access token (TPP) or API key (Cloud) with a remote server during setup. An invalid (expired, malformed) access token or API key will result in the Issuer setting `Ready=False`.

A follow-up PR will add functionality to periodically periodically perform this check.

Follow-up issue here: https://github.com/cert-manager/cert-manager/issues/5201

### Kind

bug

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixed a bug where the Venafi Issuer would not verify its access token (TPP) or API key (Cloud) before becoming ready. Venafi Issuers will now remotely verify the access token or API key.. (#5154, @jahrlin)
```
