### PR TITLE
Remove incorrect Route53 validation on AccessKeyID and SecretAccessKeyID

### DIFF
--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -404,10 +404,6 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			if len(p.Route53.Region) == 0 {
 				el = append(el, field.Required(fldPath.Child("route53", "region"), ""))
 			}
-			// accessKeyID or accessKeyIDSecretRef must be specified, but not both
-			if len(p.Route53.AccessKeyID) == 0 && p.Route53.SecretAccessKeyID == nil && p.Route53.Role == "" {
-				el = append(el, field.Required(fldPath.Child("route53"), "accessKeyID or accessKeyIDSecretRef is required"))
-			}
 			if len(p.Route53.AccessKeyID) > 0 && p.Route53.SecretAccessKeyID != nil {
 				el = append(el, field.Required(fldPath.Child("route53"), "accessKeyID and accessKeyIDSecretRef cannot both be specified"))
 			}

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -404,6 +404,9 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			if len(p.Route53.Region) == 0 {
 				el = append(el, field.Required(fldPath.Child("route53", "region"), ""))
 			}
+			// We don't include a validation here asserting that either the
+			// AccessKeyID or SecretAccessKeyID must be specified, because it is
+			// valid to use neither when using ambient credentials.
 			if len(p.Route53.AccessKeyID) > 0 && p.Route53.SecretAccessKeyID != nil {
 				el = append(el, field.Required(fldPath.Child("route53"), "accessKeyID and accessKeyIDSecretRef cannot both be specified"))
 			}

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -405,7 +405,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 				el = append(el, field.Required(fldPath.Child("route53", "region"), ""))
 			}
 			// accessKeyID or accessKeyIDSecretRef must be specified, but not both
-			if len(p.Route53.AccessKeyID) == 0 && p.Route53.SecretAccessKeyID == nil {
+			if len(p.Route53.AccessKeyID) == 0 && p.Route53.SecretAccessKeyID == nil && p.Route53.Role == "" {
 				el = append(el, field.Required(fldPath.Child("route53"), "accessKeyID or accessKeyIDSecretRef is required"))
 			}
 			if len(p.Route53.AccessKeyID) > 0 && p.Route53.SecretAccessKeyID != nil {

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -713,7 +713,7 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(fldPath.Child("route53", "region"), ""),
 			},
 		},
-		"missing route53 accessKeyID and accessKeyIDSecretRef should be valid": {
+		"missing route53 accessKeyID and accessKeyIDSecretRef should be valid because ambient credentials may be used instead": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
 					Region: "valid",

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -724,6 +724,15 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(fldPath.Child("route53"), "accessKeyID or accessKeyIDSecretRef is required"),
 			},
 		},
+		"missing route53 accessKeyID and accessKeyIDSecretRef, but role specified": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					Region: "valid",
+					Role:   "valid",
+				},
+			},
+			errs: []*field.Error{},
+		},
 		"both route53 accessKeyID and accessKeyIDSecretRef specified": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -711,24 +711,12 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Required(fldPath.Child("route53", "region"), ""),
-				field.Required(fldPath.Child("route53"), "accessKeyID or accessKeyIDSecretRef is required"),
 			},
 		},
-		"missing route53 accessKeyID and accessKeyIDSecretRef": {
+		"missing route53 accessKeyID and accessKeyIDSecretRef should be valid": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
 					Region: "valid",
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("route53"), "accessKeyID or accessKeyIDSecretRef is required"),
-			},
-		},
-		"missing route53 accessKeyID and accessKeyIDSecretRef, but role specified": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-					Region: "valid",
-					Role:   "valid",
 				},
 			},
 			errs: []*field.Error{},


### PR DESCRIPTION
In PR https://github.com/cert-manager/cert-manager/pull/5194, we introduced a validation whereby an issuer would be rejected if it did
not contain `AccessKeyID` or `SecretAccessKeyID` when using the route53 DNS
solver. This is incorrect, since neither should need to be defined when
using AWS ambient credentials.

This is a critical bug which should be backported to `v1.9`.

/kind bug

fixes https://github.com/cert-manager/cert-manager/issues/5334

```release-note
DNS Route53: Remove incorrect validation which rejects solvers that don't define either a `accessKeyID` or `secretAccessKeyID`.
```
