### PR TITLE
[SelfSigned] CertificateSigningRequest: don't mark failed when referenced Secret doesn't exist

### DIFF
--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -115,8 +115,6 @@ func (s *SelfSigned) Sign(ctx context.Context, csr *certificatesv1.CertificateSi
 		message := fmt.Sprintf("Referenced Secret %s/%s not found", resourceNamespace, secretName)
 		log.Error(err, message)
 		s.recorder.Event(csr, corev1.EventTypeWarning, "SecretNotFound", message)
-		util.CertificateSigningRequestSetFailed(csr, "SecretNotFound", message)
-		_, err = util.UpdateOrApplyStatus(ctx, s.certClient, csr, certificatesv1.CertificateFailed, s.fieldManager)
 		return err
 	}
 


### PR DESCRIPTION
/kind bug

As part of the [flaky e2e test initiative work](https://github.com/cert-manager/cert-manager/issues/4950), one of the reoccurring flaky tests is the  CertificateSigningRequest with SelfSigned issuer. Upon investigating, the reason for this is that there is a race in our test whereby [the Secret we create to contain the private key](https://github.com/cert-manager/cert-manager/blob/519d4dd80378581381b19ee32c5cbc7446307132/test/e2e/suite/conformance/certificatesigningrequests/selfsigned/selfsigned.go#L67) may not be yet observed by the [Secret lister in the cert-manager controller](https://github.com/cert-manager/cert-manager/blob/519d4dd80378581381b19ee32c5cbc7446307132/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go#L113).

Currently, cert-manager will mark a CertificateSigningRequest as _failed_ if it wasn't able to find that Secret. This results in the e2es to often fail.

To resolve this, this PR changes the behavior of the controller to instead only fire an event and return an error when the Secret is not found. This is more in line with the [CertificateRequest controller and behavior](https://github.com/cert-manager/cert-manager/blob/519d4dd80378581381b19ee32c5cbc7446307132/pkg/controller/certificaterequests/selfsigned/selfsigned.go#L98).

We need to make a decision about whether to class this as a bug or not, and whether the back port to get perodics green again for these tests. If we decide not to, we will need to come up with a reliable way to ensure the cert-manager controller has observed the create test Secret, which is tricky.

```release-note
CertificateSigningRequest: no longer mark a request as failed when using the SelfSigned issuer, and the Secret referenced in `experimental.cert-manager.io/private-key-secret-name` doesn't exist.
```
