### PR TITLE
Ensure forward-compatibility with k8s.io/apiserver's Storage interface

### DIFF
--- a/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
+++ b/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
@@ -100,3 +100,6 @@ func (r *REST) callSolver(req v1alpha1.ChallengeRequest) (v1alpha1.ChallengeResp
 		},
 	}, nil
 }
+
+func (r *REST) Destroy() {
+}

--- a/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
+++ b/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
@@ -101,5 +101,9 @@ func (r *REST) callSolver(req v1alpha1.ChallengeRequest) (v1alpha1.ChallengeResp
 	}, nil
 }
 
+// This resource type isn't actually persisted anywhere, it is only submitted to the
+// DNS01 solver webhooks, so there's nothing to do to delete a resource/it doesn't
+// make sense in this context.
+// see: https://github.com/cert-manager/cert-manager/pull/5346#discussion_r959521656
 func (r *REST) Destroy() {
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes #5450, avoiding mismatched interfaces between cert-manager and k8s.io/apiserver

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```

---

Aside from that, I didn't bump k8s deps at the same time, since these breaking commits aren't tagged yet (neither on apiserver nor on components-base), as they landed in the default branches there a few hours ago only.