### PR TITLE
Unify semver version generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ GOFLAGS := -trimpath
 ## @category Build
 GOLDFLAGS := -w -s \
 	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
-    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GIT_COMMIT)
 
 include make/tools.mk
 include make/ci.mk

--- a/hack/build/version.sh
+++ b/hack/build/version.sh
@@ -34,111 +34,84 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# -----------------------------------------------------------------------------
-# Version management helpers.  These functions help to set, save and load the
-# following variables:
-#
-#    KUBE_GIT_COMMIT - The git commit id corresponding to this
-#          source code.
-#    KUBE_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
-#        "dirty" indicates source code changes after the git commit id
-#        "archive" indicates the tree was produced by 'git archive'
-#    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
-#    KUBE_GIT_MAJOR - The major part of the version
-#    KUBE_GIT_MINOR - The minor component of the version
-
-export GO_PACKAGE="github.com/cert-manager/cert-manager"
-
 # Grovels through git to set a set of env variables.
-#
-# If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
-# querying git.
-# This function reads the path to cert-manager repo from a
-# REPO_PATH variable that needs to be set before calling it.
-kube::version::get_version_vars() {
-  if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
-    kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
-    return
-  fi
-
-  # If the kubernetes source was exported through git archive, then
-  # we likely don't have a git tree, but these magic values may be filled in.
-  # shellcheck disable=SC2016,SC2050
-  # Disabled as we're not expanding these at runtime, but rather expecting
-  # that another tool may have expanded these and rewritten the source (!)
-  if [[ '$Format:%%$' == "%" ]]; then
-    KUBE_GIT_COMMIT='$Format:%H$'
-    KUBE_GIT_TREE_STATE="archive"
-    # When a 'git archive' is exported, the '$Format:%D$' below will look
-    # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
-    # can be extracted from it.
-    if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
-     KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
-    fi
-  fi
-
+#    GIT_COMMIT - The git commit id corresponding to this source code.
+#    GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#      dirty" indicates source code changes after the git commit id
+#      archive" indicates the tree was produced by 'git archive'
+#    GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    GIT_MAJOR - The major part of the version
+#    GIT_MINOR - The minor component of the version
+version::get_version() {
   local git=(git --work-tree "${REPO_ROOT}")
 
-  if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
-    if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
-      # Check if the tree is dirty.  default to dirty
-      if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
-        KUBE_GIT_TREE_STATE="clean"
-      else
-        KUBE_GIT_TREE_STATE="dirty"
-      fi
+  GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null)
+
+  # Check if the tree is dirty.  default to dirty
+  if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+    GIT_TREE_STATE="clean"
+  else
+    GIT_TREE_STATE="dirty"
+  fi
+
+  # Use git describe to find the version based on tags.
+  GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null)
+
+  GIT_IS_TAGGED_RELEASE=$("${git[@]}" git describe --exact-match HEAD >/dev/null 2>&1 && echo "true" || echo "false")
+  
+  # This translates the "git describe" to an actual semver.org
+  # compatible semantic version that looks something like this:
+  #   v1.1.0-alpha.0.6+84c76d1142ea4d
+  #
+  # TODO: We continue calling this "git version" because so many
+  # downstream consumers are expecting it there.
+  #
+  # These regexes are painful enough in sed...
+  # We don't want to do them in pure shell, so disable SC2001
+  # shellcheck disable=SC2001
+  DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+  if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+    # shellcheck disable=SC2001
+    # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+    GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+  elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+    # shellcheck disable=SC2001
+    # We have distance to base tag (v1.1.0-1-gCommitHash)
+    GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+  fi
+  if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+    # git describe --dirty only considers changes to existing files, but
+    # that is problematic since new untracked .go files affect the build,
+    # so use our idea of "dirty" from git status instead.
+    GIT_VERSION+="-dirty"
+  fi
+
+  # Try to match the "git describe" output to a regex to try to extract
+  # the "major", "minor" and "patch" versions and whether this is the exact tagged
+  # version or whether the tree is between two tagged versions.
+  # Cert-manager release tag always has all three of major, minor and patch versions.
+  if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z.-]+))?(\+([0-9A-Za-z.-]+))?$ ]]; then
+    GIT_MAJOR=${BASH_REMATCH[1]}
+    GIT_MINOR=${BASH_REMATCH[2]}
+    GIT_PATCH=${BASH_REMATCH[3]}
+    IMAGE_NAME_SHORT="v${GIT_MAJOR}.${GIT_MINOR}.${GIT_PATCH}"
+    
+    GIT_SUBVERSION=${BASH_REMATCH[5]}
+    GIT_IS_PRERELEASE="false"
+    if [[ -n "$GIT_SUBVERSION" ]]; then
+      IMAGE_NAME_SHORT+="-${GIT_SUBVERSION}"
+      GIT_IS_PRERELEASE="true"
     fi
-
-    # Use git describe to find the version based on tags.
-    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
-      # This translates the "git describe" to an actual semver.org
-      # compatible semantic version that looks something like this:
-      #   v1.1.0-alpha.0.6+84c76d1142ea4d
-      #
-      # TODO: We continue calling this "git version" because so many
-      # downstream consumers are expecting it there.
-      #
-      # These regexes are painful enough in sed...
-      # We don't want to do them in pure shell, so disable SC2001
-      # shellcheck disable=SC2001
-      DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
-      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
-        # shellcheck disable=SC2001
-        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
-        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
-      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
-        # shellcheck disable=SC2001
-        # We have distance to base tag (v1.1.0-1-gCommitHash)
-        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
-      fi
-      if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
-        # git describe --dirty only considers changes to existing files, but
-        # that is problematic since new untracked .go files affect the build,
-        # so use our idea of "dirty" from git status instead.
-        KUBE_GIT_VERSION+="-dirty"
-      fi
-
-
-      # Try to match the "git describe" output to a regex to try to extract
-      # the "major", "minor" and "patch" versions and whether this is the exact tagged
-      # version or whether the tree is between two tagged versions.
-      # Cert-manager release tag always has all three of major, minor and patch versions.
-      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then
-        KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
-        KUBE_GIT_MINOR=${BASH_REMATCH[2]}
-        KUBE_GIT_PATCH=${BASH_REMATCH[3]}
-        if [[ -n "${BASH_REMATCH[4]}" ]]; then
-          KUBE_GIT_MINOR+="+"
-        fi
-      fi
-
-      # If KUBE_GIT_VERSION is not a valid Semantic Version, then refuse to build.
-      if ! [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-          echo "KUBE_GIT_VERSION should be a valid Semantic Version. Current value: ${KUBE_GIT_VERSION}"
-          echo "Please see more details here: https://semver.org"
-          exit 1
-      fi
+    
+    IMAGE_NAME_LONG="$IMAGE_NAME_SHORT"
+    if [[ -n "${BASH_REMATCH[7]}" ]]; then
+      IMAGE_NAME_LONG+="-${BASH_REMATCH[7]}"
     fi
+  else
+    # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+    echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+    echo "Please see more details here: https://semver.org"
+    exit 1
   fi
 }
 
@@ -148,54 +121,97 @@ kube::version::get_version_vars() {
 # v1.2.3.
 # If the last published releases are v1.2.3 and v1.3.0-alpha.0 it will set
 # KUBE_LAST_VERSION to v1.2.3
-# This function reads the path to cert-manager
-# repo from a REPO_PATH variable that needs to be set before calling it.
-kube::version::last_published_release() {
-    # KUBE_GIT_COMMIT get_version_vars
-    kube::version::get_version_vars
+version::last_published_release() {
+  version::list_published_releases
 
-    local git=(git --work-tree "${REPO_ROOT}")
+  local latest
 
-    # Find the last git tag which is not alpha or beta tag
-    local latest=$("${git[@]}" tag --list 'v*' | grep -v 'alpha\|beta' | tail -n1)
+  latest=$(
+    echo "$RELEASE_LIST" | \
+    grep -v 'alpha\|beta' | \
+    tail -n1
+  )
 
-
-    if [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then
-      major=${BASH_REMATCH[1]}
-      minor=${BASH_REMATCH[2]}
-      patch=${BASH_REMATCH[3]}
-      KUBE_LAST_RELEASE="v${major}.${minor}.${patch}"
-    else
-      echo "Latest found Git tag that is not alpha or beta tag is not a valid semver tag: ${latest}"
-      echo "Please see more details here: https://semver.org"
-      exit 1
-    fi
+  if [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then
+    major=${BASH_REMATCH[1]}
+    minor=${BASH_REMATCH[2]}
+    patch=${BASH_REMATCH[3]}
+    LAST_RELEASE="v${major}.${minor}.${patch}"
+  else
+    echo "Latest found Git tag that is not alpha or beta tag is not a valid semver tag: ${latest}"
+    echo "Please see more details here: https://semver.org"
+    exit 1
+  fi
 }
 
-# Saves the environment flags to $1
-kube::version::save_version_vars() {
-  local version_file=${1-}
-  [[ -n ${version_file} ]] || {
-    echo "!!! Internal error.  No file specified in kube::version::save_version_vars"
-    return 1
-  }
+version::list_published_releases() {
+  local list
 
-  cat <<EOF >"${version_file}"
-KUBE_GIT_COMMIT='${KUBE_GIT_COMMIT-}'
-KUBE_GIT_TREE_STATE='${KUBE_GIT_TREE_STATE-}'
-KUBE_GIT_VERSION='${KUBE_GIT_VERSION-}'
-KUBE_GIT_MAJOR='${KUBE_GIT_MAJOR-}'
-KUBE_GIT_MINOR='${KUBE_GIT_MINOR-}'
+  # Lists all remote tags on the upstream, which gives tags in format:
+  # "<commit> ref/tags/<tag>". Strips commit + tag prefix, filters out tags for v1+,
+  # and manually removes v1.2.0-alpha.1, since that version's manifest contains
+  # duplicate CRD resources (2 CRDs with the same name) which in turn can cause problems
+  # with the versionchecker test.
+  list=$(
+    git ls-remote --tags --refs "${REPO_URL}" | \
+		awk '{print $2;}' | \
+		sed 's/refs\/tags\///' | \
+		sed -n '/v1.0.0/,$p' | \
+		grep -v "v1.2.0-alpha.1"
+  )
+
+  RELEASE_LIST=$list
+}
+
+
+help() {
+  cat <<EOF
+Usage:
+    $0 version <root-of-repo>
+    $0 last-published-release <git-repo-url>
+    $0 list-published-releases <git-repo-url>
 EOF
+  exit
 }
 
-# Loads up the version variables from file $1
-kube::version::load_version_vars() {
-  local version_file=${1-}
-  [[ -n ${version_file} ]] || {
-    echo "!!! Internal error.  No file specified in kube::version::load_version_vars"
-    return 1
-  }
+if [ $# -eq 2 ]; then
+  case "$1" in
+    version)
+      REPO_ROOT=$2
+      version::get_version
 
-  source "${version_file}"
-}
+      results=(
+        "GIT_COMMIT=$GIT_COMMIT"
+        "GIT_TREE_STATE=$GIT_TREE_STATE"
+        "GIT_VERSION=$GIT_VERSION"
+        "GIT_MAJOR=$GIT_MAJOR"
+        "GIT_MINOR=$GIT_MINOR"
+        "GIT_PATCH=$GIT_PATCH"
+        "GIT_SUBVERSION=$GIT_SUBVERSION"
+        "IMAGE_NAME_SHORT=$IMAGE_NAME_SHORT"
+        "IMAGE_NAME_LONG=$IMAGE_NAME_LONG"
+        "GIT_IS_PRERELEASE=$GIT_IS_PRERELEASE"
+        "GIT_IS_TAGGED_RELEASE=$GIT_IS_TAGGED_RELEASE"
+      )
+
+      echo "${results[@]}"
+
+      exit 0
+      ;;
+    last-published-release)
+      REPO_URL=$2
+      version::last_published_release
+      echo "$LAST_RELEASE"
+      exit 0
+      ;;
+    list-published-releases)
+      REPO_URL=$2
+      version::list_published_releases
+      echo "$RELEASE_LIST"
+      exit 0
+      ;;
+  esac
+fi
+
+help
+exit 124

--- a/make/git.mk
+++ b/make/git.mk
@@ -1,34 +1,27 @@
-RELEASE_VERSION := $(shell git describe --tags --match='v*' --abbrev=14)
+VERSION_INFO := $(shell ./hack/build/version.sh version .)
 
-GITCOMMIT := $(shell git rev-parse HEAD)
-
-IS_TAGGED_RELEASE := $(shell git describe --exact-match HEAD >/dev/null 2>&1 && echo "true" || echo "false")
-
-IS_PRERELEASE := $(shell echo $(RELEASE_VERSION) | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' - && echo "false" || echo "true")
+GIT_VERSION := $(patsubst GIT_VERSION=%,%,$(filter GIT_VERSION=%,$(VERSION_INFO)))
+GIT_COMMIT := $(patsubst GIT_COMMIT=%,%,$(filter GIT_COMMIT=%,$(VERSION_INFO)))
+IS_TAGGED_RELEASE := $(patsubst GIT_IS_TAGGED_RELEASE=%,%,$(filter GIT_IS_TAGGED_RELEASE=%,$(VERSION_INFO)))
+IS_PRERELEASE := $(patsubst GIT_IS_PRERELEASE=%,%,$(filter GIT_IS_PRERELEASE=%,$(VERSION_INFO)))
+IMAGE_NAME_SHORT := $(patsubst IMAGE_NAME_SHORT=%,%,$(filter IMAGE_NAME_SHORT=%,$(VERSION_INFO)))
+IMAGE_NAME_LONG := $(patsubst IMAGE_NAME_LONG=%,%,$(filter IMAGE_NAME_LONG=%,$(VERSION_INFO)))
+RELEASE_VERSION := $(IMAGE_NAME_LONG)
 
 .PHONY: gitver
 gitver:
 	@echo "Release version:   \"$(RELEASE_VERSION)\""
 	@echo "Is tagged release: \"$(IS_TAGGED_RELEASE)\""
 	@echo "Is prerelease:     \"$(IS_PRERELEASE)\""
-	@echo "Git commit hash:   \"$(GITCOMMIT)\""
+	@echo "Git commit hash:   \"$(GIT_COMMIT)\""
 
-.PHONY: release-version
-release-version:
-	@echo "$(RELEASE_VERSION)"
+.PHONY: last-published-release
+last-published-release:
+	@./hack/build/version.sh last-published-release https://github.com/cert-manager/cert-manager.git
 
-# Lists all remote tags on the upstream, which gives tags in format:
-# "<commit> ref/tags/<tag>". Strips commit + tag prefix, filters out tags for v1+,
-# and manually removes v1.2.0-alpha.1, since that version's manifest contains
-# duplicate CRD resources (2 CRDs with the same name) which in turn can cause problems
-# with the versionchecker test.
 # Open question: how do we decide when to refresh this target?
 $(BINDIR)/scratch/git/upstream-tags.txt: | $(BINDIR)/scratch/git
-	git ls-remote --tags --refs https://github.com/cert-manager/cert-manager.git | \
-		awk '{print $$2;}' | \
-		sed 's/refs\/tags\///' | \
-		sed -n '/v1.0.0/,$$p' | \
-		grep -v "v1.2.0-alpha.1" > $@
+	./hack/build/version.sh list-published-releases https://github.com/cert-manager/cert-manager.git > $@
 
 # The file "release-version" gets updated whenever git describe --tags changes.
 # This is used by the $(BINDIR)/containers/*.tar.gz targets to make sure that the

--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -14,7 +14,7 @@ $(BINDIR)/scratch/license.yaml: hack/boilerplate/boilerplate.sh.txt | $(BINDIR)/
 # which presumably nobody will ever read or care about. Instead, just add a little footnote pointing
 # to the cert-manager repo in case anybody actually decides that they care.
 $(BINDIR)/scratch/license-footnote.yaml: | $(BINDIR)/scratch
-	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GITCOMMIT)/LICENSES" > $@
+	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GIT_COMMIT)/LICENSES" > $@
 
 $(BINDIR)/scratch/cert-manager.license: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
 	cat $^ > $@

--- a/make/release.mk
+++ b/make/release.mk
@@ -58,7 +58,7 @@ $(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDI
 	jq -n \
 		--arg releaseVersion "$(RELEASE_VERSION)" \
 		--arg buildSource "make" \
-		--arg gitCommitRef "$(GITCOMMIT)" \
+		--arg gitCommitRef "$(GIT_COMMIT)" \
 		'.releaseVersion = $$releaseVersion | .gitCommitRef = $$gitCommitRef | .buildSource = $$buildSource | .artifacts += [inputs]' $^ > $@
 
 .PHONY: release-containers

--- a/make/test.mk
+++ b/make/test.mk
@@ -78,7 +78,15 @@ e2e-ci: e2e-setup-kind e2e-setup
 
 .PHONY: test-upgrade
 test-upgrade: | $(BINDIR)/tools/helm $(BINDIR)/tools/kind $(BINDIR)/tools/ytt $(BINDIR)/tools/kubectl $(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
-	./hack/verify-upgrade.sh $(BINDIR)/tools/helm $(BINDIR)/tools/kind $(BINDIR)/tools/ytt $(BINDIR)/tools/kubectl $(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
+	./hack/verify-upgrade.sh \
+		$(RELEASE_VERSION) \
+		$(GIT_COMMIT) \
+		$(shell $(MAKE) last-published-release) \
+		$(BINDIR)/tools/helm \
+		$(BINDIR)/tools/kind \
+		$(BINDIR)/tools/ytt \
+		$(BINDIR)/tools/kubectl \
+		$(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
 
 test/integration/versionchecker/testdata/test_manifests.tar: $(BINDIR)/scratch/oldcrds.tar $(BINDIR)/yaml/cert-manager.yaml
 	@# Remove the temp files if they exist


### PR DESCRIPTION
Currently, the output of `git describe --tags --match='v*' --abbrev=14` is used directly as version number for pre-release images.
This PR instead uses the `./hack/build/version.sh` script that was already present to generate a semver version.
The build metadata should normally be seperated by a "+", but this character is not supported in a docker image tag.

Current pre-release image tag: v1.9.0-beta.1-74-gc19de0df772e5c
Semver: v1.9.0-beta.1.74+c19de0df772e5c
New pre-release image tag: v1.9.0-beta.1.74-c19de0df772e5c

Currently the image tags and "version" embedded in each binary are the same, preventing unwanted errors.

The goal of this PR is to simplify the version logic & make it more uniform across the codebase.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
