### PR TITLE
[release-1.8]: Don't verify chart in ci-presubmit

### DIFF
--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -32,7 +32,7 @@ common_flags=""
 
 echo "+++ running goimports" >&2
 
-output=$($goimports $common_flags -l .)
+output=$($goimports $common_flags -l cmd internal pkg test)
 
 if [ ! -z "${output}" ]; then
     echo "${output}"

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,7 +1,7 @@
 __PYTHON := python3
 
 .PHONY: ci-presubmit
-ci-presubmit: verify-imports verify-chart verify-errexit verify-boilerplate
+ci-presubmit: verify-imports verify-errexit verify-boilerplate
 
 .PHONY: verify-imports
 verify-imports: bin/tools/goimports


### PR DESCRIPTION
### Pull Request Motivation

Backports #5124 to release-1.8; we have a separate test to verify the chart (see commit message). I'm not sure why I ever added `verify-chart` to `ci-presubmit` but it was a mistake.

This will unblock the [periodic tests](https://testgrid.k8s.io/cert-manager-periodics-release-1.8#ci-cert-manager-release-1.8-make-test).

Also stops goimports from looking in bin; this is fixed by the BINDIR change in release-1.9 and onwards, but that would be too big to backport

### Kind

/kind bug

### Release Note

```release-note
NONE
```
