### PR TITLE
move e2e-ci to a script

### DIFF
--- a/make/e2e-ci.sh
+++ b/make/e2e-ci.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+make --no-print-directory e2e FLAKE_ATTEMPTS=2 K8S_VERSION="$(K8S_VERSION)"
+make kind-logs

--- a/make/e2e-ci.sh
+++ b/make/e2e-ci.sh
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+trap 'make kind-logs' EXIT
 make --no-print-directory e2e FLAKE_ATTEMPTS=2 K8S_VERSION="$(K8S_VERSION)"
-make kind-logs

--- a/make/test.mk
+++ b/make/test.mk
@@ -74,7 +74,7 @@ e2e: $(BINDIR)/scratch/kind-exists $(BINDIR)/tools/kubectl $(BINDIR)/tools/ginkg
 
 .PHONY: e2e-ci
 e2e-ci: e2e-setup-kind e2e-setup
-	$(MAKE) --no-print-directory e2e FLAKE_ATTEMPTS=2 K8S_VERSION="$(K8S_VERSION)" || ($(MAKE) kind-logs && exit 1)
+	make/e2e-ci.sh
 
 .PHONY: test-upgrade
 test-upgrade: | $(BINDIR)/tools/helm $(BINDIR)/tools/kind $(BINDIR)/tools/ytt $(BINDIR)/tools/kubectl $(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)


### PR DESCRIPTION
Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>

This should fix an issue where kind-logs from CI builds would not always be uploaded

Moved it to a script so that the commands can be run independently

/kind bug

```release-note
NONE
```
