### PR TITLE
fix: update kyverno version, policy.yaml and securityContexts

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -116,14 +116,16 @@ resources: {}
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container Security Context to be set on the controller component container
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 containerSecurityContext:
   allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop:
-  #   - ALL
+  capabilities:
+    drop:
+    - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
 
@@ -235,14 +237,16 @@ webhook:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
@@ -375,14 +379,16 @@ cainjector:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
@@ -459,14 +465,16 @@ startupapicheck:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   # Container Security Context to be set on the controller component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     allowPrivilegeEscalation: false
-    # capabilities:
-    #   drop:
-    #   - ALL
+    capabilities:
+      drop:
+      - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 

--- a/devel/addon/kyverno/BUILD.bazel
+++ b/devel/addon/kyverno/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
 container_bundle(
-    name = "bundle_v1.3.6",
+    name = "bundle_v1.7.1",
     images = {
-        "ghcr.io/kyverno/kyverno:v1.3.6": "@io_kyverno//image",
+        "ghcr.io/kyverno/kyverno:v1.7.1": "@io_kyverno//image",
     },
     tags = ["manual"],
 )
 
 container_bundle(
-    name = "pre_bundle_v1.3.6",
+    name = "pre_bundle_v1.7.1",
     images = {
-        "ghcr.io/kyverno/kyvernopre:v1.3.6": "@io_kyverno_pre//image",
+        "ghcr.io/kyverno/kyvernopre:v1.7.1": "@io_kyverno_pre//image",
     },
     tags = ["manual"],
 )

--- a/devel/addon/kyverno/install.sh
+++ b/devel/addon/kyverno/install.sh
@@ -31,9 +31,9 @@ source "${SCRIPT_ROOT}/../../lib/lib.sh"
 check_tool kubectl
 check_tool helm
 
-CHART_VERSION="v1.3.6"
-IMAGE_TAG="v1.3.6"
-PRE_IMAGE_TAG="v1.3.6"
+CHART_VERSION="v2.5.1"
+IMAGE_TAG="v1.7.1"
+PRE_IMAGE_TAG="v1.7.1"
 
 require_image "ghcr.io/kyverno/kyverno:${IMAGE_TAG}" "//devel/addon/kyverno:bundle_${IMAGE_TAG}"
 require_image "ghcr.io/kyverno/kyvernopre:${PRE_IMAGE_TAG}" "//devel/addon/kyverno:pre_bundle_${PRE_IMAGE_TAG}"

--- a/devel/addon/kyverno/kustomization.yaml
+++ b/devel/addon/kyverno/kustomization.yaml
@@ -4,7 +4,7 @@
 # Use as follows:
 #  kustomize build . > policy.yaml
 bases:
-  - https://github.com/kyverno/policies/pod-security
+  - https://github.com/kyverno/policies/pod-security/enforce
 patches:
   - patch: |-
       - op: replace

--- a/devel/addon/kyverno/policy.yaml
+++ b/devel/addon/kyverno/policy.yaml
@@ -2,95 +2,145 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: Privilege escalation, such as via set-user-ID
-      or set-group-ID file mode, should not be allowed.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: deny-privilege-escalation
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: deny-privilege-escalation
-    validate:
-      message: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation,
-        and spec.initContainers[*].securityContext.allowPrivilegeEscalation must be
-        undefined or set to `false`.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(allowPrivilegeEscalation): "false"
-          containers:
-          - =(securityContext):
-              =(allowPrivilegeEscalation): "false"
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Capabilities permit privileged actions without
-      giving full root access. Adding capabilities beyond the default set must not
-      be allowed.
+    policies.kyverno.io/description: Adding capabilities beyond those listed in the
+      policy must be disallowed.
+    policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-  name: disallow-add-capabilities
+    policies.kyverno.io/title: Disallow Capabilities
+  name: disallow-capabilities
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: capabilities
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: adding-capabilities
     validate:
-      message: Adding of additional capabilities beyond the default set is not allowed.
-        The fields spec.containers[*].securityContext.capabilities.add and  spec.initContainers[*].securityContext.capabilities.add
-        must be empty.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(capabilities):
-                X(add): null
-          containers:
-          - =(securityContext):
-              =(capabilities):
-                X(add): null
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.[ephemeralContainers, initContainers, containers][].securityContext.capabilities.add[]
+              }}'
+            operator: AnyNotIn
+            value:
+            - AUDIT_WRITE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - MKNOD
+            - NET_BIND_SERVICE
+            - SETFCAP
+            - SETGID
+            - SETPCAP
+            - SETUID
+            - SYS_CHROOT
+      message: Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN,
+        DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID,
+        SETPCAP, SETUID, SYS_CHROOT) are disallowed.
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Adding capabilities other than `NET_BIND_SERVICE`
+      is disallowed. In addition, all containers must explicitly drop `ALL` capabilities.
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Capabilities (Strict)
+  name: disallow-capabilities-strict
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: require-drop-all
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: ALL
+              operator: AnyNotIn
+              value: '{{ element.securityContext.capabilities.drop || '''' }}'
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Containers must drop `ALL` capabilities.
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: adding-capabilities-strict
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: '{{ element.securityContext.capabilities.add[] || '''' }}'
+              operator: AnyNotIn
+              value:
+              - NET_BIND_SERVICE
+              - ""
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Host namespaces (Process ID namespace, Inter-Process
       Communication namespace, and network namespace) allow access to shared information
       and can be used to elevate privileges. Pods should not be allowed access to
-      host namespaces.
+      host namespaces. This policy ensures fields which make use of these host namespaces
+      are unset or set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Host Namespaces
   name: disallow-host-namespaces
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: host-namespaces
     validate:
       message: Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
-        spec.hostIPC, and spec.hostPID must not be set to true.
+        spec.hostIPC, and spec.hostPID must be unset or set to `false`.
       pattern:
         spec:
           =(hostIPC): "false"
@@ -102,25 +152,30 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: HostPath volumes let pods use host directories
+    policies.kyverno.io/description: HostPath volumes let Pods use host directories
       and volumes in containers. Using host resources can be used to access shared
-      data or escalate privileges and should not be allowed.
+      data or escalate privileges and should not be allowed. This policy ensures no
+      hostPath volumes are in use.
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/subject: Pod,Volume
+    policies.kyverno.io/title: Disallow hostPath
   name: disallow-host-path
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: host-path
     validate:
-      message: HostPath volumes are forbidden. The fields spec.volumes[*].hostPath
-        must not be set.
+      message: HostPath volumes are forbidden. The field spec.volumes[*].hostPath
+        must be unset.
       pattern:
         spec:
           =(volumes):
@@ -131,59 +186,164 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Access to host ports allows potential snooping
+    policies.kyverno.io/description: 'Access to host ports allows potential snooping
       of network traffic and should not be allowed, or at minimum restricted to a
-      known list.
+      known list. This policy ensures the `hostPort` field is unset or set to `0`. '
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostPorts
   name: disallow-host-ports
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: host-ports
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: host-ports-none
     validate:
       message: Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort
-        and spec.initContainers[*].ports[*].hostPort must be empty.
+        , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
+        must either be unset or set to `0`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(ports):
+            - =(hostPort): 0
           =(initContainers):
           - =(ports):
-            - X(hostPort): 0
+            - =(hostPort): 0
           containers:
           - =(ports):
-            - X(hostPort): 0
+            - =(hostPort): 0
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Privileged mode disables most security mechanisms
-      and must not be allowed.
+    policies.kyverno.io/description: Windows pods offer the ability to run HostProcess
+      containers which enables privileged access to the Windows node. Privileged access
+      to the host is disallowed in the baseline policy. HostProcess pods are an alpha
+      feature as of Kubernetes v1.22. This policy ensures the `hostProcess` field,
+      if present, is set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostProcess
+  name: disallow-host-process
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: host-process-containers
+    validate:
+      message: HostProcess containers are disallowed. The fields spec.securityContext.windowsOptions.hostProcess,
+        spec.containers[*].securityContext.windowsOptions.hostProcess, spec.initContainers[*].securityContext.windowsOptions.hostProcess,
+        and spec.ephemeralContainers[*].securityContext.windowsOptions.hostProcess
+        must either be undefined or set to `false`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+          =(initContainers):
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+          containers:
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Privilege escalation, such as via set-user-ID
+      or set-group-ID file mode, should not be allowed. This policy ensures the `allowPrivilegeEscalation`
+      field is set to `false`.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privilege Escalation
+  name: disallow-privilege-escalation
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: privilege-escalation
+    validate:
+      message: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation,
+        spec.initContainers[*].securityContext.allowPrivilegeEscalation, and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+        must be set to `false`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+          =(initContainers):
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+          containers:
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: Privileged mode disables most security mechanisms
+      and must not be allowed. This policy ensures Pods do not call for privileged
+      mode.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privileged Containers
   name: disallow-privileged-containers
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: priviledged-containers
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: privileged-containers
     validate:
       message: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
-        and spec.initContainers[*].securityContext.privileged must not be set to true.
+        and spec.initContainers[*].securityContext.privileged must be unset or set
+        to `false`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(privileged): "false"
           =(initContainers):
           - =(securityContext):
               =(privileged): "false"
@@ -196,9 +356,55 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: The default /proc masks are set up to reduce
+      attack surface and should be required. This policy ensures nothing but the default
+      procMount can be specified. Note that in order for users to deviate from the
+      `Default` procMount requires setting a feature gate at the API server.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow procMount
+  name: disallow-proc-mount
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-proc-mount
+    validate:
+      message: Changing the proc mount from the default is not allowed. The fields
+        spec.containers[*].securityContext.procMount, spec.initContainers[*].securityContext.procMount,
+        and spec.ephemeralContainers[*].securityContext.procMount must be unset or
+        set to `Default`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(procMount): Default
+          =(initContainers):
+          - =(securityContext):
+              =(procMount): Default
+          containers:
+          - =(securityContext):
+              =(procMount): Default
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: SELinux options can be used to escalate privileges
-      and should not be allowed.
+      and should not be allowed. This policy ensures that the `seLinuxOptions` field
+      is undefined.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Disallow SELinux
@@ -208,141 +414,145 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: seLinux
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: selinux-type
     validate:
-      message: Setting custom SELinux options is disallowed. The fields spec.securityContext.seLinuxOptions,
-        spec.containers[*].securityContext.seLinuxOptions, and spec.initContainers[*].securityContext.seLinuxOptions
-        must be empty.
+      message: Setting the SELinux type is restricted. The fields spec.securityContext.seLinuxOptions.type,
+        spec.containers[*].securityContext.seLinuxOptions.type, , spec.initContainers[*].securityContext.seLinuxOptions,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type must either
+        be unset or set to one of the allowed values (container_t, container_init_t,
+        or container_kvm_t).
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
           =(initContainers):
           - =(securityContext):
-              X(seLinuxOptions): "null"
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
           =(securityContext):
-            X(seLinuxOptions): "null"
+            =(seLinuxOptions):
+              =(type): container_t | container_init_t | container_kvm_t
           containers:
           - =(securityContext):
-              X(seLinuxOptions): "null"
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: selinux-user-role
+    validate:
+      message: Setting the SELinux user or role is forbidden. The fields spec.securityContext.seLinuxOptions.user,
+        spec.securityContext.seLinuxOptions.role, spec.containers[*].securityContext.seLinuxOptions.user,
+        spec.containers[*].securityContext.seLinuxOptions.role, spec.initContainers[*].securityContext.seLinuxOptions.user,
+        spec.initContainers[*].securityContext.seLinuxOptions.role, spec.ephemeralContainers[*].securityContext.seLinuxOptions.user,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role must be
+        unset.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
+          =(initContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
+          =(securityContext):
+            =(seLinuxOptions):
+              X(role): "null"
+              X(user): "null"
+          containers:
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: The default /proc masks are set up to reduce
-      attack surface and should be required.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: require-default-proc-mount
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-proc-mount
-    validate:
-      message: Changing the proc mount from the default is not allowed. The fields
-        spec.containers[*].securityContext.procMount and spec.initContainers[*].securityContext.procMount
-        must not be changed  from `Default`.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(procMount): Default
-          containers:
-          - =(securityContext):
-              =(procMount): Default
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: Containers should be forbidden from running with
-      a root primary or supplementary GID.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: require-non-root-groups
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-runasgroup
-    validate:
-      message: "Running with root group IDs is disallowed. The fields\t spec.securityContext.runAsGroup,
-        spec.containers[*].securityContext.runAsGroup,\t and spec.initContainers[*].securityContext.runAsGroup
-        must be empty\t or greater than zero."
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(runAsGroup): '>0'
-          =(securityContext):
-            =(runAsGroup): '>0'
-          containers:
-          - =(securityContext):
-              =(runAsGroup): '>0'
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-supplementalGroups
-    validate:
-      message: "Adding of supplemental group IDs is not allowed. The field\t spec.securityContext.supplementalGroups
-        must not be defined."
-      pattern:
-        spec:
-          =(securityContext):
-            =(supplementalGroups):
-            - "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-fsGroup
-    validate:
-      message: Changing to root group ID is disallowed. The field spec.securityContext.fsGroup
-        must be empty or greater than zero.
-      pattern:
-        spec:
-          =(securityContext):
-            =(fsGroup): '>0'
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Containers must be required to run as non-root
-      users.
+      users. This policy ensures `runAsUser` is either unset or set to a number greater
+      than zero.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-  name: require-run-as-non-root
+    policies.kyverno.io/title: Require Run As Non-Root User
+  name: require-run-as-non-root-user
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-containers
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: run-as-non-root-user
+    validate:
+      message: Running as root is not allowed. The fields spec.securityContext.runAsUser,
+        spec.containers[*].securityContext.runAsUser, spec.initContainers[*].securityContext.runAsUser,
+        and spec.ephemeralContainers[*].securityContext.runAsUser must be unset or
+        set to a number greater than zero.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(runAsUser): '>0'
+          =(initContainers):
+          - =(securityContext):
+              =(runAsUser): '>0'
+          =(securityContext):
+            =(runAsUser): '>0'
+          containers:
+          - =(securityContext):
+              =(runAsUser): '>0'
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Containers must be required to run as non-root
+      users. This policy ensures `runAsNonRoot` is set to `true`. A known issue prevents
+      a policy such as this using `anyPattern` from being persisted properly in Kubernetes
+      1.23.0-1.23.2.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Require runAsNonRoot
+  name: require-run-as-nonroot
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: run-as-non-root
     validate:
       anyPattern:
       - spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(runAsNonRoot): true
           =(initContainers):
           - =(securityContext):
               =(runAsNonRoot): true
@@ -352,25 +562,33 @@ spec:
           securityContext:
             runAsNonRoot: true
       - spec:
+          =(ephemeralContainers):
+          - securityContext:
+              runAsNonRoot: true
           =(initContainers):
           - securityContext:
               runAsNonRoot: true
           containers:
           - securityContext:
               runAsNonRoot: true
-      message: Running as root is not allowed. The fields spec.securityContext.runAsNonRoot,
-        spec.containers[*].securityContext.runAsNonRoot, and spec.initContainers[*].securityContext.runAsNonRoot
-        must be `true`.
+      message: Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot
+        must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot,
+        spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
+        must be set to `true`.
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: On supported hosts, the 'runtime/default' AppArmor
-      profile is applied by default.  The default policy should prevent overriding
-      or disabling the policy, or restrict  overrides to an allowed set of profiles.
+      profile is applied by default. The default policy should prevent overriding
+      or disabling the policy, or restrict overrides to an allowed set of profiles.
+      This policy ensures Pods do not specify any other AppArmor profiles than `runtime/default`
+      or `localhost/*`.
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod, Annotation
@@ -381,26 +599,31 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: app-armor
     validate:
-      message: Specifying other AppArmor profiles is disallowed. The annotation container.apparmor.security.beta.kubernetes.io
-        must not be defined, or must not be set to anything other than `runtime/default`.
+      message: Specifying other AppArmor profiles is disallowed. The annotation `container.apparmor.security.beta.kubernetes.io`
+        if defined must not be set to anything other than `runtime/default` or `localhost/*`.
       pattern:
-        metadata:
+        =(metadata):
           =(annotations):
-            =(container.apparmor.security.beta.kubernetes.io/*): runtime/default
+            =(container.apparmor.security.beta.kubernetes.io/*): runtime/default |
+              localhost/*
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: The runtime default seccomp profile must be required,
-      or only specific additional profiles should be allowed.
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: The seccomp profile must not be explicitly set
+      to Unconfined. This policy,  requiring Kubernetes v1.19 or later, ensures that
+      seccomp is unset or  set to `RuntimeDefault` or `Localhost`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Restrict Seccomp
@@ -410,316 +633,181 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: seccomp
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-seccomp
     validate:
       message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
-        spec.containers[*].securityContext.seccompProfile.type, and spec.initContainers[*].securityContext.seccompProfile.type
-        must be unset or set to `runtime/default`.
+        spec.containers[*].securityContext.seccompProfile.type, spec.initContainers[*].securityContext.seccompProfile.type,
+        and spec.ephemeralContainers[*].securityContext.seccompProfile.type must be
+        unset or set to `RuntimeDefault` or `Localhost`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
           =(initContainers):
           - =(securityContext):
               =(seccompProfile):
-                =(type): runtime/default
+                =(type): RuntimeDefault | Localhost
           =(securityContext):
             =(seccompProfile):
-              =(type): runtime/default
+              =(type): RuntimeDefault | Localhost
           containers:
           - =(securityContext):
               =(seccompProfile):
-                =(type): runtime/default
+                =(type): RuntimeDefault | Localhost
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: The seccomp profile in the Restricted group must
+      not be explicitly set to Unconfined but additionally must also not allow an
+      unset value. This policy,  requiring Kubernetes v1.19 or later, ensures that
+      seccomp is  set to `RuntimeDefault` or `Localhost`. A known issue prevents a
+      policy such as this using `anyPattern` from being persisted properly in Kubernetes
+      1.23.0-1.23.2.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Restrict Seccomp (Strict)
+  name: restrict-seccomp-strict
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-seccomp-strict
+    validate:
+      anyPattern:
+      - spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          =(initContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          containers:
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault | Localhost
+      - spec:
+          =(ephemeralContainers):
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+          =(initContainers):
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+          containers:
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+      message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
+        spec.containers[*].securityContext.seccompProfile.type, spec.initContainers[*].securityContext.seccompProfile.type,
+        and spec.ephemeralContainers[*].securityContext.seccompProfile.type must be
+        set to `RuntimeDefault` or `Localhost`.
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Sysctls can disable security mechanisms or affect
       all containers on a host, and should be disallowed except for an allowed "safe"
       subset. A sysctl is considered safe if it is namespaced in the container or
-      the Pod, and it is isolated from other Pods or processes on the same Node.
+      the Pod, and it is isolated from other Pods or processes on the same Node. This
+      policy ensures that only those "safe" subsets can be specified in a Pod.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Restrict sysctls
   name: restrict-sysctls
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: sysctls
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-sysctls
     validate:
       message: Setting additional sysctls above the allowed type is disallowed. The
-        field spec.securityContext.sysctls must not use any other names than 'kernel.shm_rmid_forced',
-        'net.ipv4.ip_local_port_range', 'net.ipv4.tcp_syncookies' and 'net.ipv4.ping_group_range'.
+        field spec.securityContext.sysctls must be unset or not use any other names
+        than kernel.shm_rmid_forced, net.ipv4.ip_local_port_range, net.ipv4.ip_unprivileged_port_start,
+        net.ipv4.tcp_syncookies and net.ipv4.ping_group_range.
       pattern:
         spec:
           =(securityContext):
             =(sysctls):
-            - name: kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.tcp_syncookies
-                | net.ipv4.ping_group_range
-              value: ?*
+            - =(name): kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.ip_unprivileged_port_start
+                | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: In addition to restricting HostPath volumes,
       the restricted pod security profile limits usage of non-core volume types to
-      those defined through PersistentVolumes.
+      those defined through PersistentVolumes. This policy blocks any other type of
+      volume other than those in the allow list.
+    policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/subject: Pod,Volume
+    policies.kyverno.io/title: Restrict Volume Types
   name: restrict-volume-types
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-gcePersistentDisk
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: restricted-volumes
     validate:
-      message: Use of the gcePersistentDisk type volume is disallowed. The fields
-        spec.volumes[*].gcePersistentDisk must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(gcePersistentDisk): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-awsElasticBlockStore
-    validate:
-      message: Use of the awsElasticBlockStore type volume is disallowed. The fields
-        spec.volumes[*].awsElasticBlockStore must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(awsElasticBlockStore): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-gitRepo
-    validate:
-      message: Use of the gitRepo type volume is disallowed. The fields spec.volumes[*].gitRepo
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(gitRepo): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-nfs
-    validate:
-      message: Use of the nfs type volume is disallowed. The fields spec.volumes[*].nfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(nfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-iscsi
-    validate:
-      message: Use of the iscsi type volume is disallowed. The fields spec.volumes[*].iscsi
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(iscsi): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-glusterfs
-    validate:
-      message: Use of the glusterfs type volume is disallowed. The fields spec.volumes[*].glusterfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(glusterfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-rbd
-    validate:
-      message: Use of the rbd type volume is disallowed. The fields spec.volumes[*].rbd
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(rbd): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-flexVolume
-    validate:
-      message: Use of the flexVolume type volume is disallowed. The fields spec.volumes[*].flexVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(flexVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-cinder
-    validate:
-      message: Use of the cinder type volume is disallowed. The fields spec.volumes[*].cinder
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(cinder): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-cephfs
-    validate:
-      message: Use of the cephfs type volume is disallowed. The fields spec.volumes[*].cephfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(cephfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-flocker
-    validate:
-      message: Use of the flocker type volume is disallowed. The fields spec.volumes[*].flocker
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(flocker): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-fc
-    validate:
-      message: Use of the fc type volume is disallowed. The fields spec.volumes[*].fc
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(fc): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-azureFile
-    validate:
-      message: Use of the azureFile type volume is disallowed. The fields spec.volumes[*].azureFile
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(azureFile): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-vsphereVolume
-    validate:
-      message: Use of the vsphereVolume type volume is disallowed. The fields spec.volumes[*].vsphereVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(vsphereVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-quobyte
-    validate:
-      message: Use of the quobyte type volume is disallowed. The fields spec.volumes[*].quobyte
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(quobyte): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-azureDisk
-    validate:
-      message: Use of the azureDisk type volume is disallowed. The fields spec.volumes[*].azureDisk
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(azureDisk): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-portworxVolume
-    validate:
-      message: Use of the portworxVolume type volume is disallowed. The fields spec.volumes[*].portworxVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(portworxVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-scaleIO
-    validate:
-      message: Use of the scaleIO type volume is disallowed. The fields spec.volumes[*].scaleIO
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(scaleIO): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-storageos
-    validate:
-      message: Use of the storageos type volume is disallowed. The fields spec.volumes[*].storageos
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(storageos): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-csi
-    validate:
-      message: Use of the csi type volume is disallowed. The fields spec.volumes[*].csi
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(csi): "null"
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.volumes[].keys(@)[] || '''' }}'
+            operator: AnyNotIn
+            value:
+            - name
+            - configMap
+            - csi
+            - downwardAPI
+            - emptyDir
+            - ephemeral
+            - persistentVolumeClaim
+            - projected
+            - secret
+            - ""
+      message: 'Only the following types of volumes may be used: configMap, csi, downwardAPI,
+        emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.'
   validationFailureAction: enforce

--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -4,7 +4,7 @@
 # Use as follows:
 #  kustomize build . > policy.yaml
 bases:
-  - https://github.com/kyverno/policies/pod-security
+  - https://github.com/kyverno/policies/pod-security/enforce
 patches:
   - patch: |-
       - op: replace

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -2,95 +2,145 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: Privilege escalation, such as via set-user-ID
-      or set-group-ID file mode, should not be allowed.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: deny-privilege-escalation
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: deny-privilege-escalation
-    validate:
-      message: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation,
-        and spec.initContainers[*].securityContext.allowPrivilegeEscalation must be
-        undefined or set to `false`.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(allowPrivilegeEscalation): "false"
-          containers:
-          - =(securityContext):
-              =(allowPrivilegeEscalation): "false"
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Capabilities permit privileged actions without
-      giving full root access. Adding capabilities beyond the default set must not
-      be allowed.
+    policies.kyverno.io/description: Adding capabilities beyond those listed in the
+      policy must be disallowed.
+    policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-  name: disallow-add-capabilities
+    policies.kyverno.io/title: Disallow Capabilities
+  name: disallow-capabilities
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: capabilities
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: adding-capabilities
     validate:
-      message: Adding of additional capabilities beyond the default set is not allowed.
-        The fields spec.containers[*].securityContext.capabilities.add and  spec.initContainers[*].securityContext.capabilities.add
-        must be empty.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(capabilities):
-                X(add): null
-          containers:
-          - =(securityContext):
-              =(capabilities):
-                X(add): null
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.[ephemeralContainers, initContainers, containers][].securityContext.capabilities.add[]
+              }}'
+            operator: AnyNotIn
+            value:
+            - AUDIT_WRITE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - MKNOD
+            - NET_BIND_SERVICE
+            - SETFCAP
+            - SETGID
+            - SETPCAP
+            - SETUID
+            - SYS_CHROOT
+      message: Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN,
+        DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID,
+        SETPCAP, SETUID, SYS_CHROOT) are disallowed.
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Adding capabilities other than `NET_BIND_SERVICE`
+      is disallowed. In addition, all containers must explicitly drop `ALL` capabilities.
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Capabilities (Strict)
+  name: disallow-capabilities-strict
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: require-drop-all
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: ALL
+              operator: AnyNotIn
+              value: '{{ element.securityContext.capabilities.drop || '''' }}'
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Containers must drop `ALL` capabilities.
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: adding-capabilities-strict
+    preconditions:
+      all:
+      - key: '{{ request.operation }}'
+        operator: NotEquals
+        value: DELETE
+    validate:
+      foreach:
+      - deny:
+          conditions:
+            all:
+            - key: '{{ element.securityContext.capabilities.add[] || '''' }}'
+              operator: AnyNotIn
+              value:
+              - NET_BIND_SERVICE
+              - ""
+        list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+      message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Host namespaces (Process ID namespace, Inter-Process
       Communication namespace, and network namespace) allow access to shared information
       and can be used to elevate privileges. Pods should not be allowed access to
-      host namespaces.
+      host namespaces. This policy ensures fields which make use of these host namespaces
+      are unset or set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Host Namespaces
   name: disallow-host-namespaces
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: host-namespaces
     validate:
       message: Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
-        spec.hostIPC, and spec.hostPID must not be set to true.
+        spec.hostIPC, and spec.hostPID must be unset or set to `false`.
       pattern:
         spec:
           =(hostIPC): "false"
@@ -102,25 +152,30 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: HostPath volumes let pods use host directories
+    policies.kyverno.io/description: HostPath volumes let Pods use host directories
       and volumes in containers. Using host resources can be used to access shared
-      data or escalate privileges and should not be allowed.
+      data or escalate privileges and should not be allowed. This policy ensures no
+      hostPath volumes are in use.
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/subject: Pod,Volume
+    policies.kyverno.io/title: Disallow hostPath
   name: disallow-host-path
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: host-path
     validate:
-      message: HostPath volumes are forbidden. The fields spec.volumes[*].hostPath
-        must not be set.
+      message: HostPath volumes are forbidden. The field spec.volumes[*].hostPath
+        must be unset.
       pattern:
         spec:
           =(volumes):
@@ -131,59 +186,164 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Access to host ports allows potential snooping
+    policies.kyverno.io/description: 'Access to host ports allows potential snooping
       of network traffic and should not be allowed, or at minimum restricted to a
-      known list.
+      known list. This policy ensures the `hostPort` field is unset or set to `0`. '
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostPorts
   name: disallow-host-ports
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: host-ports
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: host-ports-none
     validate:
       message: Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort
-        and spec.initContainers[*].ports[*].hostPort must be empty.
+        , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
+        must either be unset or set to `0`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(ports):
+            - =(hostPort): 0
           =(initContainers):
           - =(ports):
-            - X(hostPort): 0
+            - =(hostPort): 0
           containers:
           - =(ports):
-            - X(hostPort): 0
+            - =(hostPort): 0
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: Privileged mode disables most security mechanisms
-      and must not be allowed.
+    policies.kyverno.io/description: Windows pods offer the ability to run HostProcess
+      containers which enables privileged access to the Windows node. Privileged access
+      to the host is disallowed in the baseline policy. HostProcess pods are an alpha
+      feature as of Kubernetes v1.22. This policy ensures the `hostProcess` field,
+      if present, is set to `false`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostProcess
+  name: disallow-host-process
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: host-process-containers
+    validate:
+      message: HostProcess containers are disallowed. The fields spec.securityContext.windowsOptions.hostProcess,
+        spec.containers[*].securityContext.windowsOptions.hostProcess, spec.initContainers[*].securityContext.windowsOptions.hostProcess,
+        and spec.ephemeralContainers[*].securityContext.windowsOptions.hostProcess
+        must either be undefined or set to `false`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+          =(initContainers):
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+          containers:
+          - =(securityContext):
+              =(windowsOptions):
+                =(hostProcess): "false"
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Privilege escalation, such as via set-user-ID
+      or set-group-ID file mode, should not be allowed. This policy ensures the `allowPrivilegeEscalation`
+      field is set to `false`.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privilege Escalation
+  name: disallow-privilege-escalation
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: privilege-escalation
+    validate:
+      message: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation,
+        spec.initContainers[*].securityContext.allowPrivilegeEscalation, and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+        must be set to `false`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+          =(initContainers):
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+          containers:
+          - securityContext:
+              allowPrivilegeEscalation: "false"
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: Privileged mode disables most security mechanisms
+      and must not be allowed. This policy ensures Pods do not call for privileged
+      mode.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privileged Containers
   name: disallow-privileged-containers
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: priviledged-containers
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: privileged-containers
     validate:
       message: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
-        and spec.initContainers[*].securityContext.privileged must not be set to true.
+        and spec.initContainers[*].securityContext.privileged must be unset or set
+        to `false`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(privileged): "false"
           =(initContainers):
           - =(securityContext):
               =(privileged): "false"
@@ -196,9 +356,55 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: The default /proc masks are set up to reduce
+      attack surface and should be required. This policy ensures nothing but the default
+      procMount can be specified. Note that in order for users to deviate from the
+      `Default` procMount requires setting a feature gate at the API server.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Disallow procMount
+  name: disallow-proc-mount
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-proc-mount
+    validate:
+      message: Changing the proc mount from the default is not allowed. The fields
+        spec.containers[*].securityContext.procMount, spec.initContainers[*].securityContext.procMount,
+        and spec.ephemeralContainers[*].securityContext.procMount must be unset or
+        set to `Default`.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(procMount): Default
+          =(initContainers):
+          - =(securityContext):
+              =(procMount): Default
+          containers:
+          - =(securityContext):
+              =(procMount): Default
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: SELinux options can be used to escalate privileges
-      and should not be allowed.
+      and should not be allowed. This policy ensures that the `seLinuxOptions` field
+      is undefined.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Disallow SELinux
@@ -208,141 +414,145 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: seLinux
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: selinux-type
     validate:
-      message: Setting custom SELinux options is disallowed. The fields spec.securityContext.seLinuxOptions,
-        spec.containers[*].securityContext.seLinuxOptions, and spec.initContainers[*].securityContext.seLinuxOptions
-        must be empty.
+      message: Setting the SELinux type is restricted. The fields spec.securityContext.seLinuxOptions.type,
+        spec.containers[*].securityContext.seLinuxOptions.type, , spec.initContainers[*].securityContext.seLinuxOptions,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type must either
+        be unset or set to one of the allowed values (container_t, container_init_t,
+        or container_kvm_t).
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
           =(initContainers):
           - =(securityContext):
-              X(seLinuxOptions): "null"
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
           =(securityContext):
-            X(seLinuxOptions): "null"
+            =(seLinuxOptions):
+              =(type): container_t | container_init_t | container_kvm_t
           containers:
           - =(securityContext):
-              X(seLinuxOptions): "null"
+              =(seLinuxOptions):
+                =(type): container_t | container_init_t | container_kvm_t
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: selinux-user-role
+    validate:
+      message: Setting the SELinux user or role is forbidden. The fields spec.securityContext.seLinuxOptions.user,
+        spec.securityContext.seLinuxOptions.role, spec.containers[*].securityContext.seLinuxOptions.user,
+        spec.containers[*].securityContext.seLinuxOptions.role, spec.initContainers[*].securityContext.seLinuxOptions.user,
+        spec.initContainers[*].securityContext.seLinuxOptions.role, spec.ephemeralContainers[*].securityContext.seLinuxOptions.user,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role must be
+        unset.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
+          =(initContainers):
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
+          =(securityContext):
+            =(seLinuxOptions):
+              X(role): "null"
+              X(user): "null"
+          containers:
+          - =(securityContext):
+              =(seLinuxOptions):
+                X(role): "null"
+                X(user): "null"
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Baseline)
-    policies.kyverno.io/description: The default /proc masks are set up to reduce
-      attack surface and should be required.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: require-default-proc-mount
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-proc-mount
-    validate:
-      message: Changing the proc mount from the default is not allowed. The fields
-        spec.containers[*].securityContext.procMount and spec.initContainers[*].securityContext.procMount
-        must not be changed  from `Default`.
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(procMount): Default
-          containers:
-          - =(securityContext):
-              =(procMount): Default
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: Containers should be forbidden from running with
-      a root primary or supplementary GID.
-    policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
-  name: require-non-root-groups
-  namespace: cert-manager
-spec:
-  background: true
-  rules:
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-runasgroup
-    validate:
-      message: "Running with root group IDs is disallowed. The fields\t spec.securityContext.runAsGroup,
-        spec.containers[*].securityContext.runAsGroup,\t and spec.initContainers[*].securityContext.runAsGroup
-        must be empty\t or greater than zero."
-      pattern:
-        spec:
-          =(initContainers):
-          - =(securityContext):
-              =(runAsGroup): '>0'
-          =(securityContext):
-            =(runAsGroup): '>0'
-          containers:
-          - =(securityContext):
-              =(runAsGroup): '>0'
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-supplementalGroups
-    validate:
-      message: "Adding of supplemental group IDs is not allowed. The field\t spec.securityContext.supplementalGroups
-        must not be defined."
-      pattern:
-        spec:
-          =(securityContext):
-            =(supplementalGroups):
-            - "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-fsGroup
-    validate:
-      message: Changing to root group ID is disallowed. The field spec.securityContext.fsGroup
-        must be empty or greater than zero.
-      pattern:
-        spec:
-          =(securityContext):
-            =(fsGroup): '>0'
-  validationFailureAction: enforce
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: Containers must be required to run as non-root
-      users.
+      users. This policy ensures `runAsUser` is either unset or set to a number greater
+      than zero.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-  name: require-run-as-non-root
+    policies.kyverno.io/title: Require Run As Non-Root User
+  name: require-run-as-non-root-user
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: check-containers
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: run-as-non-root-user
+    validate:
+      message: Running as root is not allowed. The fields spec.securityContext.runAsUser,
+        spec.containers[*].securityContext.runAsUser, spec.initContainers[*].securityContext.runAsUser,
+        and spec.ephemeralContainers[*].securityContext.runAsUser must be unset or
+        set to a number greater than zero.
+      pattern:
+        spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(runAsUser): '>0'
+          =(initContainers):
+          - =(securityContext):
+              =(runAsUser): '>0'
+          =(securityContext):
+            =(runAsUser): '>0'
+          containers:
+          - =(securityContext):
+              =(runAsUser): '>0'
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: Containers must be required to run as non-root
+      users. This policy ensures `runAsNonRoot` is set to `true`. A known issue prevents
+      a policy such as this using `anyPattern` from being persisted properly in Kubernetes
+      1.23.0-1.23.2.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Require runAsNonRoot
+  name: require-run-as-nonroot
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: run-as-non-root
     validate:
       anyPattern:
       - spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(runAsNonRoot): true
           =(initContainers):
           - =(securityContext):
               =(runAsNonRoot): true
@@ -352,25 +562,33 @@ spec:
           securityContext:
             runAsNonRoot: true
       - spec:
+          =(ephemeralContainers):
+          - securityContext:
+              runAsNonRoot: true
           =(initContainers):
           - securityContext:
               runAsNonRoot: true
           containers:
           - securityContext:
               runAsNonRoot: true
-      message: Running as root is not allowed. The fields spec.securityContext.runAsNonRoot,
-        spec.containers[*].securityContext.runAsNonRoot, and spec.initContainers[*].securityContext.runAsNonRoot
-        must be `true`.
+      message: Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot
+        must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot,
+        spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
+        must be set to `true`.
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: On supported hosts, the 'runtime/default' AppArmor
-      profile is applied by default.  The default policy should prevent overriding
-      or disabling the policy, or restrict  overrides to an allowed set of profiles.
+      profile is applied by default. The default policy should prevent overriding
+      or disabling the policy, or restrict overrides to an allowed set of profiles.
+      This policy ensures Pods do not specify any other AppArmor profiles than `runtime/default`
+      or `localhost/*`.
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod, Annotation
@@ -381,26 +599,31 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     name: app-armor
     validate:
-      message: Specifying other AppArmor profiles is disallowed. The annotation container.apparmor.security.beta.kubernetes.io
-        must not be defined, or must not be set to anything other than `runtime/default`.
+      message: Specifying other AppArmor profiles is disallowed. The annotation `container.apparmor.security.beta.kubernetes.io`
+        if defined must not be set to anything other than `runtime/default` or `localhost/*`.
       pattern:
-        metadata:
+        =(metadata):
           =(annotations):
-            =(container.apparmor.security.beta.kubernetes.io/*): runtime/default
+            =(container.apparmor.security.beta.kubernetes.io/*): runtime/default |
+              localhost/*
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
-    policies.kyverno.io/category: Pod Security Standards (Restricted)
-    policies.kyverno.io/description: The runtime default seccomp profile must be required,
-      or only specific additional profiles should be allowed.
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/description: The seccomp profile must not be explicitly set
+      to Unconfined. This policy,  requiring Kubernetes v1.19 or later, ensures that
+      seccomp is unset or  set to `RuntimeDefault` or `Localhost`.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/title: Restrict Seccomp
@@ -410,316 +633,181 @@ spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: seccomp
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-seccomp
     validate:
       message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
-        spec.containers[*].securityContext.seccompProfile.type, and spec.initContainers[*].securityContext.seccompProfile.type
-        must be unset or set to `runtime/default`.
+        spec.containers[*].securityContext.seccompProfile.type, spec.initContainers[*].securityContext.seccompProfile.type,
+        and spec.ephemeralContainers[*].securityContext.seccompProfile.type must be
+        unset or set to `RuntimeDefault` or `Localhost`.
       pattern:
         spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
           =(initContainers):
           - =(securityContext):
               =(seccompProfile):
-                =(type): runtime/default
+                =(type): RuntimeDefault | Localhost
           =(securityContext):
             =(seccompProfile):
-              =(type): runtime/default
+              =(type): RuntimeDefault | Localhost
           containers:
           - =(securityContext):
               =(seccompProfile):
-                =(type): runtime/default
+                =(type): RuntimeDefault | Localhost
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/description: The seccomp profile in the Restricted group must
+      not be explicitly set to Unconfined but additionally must also not allow an
+      unset value. This policy,  requiring Kubernetes v1.19 or later, ensures that
+      seccomp is  set to `RuntimeDefault` or `Localhost`. A known issue prevents a
+      policy such as this using `anyPattern` from being persisted properly in Kubernetes
+      1.23.0-1.23.2.
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Restrict Seccomp (Strict)
+  name: restrict-seccomp-strict
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-seccomp-strict
+    validate:
+      anyPattern:
+      - spec:
+          =(ephemeralContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          =(initContainers):
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          containers:
+          - =(securityContext):
+              =(seccompProfile):
+                =(type): RuntimeDefault | Localhost
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault | Localhost
+      - spec:
+          =(ephemeralContainers):
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+          =(initContainers):
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+          containers:
+          - securityContext:
+              seccompProfile:
+                type: RuntimeDefault | Localhost
+      message: Use of custom Seccomp profiles is disallowed. The fields spec.securityContext.seccompProfile.type,
+        spec.containers[*].securityContext.seccompProfile.type, spec.initContainers[*].securityContext.seccompProfile.type,
+        and spec.ephemeralContainers[*].securityContext.seccompProfile.type must be
+        set to `RuntimeDefault` or `Localhost`.
+  validationFailureAction: enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/description: Sysctls can disable security mechanisms or affect
       all containers on a host, and should be disallowed except for an allowed "safe"
       subset. A sysctl is considered safe if it is namespaced in the container or
-      the Pod, and it is isolated from other Pods or processes on the same Node.
+      the Pod, and it is isolated from other Pods or processes on the same Node. This
+      policy ensures that only those "safe" subsets can be specified in a Pod.
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Restrict sysctls
   name: restrict-sysctls
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: sysctls
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: check-sysctls
     validate:
       message: Setting additional sysctls above the allowed type is disallowed. The
-        field spec.securityContext.sysctls must not use any other names than 'kernel.shm_rmid_forced',
-        'net.ipv4.ip_local_port_range', 'net.ipv4.tcp_syncookies' and 'net.ipv4.ping_group_range'.
+        field spec.securityContext.sysctls must be unset or not use any other names
+        than kernel.shm_rmid_forced, net.ipv4.ip_local_port_range, net.ipv4.ip_unprivileged_port_start,
+        net.ipv4.tcp_syncookies and net.ipv4.ping_group_range.
       pattern:
         spec:
           =(securityContext):
             =(sysctls):
-            - name: kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.tcp_syncookies
-                | net.ipv4.ping_group_range
-              value: ?*
+            - =(name): kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.ip_unprivileged_port_start
+                | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range
   validationFailureAction: enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    kyverno.io/kubernetes-version: 1.22-1.23
+    kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/description: In addition to restricting HostPath volumes,
       the restricted pod security profile limits usage of non-core volume types to
-      those defined through PersistentVolumes.
+      those defined through PersistentVolumes. This policy blocks any other type of
+      volume other than those in the allow list.
+    policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/subject: Pod,Volume
+    policies.kyverno.io/title: Restrict Volume Types
   name: restrict-volume-types
   namespace: cert-manager
 spec:
   background: true
   rules:
   - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-gcePersistentDisk
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: restricted-volumes
     validate:
-      message: Use of the gcePersistentDisk type volume is disallowed. The fields
-        spec.volumes[*].gcePersistentDisk must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(gcePersistentDisk): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-awsElasticBlockStore
-    validate:
-      message: Use of the awsElasticBlockStore type volume is disallowed. The fields
-        spec.volumes[*].awsElasticBlockStore must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(awsElasticBlockStore): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-gitRepo
-    validate:
-      message: Use of the gitRepo type volume is disallowed. The fields spec.volumes[*].gitRepo
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(gitRepo): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-nfs
-    validate:
-      message: Use of the nfs type volume is disallowed. The fields spec.volumes[*].nfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(nfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-iscsi
-    validate:
-      message: Use of the iscsi type volume is disallowed. The fields spec.volumes[*].iscsi
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(iscsi): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-glusterfs
-    validate:
-      message: Use of the glusterfs type volume is disallowed. The fields spec.volumes[*].glusterfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(glusterfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-rbd
-    validate:
-      message: Use of the rbd type volume is disallowed. The fields spec.volumes[*].rbd
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(rbd): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-flexVolume
-    validate:
-      message: Use of the flexVolume type volume is disallowed. The fields spec.volumes[*].flexVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(flexVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-cinder
-    validate:
-      message: Use of the cinder type volume is disallowed. The fields spec.volumes[*].cinder
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(cinder): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-cephfs
-    validate:
-      message: Use of the cephfs type volume is disallowed. The fields spec.volumes[*].cephfs
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(cephfs): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-flocker
-    validate:
-      message: Use of the flocker type volume is disallowed. The fields spec.volumes[*].flocker
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(flocker): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-fc
-    validate:
-      message: Use of the fc type volume is disallowed. The fields spec.volumes[*].fc
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(fc): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-azureFile
-    validate:
-      message: Use of the azureFile type volume is disallowed. The fields spec.volumes[*].azureFile
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(azureFile): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-vsphereVolume
-    validate:
-      message: Use of the vsphereVolume type volume is disallowed. The fields spec.volumes[*].vsphereVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(vsphereVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-quobyte
-    validate:
-      message: Use of the quobyte type volume is disallowed. The fields spec.volumes[*].quobyte
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(quobyte): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-azureDisk
-    validate:
-      message: Use of the azureDisk type volume is disallowed. The fields spec.volumes[*].azureDisk
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(azureDisk): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-portworxVolume
-    validate:
-      message: Use of the portworxVolume type volume is disallowed. The fields spec.volumes[*].portworxVolume
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(portworxVolume): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-scaleIO
-    validate:
-      message: Use of the scaleIO type volume is disallowed. The fields spec.volumes[*].scaleIO
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(scaleIO): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-storageos
-    validate:
-      message: Use of the storageos type volume is disallowed. The fields spec.volumes[*].storageos
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(storageos): "null"
-  - match:
-      resources:
-        kinds:
-        - Pod
-    name: restricted-vol-csi
-    validate:
-      message: Use of the csi type volume is disallowed. The fields spec.volumes[*].csi
-        must not be set.
-      pattern:
-        spec:
-          =(volumes):
-          - X(csi): "null"
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.volumes[].keys(@)[] || '''' }}'
+            operator: AnyNotIn
+            value:
+            - name
+            - configMap
+            - csi
+            - downwardAPI
+            - emptyDir
+            - ephemeral
+            - persistentVolumeClaim
+            - projected
+            - secret
+            - ""
+      message: 'Only the following types of volumes may be used: configMap, csi, downwardAPI,
+        emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.'
   validationFailureAction: enforce

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -175,6 +175,9 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: pointer.BoolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -207,6 +210,9 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
 					},
 				},
 			},

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -50,16 +50,16 @@ def install():
         name = "io_kyverno",
         registry = "ghcr.io",
         repository = "kyverno/kyverno",
-        tag = "v1.3.6",
-        digest = "sha256:7d7972e7d9ed2a6da27b06ccb1c3c5d3544838d6cedb67a050ba7d655461ef52",
+        tag = "v1.7.1",
+        digest = "sha256:9c73f1841ebc61b6a23c935154521cb12289a38de3422f56aa87a7d7ff9b39fe",
     )
 
     container_pull(
         name = "io_kyverno_pre",
         registry = "ghcr.io",
         repository = "kyverno/kyvernopre",
-        tag = "v1.3.6",
-        digest = "sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df",
+        tag = "v1.7.1",
+        digest = "sha256:185d2eebc60cc693056d9359f0434b7eca4152b06f21f58c6289815257c41af8",
     )
 
     ## Fetch vault for use during e2e tests


### PR DESCRIPTION
### Pull Request Motivation

Updates kyverno to v1.7.1, kyverno `policy.yaml` to the current PSS/restricted policies,
and fixes cert-manager deployments to comply with the updated policies.

Fixes #5258 
Fixes #4693 @wallrj 

See #4036 for prior work.

Notes to maintainers:
1. The first commit updates the kyverno version and policies, but the e2e tests still pass because kyverno and its policies are installed *after* the cert-manager deployment
2. The second commit updates the cert-manager and ACME/http deployments to comply

The following command demonstrates that cert-manager v1.8.2 does not comply with the updated policies:

```bash
kustomize build https://github.com/joebowbeer/cert-manager//make/config/kyverno\?ref=kyverno-sync | \
  kyverno apply --policy-report -r \
  <(wget -qO- https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml) \
  -
```

To "fix" the e2e tests so that the kyverno policies _are_ validating the cert-manager namespace, kyverno and its policies should be installed prior to cert-manager.

However, it would be more efficient to skip the kyverno installation and just run the kyverno-cli against the e2e cluster:

```bash
kyverno apply make/config/kyverno/policy.yaml --cluster
```

Looking ahead, consider using PSA to verify PSS/restricted compliance:

https://kubernetes.io/docs/tutorials/security/ns-level-pss/

PSA is enabled by default in Kubernetes v1.23 and later.

### Kind

/kind bug

### Release Note

```release-note
Enhanced securityContext for PSS/restricted compliance.
```
