### PR TITLE
Simplify static manifest generation

### DIFF
--- a/hack/concat-yaml.sh
+++ b/hack/concat-yaml.sh
@@ -27,12 +27,12 @@ while (($#)); do
 	# We probably won't have any directives, so we just check for any directive and
 	# fail if there's one in any of the files
 	# https://yaml.org/spec/1.2.2/#681-yaml-directives
-	if grep -q "%YAML" $f; then
+	if grep -q "%YAML" "$f"; then
 		echo "found %YAML directive in file; this can't be handled safely by this script" 1>&2
 		exit 1
 	fi
 
-	cat $f
+	cat "$f"
 
 	shift
 


### PR DESCRIPTION
### Pull Request Motivation

The current makefiles for generating static manifests and CRDs are quite complex.
I changed the process, such that the CRD templates are generated from the same chart as the other static manifests.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
