### PR TITLE
Move CSR resource in design to GA

### DIFF
--- a/design/20210209.certificates.k8s.io-adoption.md
+++ b/design/20210209.certificates.k8s.io-adoption.md
@@ -40,6 +40,12 @@ status: implemented
   * [Graduation](#graduation)
 <!-- /toc -->
 
+
+## State
+Support for CertificateSigningRequests has graduated to GA, and is enable by
+default in cert-manager.
+
+
 ## Summary
 
 In Kubernetes v1.19 the
@@ -168,7 +174,7 @@ rules:
 [Until 1.22](https://github.com/kubernetes/kubernetes/pull/99494)
 `CertificateSigningRequests` did not include a `duration` field. To have parity
 with the `CertificateRequest` resource, the duration field will be moved to the
-annotation `experimental.cert-manager.io/request-duration` who's value is a [Go
+annotation `cert-manager.io/request-duration` who's value is a [Go
 time duration string](https://golang.org/pkg/time/#Duration.String).
 
 When 1.22 is released, cert-manager can optimistically read the
@@ -249,16 +255,16 @@ nothing, else sign.
 
 Some special cases for some `[Cluster]Issuers` that need to be addressed:
 
-- SelfSigned: The `experimental.cert-manager.io/private-key-secret-name`
+- SelfSigned: The `cert-manager.io/private-key-secret-name`
     annotation is used to reference a secret containing the private key of the
     self-signed certificate. The Secret must reside in either the namespace of
     the reference Issuer, or the cluster resource namespace in the case of a
     ClusterIssuer.
 
 - Venafi:
-  - The `venafi.experimental.cert-manager.io/custom-fields` annotation is set by
+  - The `venafi.cert-manager.io/custom-fields` annotation is set by
       the user to request a Venafi certificate with custom fields.
-  - The `venafi.experimental.cert-manager.io/pickup-id` annotation is used by
+  - The `venafi.cert-manager.io/pickup-id` annotation is used by
       the cert-manager Venafi signer to keep track of the request against the
       Venafi API.
 
@@ -290,10 +296,10 @@ will be updated with the sign certificate.
 
 ### API Changes
 
-- IsCA: The `experimental.cert-manager.io/request-is-ca` annotation is used to
+- IsCA: The `cert-manager.io/request-is-ca` annotation is used to
     request a certificate with the X.509 `IsCA` flag set.
 
-- Duration: The `experimental.cert-manager.io/request-duration` annotation is used to
+- Duration: The `cert-manager.io/request-duration` annotation is used to
     request a certificate with a particular duration. Accepts a Go time duration
     string.
 


### PR DESCRIPTION
This PR is intended as more of a proposal than a real code change.

I propose that we graduate the CertificateSigningRequest controllers to GA. In real terms, this means that 1. the CertificateSigningRequest controllers will be enabled by default, and 2. the annotations required for adding extra issuer information on the request will loose the `experimental` sub domain (as shown in the design document changes).

cert-manager currently implements signers for the SelfSigned, CA, Vault, Venafi, and ACME issuers.

Support for [CertificateSigningRequest](https://github.com/cert-manager/cert-manager/pull/3646) was merged just over a year ago from this PR and release in `v1.5.0`. In that time, the implementation of these controllers has changed very little, with bug reports/improvements being almost none. This could be considered a signal that the feature itself is very stable and implemented correctly.

In the wild, I have found the following examples of this feature being used:

- [istio custom CA](https://istio.io/latest/docs/tasks/security/cert-management/custom-ca-k8s/)
...

This proposal is not suggesting to replace or have some migration of CertificateRequests to CertificateSigningRequest. The would belong in a separate or updated design document.

```release-note
Move CertificateSigningRequest feature to GA.
```

---

Changes to the code:

- [Update](https://github.com/cert-manager/cert-manager/blob/e82c72cff03dda703ca918d32ab11f719edfcd88/internal/controller/feature/features.go#L72) the feature gate to be marked as Graduated.
- Remove the experimental sub domains from the [CSR annotation keys](https://github.com/cert-manager/cert-manager/blob/e82c72cff03dda703ca918d32ab11f719edfcd88/pkg/apis/experimental/v1alpha1/types.go#L23), and move them into the [cert-manager v1 package](https://github.com/cert-manager/cert-manager/blob/master/pkg/apis/certmanager/v1/types.go).
- Adds a log line when a user uses the flag `--feature-gates=ExperimentalCertificateSigningRequestControllers=true` to explain that it is no longer required because the feature is graduated.