### PR TITLE
[release-1.7] Go and base image version bumps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//hack/build:nogo_vet",
-    version = "1.17.8",
+    version = "1.17.11",
 )
 
 ## Load gazelle and dependencies

--- a/build/images.bzl
+++ b/build/images.bzl
@@ -23,7 +23,7 @@ def define_base_images():
         name = "static_base",
         registry = "gcr.io",
         repository = "distroless/static",
-        digest = "sha256:f4e4259820649c75fef543614974adc1dfe1c937d5c663a81b3edca5da472442"
+        digest = "sha256:3e8b85e48c98349a4b6e853c63704b3df78ba8b73279663da26f42a3472ff888"
     )
     # Use 'dynamic' distroless image for modified cert-manager deployments that
     # are dynamically linked. (This is not the default and you probably don't
@@ -35,5 +35,5 @@ def define_base_images():
         name = "dynamic_base",
         registry = "gcr.io",
         repository = "distroless/base",
-        digest = "sha256:0d7168393f3b5182e0b4573b181498ba592ab18d14f35e299c2375ead522254a"
+        digest = "sha256:6010a285f9a871e8f1f33142d53e2ad6d9d102d647704ac191c191f5becc2516"
     )


### PR DESCRIPTION
### Pull Request Motivation

Since we're likely to make our last-ever release from the 1.7 branch (since the release of 1.9 will mean 1.7.x is no longer supported), it seems prudent to update our base images and our go version to the latest currently available to maximise its useful lifespan for people!

This PR bumps to the latest [go version](https://groups.google.com/g/golang-announce/c/TzIC9-t8Ytg) (inspired by [this PR](https://github.com/cert-manager/cert-manager/commit/091549620bea6bd971f859ca32f2c7755dd4eb58)) and also updates the base images we use to their latest versions as seen on `master` ( as was done in #5222 )

(This is a second attempt to raise the PR; I originally raised #5233 with the wrong base branch which caused a lot of problems. Easiest solution seemed to be to try again.)

### Kind

/kind cleanup

### Release Note

```release-note
Bumps go to 1.17.11 and base images to latest distroless base images
```
