### PR TITLE
Use variable for curl, add retries

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -254,7 +254,7 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 	$(BINDIR)/tools/kubectl apply -f make/config/kyverno/policy.yaml >/dev/null
 
 $(BINDIR)/downloaded/pebble-$(PEBBLE_COMMIT).tar.gz: | $(BINDIR)/downloaded
-	curl -sSL https://github.com/letsencrypt/pebble/archive/$(PEBBLE_COMMIT).tar.gz -o $@
+	$(CURL) https://github.com/letsencrypt/pebble/archive/$(PEBBLE_COMMIT).tar.gz -o $@
 
 # We can't use GOBIN with "go install" because cross-compilation is not
 # possible with go install. That's a problem when cross-compiling for


### PR DESCRIPTION
This adds multiple retries on every attempt we make to use curl, which should help to reduce flakes. Uses a $(CURL) variable where possible so that we have the same invocation everywhere.

Also switches to using the more verbose curl arguments, in an attempt to make it easier to reason about how curl is configured.



Note the documentation for curl's retry flag:

```text
--retry <num>
  If a transient error is returned when curl tries to perform a transfer, it will retry this number of times
  before giving up. Setting the number to 0 makes curl do no retries (which is the default).
  Transient error means either: a timeout,  an  FTP  4xx  response
  code or an HTTP 408 or 5xx response code.

  When  curl is about to retry a transfer, it will first wait one second and then for all forthcoming
  retries it will double the waiting time until it reaches 10 minutes which then will be the delay
  between the rest of the retries.  By using --retry-delay you disable this exponential backoff
  algorithm. See also --retry-max-time to limit the total time allowed for retries.

  Since curl 7.66.0, curl will comply with the Retry-After: response header if one was present
  to know when to issue the next retry.

  If this option is used several times, the last one will be used. Added in 7.12.3.
```

With 10 retries as given in this PR, I think we'll hit that 10 minute retry delay maximum exactly once:

```text
(1 * 2**10) / 60 = 17.06 minutes # 10 retries; this will be rounded down to 10
(1 * 2**9)  / 60 = 8.533 minutes # 9  retries
```

#### `--retry-all-errors`

I'd originally written this to use curl's `--retry-all-errors` flag but that's not available in the version of curl we have in CI, so I left it out

```console
$ podman run -it --rm -e GOPROXY -v `pwd`:/workspace eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 bash
$ root@52406c8271a7:/workspace# curl --version
curl 7.64.0 (x86_64-pc-linux-gnu) libcurl/7.64.0 OpenSSL/1.1.1n zlib/1.2.11 libidn2/2.0.5 libpsl/0.20.2 (+libidn2/2.0.5) libssh2/1.8.0 nghttp2/1.36.0 librtmp/2.3
Release-Date: 2019-02-06
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy PS
```

Instead I've added `--retry-connrefused`. I think that should be fine!

### Kind

/kind feature

### Release Note

```release-note
Use multiple retries when provisioning tools using `curl`, to reduce flakes in tests and development environments
```
