### PR TITLE
[release-1.8] make: cmctl and kubectl-cert_manager were using two -ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,26 @@ SOURCES := $(shell find . -type f -name "*.go" -not -path "./bin/*" -not -path "
 ## of GOBUILDPROCS or else you could end up running N parallel invocations of
 ## go build, each of which will spin up as many threads as are available on your
 ## system.
+## @category Build
 GOBUILDPROCS ?=
 
 include make/git.mk
 
-GOFLAGS := -trimpath -ldflags '-w -s \
+## By default, we don't link Go binaries to the libc. In some case, you might
+## want to build libc-linked binaries, in which case you can set this to "1".
+## @category Build
+CGO_ENABLED ?= 0
+
+## Extra flags passed to 'go' when building. For example, use GOFLAGS=-v to turn on the
+## verbose output.
+## @category Build
+GOFLAGS := -trimpath
+
+## Extra linking flags passed to 'go' via '-ldflags' when building.
+## @category Build
+GOLDFLAGS := -w -s \
 	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
-    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)'
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)
 
 include make/tools.mk
 include make/ci.mk

--- a/make/cmctl.mk
+++ b/make/cmctl.mk
@@ -1,6 +1,6 @@
-CMCTL_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"'
+CMCTL_GOLDFLAGS := $(GOLDFLAGS) -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"
 
-KUBECTL_PLUGIN_GOFLAGS := $(GOFLAGS) -ldflags '-X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"'
+KUBECTL_PLUGIN_GOLDFLAGS := $(GOLDFLAGS) -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=kubectl cert-manager" -X "github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=false"
 
 bin/cmctl:
 	@mkdir -p $@
@@ -21,10 +21,10 @@ cmctl-linux-tarballs: bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/rele
 cmctl-linux-metadata: bin/metadata/cert-manager-cmctl-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-linux-arm.tar.gz.metadata.json | bin/metadata
 
 bin/cmctl/cmctl-linux-amd64 bin/cmctl/cmctl-linux-arm64 bin/cmctl/cmctl-linux-s390x bin/cmctl/cmctl-linux-ppc64le: bin/cmctl/cmctl-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
-	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/cmctl/cmctl-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-cmctl-linux-amd64.tar.gz bin/release/cert-manager-cmctl-linux-arm64.tar.gz bin/release/cert-manager-cmctl-linux-s390x.tar.gz bin/release/cert-manager-cmctl-linux-ppc64le.tar.gz bin/release/cert-manager-cmctl-linux-arm.tar.gz: bin/release/cert-manager-cmctl-linux-%.tar.gz: bin/cmctl/cmctl-linux-% bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))
@@ -52,7 +52,7 @@ cmctl-darwin-tarballs: bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/re
 cmctl-darwin-metadata: bin/metadata/cert-manager-cmctl-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-darwin-arm64.tar.gz.metadata.json | bin/metadata
 
 bin/cmctl/cmctl-darwin-amd64 bin/cmctl/cmctl-darwin-arm64:  bin/cmctl/cmctl-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
-	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-cmctl-darwin-amd64.tar.gz bin/release/cert-manager-cmctl-darwin-arm64.tar.gz: bin/release/cert-manager-cmctl-darwin-%.tar.gz:  bin/cmctl/cmctl-darwin-% bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))
@@ -80,7 +80,7 @@ cmctl-windows-tarballs: bin/release/cert-manager-cmctl-windows-amd64.tar.gz bin/
 cmctl-windows-metadata: bin/metadata/cert-manager-cmctl-windows-amd64.tar.gz.metadata.json bin/metadata/cert-manager-cmctl-windows-amd64.zip.metadata.json | bin/release
 
 bin/cmctl/cmctl-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | bin/cmctl
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(CMCTL_GOFLAGS) cmd/ctl/main.go
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(CMCTL_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-cmctl-windows-amd64.zip: bin/cmctl/cmctl-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))
@@ -127,10 +127,10 @@ kubectl-cert_manager-linux-tarballs: bin/release/cert-manager-kubectl-cert_manag
 kubectl-cert_manager-linux-metadata: bin/metadata/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-linux-arm.tar.gz.metadata.json | bin/metadata
 
 bin/kubectl-cert_manager/kubectl-cert_manager-linux-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm64 bin/kubectl-cert_manager/kubectl-cert_manager-linux-s390x bin/kubectl-cert_manager/kubectl-cert_manager-linux-ppc64le: bin/kubectl-cert_manager/kubectl-cert_manager-linux-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
-	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/kubectl-cert_manager/kubectl-cert_manager-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-kubectl-cert_manager-linux-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm64.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-s390x.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-ppc64le.tar.gz bin/release/cert-manager-kubectl-cert_manager-linux-arm.tar.gz: bin/release/cert-manager-kubectl-cert_manager-linux-%.tar.gz: bin/kubectl-cert_manager/kubectl-cert_manager-linux-% bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))
@@ -158,7 +158,7 @@ kubectl-cert_manager-darwin-tarballs: bin/release/cert-manager-kubectl-cert_mana
 kubectl-cert_manager-darwin-metadata: bin/metadata/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz.metadata.json | bin/metadata
 
 bin/kubectl-cert_manager/kubectl-cert_manager-darwin-amd64 bin/kubectl-cert_manager/kubectl-cert_manager-darwin-arm64:  bin/kubectl-cert_manager/kubectl-cert_manager-darwin-%: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
-	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=darwin GOARCH=$* $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-kubectl-cert_manager-darwin-amd64.tar.gz bin/release/cert-manager-kubectl-cert_manager-darwin-arm64.tar.gz: bin/release/cert-manager-kubectl-cert_manager-darwin-%.tar.gz:  bin/kubectl-cert_manager/kubectl-cert_manager-darwin-% bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))
@@ -186,7 +186,7 @@ kubectl-cert_manager-windows-tarballs: bin/release/cert-manager-kubectl-cert_man
 kubectl-cert_manager-windows-metadata: bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.tar.gz.metadata.json bin/metadata/cert-manager-kubectl-cert_manager-windows-amd64.zip.metadata.json | bin/release
 
 bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe: $(SOURCES) $(DEPENDS_ON_GO) | bin/kubectl-cert_manager
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(KUBECTL_PLUGIN_GOFLAGS) cmd/ctl/main.go
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(KUBECTL_PLUGIN_GOLDFLAGS)' cmd/ctl/main.go
 
 bin/release/cert-manager-kubectl-cert_manager-windows-amd64.zip: bin/kubectl-cert_manager/kubectl-cert_manager-windows-amd64.exe bin/scratch/cert-manager.license | bin/scratch bin/release
 	@$(eval TARDIR := bin/scratch/$(notdir $@))

--- a/make/server.mk
+++ b/make/server.mk
@@ -8,70 +8,70 @@ bin/server:
 controller: bin/server/controller-linux-amd64 bin/server/controller-linux-arm64 bin/server/controller-linux-s390x bin/server/controller-linux-ppc64le bin/server/controller-linux-arm $(DEPENDS_ON_GO) | bin/server
 
 bin/server/controller-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 bin/server/controller-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 bin/server/controller-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 bin/server/controller-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 bin/server/controller-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/controller/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/controller/main.go
 
 .PHONY: acmesolver
 acmesolver: bin/server/acmesolver-linux-amd64 bin/server/acmesolver-linux-arm64 bin/server/acmesolver-linux-s390x bin/server/acmesolver-linux-ppc64le bin/server/acmesolver-linux-arm $(DEPENDS_ON_GO) | bin/server
 
 bin/server/acmesolver-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 bin/server/acmesolver-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 bin/server/acmesolver-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 bin/server/acmesolver-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 bin/server/acmesolver-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/acmesolver/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/acmesolver/main.go
 
 .PHONY: webhook
 webhook: bin/server/webhook-linux-amd64 bin/server/webhook-linux-arm64 bin/server/webhook-linux-s390x bin/server/webhook-linux-ppc64le bin/server/webhook-linux-arm $(DEPENDS_ON_GO) | bin/server
 
 bin/server/webhook-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 bin/server/webhook-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 bin/server/webhook-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 bin/server/webhook-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 bin/server/webhook-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/webhook/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/webhook/main.go
 
 .PHONY: cainjector
 cainjector: bin/server/cainjector-linux-amd64 bin/server/cainjector-linux-arm64 bin/server/cainjector-linux-s390x bin/server/cainjector-linux-ppc64le bin/server/cainjector-linux-arm $(DEPENDS_ON_GO) | bin/server
 
 bin/server/cainjector-linux-amd64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 bin/server/cainjector-linux-arm64: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 bin/server/cainjector-linux-s390x: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=s390x $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 bin/server/cainjector-linux-ppc64le: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=ppc64le $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go
 
 bin/server/cainjector-linux-arm: $(SOURCES) $(DEPENDS_ON_GO) | bin/server
-	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) cmd/cainjector/main.go
+	GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o $@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' cmd/cainjector/main.go

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -78,7 +78,6 @@ tools: bin/tools/helm bin/tools/kubectl bin/tools/kind bin/tools/cosign bin/tool
 ######
 
 GO = go
-CGO_ENABLED ?= 0
 
 # DEPENDS_ON_GO is a target that is set as an order-only prerequisite in
 # any target that calls $(GO), e.g.:


### PR DESCRIPTION
Manual backport of #5022 - part of #5020 

(Actually not that manual; this is the original commit which @maelvls wrote. #5022 now applies against master and release-1.9 and the original applies against release-1.8)

### Kind

/kind bug

### Release Note

```release-note
`cmctl` and `kubectl cert-manager` now report their actual versions instead of "canary", fixing issue [#5020](https://github.com/cert-manager/cert-manager/issues/5020)
```

