### PR TITLE
fix: securityContext

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -116,14 +116,16 @@ resources: {}
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container Security Context to be set on the controller component container
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 containerSecurityContext:
   allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop:
-  #   - ALL
+  capabilities:
+    drop:
+    - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
 
@@ -235,14 +237,16 @@ webhook:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
@@ -375,14 +379,16 @@ cainjector:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
@@ -459,14 +465,16 @@ startupapicheck:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the controller component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 


### PR DESCRIPTION
### Pull Request Motivation

Brings cert-manager deployments in compliance with PSS/restricted.

Fixes #4693 

See #4036 for prior work.

Note to maintainers:

I noticed that the kyverno version and policies used internally are out of date:
1. The kyverno version [installed](https://github.com/cert-manager/cert-manager/blob/master/devel/addon/kyverno/install.sh#L35) is 1.3.6 whereas the current version is 1.7.1
2. `kustomize build https://github.com/kyverno/policies//pod-security` (the latest policies) are significantly different from those that are [currently used](https://github.com/cert-manager/cert-manager/blob/master/devel/addon/kyverno/policy.yaml)

However, instead of updating kyverno and its policies, it may be better to remove kyverno from the devel tests and instead use PSA to verify PSS/restricted compliance:

https://kubernetes.io/docs/tutorials/security/ns-level-pss/

PSA is enabled by default in Kubernetes v1.23 and later.

### Kind

/kind bug

### Release Note

```release-note
Enhanced securityContext for PSS/restricted compliance.
```
