### PR TITLE
Add option tokenPath to Vault (cluster)issuer

### DIFF
--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -195,6 +195,9 @@ type VaultAuth struct {
 	// TokenSecretRef authenticates with Vault by presenting a token.
 	TokenSecretRef *cmmeta.SecretKeySelector
 
+	// Path to Vault token on local file system.
+	TokenPath string
+
 	// AppRole authenticates with Vault using the App Role auth mechanism,
 	// with the role and secret stored in a Kubernetes Secret resource.
 	AppRole *VaultAppRole

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -153,6 +154,17 @@ func (v *Vault) setToken(client Client) error {
 			return err
 		}
 		client.SetToken(token)
+
+		return nil
+	}
+
+	tokenPath := v.issuer.GetSpec().Vault.Auth.TokenPath
+	if tokenPath != "" {
+		token, err := ioutil.ReadFile(tokenPath)
+		if err != nil {
+			return err
+		}
+		client.SetToken(string(token))
 
 		return nil
 	}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -410,7 +410,7 @@ func TestSetToken(t *testing.T) {
 			fakeClient:    vaultfake.NewFakeClient(),
 			expectedToken: "",
 			expectedErr: errors.New(
-				"error initializing Vault client: tokenSecretRef, appRoleSecretRef, or Kubernetes auth role not set",
+				"error initializing Vault client: tokenSecretRef, tokenPath, appRoleSecretRef, or Kubernetes auth role not set",
 			),
 		},
 

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -218,6 +218,10 @@ type VaultAuth struct {
 	// +optional
 	TokenSecretRef *cmmeta.SecretKeySelector `json:"tokenSecretRef,omitempty"`
 
+	// TokenPath is path to Vault token on local file system.
+	// +optional
+	TokenPath string `json:"tokenPath,omitempty"`
+
 	// AppRole authenticates with Vault using the App Role auth mechanism,
 	// with the role and secret stored in a Kubernetes Secret resource.
 	// +optional

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -37,7 +37,7 @@ const (
 	messageVaultStatusVerificationFailed = "Vault is not initialized or is sealed"
 	messageVaultConfigRequired           = "Vault config cannot be empty"
 	messageServerAndPathRequired         = "Vault server and path are required fields"
-	messageAuthFieldsRequired            = "Vault tokenSecretRef, appRole, or kubernetes is required"
+	messageAuthFieldsRequired            = "Vault tokenSecretRef, tokenPath, appRole, or kubernetes is required"
 	messageMultipleAuthFieldsSet         = "Multiple auth methods cannot be set on the same Vault issuer"
 
 	messageKubeAuthFieldsRequired    = "Vault Kubernetes auth requires both role and secretRef.name"
@@ -62,11 +62,12 @@ func (v *Vault) Setup(ctx context.Context) error {
 	}
 
 	tokenAuth := v.issuer.GetSpec().Vault.Auth.TokenSecretRef
+	tokenPath := v.issuer.GetSpec().Vault.Auth.TokenPath
 	appRoleAuth := v.issuer.GetSpec().Vault.Auth.AppRole
 	kubeAuth := v.issuer.GetSpec().Vault.Auth.Kubernetes
 
 	// check if at least one auth method is specified.
-	if tokenAuth == nil && appRoleAuth == nil && kubeAuth == nil {
+	if tokenAuth == nil && tokenPath == "" && appRoleAuth == nil && kubeAuth == nil {
 		logf.V(logf.WarnLevel).Infof("%s: %s", v.issuer.GetObjectMeta().Name, messageAuthFieldsRequired)
 		apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, messageAuthFieldsRequired)
 		return nil


### PR DESCRIPTION
The Vault (cluster)issuer does not allow to read a token from local filesystem, while it does not take care about renewing Vault tokens itself: https://github.com/cert-manager/cert-manager/issues/5437

This means that we have to take care of renewing the Vault token. HashiCorp provides excellent means by running a `vault-agent` side-container (https://www.vaultproject.io/docs/platform/k8s/injector). In this setup, cert-manager and `vault-agent` share a volume mount on the local file system, and the agent keeps renewing the token before it's TTL expires.

The problem is that cert-manager does not provide an option for reading the vault token from the filesystem. This PR adds the option `tokenPath` that reads the token from the filesystem.

Signed-off-by: Andrej van der Zee [andrejvanderzee@gmail.com](mailto:andrejvanderzee@gmail.com)

**Does this PR introduce a user-facing change?**

Added option in Vault (cluster)issuer for reading Vault token from filesystem. 