### PR TITLE
Document that pod template spec should be used instead of flags

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -290,6 +290,11 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"'foo'.\nAll controllers: %s",
 		strings.Join(allControllers, ", ")))
 
+	// HTTP-01 solver pod configuration via flags is a now deprecated
+	// mechanism- please use pod template instead when adding any new
+	// configuration options
+	// https://github.com/cert-manager/cert-manager/blob/f1d7c432763100c3fb6eb6a1654d29060b479b3c/pkg/apis/acme/v1/types_issuer.go#L270
+	// These flags however will not be deprecated for backwards compatibility purposes.
 	fs.StringVar(&s.ACMEHTTP01SolverImage, "acme-http01-solver-image", defaultACMEHTTP01SolverImage, ""+
 		"The docker image to use to solve ACME HTTP01 challenges. You most likely will not "+
 		"need to change this parameter unless you are testing a new feature or developing cert-manager.")

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -155,6 +155,12 @@ func (s *Solver) buildPod(ch *cmacme.Challenge) *corev1.Pod {
 	return pod
 }
 
+// Note: this function builds pod spec using defaults and any configuration
+// options passed via flags to cert-manager controller.
+// Solver pod configuration via flags is a now deprecated
+// mechanism- please use pod template instead when adding any new
+// configuration options
+// https://github.com/cert-manager/cert-manager/blob/f1d7c432763100c3fb6eb6a1654d29060b479b3c/pkg/apis/acme/v1/types_issuer.go#L270
 func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	podLabels := podLabels(ch)
 


### PR DESCRIPTION
Document that new configuration options for ACME HTTP-01 solver pod need to be added via pod spec template on issuer config instead of adding new flags to controller.
See https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1660041935692369 for context

I considered documenting this in the contributing section on the website, but it feels too small for that and seems like it would be more noticeable by anyone looking to add extra config options as code comments.

```release-note
NONE
```

Signed-off-by: irbekrm [irbekrm@gmail.com](mailto:irbekrm@gmail.com)
