### PR TITLE
Allow extra DNS-01 propagation time to be configured

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -286,6 +286,7 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.DNS01CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.DNS01RecursiveNameserversOnly,
+			DNS01PropagationTime:    opts.DNS01PropagationTime,
 
 			AccountRegistry: acmeAccountRegistry,
 		},

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -115,6 +115,7 @@ type ControllerOptions struct {
 	// challenge URL can be reached by cert-manager controller. This is used
 	// for both DNS-01 and HTTP-01 challenges.
 	DNS01CheckRetryPeriod time.Duration
+	DNS01PropagationTime  time.Duration
 
 	// Annotations copied Certificate -> CertificateRequest,
 	// CertificateRequest -> Order. Slice of string literals that are
@@ -147,6 +148,7 @@ const (
 
 	// default time period to wait between checking DNS01 and HTTP01 challenge propagation
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+	defaultDNS01PropagationTime  = 60 * time.Second
 )
 
 var (
@@ -245,6 +247,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
+		DNS01PropagationTime:              defaultDNS01PropagationTime,
 		EnablePprof:                       cmdutil.DefaultEnableProfiling,
 		PprofAddress:                      cmdutil.DefaultProfilerAddr,
 	}
@@ -357,6 +360,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The maximum number of challenges that can be scheduled as 'processing' at once.")
 	fs.DurationVar(&s.DNS01CheckRetryPeriod, "dns01-check-retry-period", defaultDNS01CheckRetryPeriod, ""+
 		"The duration the controller should wait between a propagation check. Despite the name, this flag is used to configure the wait period for both DNS01 and HTTP01 challenge propagation checks. For DNS01 challenges the propagation check verifies that a TXT record with the challenge token has been created. For HTTP01 challenges the propagation check verifies that the challenge token is served at the challenge URL."+
+		"This should be a valid duration string, for example 180s or 1h")
+	fs.DurationVar(&s.DNS01PropagationTime, "dns01-propagation-time", defaultDNS01PropagationTime, ""+
+		"The duration the controller should wait after determining that an ACME dns entry exists."+
 		"This should be a valid duration string, for example 180s or 1h")
 
 	fs.StringVar(&s.MetricsListenAddress, "metrics-listen-address", defaultPrometheusMetricsServerAddress, ""+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -188,6 +188,9 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// DNS01PropagationTime is the additional time the controller should wait for DNS propagation after pre-checks have passed.
+	DNS01PropagationTime time.Duration
 }
 
 // IngressShimOptions contain default Issuer GVK config for the certificate-shim controllers.

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -124,9 +124,10 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 		return fmt.Errorf("DNS record for %q not yet propagated", ch.Spec.DNSName)
 	}
 
-	ttl := 60
-	log.V(logf.DebugLevel).Info("waiting DNS record TTL to allow the DNS01 record to propagate for domain", "ttl", ttl, "fqdn", fqdn)
-	time.Sleep(time.Second * time.Duration(ttl))
+	if s.DNS01PropagationTime > 0 {
+		log.V(logf.DebugLevel).Info("waiting DNS01 record to propagate for domain", "duration", s.DNS01PropagationTime, "fqdn", fqdn)
+		time.Sleep(s.DNS01PropagationTime)
+	}
 	log.V(logf.DebugLevel).Info("ACME DNS01 validation record propagated", "fqdn", fqdn)
 
 	return nil


### PR DESCRIPTION
### Pull Request Motivation

This PR makes the hardcoded 60s propagation time for DNS-01 configurable.  

See details/questions in: https://github.com/cert-manager/cert-manager/issues/5430

### Kind

feature

### Release Note

```release-note
Allow extra DNS-01 propagation time to be configured
```
