### PR TITLE
helm: Add PodMonitoring support for Google Managed Prometheus

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -110,8 +110,11 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
+| `prometheus.podmonitoring.annotations` | Annotations to add to the PodMonitoring resource | `{}` |
 | `prometheus.podmonitoring.enabled` | Enable Google Managed Prometheus Operator PodMonitoring monitoring | `false` |
 | `prometheus.podmonitoring.interval` | Prometheus scrape interval | `60s` |
+| `prometheus.podmonitoring.labels` | Add custom labels to PodMonitoring | |
+| `prometheus.podmonitoring.namespace` | Define namespace where to deploy the PodMonitoring resource | (namespace where you are deploying) |
 | `prometheus.podmonitoring.portName` | Prometheus scrape port | `http-metrics` |
 | `prometheus.podmonitoring.prometheusInstance` | Prometheus Instance definition | `default` |
 | `prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
-| `prometheus.podmonitoring.enabled` | Enable Google Managed PrometheusOperator PodMonitoring monitoring | `false` |
+| `prometheus.podmonitoring.enabled` | Enable Google Managed Prometheus Operator PodMonitoring monitoring | `false` |
 | `prometheus.podmonitoring.interval` | Prometheus scrape interval | `60s` |
 | `prometheus.podmonitoring.portName` | Prometheus scrape port | `http-metrics` |
 | `prometheus.podmonitoring.prometheusInstance` | Prometheus Instance definition | `default` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
-| `prometheus.podmonitoring.enabled` | Enable Prometheus Operator PodMonitoring monitoring | `false` |
+| `prometheus.podmonitoring.enabled` | Enable Google Managed PrometheusOperator PodMonitoring monitoring | `false` |
 | `prometheus.podmonitoring.interval` | Prometheus scrape interval | `60s` |
 | `prometheus.podmonitoring.portName` | Prometheus scrape port | `http-metrics` |
 | `prometheus.podmonitoring.prometheusInstance` | Prometheus Instance definition | `default` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -110,6 +110,10 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
+| `prometheus.podmonitoring.enabled` | Enable Prometheus Operator PodMonitoring monitoring | `false` |
+| `prometheus.podmonitoring.interval` | Prometheus scrape interval | `60s` |
+| `prometheus.podmonitoring.portName` | Prometheus scrape port | `http-metrics` |
+| `prometheus.podmonitoring.prometheusInstance` | Prometheus Instance definition | `default` |
 | `prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false` |
 | `prometheus.servicemonitor.namespace` | Define namespace where to deploy the ServiceMonitor resource | (namespace where you are deploying) |
 | `prometheus.servicemonitor.prometheusInstance` | Prometheus Instance definition | `default` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -113,7 +113,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `prometheus.podmonitoring.annotations` | Annotations to add to the PodMonitoring resource | `{}` |
 | `prometheus.podmonitoring.enabled` | Enable Google Managed Prometheus Operator PodMonitoring monitoring | `false` |
 | `prometheus.podmonitoring.interval` | Prometheus scrape interval | `60s` |
-| `prometheus.podmonitoring.labels` | Add custom labels to PodMonitoring | |
+| `prometheus.podmonitoring.labels` | Add custom labels to PodMonitoring | `{}` |
 | `prometheus.podmonitoring.namespace` | Define namespace where to deploy the PodMonitoring resource | (namespace where you are deploying) |
 | `prometheus.podmonitoring.portName` | Prometheus scrape port | `http-metrics` |
 | `prometheus.podmonitoring.prometheusInstance` | Prometheus Instance definition | `default` |

--- a/deploy/charts/cert-manager/templates/podmonitoring.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitoring.yaml
@@ -30,11 +30,6 @@ spec:
       app.kubernetes.io/name: {{ template "cert-manager.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
-{{- if .Values.prometheus.podmonitoring.namespace }}
-  namespaceSelector:
-    matchNames:
-      - {{ include "cert-manager.namespace" . }}
-{{- end }}
   endpoints:
   - port: {{ .Values.prometheus.podmonitoring.portName }}
     interval: {{ .Values.prometheus.podmonitoring.interval }}

--- a/deploy/charts/cert-manager/templates/podmonitoring.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitoring.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.podmonitoring.enabled }}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+{{- if .Values.prometheus.podmonitoring.namespace }}
+  namespace: {{ .Values.prometheus.podmonitoring.namespace }}
+{{- else }}
+  namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+    prometheus: {{ .Values.prometheus.podmonitoring.prometheusInstance }}
+    {{- with .Values.prometheus.podmonitoring.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.prometheus.podmonitoring.annotations }}
+  annotations:
+    {{- with .Values.prometheus.podmonitoring.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
+{{- if .Values.prometheus.podmonitoring.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "cert-manager.namespace" . }}
+{{- end }}
+  endpoints:
+  - port: {{ .Values.prometheus.podmonitoring.portName }}
+    interval: {{ .Values.prometheus.podmonitoring.interval }}
+{{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -189,10 +189,12 @@ prometheus:
     annotations: {}
     honorLabels: false
   podmonitoring:
-    enabled: true
+    enabled: false
     prometheusInstance: default
     interval: 60s
     portName: http-metrics
+    labels: {}
+    annotations: {}
     namespace: ~
 
 # Use these variables to configure the HTTP_PROXY environment variables

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -189,10 +189,11 @@ prometheus:
     annotations: {}
     honorLabels: false
   podmonitoring:
-    enabled: false
+    enabled: true
     prometheusInstance: default
     interval: 60s
     portName: http-metrics
+    namespace: ~
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -188,6 +188,11 @@ prometheus:
     labels: {}
     annotations: {}
     honorLabels: false
+  podmonitoring:
+    enabled: false
+    prometheusInstance: default
+    interval: 60s
+    portName: http-metrics
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
Signed-off-by: 11425176+ptran32@users.noreply.github.com <11425176+ptran32@users.noreply.github.com>

### Pull Request Motivation

This PR adds PodMonitoring support to work with [Google Managed Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed)

### Kind

Feature (for helm chart)


### Release Note

```release-note
Helm: Added PodMonitoring support
```

