### PR TITLE
Update year to 2022

### DIFF
--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -2,7 +2,7 @@
 # It would be possible to make this more dynamic, but there's seemingly no need:
 # https://stackoverflow.com/a/2391555/1615417
 # As such, this is hardcoded to avoid needless complexity
-LICENSE_YEAR=2021
+LICENSE_YEAR=2022
 
 # Creates the boilerplate header for YAML files, assumed to be the same as the one in
 # shell scripts (hence the use of boilerplate.sh.txt)


### PR DESCRIPTION
Signed-off-by: Matt Dainty <matt@bodgit-n-scarper.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I recently updated to cert-manager 1.9.1 and as part of the `git diff` output noticed the year had gone backwards from 2022 back to 2021 in the license header.

I think I've found the right place to fix it :smile:

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

documentation

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
