### PR TITLE
Don't require python to be installed for everything

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,5 +1,3 @@
-__PYTHON := python3
-
 .PHONY: ci-presubmit
 ## Run all checks (but not Go tests) which should pass before any given pull
 ## request or change is merged.
@@ -19,8 +17,11 @@ verify-chart: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
 verify-errexit:
 	./hack/verify-errexit.sh
 
+__PYTHON := python3
+
 .PHONY: verify-boilerplate
 verify-boilerplate:
+	@command -v $(__PYTHON) >/dev/null || (echo "couldn't find python3 at '$(__PYTHON)', required for $@. Install python3 or set '__PYTHON'" && exit 1)
 	$(__PYTHON) hack/verify_boilerplate.py
 
 .PHONY: verify-licenses

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -47,7 +47,7 @@ SERVICE_IP_PREFIX = 10.0.0
 ## The Kind image is pre-pulled to avoid 'kind create' from blocking other make
 ## targets.
 ##
-##	make kind [KIND_CLUSTER_NAME=name] [K8S_VERSION=<kubernetes_version>]
+##	make [KIND_CLUSTER_NAME=name] [K8S_VERSION=<kubernetes_version>] e2e-setup-kind
 ##
 ## @category Development
 e2e-setup-kind: kind-exists

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -437,7 +437,6 @@ else
 # to be available on the system. The vendor-go MAKECMDGOALS trick prevents the
 # check for the presence of Go when 'make vendor-go' is run.
 MISSING=$(shell (command -v curl >/dev/null || echo curl) \
-             && (command -v python3 >/dev/null || echo python3) \
              && (command -v jq >/dev/null || echo jq) \
              && (command -v sha256sum >/dev/null || echo sha256sum) \
              && (command -v git >/dev/null || echo git) \


### PR DESCRIPTION
We only use python in one place and probably won't start using it more without some kind of policy change.

We don't need to require that everyone has it installed, and can instead only require it for people who're running the boilerplate check.

### Kind

/kind cleanup

### Release Note

```release-note
Only require python for the one test we have which needs it, rather than requiring it globally
```
