### PR TITLE
Add flag to allow switching ingressClassName specification

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -281,7 +281,8 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 			HTTP01SolverResourceLimitsMemory:  http01SolverResourceLimitsMemory,
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-			HTTP01SolverNameservers: opts.ACMEHTTP01SolverNameservers,
+			HTTP01SolverNameservers:     opts.ACMEHTTP01SolverNameservers,
+			HTTP01SolverUseIngressClass: opts.ACMEHTTP01SolverUseIngressClassName,
 
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.DNS01CheckRetryPeriod,

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -281,8 +281,7 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 			HTTP01SolverResourceLimitsMemory:  http01SolverResourceLimitsMemory,
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-			HTTP01SolverNameservers:     opts.ACMEHTTP01SolverNameservers,
-			HTTP01SolverUseIngressClass: opts.ACMEHTTP01SolverUseIngressClassName,
+			HTTP01SolverNameservers: opts.ACMEHTTP01SolverNameservers,
 
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.DNS01CheckRetryPeriod,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -81,8 +81,7 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-	ACMEHTTP01SolverNameservers         []string
-	ACMEHTTP01SolverUseIngressClassName bool
+	ACMEHTTP01SolverNameservers []string
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
@@ -309,10 +308,6 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		[]string{}, "A list of comma separated dns server endpoints used for "+
 			"ACME HTTP01 check requests. This should be a list containing host and "+
 			"port, for example 8.8.8.8:53,8.8.4.4:53")
-
-	fs.BoolVar(&s.ACMEHTTP01SolverUseIngressClassName, "acme-http01-solver-use-ingress-class-name", defaultACMEHTTP01SolverUseIngressClassName, ""+
-		"Whether ACME HTTP01 Ingress resources should use the new ingressClassName "+
-		"or the deprecated annotation.")
 
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -81,7 +81,8 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-	ACMEHTTP01SolverNameservers []string
+	ACMEHTTP01SolverNameservers         []string
+	ACMEHTTP01SolverUseIngressClassName bool
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
@@ -135,6 +136,8 @@ const (
 	defaultTLSACMEIssuerKind         = "Issuer"
 	defaultTLSACMEIssuerGroup        = cm.GroupName
 	defaultEnableCertificateOwnerRef = false
+
+	defaultACMEHTTP01SolverUseIngressClassName = false
 
 	defaultDNS01RecursiveNameserversOnly = false
 
@@ -306,6 +309,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		[]string{}, "A list of comma separated dns server endpoints used for "+
 			"ACME HTTP01 check requests. This should be a list containing host and "+
 			"port, for example 8.8.8.8:53,8.8.4.4:53")
+
+	fs.BoolVar(&s.ACMEHTTP01SolverUseIngressClassName, "acme-http01-solver-use-ingress-class-name", defaultACMEHTTP01SolverUseIngressClassName, ""+
+		"Whether ACME HTTP01 Ingress resources should use the new ingressClassName "+
+		"or the deprecated annotation.")
 
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -202,9 +202,16 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	ServiceType corev1.ServiceType
 
-	// The ingress class to use when creating Ingress resources to solve ACME
-	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// This field configures the `ingressClassName` when creating Ingress
+	// resources to solve ACME challenges that use this challenge solver. This
+	// is the recommended way of configuring the ingress class. Only one of
+	// `class`, `name` or `ingressClassName` may be specified.
+	IngressClassName *string
+
+	// This field configures the annotation `kubernetes.io/ingress.class` when
+	// creating Ingress resources to solve ACME challenges that use this
+	// challenge solver. Only one of `class`, `name` or `ingressClassName` may
+	// be specified.
 	Class *string
 
 	// The name of the ingress resource that should have ACME challenge solving

--- a/internal/apis/acme/v1alpha2/types_issuer.go
+++ b/internal/apis/acme/v1alpha2/types_issuer.go
@@ -221,9 +221,16 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The ingress class to use when creating Ingress resources to solve ACME
-	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// This field configures the field `ingressClassName` on the created Ingress
+	// resources used to solve ACME challenges that use this challenge solver.
+	// This is the recommended way of configuring the ingress class. Only one of
+	// `class`, `name` or `ingressClassName` may be specified. +optional
+	IngressClassName *string `json:"ingressClassName,omitempty"`
+
+	// This field configures the annotation `kubernetes.io/ingress.class` when
+	// creating Ingress resources to solve ACME challenges that use this
+	// challenge solver. Only one of `class`, `name` or `ingressClassName` may
+	// be specified.
 	// +optional
 	Class *string `json:"class,omitempty"`
 

--- a/internal/apis/acme/v1alpha3/types_issuer.go
+++ b/internal/apis/acme/v1alpha3/types_issuer.go
@@ -221,9 +221,16 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The ingress class to use when creating Ingress resources to solve ACME
-	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// This field configures the field `ingressClassName` on the created Ingress
+	// resources used to solve ACME challenges that use this challenge solver.
+	// This is the recommended way of configuring the ingress class. Only one of
+	// `class`, `name` or `ingressClassName` may be specified. +optional
+	IngressClassName *string `json:"ingressClassName,omitempty"`
+
+	// This field configures the annotation `kubernetes.io/ingress.class` when
+	// creating Ingress resources to solve ACME challenges that use this
+	// challenge solver. Only one of `class`, `name` or `ingressClassName` may
+	// be specified.
 	// +optional
 	Class *string `json:"class,omitempty"`
 

--- a/internal/apis/acme/v1beta1/types_issuer.go
+++ b/internal/apis/acme/v1beta1/types_issuer.go
@@ -220,9 +220,16 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The ingress class to use when creating Ingress resources to solve ACME
-	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// This field configures the field `ingressClassName` on the created Ingress
+	// resources used to solve ACME challenges that use this challenge solver.
+	// This is the recommended way of configuring the ingress class. Only one of
+	// `class`, `name` or `ingressClassName` may be specified. +optional
+	IngressClassName *string `json:"ingressClassName,omitempty"`
+
+	// This field configures the annotation `kubernetes.io/ingress.class` when
+	// creating Ingress resources to solve ACME challenges that use this
+	// challenge solver. Only one of `class`, `name` or `ingressClassName` may
+	// be specified.
 	// +optional
 	Class *string `json:"class,omitempty"`
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -24,6 +24,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
@@ -181,9 +182,21 @@ func ValidateACMEIssuerChallengeSolverHTTP01Config(http01 *cmacme.ACMEChallengeS
 func ValidateACMEIssuerChallengeSolverHTTP01IngressConfig(ingress *cmacme.ACMEChallengeSolverHTTP01Ingress, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
-	if ingress.Class != nil && len(ingress.Name) > 0 {
-		el = append(el, field.Forbidden(fldPath, "only one of 'name' or 'class' should be specified"))
+	if ingress.Class != nil && ingress.IngressClassName != nil && len(ingress.Name) > 0 {
+		el = append(el, field.Forbidden(fldPath, "only one of 'ingressClassName', 'name' or 'class' should be specified"))
 	}
+
+	// Since "class" used to be a free string, let's have a stricter validation
+	// for "ingressClassName" since it is expected to be a valid resource name.
+	// A notable example is "azure/application-gateway" that is a valid value
+	// for "class" but not for "ingressClassName".
+	if ingress.IngressClassName != nil {
+		errs := validation.IsDNS1123Subdomain(*ingress.IngressClassName)
+		if len(errs) > 0 {
+			el = append(el, field.Invalid(fldPath.Child("ingressClassName"), *ingress.IngressClassName, "must be a valid IngressClass name: "+strings.Join(errs, ", ")))
+		}
+	}
+
 	switch ingress.ServiceType {
 	case "", corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort:
 	default:

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -527,6 +527,11 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{Class: strPtr("abc")},
 			},
 		},
+		"ingressClassName field specified": {
+			cfg: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{IngressClassName: strPtr("abc")},
+			},
+		},
 		"neither field specified": {
 			cfg: &cmacme.ACMEChallengeSolverHTTP01{
 				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
@@ -538,15 +543,26 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 				field.Required(fldPath, "no HTTP01 solver type configured"),
 			},
 		},
-		"both fields specified": {
+		"all three fields specified": {
 			cfg: &cmacme.ACMEChallengeSolverHTTP01{
 				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
-					Name:  "abc",
-					Class: strPtr("abc"),
+					Name:             "abc",
+					Class:            strPtr("abc"),
+					IngressClassName: strPtr("abc"),
 				},
 			},
 			errs: []*field.Error{
-				field.Forbidden(fldPath.Child("ingress"), "only one of 'name' or 'class' should be specified"),
+				field.Forbidden(fldPath.Child("ingress"), "only one of 'ingressClassName', 'name' or 'class' should be specified"),
+			},
+		},
+		"ingressClassName is invalid": {
+			cfg: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					IngressClassName: strPtr("azure/application-gateway"),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("ingress", "ingressClassName"), "azure/application-gateway", `must be a valid IngressClass name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
 			},
 		},
 		"acme issuer with valid http01 service config serviceType ClusterIP": {

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -222,9 +222,16 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
-	// The ingress class to use when creating Ingress resources to solve ACME
-	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// This field configures the field `ingressClassName` on the created Ingress
+	// resources used to solve ACME challenges that use this challenge solver.
+	// This is the recommended way of configuring the ingress class. Only one of
+	// `class`, `name` or `ingressClassName` may be specified. +optional
+	IngressClassName *string `json:"ingressClassName,omitempty"`
+
+	// This field configures the annotation `kubernetes.io/ingress.class` when
+	// creating Ingress resources to solve ACME challenges that use this
+	// challenge solver. Only one of `class`, `name` or `ingressClassName` may
+	// be specified.
 	// +optional
 	Class *string `json:"class,omitempty"`
 

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -174,6 +174,9 @@ type ACMEOptions struct {
 	// for ACME HTTP01 validations.
 	HTTP01SolverNameservers []string
 
+	// HTTP01SolverUseIngressClass indicates whether to use the ingressClassName of IngressV1 resources.
+	HTTP01SolverUseIngressClass bool
+
 	// DNS01CheckAuthoritative is a flag for controlling if auth nss are used
 	// for checking propagation of an RR. This is the ideal scenario
 	DNS01CheckAuthoritative bool

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -127,7 +127,7 @@ func ingressServiceName(ing *networkingv1.Ingress) string {
 // createIngress will create a challenge solving ingress for the given certificate,
 // domain, token and key.
 func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
-	ing, err := buildIngressResource(ch, svcName)
+	ing, err := buildIngressResource(ch, svcName, s.HTTP01SolverUseIngressClass)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcNam
 	return s.ingressCreateUpdater.Ingresses(ch.Namespace).Create(ctx, ing, metav1.CreateOptions{})
 }
 
-func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
+func buildIngressResource(ch *cmacme.Challenge, svcName string, useIngressClassName bool) (*networkingv1.Ingress, error) {
 	http01IngressCfg, err := http01IngressCfgForChallenge(ch)
 	if err != nil {
 		return nil, err
@@ -154,13 +154,21 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.I
 	// TODO: Figure out how to remove this without breaking users who depend on it.
 	ingAnnotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = "0.0.0.0/0,::/0"
 
-	// Use the Ingress Class annotation defined in networkingv1beta1 even though our Ingress objects
-	// are networkingv1, for maximum compatibility with all Ingress controllers.
-	// if the `kubernetes.io/ingress.class` annotation is present, it takes precedence over the
-	// `spec.IngressClassName` field.
-	// See discussion in https://github.com/cert-manager/cert-manager/issues/4537.
-	if http01IngressCfg.Class != nil {
-		ingAnnotations[annotationIngressClass] = *http01IngressCfg.Class
+	// Use the annotation based on whether the user wants to
+	// https://github.com/cert-manager/cert-manager/issues/4821
+	var ingressClassName *string = nil
+	if useIngressClassName {
+		// https://github.com/cert-manager/cert-manager/issues/4537
+		ingressClassName = http01IngressCfg.Class
+	} else {
+		// Use the Ingress Class annotation defined in networkingv1beta1 even though our Ingress objects
+		// are networkingv1, for maximum compatibility with all Ingress controllers.
+		// if the `kubernetes.io/ingress.class` annotation is present, it takes precedence over the
+		// `spec.IngressClassName` field.
+		// See discussion in https://github.com/cert-manager/cert-manager/issues/4537.
+		if http01IngressCfg.Class != nil {
+			ingAnnotations[annotationIngressClass] = *http01IngressCfg.Class
+		}
 	}
 
 	ingPathToAdd := ingressPath(ch.Spec.Token, svcName)
@@ -179,8 +187,7 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.I
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
 		},
 		Spec: networkingv1.IngressSpec{
-			// https://github.com/cert-manager/cert-manager/issues/4537
-			IngressClassName: nil,
+			IngressClassName: ingressClassName,
 			Rules: []networkingv1.IngressRule{
 				{
 					Host: httpHost,

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -127,7 +127,7 @@ func ingressServiceName(ing *networkingv1.Ingress) string {
 // createIngress will create a challenge solving ingress for the given certificate,
 // domain, token and key.
 func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
-	ing, err := buildIngressResource(ch, svcName, s.HTTP01SolverUseIngressClass)
+	ing, err := buildIngressResource(ch, svcName)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcNam
 	return s.ingressCreateUpdater.Ingresses(ch.Namespace).Create(ctx, ing, metav1.CreateOptions{})
 }
 
-func buildIngressResource(ch *cmacme.Challenge, svcName string, useIngressClassName bool) (*networkingv1.Ingress, error) {
+func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
 	http01IngressCfg, err := http01IngressCfgForChallenge(ch)
 	if err != nil {
 		return nil, err
@@ -154,21 +154,18 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string, useIngressClassN
 	// TODO: Figure out how to remove this without breaking users who depend on it.
 	ingAnnotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = "0.0.0.0/0,::/0"
 
-	// Use the annotation based on whether the user wants to
-	// https://github.com/cert-manager/cert-manager/issues/4821
-	var ingressClassName *string = nil
-	if useIngressClassName {
-		// https://github.com/cert-manager/cert-manager/issues/4537
-		ingressClassName = http01IngressCfg.Class
-	} else {
-		// Use the Ingress Class annotation defined in networkingv1beta1 even though our Ingress objects
-		// are networkingv1, for maximum compatibility with all Ingress controllers.
-		// if the `kubernetes.io/ingress.class` annotation is present, it takes precedence over the
-		// `spec.IngressClassName` field.
-		// See discussion in https://github.com/cert-manager/cert-manager/issues/4537.
-		if http01IngressCfg.Class != nil {
-			ingAnnotations[annotationIngressClass] = *http01IngressCfg.Class
-		}
+	// We don't allow setting both the annotation and field because no use-case
+	// has been identified for doing so.
+	if http01IngressCfg.Class != nil && http01IngressCfg.IngressClassName != nil {
+		return nil, fmt.Errorf("the fields ingressClassName and class cannot be set at the same time")
+	}
+
+	var ingressClassName *string
+	if http01IngressCfg.Class != nil {
+		ingAnnotations[annotationIngressClass] = *http01IngressCfg.Class
+	}
+	if http01IngressCfg.IngressClassName != nil {
+		ingressClassName = http01IngressCfg.IngressClassName
 	}
 
 	ingPathToAdd := ingressPath(ch.Spec.Token, svcName)

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -519,7 +519,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
+				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice", false)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -597,7 +597,7 @@ func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
+				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice", false)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -473,6 +475,28 @@ func TestEnsureIngress(t *testing.T) {
 				}
 			},
 		},
+		"class field is passed to ingress as the annotation kubernetes.io/ingress.class": {
+			Challenge: &cmacme.Challenge{Spec: cmacme.ChallengeSpec{Solver: cmacme.ACMEChallengeSolver{HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					Class: strPtr("nginx"),
+				}}}},
+			},
+			CheckFn: checkOneIngress(func(t *testing.T, ingress *networkingv1.Ingress) {
+				assert.Equal(t, "nginx", ingress.Annotations["kubernetes.io/ingress.class"])
+				assert.Empty(t, ingress.Spec.IngressClassName)
+			}),
+		},
+		"ingressClassName field is passed to the ingress": {
+			Challenge: &cmacme.Challenge{Spec: cmacme.ChallengeSpec{Solver: cmacme.ACMEChallengeSolver{HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					IngressClassName: strPtr("nginx"),
+				}}}},
+			},
+			CheckFn: checkOneIngress(func(t *testing.T, ingress *networkingv1.Ingress) {
+				assert.Empty(t, ingress.Annotations["kubernetes.io/ingress.class"])
+				assert.Equal(t, strPtr("nginx"), ingress.Spec.IngressClassName)
+			}),
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -486,6 +510,19 @@ func TestEnsureIngress(t *testing.T) {
 			}
 			test.Finish(t, resp, err)
 		})
+	}
+}
+
+func Test_createIngress(t *testing.T) {
+
+}
+
+func checkOneIngress(check func(*testing.T, *networkingv1.Ingress)) func(*testing.T, *solverFixture, ...interface{}) {
+	return func(t *testing.T, s *solverFixture, _ ...interface{}) {
+		ingresses, err := s.Solver.ingressLister.List(labels.NewSelector())
+		assert.NoError(t, err)
+		require.Len(t, ingresses, 1)
+		check(t, ingresses[0])
 	}
 }
 
@@ -519,7 +556,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice", false)
+				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -597,7 +634,7 @@ func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice", false)
+				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

In order to support both the legacy annotation and the new ingressClassName of Ingress v1, a flag has been added to allow switching. This should allow users with clusters supporting only ingressClassName to use the latest version, while being fully backwards compatible with existing users that use clusters that do not support ingressClassName.

Closes: #4821 

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add new flag `acme-http01-solver-use-ingress-class-name` to allow switching between the legacy annotation and new ingressClassName field.
```
