### PR TITLE
Increase timeout  waitForCertificateRequestToExist

### DIFF
--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -409,7 +409,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 }
 
 func (c *controller) waitForCertificateRequestToExist(namespace, name string) error {
-	return wait.Poll(time.Millisecond*100, time.Second*5, func() (bool, error) {
+	return wait.Poll(time.Millisecond*100, time.Second*60, func() (bool, error) {
 		_, err := c.certificateRequestLister.CertificateRequests(namespace).Get(name)
 		if apierrors.IsNotFound(err) {
 			return false, nil


### PR DESCRIPTION
### Pull Request Motivation
Although this may not be fixing the root cause of https://github.com/cert-manager/cert-manager/issues/4956, @munnerz identified this as a possible workaround until a more robust solution can be developed. Presently, the working theory is that the apiserver is not responding in the allotted time and thus a duplicate certificate request is created which clashes with the one that was initially created.  Ideally, we would have a way to detect that there is already another certificate in flight before we attempt to create a new one. 

Quoting @munnerz :
>A short term and easy fix could be to increase the timeout from 5s to say, 60s.. this should only be relevant in edge cases anyway

More details about the discussion can be found on [this slack thread](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1664926850463129)

Signed-off-by: Cody W. Eilar <ecody@vmware.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


### Kind
/kind feature


### Release Note

```release-note
Increase the timeout to 60 seconds, from 5, for `waitForCertificateRequestToExist` to help prevent the error "multiple CertificateRequests were found for the 'next' revision..."
```
