### PR TITLE
add missing target for $(BINDIR)

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -424,7 +424,7 @@ $(BINDIR)/downloaded/gatewayapi-v$(GATEWAY_API_VERSION).tar.gz: | $(BINDIR)/down
 # Other Targets #
 #################
 
-$(BINDIR)/tools $(BINDIR)/downloaded $(BINDIR)/downloaded/tools:
+$(BINDIR) $(BINDIR)/tools $(BINDIR)/downloaded $(BINDIR)/downloaded/tools:
 	@mkdir -p $@
 
 # Although we "vendor" most tools in $(BINDIR)/tools, we still require some binaries


### PR DESCRIPTION
[This change](https://github.com/cert-manager/cert-manager/commit/35f2206404785659deaf674cb1d79bf6176dd1fd#r78206534) added in #5130 introduced a bug where the target to create `$(BINDIR)` was accidentally removed. Sometimes when running in parallel a [dependency](https://github.com/cert-manager/cert-manager/blob/44a022a83c7d18374b3f7f4ce6c6fbee9ae3a372/make/git.mk#L44) on `$(BINDIR)` would fail since there's no target for creating it. It was often implicitly created by `mkdir -p`.

This PR adds an explicit target for `$(BINDIR)`

### Kind

/kind bug
/cherry-pick release-1.9

### Release Note

```release-note
NONE
```
