### PR TITLE
Kubebuilder Assets darwin/arm64

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -36,7 +36,6 @@ IMAGE_kind_amd64 := $(shell make/cluster.sh --show-image)
 IMAGE_kind_arm64 := $(IMAGE_kind_amd64)
 
 PEBBLE_COMMIT = ba5f81dd80fa870cbc19326f2d5a46f45f0b5ee3
-GATEWAY_API_VERSION = 0.4.1
 
 # TODO: move the installation commands in this file to separate scripts like those in https://github.com/cert-manager/cert-manager/tree/master/devel/addon for readability
 # Once that is done, we can consume this variable from ./make/config/lib.sh

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -377,12 +377,7 @@ $(BINDIR)/downloaded/tools/yq_$(YQ_VERSION)_%: | $(BINDIR)/downloaded/tools
 
 KUBEBUILDER_TOOLS_linux_amd64_SHA256SUM=6d9f0a6ab0119c5060799b4b8cbd0a030562da70b7ad4125c218eaf028c6cc28
 KUBEBUILDER_TOOLS_darwin_amd64_SHA256SUM=3367987e2b40dadb5081a92a59d82664bee923eeeea77017ec88daf735e26cae
-
-# We get our testing binaries from kubebuilder-tools, but they don't currently
-# publish darwin/arm64 binaries because of a lack of etcd / kube-apiserver support;
-# as such, we install the amd64 versions and hope that Rosetta sorts the problem
-# out for us. This means that the hash we expect is the same as the amd64 hash.
-KUBEBUILDER_TOOLS_darwin_arm64_SHA256SUM=$(KUBEBUILDER_TOOLS_darwin_amd64_SHA256SUM)
+KUBEBUILDER_TOOLS_darwin_arm64_SHA256SUM=4b440713e32ca496a0a96c8e6cdc531afe9f9c2cc8d7e8e4eddfb5eb9bdc779f
 
 $(BINDIR)/tools/etcd: $(BINDIR)/downloaded/tools/etcd-kubebuilder-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(HOST_ARCH) $(BINDIR)/scratch/KUBEBUILDER_ASSETS_VERSION | $(BINDIR)/tools
 	@cd $(dir $@) && $(LN) $(patsubst $(BINDIR)/%,../%,$<) $(notdir $@)
@@ -401,13 +396,7 @@ $(BINDIR)/downloaded/tools/kube-apiserver-kubebuilder-$(KUBEBUILDER_ASSETS_VERSI
 	tar xfO $< kubebuilder/bin/kube-apiserver > $@ && chmod 775 $@
 
 $(BINDIR)/downloaded/tools/kubebuilder-tools-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(HOST_ARCH).tar.gz: | $(BINDIR)/downloaded/tools
-ifeq ($(HOST_OS)-$(HOST_ARCH),darwin-arm64)
-	@$(eval KUBEBUILDER_ARCH := amd64)
-	$(warning Downloading amd64 kubebuilder-tools for integration tests since darwin/arm64 isn't currently packaged. This will require rosetta in order to work)
-else
-	@$(eval KUBEBUILDER_ARCH := $(HOST_ARCH))
-endif
-	curl -sSfL https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(KUBEBUILDER_ARCH).tar.gz > $@
+	curl -sSfL https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(HOST_ARCH).tar.gz > $@
 
 $(BINDIR)/downloaded/gatewayapi-v%: | $(BINDIR)/downloaded
 	@mkdir -p $@

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -21,6 +21,7 @@ CONTROLLER_GEN_VERSION=0.8.0
 COSIGN_VERSION=1.3.1
 CMREL_VERSION=a1e2bad95be9688794fd0571c4c40e88cccf9173
 K8S_RELEASE_NOTES_VERSION=0.7.0
+GATEWAY_API_VERSION = 0.4.1
 GOIMPORTS_VERSION=0.1.8
 GOLICENSES_VERSION=1.2.1
 GOTESTSUM_VERSION=1.7.0
@@ -398,9 +399,23 @@ $(BINDIR)/downloaded/tools/kube-apiserver-kubebuilder-$(KUBEBUILDER_ASSETS_VERSI
 $(BINDIR)/downloaded/tools/kubebuilder-tools-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(HOST_ARCH).tar.gz: | $(BINDIR)/downloaded/tools
 	curl -sSfL https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(KUBEBUILDER_ASSETS_VERSION)-$(HOST_OS)-$(HOST_ARCH).tar.gz > $@
 
-$(BINDIR)/downloaded/gatewayapi-v%: | $(BINDIR)/downloaded
+##############
+# gatewayapi #
+##############
+
+GATEWAY_API_SHA256SUM=0eed80ad85850a6cbd17ab705aea59e49641c7bf1e6d3fbed1fc0156ffd62734
+
+$(BINDIR)/downloaded/gatewayapi-v$(GATEWAY_API_VERSION): $(BINDIR)/downloaded/gatewayapi-v$(GATEWAY_API_VERSION).tar.gz | $(BINDIR)/downloaded
+	./hack/util/checkhash.sh $< $(GATEWAY_API_SHA256SUM)
 	@mkdir -p $@
-	curl -sSfL https://github.com/kubernetes-sigs/gateway-api/archive/refs/tags/v$*.tar.gz | tar xz -C $@
+	tar xz -C $@ -f $<
+
+$(BINDIR)/downloaded/gatewayapi-v$(GATEWAY_API_VERSION).tar.gz: | $(BINDIR)/downloaded
+	curl -sSfL https://github.com/kubernetes-sigs/gateway-api/archive/refs/tags/v$(GATEWAY_API_VERSION).tar.gz > $@
+
+#################
+# Other Targets #
+#################
 
 $(BINDIR)/tools $(BINDIR)/downloaded $(BINDIR)/downloaded/tools:
 	@mkdir -p $@


### PR DESCRIPTION
### Pull Request Motivation

Adds support for using native arm64 binaries for kubebuilder assets

Also adds checks for sha256sum on gateway api assets

### Directory Structure

To show that the directory structure is unchanged by this PR, on `master` currently:

```console
$ make _bin/downloaded/gatewayapi-v0.4.1
$ tree _bin/downloaded/gatewayapi-v0.4.1 | head -n5
_bin/downloaded/gatewayapi-v0.4.1
└── gateway-api-0.4.1
    ├── apis
    │   ├── v1alpha1
    │   │   ├── backendpolicy_types.go
```

And using this PR:

```console
$ make _bin/downloaded/gatewayapi-v0.4.1
$ tree _bin/downloaded/gatewayapi-v0.4.1 | head -n5
_bin/downloaded/gatewayapi-v0.4.1
└── gateway-api-0.4.1
    ├── apis
    │   ├── v1alpha1
    │   │   ├── backendpolicy_types.go
```

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
