### PR TITLE
Fix incorrect uses of loop variable

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -119,6 +119,7 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) error {
 	}
 
 	for _, f := range c.runDurationFuncs {
+		f := f // capture range variable
 		go wait.Until(func() { f.fn(ctx) }, f.duration, stopCh)
 	}
 

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -173,6 +173,7 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 
 				_, err = crClient.Create(context.TODO(), gen.CertificateRequestFrom(basicCR,
 					gen.SetCertificateRequestCSR(csr),
+					gen.SetCertificateRequestDuration(v.inputDuration),
 				), metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -163,6 +163,7 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 			},
 		}
 		for _, v := range cases {
+			v := v // capture range variable
 			It("should generate a signed certificate valid for "+v.label, func() {
 				crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 


### PR DESCRIPTION
### Pull Request Motivation

This fixes two instances where loop variables were being incorrectly
used:

- using a loop variable in a closure passed to `ginkgo.It()` is
incorrect, as the capture happens by reference and only the last test
case will be executed (multiple times).
- a similar issue happens in the context of a goroutine; specifically,
we need to create a copy of the `runDurationFunc` before calling it in
a goroutine as done by the controller's `Run` function.

With regards to the second issue, I believe it never came to the
surface because, in production code, only one `runDurationFunc` is
passed; tests don't exercise the multiple funcs path either.

Issues were automatically found with the `loopvarcapture` linter.

### Kind

bug

### Release Note

```release-note
NONE
```
