### PR TITLE
Apply go fmt for go1.19

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -115,7 +115,7 @@ spec:
                   description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
-                    description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'
+                    description: "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\""
                     type: string
                     enum:
                       - signing

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -274,7 +274,7 @@ spec:
                   description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
-                    description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'
+                    description: "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\""
                     type: string
                     enum:
                       - signing

--- a/internal/apis/certmanager/types.go
+++ b/internal/apis/certmanager/types.go
@@ -130,8 +130,10 @@ const (
 )
 
 // KeyUsage specifies valid usage contexts for keys.
-// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// See:
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // Valid KeyUsage values are as follows:
 // "signing",
 // "digital signature",

--- a/internal/apis/certmanager/v1alpha2/types.go
+++ b/internal/apis/certmanager/v1alpha2/types.go
@@ -137,8 +137,10 @@ const (
 )
 
 // KeyUsage specifies valid usage contexts for keys.
-// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// See:
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // Valid KeyUsage values are as follows:
 // "signing",
 // "digital signature",

--- a/internal/apis/certmanager/v1alpha3/types.go
+++ b/internal/apis/certmanager/v1alpha3/types.go
@@ -137,8 +137,10 @@ const (
 )
 
 // KeyUsage specifies valid usage contexts for keys.
-// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// See:
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // Valid KeyUsage values are as follows:
 // "signing",
 // "digital signature",

--- a/internal/apis/certmanager/v1beta1/types.go
+++ b/internal/apis/certmanager/v1beta1/types.go
@@ -137,8 +137,10 @@ const (
 )
 
 // KeyUsage specifies valid usage contexts for keys.
-// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// See:
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // Valid KeyUsage values are as follows:
 // "signing",
 // "digital signature",

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -29,7 +29,7 @@ const (
 // Owner (responsible for graduating feature through to GA): @username
 // Alpha: vX.Y
 // Beta: ...
-//FeatureName featuregate.Feature = "FeatureName"
+// FeatureName featuregate.Feature = "FeatureName"
 )
 
 func init() {
@@ -39,6 +39,8 @@ func init() {
 // cainjectorFeatureGates defines all feature gates for the cainjector component.
 // To add a new feature, define a key for it above and add it here.
 // To check whether a feature is enabled, use:
-//   utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
+//
+//	utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
+//
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -375,8 +375,8 @@ func SecretTemplateMismatchesSecretManagedFields(fieldManager string) Func {
 // expected Certificate AdditionalOutputFormats.
 // Returns true (violation) if AdditionalOutputFormat(s) are present and any of
 // the following:
-//   * Secret key is missing
-//   * Secret value is incorrect
+//   - Secret key is missing
+//   - Secret value is incorrect
 func SecretAdditionalOutputFormatsDataMismatch(input Input) (string, string, bool) {
 	const message = "Certificate's AdditionalOutputFormats doesn't match Secret Data"
 	for _, format := range input.Certificate.Spec.AdditionalOutputFormats {
@@ -404,8 +404,9 @@ func SecretAdditionalOutputFormatsDataMismatch(input Input) (string, string, boo
 // SecretAdditionalOutputFormatsOwnerMismatch validates that the field manager
 // owns the correct Certificate's AdditionalOutputFormats in the Secret.
 // Returns true (violation) if:
-//   * missing AdditionalOutputFormat key owned by the field manager
-//   * AdditionalOutputFormat key owned by the field manager shouldn't exist
+//   - missing AdditionalOutputFormat key owned by the field manager
+//   - AdditionalOutputFormat key owned by the field manager shouldn't exist
+//
 // A violation with the reason `ManagedFieldsParseError` should be considered a
 // non re-triable error.
 func SecretAdditionalOutputFormatsOwnerMismatch(fieldManager string) Func {

--- a/internal/controller/certificates/policies/policies.go
+++ b/internal/controller/certificates/policies/policies.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package policies provides functionality to evaluate Certificate's state
+// Package policies provides functionality to evaluate Certificate's state
 package policies
 
 import (

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -52,7 +52,9 @@ func init() {
 // webhookFeatureGates defines all feature gates for the webhook component.
 // To add a new feature, define a key for it above and add it here.
 // To check whether a feature is enabled, use:
-//   utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
+//
+//	utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
+//
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AdditionalCertificateOutputFormats: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/api/scheme.go
+++ b/pkg/api/scheme.go
@@ -69,14 +69,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -47,13 +47,14 @@ func IssuerHasCondition(i cmapi.GenericIssuer, c cmapi.IssuerCondition) bool {
 }
 
 // SetIssuerCondition will set a 'condition' on the given GenericIssuer.
-// - If no condition of the same type already exists, the condition will be
-//   inserted with the LastTransitionTime set to the current time.
-// - If a condition of the same type and state already exists, the condition
-//   will be updated but the LastTransitionTime will not be modified.
-// - If a condition of the same type and different state already exists, the
-//   condition will be updated and the LastTransitionTime set to the current
-//   time.
+//   - If no condition of the same type already exists, the condition will be
+//     inserted with the LastTransitionTime set to the current time.
+//   - If a condition of the same type and state already exists, the condition
+//     will be updated but the LastTransitionTime will not be modified.
+//   - If a condition of the same type and different state already exists, the
+//     condition will be updated and the LastTransitionTime set to the current
+//     time.
+//
 // This function works with both Issuer and ClusterIssuer resources.
 func SetIssuerCondition(i cmapi.GenericIssuer, observedGeneration int64, conditionType cmapi.IssuerConditionType, status cmmeta.ConditionStatus, reason, message string) {
 	newCondition := cmapi.IssuerCondition{
@@ -151,13 +152,14 @@ func GetCertificateRequestCondition(req *cmapi.CertificateRequest, conditionType
 }
 
 // SetCertificateCondition will set a 'condition' on the given Certificate.
-// - If no condition of the same type already exists, the condition will be
-//   inserted with the LastTransitionTime set to the current time.
-// - If a condition of the same type and state already exists, the condition
-//   will be updated but the LastTransitionTime will not be modified.
-// - If a condition of the same type and different state already exists, the
-//   condition will be updated with the LastTransitionTime set to the current
-//   time.
+//   - If no condition of the same type already exists, the condition will be
+//     inserted with the LastTransitionTime set to the current time.
+//   - If a condition of the same type and state already exists, the condition
+//     will be updated but the LastTransitionTime will not be modified.
+//   - If a condition of the same type and different state already exists, the
+//     condition will be updated with the LastTransitionTime set to the current
+//     time.
+//
 // The given ObservedGeneration will always set on the condition, whether the
 // lastTransitionTime is modified or not.
 func SetCertificateCondition(crt *cmapi.Certificate, observedGeneration int64, conditionType cmapi.CertificateConditionType,
@@ -217,13 +219,13 @@ func RemoveCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.Cert
 }
 
 // SetCertificateRequestCondition will set a 'condition' on the given CertificateRequest.
-// - If no condition of the same type already exists, the condition will be
-//   inserted with the LastTransitionTime set to the current time.
-// - If a condition of the same type and state already exists, the condition
-//   will be updated but the LastTransitionTime will not be modified.
-// - If a condition of the same type and different state already exists, the
-//   condition will be updated and the LastTransitionTime set to the current
-//   time.
+//   - If no condition of the same type already exists, the condition will be
+//     inserted with the LastTransitionTime set to the current time.
+//   - If a condition of the same type and state already exists, the condition
+//     will be updated but the LastTransitionTime will not be modified.
+//   - If a condition of the same type and different state already exists, the
+//     condition will be updated and the LastTransitionTime set to the current
+//     time.
 func SetCertificateRequestCondition(cr *cmapi.CertificateRequest, conditionType cmapi.CertificateRequestConditionType, status cmmeta.ConditionStatus, reason, message string) {
 	newCondition := cmapi.CertificateRequestCondition{
 		Type:    conditionType,
@@ -283,7 +285,7 @@ func CertificateRequestHasCondition(cr *cmapi.CertificateRequest, c cmapi.Certif
 }
 
 // This returns the status reason of a CertificateRequest. The order of reason
-// hierarchy is 'Failed' -> 'Ready' -> 'Pending' -> ''
+// hierarchy is 'Failed' -> 'Ready' -> 'Pending' -> ”
 func CertificateRequestReadyReason(cr *cmapi.CertificateRequest) string {
 	for _, reason := range []string{
 		cmapi.CertificateRequestReasonFailed,

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -176,8 +176,10 @@ const (
 )
 
 // KeyUsage specifies valid usage contexts for keys.
-// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// See:
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // Valid KeyUsage values are as follows:
 // "signing",
 // "digital signature",

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -112,16 +112,16 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 // example, the following Certificate "cert-1" is controlled by the Gateway
 // "gateway-1":
 //
-//     kind: Certificate
-//     metadata:                                           Note that the owner
-//       namespace: cert-1                                 reference does not
-//       ownerReferences:                                  have a namespace,
-//       - controller: true                                since owner refs
-//         apiVersion: networking.x-k8s.io/v1alpha1        only work inside
-//         kind: Gateway                                   the same namespace.
-//         name: gateway-1
-//         blockOwnerDeletion: true
-//         uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
+//	kind: Certificate
+//	metadata:                                           Note that the owner
+//	  namespace: cert-1                                 reference does not
+//	  ownerReferences:                                  have a namespace,
+//	  - controller: true                                since owner refs
+//	    apiVersion: networking.x-k8s.io/v1alpha1        only work inside
+//	    kind: Gateway                                   the same namespace.
+//	    name: gateway-1
+//	    blockOwnerDeletion: true
+//	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
 func certificateHandler(queue workqueue.RateLimitingInterface) func(obj interface{}) {
 	return func(obj interface{}) {
 		crt, ok := obj.(*cmapi.Certificate)

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -38,26 +38,26 @@ var (
 // translateAnnotations updates the Certificate spec using the ingress-like
 // annotations. For example, the following Ingress:
 //
-//   kind: Ingress
-//   metadata:
-//     annotations:
-//       cert-manager.io/common-name: example.com
-//       cert-manager.io/duration: 2160h
-//       cert-manager.io/renew-before: 1440h
-//       cert-manager.io/usages: "digital signature,key encipherment"
-//       cert-manager.io/revision-history-limit: 7
+//	kind: Ingress
+//	metadata:
+//	  annotations:
+//	    cert-manager.io/common-name: example.com
+//	    cert-manager.io/duration: 2160h
+//	    cert-manager.io/renew-before: 1440h
+//	    cert-manager.io/usages: "digital signature,key encipherment"
+//	    cert-manager.io/revision-history-limit: 7
 //
 // is mapped to the following Certificate:
 //
-//   kind: Certificate
-//   spec:
-//     commonName: example.com
-//     duration: 2160h
-//     renewBefore: 1440h
-//     usages:
-//       - digital signature
-//       - key encipherment
-//     revisionHistoryLimit: 7
+//	kind: Certificate
+//	spec:
+//	  commonName: example.com
+//	  duration: 2160h
+//	  renewBefore: 1440h
+//	  usages:
+//	    - digital signature
+//	    - key encipherment
+//	  revisionHistoryLimit: 7
 func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]string) error {
 	if crt == nil {
 		return errNilCertificate

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -110,16 +110,16 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 // example, the following Certificate "cert-1" is controlled by the Ingress
 // "ingress-1":
 //
-//     kind: Certificate
-//     metadata:                                           Note that the owner
-//       namespace: cert-1                                 reference does not
-//       ownerReferences:                                  have a namespace,
-//       - controller: true                                since owner refs
-//         apiVersion: networking.k8s.io/v1beta1           only work inside
-//         kind: Ingress                                   the same namespace.
-//         name: ingress-1
-//         blockOwnerDeletion: true
-//         uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
+//	kind: Certificate
+//	metadata:                                           Note that the owner
+//	  namespace: cert-1                                 reference does not
+//	  ownerReferences:                                  have a namespace,
+//	  - controller: true                                since owner refs
+//	    apiVersion: networking.k8s.io/v1beta1           only work inside
+//	    kind: Ingress                                   the same namespace.
+//	    name: ingress-1
+//	    blockOwnerDeletion: true
+//	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
 func certificateHandler(queue workqueue.RateLimitingInterface) func(obj interface{}) {
 	return func(obj interface{}) {
 		cert, ok := obj.(*cmapi.Certificate)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -566,27 +566,29 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 // setIssuerSpecificConfig configures given Certificate's annotation by reading
 // two Ingress-specific annotations.
 //
-// (1) The edit-in-place Ingress annotation allows the use of Ingress
-//     controllers that map a single IP address to a single Ingress
-//     resource, such as the GCE ingress controller. The the following
-//     annotation on an Ingress named "my-ingress":
+// (1)
+// The edit-in-place Ingress annotation allows the use of Ingress
+// controllers that map a single IP address to a single Ingress
+// resource, such as the GCE ingress controller. The the following
+// annotation on an Ingress named "my-ingress":
 //
-//       acme.cert-manager.io/http01-edit-in-place: "true"
+//	acme.cert-manager.io/http01-edit-in-place: "true"
 //
-//     configures the Certificate with two annotations:
+// configures the Certificate with two annotations:
 //
-//       acme.cert-manager.io/http01-override-ingress-name: my-ingress
-//       cert-manager.io/issue-temporary-certificate: "true"
+//	acme.cert-manager.io/http01-override-ingress-name: my-ingress
+//	cert-manager.io/issue-temporary-certificate: "true"
 //
-// (2) The ingress-class Ingress annotation allows users to override the
-//     Issuer's acme.solvers[0].http01.ingress.class. For example, on the
-//     Ingress:
+// (2)
+// The ingress-class Ingress annotation allows users to override the
+// Issuer's acme.solvers[0].http01.ingress.class. For example, on the
+// Ingress:
 //
-//       acme.cert-manager.io/http01-ingress-class: traefik
+//	acme.cert-manager.io/http01-ingress-class: traefik
 //
-//     configures the Certificate using the override-ingress-class annotation:
+// configures the Certificate using the override-ingress-class annotation:
 //
-//       acme.cert-manager.io/http01-override-ingress-class: traefik
+//	acme.cert-manager.io/http01-override-ingress-class: traefik
 func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 	ingAnnotations := ingLike.GetAnnotations()
 	if ingAnnotations == nil {
@@ -620,15 +622,14 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 // hasShimAnnotation returns true if the given ingress-like resource contains
 // one of the trigger annotations:
 //
-//   cert-manager.io/issuer
-//   cert-manager.io/cluster-issuer
+//	cert-manager.io/issuer
+//	cert-manager.io/cluster-issuer
 //
 // The autoCertificateAnnotations can also be used to customize additional
 // annotations to trigger a Certificate shim. For example, for Ingress
 // resources, we default autoCertificateAnnotations to:
 //
-//   kubernetes.io/tls-acme: "true"
-//
+//	kubernetes.io/tls-acme: "true"
 func hasShimAnnotation(ingLike metav1.Object, autoCertificateAnnotations []string) bool {
 	annotations := ingLike.GetAnnotations()
 	if annotations == nil {
@@ -655,10 +656,10 @@ func hasShimAnnotation(ingLike metav1.Object, autoCertificateAnnotations []strin
 // the default issuer given to the controller is used. We look up the following
 // Ingress annotations:
 //
-//   cert-manager.io/cluster-issuer
-//   cert-manager.io/issuer
-//   cert-manager.io/issuer-kind
-//   cert-manager.io/issuer-group
+//	cert-manager.io/cluster-issuer
+//	cert-manager.io/issuer
+//	cert-manager.io/issuer-kind
+//	cert-manager.io/issuer-group
 func issuerForIngressLike(defaults controller.IngressShimOptions, ingLike metav1.Object) (name, kind, group string, err error) {
 	var errs []string
 

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -300,7 +300,7 @@ func GenerateLocallySignedTemporaryCertificate(crt *cmapi.Certificate, pkData []
 	return b, nil
 }
 
-//RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
+// RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
 type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration) *metav1.Time
 
 // RenewalTime calculates renewal time for a certificate. Default renewal time

--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -16,9 +16,12 @@ limitations under the License.
 
 // Package acmedns implements a DNS provider for solving DNS-01 challenges using
 // Joohoi's acme-dns project. For more information see the ACME-DNS homepage:
-//    https://github.com/joohoi/acme-dns
+//
+//	https://github.com/joohoi/acme-dns
+//
 // This code was adapted from lego:
-// 	  https://github.com/xenolf/lego
+//
+//	https://github.com/xenolf/lego
 package acmedns
 
 import (

--- a/pkg/issuer/acme/dns/akamai/akamai.go
+++ b/pkg/issuer/acme/dns/akamai/akamai.go
@@ -41,7 +41,7 @@ type OpenEdgegridDNSService interface {
 	RecordDelete(rec *dns.RecordBody, zone string) error
 }
 
-//OpenDNSConfig contains akamai's config to create authorization header.
+// OpenDNSConfig contains akamai's config to create authorization header.
 type OpenDNSConfig struct {
 	config edgegrid.Config
 }

--- a/pkg/issuer/acme/dns/akamai/akamai_test.go
+++ b/pkg/issuer/acme/dns/akamai/akamai_test.go
@@ -54,7 +54,6 @@ type StubOpenDNSConfig struct {
 	FuncErrors map[string]error
 }
 
-//
 func findStubHostedDomainByFqdn(fqdn string, ns []string) (string, error) {
 
 	return "test.example.com", nil

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -93,9 +93,11 @@ func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []stri
 
 // FindNearestZoneForFQDN will try to traverse the official Cloudflare API to find the nearest valid Zone.
 // It's a replacement for /pkg/issuer/acme/dns/util/wait.go#FindZoneByFqdn
-//  example.com.                                   ← Zone-Record found for the SLD (in most cases)
-//  └── foo.example.com.                           ← Zone-Record could be possibly here, but in this case not.
-//      └── _acme-challenge.foo.example.com.       ← Starting point, the FQDN.
+//
+//	example.com.                                   ← Zone-Record found for the SLD (in most cases)
+//	└── foo.example.com.                           ← Zone-Record could be possibly here, but in this case not.
+//	    └── _acme-challenge.foo.example.com.       ← Starting point, the FQDN.
+//
 // It will try to call the API for each branch (from bottom to top) and see if there's a Zone-Record returned.
 // Calling See https://api.cloudflare.com/#zone-list-zones
 func FindNearestZoneForFQDN(c DNSProviderType, fqdn string) (DNSZone, error) {

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -321,13 +321,13 @@ func (c *chainNode) toBundleAndCA() (PEMBundle, error) {
 // following diagram, C.CheckSignatureFrom(P) is satisfied, i.e., the
 // signature ("sig") on the certificate C can be verified using the parent P:
 //
-//       head                                         tail
-//  +------+-------+      +------+-------+      +------+-------+
-//  |      |       |      |      |       |      |      |       |
-//  |      |  sig ------->|  C   |  sig ------->|  P   |       |
-//  |      |       |      |      |       |      |      |       |
-//  +------+-------+      +------+-------+      +------+-------+
-//  leaf certificate                            root certificate
+//	     head                                         tail
+//	+------+-------+      +------+-------+      +------+-------+
+//	|      |       |      |      |       |      |      |       |
+//	|      |  sig ------->|  C   |  sig ------->|  P   |       |
+//	|      |       |      |      |       |      |      |       |
+//	+------+-------+      +------+-------+      +------+-------+
+//	leaf certificate                            root certificate
 //
 // The function returns false if the chains A and B are not gluable.
 func (c *chainNode) tryMergeChain(chain *chainNode) (*chainNode, bool) {

--- a/pkg/webhook/admission/initializer/interfaces.go
+++ b/pkg/webhook/admission/initializer/interfaces.go
@@ -58,9 +58,10 @@ type WantsQuotaConfiguration interface {
 // WantsFeatures defines a function which passes the featureGates for inspection by an admission plugin.
 // Admission plugins should not hold a reference to the featureGates.  Instead, they should query a particular one
 // and assign it to a simple bool in the admission plugin struct.
-// func (a *admissionPlugin) InspectFeatureGates(features featuregate.FeatureGate){
-//     a.myFeatureIsOn = features.Enabled("my-feature")
-// }
+//
+//	func (a *admissionPlugin) InspectFeatureGates(features featuregate.FeatureGate){
+//	    a.myFeatureIsOn = features.Enabled("my-feature")
+//	}
 type WantsFeatures interface {
 	InspectFeatureGates(featuregate.FeatureGate)
 	admission.InitializationValidator

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -256,8 +256,8 @@ func AddCertificateLabels(labels map[string]string) CertificateModifier {
 // about the UID. The apiVersion, kind and name are only used for information
 // purposes.
 //
-//  [1]: https://github.com/kubernetes/apimachinery/blob/10b3882/pkg/apis/meta/v1/types.go#L273-L275
-//  [2]: https://github.com/kubernetes/apimachinery/blob/10b3882/pkg/apis/meta/v1/controller_ref.go#L29
+//	[1]: https://github.com/kubernetes/apimachinery/blob/10b3882/pkg/apis/meta/v1/types.go#L273-L275
+//	[2]: https://github.com/kubernetes/apimachinery/blob/10b3882/pkg/apis/meta/v1/controller_ref.go#L29
 func CertificateRef(certName, certUID string) metav1.OwnerReference {
 	return *metav1.NewControllerRef(
 		Certificate(certName,


### PR DESCRIPTION
### Pull Request Motivation

Some devs might use go1.19 already.
Often IDEs will try to format documents on save, causing unrelated doc changes.

### Kind

/kind documentation

### Release Note

```release-note
NONE
```
