### PR TITLE
[release-1.8] Use variable for curl, add retries

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -328,7 +328,7 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 	bin/tools/kubectl apply -f make/config/kyverno/policy.yaml >/dev/null
 
 bin/downloaded/pebble-$(PEBBLE_COMMIT).tar.gz: | bin/downloaded
-	curl -sSL https://github.com/letsencrypt/pebble/archive/$(PEBBLE_COMMIT).tar.gz -o $@
+	$(CURL) https://github.com/letsencrypt/pebble/archive/$(PEBBLE_COMMIT).tar.gz -o $@
 
 # We can't use GOBIN with "go install" because cross-compilation is not
 # possible with go install. That's a problem when cross-compiling for


### PR DESCRIPTION
Manual backport of #5272

This adds multiple retries on every attempt we make to use curl, which should help to reduce flakes. Uses a $(CURL) variable where possible so that we have the same invocation everywhere.

Also switches to using the more verbose curl arguments, in an attempt to make it easier to reason about how curl is configured.

The backport of this was manual because of conflicts relating to `$(BINDIR)`, and our new methods of installing kubebuilder tools and the gatewayapi code

### Kind

/kind feature

### Release Note

```release-note
Use multiple retries when provisioning tools using `curl`, to reduce flakes in tests and development environments
```
