### PR TITLE
helm: Add NetworkPolicy support

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -145,6 +145,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.serviceAccount.automountServiceAccountToken` | Automount API credentials for the webhook Service Account |  |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | `{}` |
 | `webhook.nodeSelector` | Node labels for webhook pod assignment | `{}` |
+| `webhook.networkPolicy.enabled` | Enable default network policies for webhooks egress and ingress traffic | `false` |
+| `webhook.networkPolicy.ingress` | Sets ingress policy block. See NetworkPolicy documentation. See `values.yaml` for example. | `{}` |
+| `webhook.networkPolicy.egress` | Sets ingress policy block. See NetworkPolicy documentation. See `values.yaml` for example. | `{}` |
 | `webhook.affinity` | Node affinity for webhook pod assignment | `{}` |
 | `webhook.tolerations` | Node tolerations for webhook pod assignment | `[]` |
 | `webhook.topologySpreadConstraints` | Topology spread constraints for webhook pod assignment | `[]` |

--- a/deploy/charts/cert-manager/templates/networkpolicy-egress.yaml
+++ b/deploy/charts/cert-manager/templates/networkpolicy-egress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.webhook.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "webhook.fullname" . }}-allow-egress
+  namespace: {{ include "cert-manager.namespace" . }}
+spec:
+  egress:
+    {{- with .Values.webhook.networkPolicy.egress }}
+      {{- toYaml . | nindent 2 }}
+    {{- end }}
+  podSelector:
+    matchLabels:
+      app: {{ include "webhook.name" . }}
+      app.kubernetes.io/name: {{ include "webhook.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "webhook"
+      {{- with .Values.webhook.podLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  policyTypes:
+  - Egress
+{{- end }}

--- a/deploy/charts/cert-manager/templates/networkpolicy-webhooks.yaml
+++ b/deploy/charts/cert-manager/templates/networkpolicy-webhooks.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.webhook.networkPolicy.enabled }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "webhook.fullname" . }}-allow-ingress
+  namespace: {{ include "cert-manager.namespace" . }}
+spec:
+  ingress:
+    {{- with .Values.webhook.networkPolicy.ingress }}
+      {{- toYaml . | nindent 2 }}
+    {{- end }}
+  podSelector:
+    matchLabels:
+        app: {{ include "webhook.name" . }}
+        app.kubernetes.io/name: {{ include "webhook.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "webhook"
+        {{- with .Values.webhook.podLabels }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}
+  policyTypes:
+  - Ingress
+
+{{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -380,6 +380,27 @@ webhook:
   url: {}
     # host:
 
+  # Enables default network policies for webhooks.
+  networkPolicy:
+    enabled: false
+    ingress:
+    - from:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+    egress:
+    - ports:
+      - port: 80
+        protocol: TCP
+      - port: 443
+        protocol: TCP
+      - port: 53
+        protocol: TCP
+      - port: 53
+        protocol: UDP
+      to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+
 cainjector:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Add support for NetworkPolicies in helm chart, so we can deploy cert-manager into NetworkPolicies enabled cluster without external actions

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

This is new feature inside helm charts deployment 

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Helm: Add NetworkPolicy support
```
