### PR TITLE
Add annotations for ServiceMonitor in helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -18,6 +18,12 @@ metadata:
     {{- with .Values.prometheus.servicemonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.prometheus.servicemonitor.annotations }}
+  annotations:
+    {{- with .Values.prometheus.servicemonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
 spec:
   jobLabel: {{ template "cert-manager.fullname" . }}
   selector:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -177,6 +177,7 @@ prometheus:
     interval: 60s
     scrapeTimeout: 30s
     labels: {}
+    annotations: {}
     honorLabels: false
 
 # Use these variables to configure the HTTP_PROXY environment variables


### PR DESCRIPTION
### Pull Request Motivation

I need this:

```yaml
prometheus:
  servicemonitor:
    enabled: true
    annotations:
      argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
```

(More info [here](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types))

### Kind

feature

### Release Note


```release-note
Add annotations for ServiceMonitor in helm chart
```
