### PR TITLE
Add Trivy scanning make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ include make/release.mk
 include make/manifests.mk
 include make/licenses.mk
 include make/e2e-setup.mk
+include make/scan.mk
 include make/legacy.mk
 include make/help.mk
 

--- a/make/scan.mk
+++ b/make/scan.mk
@@ -1,0 +1,28 @@
+.PHONY: trivy-scan-all
+## trivy-scan-all runs a scan using Trivy (https://github.com/aquasecurity/trivy)
+## against all containers that cert-manager builds. If one of the containers
+## fails a scan, then all scans will be aborted; if you need to check a specific
+## container, use "trivy-scan-<name>", e.g. "make trivy-scan-controller"
+##
+## @category Development
+trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector trivy-scan-ctl
+
+.PHONY: trivy-scan-controller
+trivy-scan-controller: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar | $(BINDIR)/tools/trivy
+	$(BINDIR)/tools/trivy image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-acmesolver
+trivy-scan-acmesolver: $(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar | $(BINDIR)/tools/trivy
+	$(BINDIR)/tools/trivy image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-webhook
+trivy-scan-webhook: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar | $(BINDIR)/tools/trivy
+	$(BINDIR)/tools/trivy image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-cainjector
+trivy-scan-cainjector: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar | $(BINDIR)/tools/trivy
+	$(BINDIR)/tools/trivy image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-ctl
+trivy-scan-ctl: $(BINDIR)/containers/cert-manager-ctl-linux-amd64.tar | $(BINDIR)/tools/trivy
+	$(BINDIR)/tools/trivy image --input $< --format json --exit-code 1


### PR DESCRIPTION
NB: If this is merged before #5361 and #5360 both merge, `make trivy-scan-all` will report vulnerabilities. After those PRs merge, all vulns should be fixed (at the time of writing!)

This was motivated by a [slack thread](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1659436139392089) pointing out we were marked poorly on artifacthub vuln scans. We can use the same scanner locally to catch things in CI / on local machines.

After this PR merges, we can use https://github.com/cert-manager/release/pull/85 to generate periodic tests which will scan each container regularly.

### Kind

/kind feature

### Release Note

```release-note
Add make targets for running scans with trivy against locally built containers
```
