### PR TITLE
Allow concurrent same-FQDN DNS-01 challenges when using route53

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -268,6 +268,64 @@ func TestScheduleN(t *testing.T) {
 			},
 		},
 		{
+			name: "schedule parallel DNS-01 challenges when using route53",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("2"),
+				),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("1"),
+				),
+				gen.Challenge("test3",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{},
+						},
+					}),
+					gen.SetChallengeCreationTimestamp(time.Unix(1, 1)),
+				),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("1"),
+				),
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("2"),
+				),
+			},
+		},
+		{
 			name: "don't schedule when total number of scheduled challenges exceeds global maximum",
 			n:    5,
 			challenges: append(

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gen
 
 import (
+	"time"
+
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +72,24 @@ func SetChallengeIssuer(o cmmeta.ObjectReference) ChallengeModifier {
 func SetChallengeDNSName(dnsName string) ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Spec.DNSName = dnsName
+	}
+}
+
+func SetChallengeSolver(s cmacme.ACMEChallengeSolver) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Solver = s
+	}
+}
+
+func SetChallengeKey(k string) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Key = k
+	}
+}
+
+func SetChallengeCreationTimestamp(t time.Time) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.CreationTimestamp.Time = t
 	}
 }
 


### PR DESCRIPTION
### Pull Request Motivation

This PR allows cert-manager to perform concurrent DNS-01 challenges for the same FQDN when using route53. This makes DNS-01 orders twice as fast when a Certificate contains both wildcard and non-wildcard `dnsNames` for the same domain. More details in: https://github.com/cert-manager/cert-manager/issues/5430

Note that https://github.com/cert-manager/cert-manager/pull/4793 makes concurrent challenges safe with route53 by switching to multivalue answers vs. a single record. That change makes this PR safe without any additional locking.

That said, route53 [caps multivalue answers to 8 records](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-multivalue.html). We could allow for more concurrency by locking over the same record (e.g., https://github.com/sclevine/cert-manager/commit/d84facb1a2876b882d85a445533b3888de09d72d), but this approach is significantly more complex.

### Kind

feature

### Release Note

```release-note
Allow concurrent same-FQDN DNS-01 challenges when using route53
```
