### PR TITLE
Add SkipTLSVerify option to Vault issuer

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -224,6 +224,7 @@ func (v *Vault) setToken(client Client) error {
 func (v *Vault) newConfig() (*vault.Config, error) {
 	cfg := vault.DefaultConfig()
 	cfg.Address = v.issuer.GetSpec().Vault.Server
+	cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = v.issuer.GetSpec().Vault.SkipTLSVerify
 
 	caBundle, err := v.caBundle()
 	if err != nil {

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -218,6 +218,12 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
+	// If true, TLS requests against the Vault server are not verified
+	// for authenticity.  This allows one to issue certificates in a
+	// failure scenario, or when the Vault certificate has expired, for
+	// example.
+	SkipTLSVerify bool
 }
 
 // VaultAuth is configuration used to authenticate with a Vault server. The

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -219,10 +219,15 @@ type VaultIssuer struct {
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
 
-	// If true, TLS requests against the Vault server are not verified
-	// for authenticity.  This allows one to issue certificates in a
-	// failure scenario, or when the Vault certificate has expired, for
-	// example.
+	// INSECURE: Enables or disables validation of the Vault server TLS certificate.
+	// If true, requests to the Vault server will not have the TLS certificate chain
+	// validated.
+	// Mutually exclusive with CABundle; prefer using CABundle to prevent various
+	// kinds of security vulnerabilities.
+	// Only enable this option in development environments.
+	// If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+	// the container is used to validate the TLS connection.
+	// Defaults to false.
 	SkipTLSVerify bool
 }
 


### PR DESCRIPTION
### Pull Request Motivation

#5419

I believe that if the issuer would just ignore the TLS certificate for a brief moment, I could get it to issue a new Vault server certificate, at which point I wold be able to turn back on TLS.  This would simplify recovery when things go badly with the Vault server.

### Kind

feature

### Release Note

```release-note
Allow TLS verification disablement for vault issuer
```
