### PR TITLE
Add tls config option for servicemonitor template file

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
   ports:
   - protocol: TCP
     port: 9402
-    name: tcp-prometheus-servicemonitor
+    name: {{ .Values.prometheus.service.portName }}
     targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
   selector:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -36,4 +36,11 @@ spec:
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
     honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
+    {{- if .Values.prometheus.servicemonitor.scheme }}
+    scheme: {{ .Values.prometheus.servicemonitor.scheme }}
+    {{- end }}
+    {{- if .Values.prometheus.servicemonitor.tlsConfig }}
+    tlsConfig: 
+      {{- toYaml .Values.prometheus.servicemonitor.tlsConfig | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -167,6 +167,8 @@ ingressShim: {}
 
 prometheus:
   enabled: true
+  service:
+    portName: tcp-prometheus-servicemonitor
   servicemonitor:
     enabled: false
     prometheusInstance: default
@@ -176,6 +178,9 @@ prometheus:
     scrapeTimeout: 30s
     labels: {}
     honorLabels: false
+    # Set tls config
+    # scheme: "https"
+    # tlsConfig: {}
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
### Pull Request Motivation

Add extra options to Prometheus service monitor in order to be able to set tls config when using Istio in mtls strict mode.

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
