### PR TITLE
Add issuer_{group|kind|name} labels to prom metrics

### DIFF
--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -93,7 +93,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		// If the Certificate no longer exists, remove it's metrics from being exposed.
-		c.metrics.RemoveCertificate(key)
+		c.metrics.RemoveCertificate(key, crt.Spec.IssuerRef.Name, crt.Spec.IssuerRef.Kind, crt.Spec.IssuerRef.Group)
 		return nil
 	}
 	if err != nil {

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -93,7 +93,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		// If the Certificate no longer exists, remove it's metrics from being exposed.
-		c.metrics.RemoveCertificate(key, crt.Spec.IssuerRef.Name, crt.Spec.IssuerRef.Kind, crt.Spec.IssuerRef.Group)
+		c.metrics.RemoveCertificate(key)
 		return nil
 	}
 	if err != nil {

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -101,8 +101,8 @@ func (m *Metrics) updateCertificateReadyStatus(crt *cmapi.Certificate, current c
 			"namespace":    crt.Namespace,
 			"condition":    string(condition),
 			"issuer_name":  crt.Spec.IssuerRef.Name,
-		    "issuer_kind":  crt.Spec.IssuerRef.Kind,
-		    "issuer_group": crt.Spec.IssuerRef.Group,
+			"issuer_kind":  crt.Spec.IssuerRef.Kind,
+			"issuer_group": crt.Spec.IssuerRef.Group,
 		}).Set(value)
 	}
 }

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -109,16 +109,14 @@ func (m *Metrics) updateCertificateReadyStatus(crt *cmapi.Certificate, current c
 
 // RemoveCertificate will delete the Certificate metrics from continuing to be
 // exposed.
-func (m *Metrics) RemoveCertificate(key, issuerName, issuerKind, issuerGroup string) {
+func (m *Metrics) RemoveCertificate(key string) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		m.log.Error(err, "failed to get namespace and name from key")
 		return
 	}
 
-	m.certificateExpiryTimeSeconds.DeleteLabelValues(name, namespace, issuerName, issuerKind, issuerGroup)
-	m.certificateRenewalTimeSeconds.DeleteLabelValues(name, namespace, issuerName, issuerKind, issuerGroup)
-	for _, condition := range readyConditionStatuses {
-		m.certificateReadyStatus.DeleteLabelValues(name, namespace, string(condition), issuerName, issuerKind, issuerGroup)
-	}
+	m.certificateExpiryTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
+	m.certificateRenewalTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
+	m.certificateReadyStatus.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
 }

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -56,6 +56,11 @@ func TestCertificateMetrics(t *testing.T) {
 		"certificate with expiry and ready status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(2208988804, 0),
 				}),
@@ -65,38 +70,48 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 1
-        certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 
 		"certificate with no expiry and no status should give an expiry of 0 and Unknown status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 
 		"certificate with expiry and status False should give an expiry and False status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(100, 0),
 				}),
@@ -106,20 +121,25 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 100
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 100
 `,
 			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 1
-        certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 		"certificate with expiry and status Unknown should give an expiry and Unknown status": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(99999, 0),
 				}),
@@ -129,20 +149,25 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 99999
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 99999
 `,
 			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 		"certificate with expiry and ready status and renew before": {
 			crt: gen.Certificate("test-certificate",
 				gen.SetCertificateNamespace("test-ns"),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name:  "test-issuer",
+					Kind:  "test-issuer-kind",
+					Group: "test-issuer-group",
+				}),
 				gen.SetCertificateNotAfter(metav1.Time{
 					Time: time.Unix(2208988804, 0),
 				}),
@@ -155,15 +180,15 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedExpiry: `
-	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+	certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 1
-        certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
+		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 		},
 	}
@@ -201,6 +226,11 @@ func TestCertificateCache(t *testing.T) {
 
 	crt1 := gen.Certificate("crt1",
 		gen.SetCertificateUID("uid-1"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(100, 0),
 		}),
@@ -213,6 +243,11 @@ func TestCertificateCache(t *testing.T) {
 		}))
 	crt2 := gen.Certificate("crt2",
 		gen.SetCertificateUID("uid-2"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(200, 0),
 		}),
@@ -226,6 +261,11 @@ func TestCertificateCache(t *testing.T) {
 	)
 	crt3 := gen.Certificate("crt3",
 		gen.SetCertificateUID("uid-3"),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{
+			Name:  "test-issuer",
+			Kind:  "test-issuer-kind",
+			Group: "test-issuer-group",
+		}),
 		gen.SetCertificateNotAfter(metav1.Time{
 			Time: time.Unix(300, 0),
 		}),
@@ -246,15 +286,15 @@ func TestCertificateCache(t *testing.T) {
 	// Check all three metrics exist
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata+`
-        certmanager_certificate_ready_status{condition="False",name="crt1",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="False",name="crt2",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="False",name="crt3",namespace="default-unit-test-ns"} 1
-        certmanager_certificate_ready_status{condition="True",name="crt1",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="crt2",namespace="default-unit-test-ns"} 1
-        certmanager_certificate_ready_status{condition="True",name="crt3",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="crt1",namespace="default-unit-test-ns"} 1
-        certmanager_certificate_ready_status{condition="Unknown",name="crt2",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="crt3",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 1
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 1
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 1
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 0
 `),
 		"certmanager_certificate_ready_status",
 	); err != nil {
@@ -262,9 +302,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt2",namespace="default-unit-test-ns"} 200
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 200
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {
@@ -273,9 +313,9 @@ func TestCertificateCache(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(m.certificateRenewalTimeSeconds,
 		strings.NewReader(renewalTimeMetadata+`
-        certmanager_certificate_renewal_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_renewal_timestamp_seconds{name="crt2",namespace="default-unit-test-ns"} 200
-        certmanager_certificate_renewal_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 200
+        certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_renewal_timestamp_seconds",
 	); err != nil {
@@ -283,15 +323,15 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove second certificate and check not exists
-	m.RemoveCertificate("default-unit-test-ns/crt2")
+	m.RemoveCertificate("default-unit-test-ns/crt2","test-issuer","test-issuer-kind","test-issuer-group")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata+`
-        certmanager_certificate_ready_status{condition="False",name="crt1",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="False",name="crt3",namespace="default-unit-test-ns"} 1
-        certmanager_certificate_ready_status{condition="True",name="crt1",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",name="crt3",namespace="default-unit-test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",name="crt1",namespace="default-unit-test-ns"} 1
-        certmanager_certificate_ready_status{condition="Unknown",name="crt3",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 1
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 0
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 1
+        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 0
 `),
 		"certmanager_certificate_ready_status",
 	); err != nil {
@@ -299,8 +339,8 @@ func TestCertificateCache(t *testing.T) {
 	}
 	if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 		strings.NewReader(expiryMetadata+`
-        certmanager_certificate_expiration_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_expiration_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 300
 `),
 		"certmanager_certificate_expiration_timestamp_seconds",
 	); err != nil {
@@ -308,9 +348,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove all Certificates (even is already removed) and observe no Certificates
-	m.RemoveCertificate("default-unit-test-ns/crt1")
-	m.RemoveCertificate("default-unit-test-ns/crt2")
-	m.RemoveCertificate("default-unit-test-ns/crt3")
+	m.RemoveCertificate("default-unit-test-ns/crt1","test-issuer","test-issuer-kind","test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt2","test-issuer","test-issuer-kind","test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt3","test-issuer","test-issuer-kind","test-issuer-group")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata),
 		"certmanager_certificate_ready_status",

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -323,7 +323,7 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove second certificate and check not exists
-	m.RemoveCertificate("default-unit-test-ns/crt2", "test-issuer", "test-issuer-kind", "test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt2")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata+`
         certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
@@ -348,9 +348,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove all Certificates (even is already removed) and observe no Certificates
-	m.RemoveCertificate("default-unit-test-ns/crt1", "test-issuer", "test-issuer-kind", "test-issuer-group")
-	m.RemoveCertificate("default-unit-test-ns/crt2", "test-issuer", "test-issuer-kind", "test-issuer-group")
-	m.RemoveCertificate("default-unit-test-ns/crt3", "test-issuer", "test-issuer-kind", "test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt1")
+	m.RemoveCertificate("default-unit-test-ns/crt2")
+	m.RemoveCertificate("default-unit-test-ns/crt3")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata),
 		"certmanager_certificate_ready_status",

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -323,7 +323,7 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove second certificate and check not exists
-	m.RemoveCertificate("default-unit-test-ns/crt2","test-issuer","test-issuer-kind","test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt2", "test-issuer", "test-issuer-kind", "test-issuer-group")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata+`
         certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
@@ -348,9 +348,9 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove all Certificates (even is already removed) and observe no Certificates
-	m.RemoveCertificate("default-unit-test-ns/crt1","test-issuer","test-issuer-kind","test-issuer-group")
-	m.RemoveCertificate("default-unit-test-ns/crt2","test-issuer","test-issuer-kind","test-issuer-group")
-	m.RemoveCertificate("default-unit-test-ns/crt3","test-issuer","test-issuer-kind","test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt1", "test-issuer", "test-issuer-kind", "test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt2", "test-issuer", "test-issuer-kind", "test-issuer-group")
+	m.RemoveCertificate("default-unit-test-ns/crt3", "test-issuer", "test-issuer-kind", "test-issuer-group")
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata),
 		"certmanager_certificate_ready_status",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
-// certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renewal_timestamp_seconds{name, namespace}
-// certificate_ready_status{name, namespace, condition}
+// certificate_expiration_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
+// certificate_renewal_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
+// certificate_ready_status{name, namespace, condition, issuer_name, issuer_kind, issuer_group}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
 // venafi_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
@@ -106,7 +106,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Name:      "certificate_expiration_timestamp_seconds",
 				Help:      "The date after which the certificate expires. Expressed as a Unix Epoch Time.",
 			},
-			[]string{"name", "namespace"},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
 
 		certificateRenewalTimeSeconds = prometheus.NewGaugeVec(
@@ -115,7 +115,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Name:      "certificate_renewal_timestamp_seconds",
 				Help:      "The number of seconds before expiration time the certificate should renew.",
 			},
-			[]string{"name", "namespace"},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
 
 		certificateReadyStatus = prometheus.NewGaugeVec(
@@ -124,7 +124,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Name:      "certificate_ready_status",
 				Help:      "The ready status of the certificate.",
 			},
-			[]string{"name", "namespace", "condition"},
+			[]string{"name", "namespace", "condition", "issuer_name", "issuer_kind", "issuer_group"},
 		)
 
 		// acmeClientRequestCount is a Prometheus summary to collect the number of

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -161,7 +161,7 @@ func TestMetricsController(t *testing.T) {
 
 	// Create Certificate
 	crt := gen.Certificate(crtName,
-		gen.SetCertificateIssuer(cmmeta.ObjectReference{Kind: "Issuer", Name: "test-issuer"}),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Kind: "Issuer", Name: "test-issuer", Group: "test-issuer-group"}),
 		gen.SetCertificateSecretName(crtName),
 		gen.SetCertificateCommonName(crtName),
 		gen.SetCertificateNamespace(namespace),
@@ -176,15 +176,15 @@ func TestMetricsController(t *testing.T) {
 	// Should expose that Certificate as unknown with no expiry
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
-certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="testns"} 0
+certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
-certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
-certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 0
-certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 1
+certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 1
 # HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
-certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 0
+certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 ` + clockCounterMetric + clockGaugeMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
@@ -212,15 +212,15 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	// Should expose that Certificate as ready with expiry
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
-certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="testns"} 100
+certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
-certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
-certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 1
-certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 0
+certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 1
+certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
-certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 100
+certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
 ` + clockCounterMetric + clockGaugeMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter


### PR DESCRIPTION
closes #4454, replaces #5038

Thanks to @4molybdenum2 for doing the initial work, hopefully this can help get this across the finish line.

/cc @irbekrm


### Pull Request Motivation

Adding issuer name, group and kind to the following metrics:
```
certmanager_certificate_expiration_timestamp_seconds
certmanager_certificate_renewal_timestamp_seconds
certmanager_certificate_ready_status
```

### Kind

/kind feature

### Release Note

```release-note
Add issuer_name, issuer_kind and issuer_group labels to "certificate_expiration_timestamp_seconds", "certmanager_certificate_renewal_timestamp_seconds" and "certmanager_certificate_ready_status" metrics
```

