### PR TITLE
fix(cmctl): typo in 'x install --help' text

### DIFF
--- a/cmd/ctl/pkg/install/install.go
+++ b/cmd/ctl/pkg/install/install.go
@@ -62,7 +62,7 @@ func installDesc() string {
 
 The latest published cert-manager chart in the "https://charts.jetstack.io" repo is used.
 Most of the features supported by 'helm install' are also supported by this command.
-In addition, his command will always correctly install the required CRD resources.
+In addition, this command will always correctly install the required CRD resources.
 
 Some example uses:
 	$ {{.BuildName}} x install


### PR DESCRIPTION
Signed-off-by: Mark Shields <4237425+beejiujitsu@users.noreply.github.com>

### Pull Request Motivation

Fix a simple spelling typo.

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

documentation

### Release Note

```release-note
NONE
```
