### PR TITLE
Added support for disableChallengePresentation for issuers and clusterissuers

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -23,7 +23,7 @@ github.com/asaskevich/govalidator,https://github.com/asaskevich/govalidator/blob
 github.com/aws/aws-sdk-go,https://github.com/aws/aws-sdk-go/blob/v1.40.21/LICENSE.txt,Apache-2.0
 github.com/aws/aws-sdk-go/internal/sync/singleflight,https://github.com/aws/aws-sdk-go/blob/v1.40.21/internal/sync/singleflight/LICENSE,BSD-3-Clause
 github.com/beorn7/perks/quantile,https://github.com/beorn7/perks/blob/v1.0.1/LICENSE,MIT
-github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/v4/LICENSE,MIT
+github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/LICENSE,MIT
 github.com/cenkalti/backoff/v3,https://github.com/cenkalti/backoff/blob/v3.0.0/LICENSE,MIT
 github.com/cert-manager/cert-manager,https://github.com/cert-manager/cert-manager/blob/HEAD/LICENSE,Apache-2.0
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/azuredns/LICENSE,MIT

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -62,6 +62,9 @@ spec:
                     disableAccountKeyGeneration:
                       description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
                       type: boolean
+                    disableChallengePresentation:
+                      description: Prevent challenges from being presented and checked. This is useful when issuing private-SSL certs using ACME providers such as DigiCert that do require challenge acceptance, but doesn't actually check the challenges.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -62,6 +62,9 @@ spec:
                     disableAccountKeyGeneration:
                       description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
                       type: boolean
+                    disableChallengePresentation:
+                      description: Prevent challenges from being presented and checked. This is useful when issuing private-SSL certs using ACME providers such as DigiCert that do require challenge acceptance, but doesn't actually check the challenges.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -92,6 +92,11 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	EnableDurationFeature bool
+
+	// Prevent challenges from being presented and checked.
+	// This is useful when issuing private-SSL certs using ACME providers such as DigiCert
+	// that do require challenge acceptance, but doesn't actually check the challenges.
+	DisableChallengePresentation bool
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -903,6 +903,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 
@@ -936,6 +937,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 

--- a/internal/apis/acme/v1alpha2/types_issuer.go
+++ b/internal/apis/acme/v1alpha2/types_issuer.go
@@ -102,6 +102,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Prevent challenges from being presented and checked.
+	// This is useful when issuing private-SSL certs using ACME providers such as DigiCert
+	// that do require challenge acceptance, but doesn't actually check the challenges.
+	DisableChallengePresentation bool `json:"disableChallengePresentation,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -902,6 +902,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *ACMEIssuer, out *acm
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 
@@ -935,6 +936,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 

--- a/internal/apis/acme/v1alpha3/types_issuer.go
+++ b/internal/apis/acme/v1alpha3/types_issuer.go
@@ -102,6 +102,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Prevent challenges from being presented and checked.
+	// This is useful when issuing private-SSL certs using ACME providers such as DigiCert
+	// that do require challenge acceptance, but doesn't actually check the challenges.
+	DisableChallengePresentation bool `json:"disableChallengePresentation,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -902,6 +902,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *ACMEIssuer, out *acm
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 
@@ -935,6 +936,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 

--- a/internal/apis/acme/v1beta1/types_issuer.go
+++ b/internal/apis/acme/v1beta1/types_issuer.go
@@ -102,6 +102,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Prevent challenges from being presented and checked.
+	// This is useful when issuing private-SSL certs using ACME providers such as DigiCert
+	// that do require challenge acceptance, but doesn't actually check the challenges.
+	DisableChallengePresentation bool `json:"disableChallengePresentation,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -902,6 +902,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *ACMEIssuer, out *acme
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 
@@ -935,6 +936,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.DisableChallengePresentation = in.DisableChallengePresentation
 	return nil
 }
 

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -102,6 +102,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Prevent challenges from being presented and checked.
+	// This is useful when issuing private-SSL certs using ACME providers such as DigiCert
+	// that do require challenge acceptance, but doesn't actually check the challenges.
+	DisableChallengePresentation bool `json:"disableChallengePresentation,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Added support for disableChallengePresentation for issuers. This allows challenges to proceed without being presented and checked. This is useful when dealing with private-SSL infrastructure where ACME challenges would never have a chance to succeed, but we still want to use the cert-manager for certificate ordering automation.

Related to #1292 and #5006 (but does not fix it in the same way). This is specifically related to private-SSL - the code is already running in our private cloud and serving certificates. We would like to upstream the change in order to ease maintenance longer-term.

### Kind

feature

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added support for disableChallengePresentation for issuers.
This allows challenges to proceed without being presented and checked.
This is useful when dealing with private-SSL infrastructure where ACME challenges would never have a chance to succeed, but we still want to use the cert-manager for certificate ordering automation.
```
