### PR TITLE
[release-1.9] Add missing target for $(BINDIR)

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -425,7 +425,7 @@ $(BINDIR)/downloaded/gatewayapi-v$(GATEWAY_API_VERSION).tar.gz: | $(BINDIR)/down
 # Other Targets #
 #################
 
-$(BINDIR)/tools $(BINDIR)/downloaded $(BINDIR)/downloaded/tools:
+$(BINDIR) $(BINDIR)/tools $(BINDIR)/downloaded $(BINDIR)/downloaded/tools:
 	@mkdir -p $@
 
 # Although we "vendor" most tools in $(BINDIR)/tools, we still require some binaries


### PR DESCRIPTION
Manual cherry-pick of #5288  since the bot didn't raise the cherry-pick PR.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
