### PR TITLE
Generate Certificate Request with predictable name

### DIFF
--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -58,6 +58,12 @@ const (
 	// This feature gate must be used together with LiteralCertificateSubject webhook feature gate.
 	// See https://github.com/cert-manager/cert-manager/issues/3203 and https://github.com/cert-manager/cert-manager/issues/4424 for context.
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
+
+	// Alpha: v1.10
+	// StableCertificateRequestName will enable generation of CertificateRequest resources with a fixed name. The name of the CertificateRequest will be a function of Certificate resource name and its revision
+	// This feature gate will disable auto-generated CertificateRequest name
+	// Github Issue: https://github.com/cert-manager/cert-manager/issues/4956
+	StableCertificateRequestName featuregate.Feature = "StableCertificateRequestName"
 )
 
 func init() {
@@ -74,4 +80,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
 	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},
+	StableCertificateRequestName:                     {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -47,6 +48,7 @@ import (
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
 )
@@ -395,6 +397,11 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		},
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(feature.StableCertificateRequestName) {
+		cr.ObjectMeta.GenerateName = ""
+		cr.ObjectMeta.Name = apiutil.DNSSafeShortenTo52Characters(crt.Name) + "-" + fmt.Sprintf("%d", nextRevision)
+	}
+
 	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
 	if err != nil {
 		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
@@ -402,8 +409,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	}
 
 	c.recorder.Eventf(crt, corev1.EventTypeNormal, reasonRequested, "Created new CertificateRequest resource %q", cr.Name)
-	if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
-		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried. %w", err)
+	if !utilfeature.DefaultFeatureGate.Enabled(feature.StableCertificateRequestName) {
+		if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
+			return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried. %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -28,12 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -78,6 +82,14 @@ func TestProcessItem(t *testing.T) {
 		},
 		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-2"}},
 	)
+	bundle3 := mustCreateCryptoBundle(t, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "test",
+			UID:       "test",
+		},
+		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-3"}},
+	)
 	fixedNow := metav1.NewTime(time.Now())
 	fixedClock := fakeclock.NewFakeClock(fixedNow.Time)
 	failedCRConditionPreviousIssuance := cmapi.CertificateRequestCondition{
@@ -97,6 +109,9 @@ func TestProcessItem(t *testing.T) {
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be ""
 		key string
+
+		// Featuregates to set for a particular test.
+		featuresToEnable []featuregate.Feature
 
 		// Certificate to be synced for the test.
 		// if not set, the 'key' will be passed to ProcessItem instead.
@@ -178,6 +193,31 @@ func TestProcessItem(t *testing.T) {
 			expectedActions: []testpkg.Action{
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
 					gen.CertificateRequestFrom(bundle1.certificateRequest,
+						gen.SetCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+							cmapi.CertificateRequestRevisionAnnotationKey:   "1",
+						}),
+					)), relaxedCertificateRequestMatcher),
+			},
+		},
+		"create a CertificateRequest if none exists and StableCertificateRequestName enabled": {
+			featuresToEnable: []featuregate.Feature{feature.StableCertificateRequestName},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle3.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+			),
+			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "test-1"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+					gen.CertificateRequestFrom(bundle3.certificateRequest,
+						gen.SetCertificateRequestName("test-1"),
+						gen.SetCertificateRequestGenerateName(""),
 						gen.SetCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
 							cmapi.CertificateRequestRevisionAnnotationKey:   "1",
@@ -614,6 +654,12 @@ func TestProcessItem(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Enable any features for a particular test
+			for _, feature := range test.featuresToEnable {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature, true)()
+			}
+
 			// Start the informers and begin processing updates
 			builder.Start()
 			defer builder.Stop()

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -114,6 +114,12 @@ func SetCertificateRequestName(name string) CertificateRequestModifier {
 	}
 }
 
+func SetCertificateRequestGenerateName(generateName string) CertificateRequestModifier {
+	return func(cr *v1.CertificateRequest) {
+		cr.ObjectMeta.GenerateName = generateName
+	}
+}
+
 func SetCertificateRequestKeyUsages(usages ...v1.KeyUsage) CertificateRequestModifier {
 	return func(cr *v1.CertificateRequest) {
 		cr.Spec.Usages = usages


### PR DESCRIPTION
Modify certificaterequest controller to generate CertificateRequest with name as function of certificate name and revision.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
As mentioned in #4956 , multiple CertificateRequest objects are created for a fixed certificate object and fixed revision. This happens when the CertificateRequest creation request from `requestmanager` controller takes more than 5 seconds to create the resource in the api server.

On timeout, the request is re-tried and a new CertificateRequest is created but with a different name. This results in multiple CertificateRequests for a given certificate name and given revision.

In this PR, this issue is being fixed by making the CertificateRequest name to be a function of certificate name and the revision. This makes sure, even if there are multiple CertificateRequest create request, they are requested with same name. Hence, this avoid multiple CertificateRequests for given cert and revision.

Other fix: #5485 
<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind
bug
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Local testing
This change has been tested by simulating API server delay locally by the following diff:

```
diff --git a/pkg/controller/certificates/requestmanager/requestmanager_controller.go b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
index 155580ec5..af87dd03c 100644
--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -395,13 +395,16 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		},
 	}
 
-	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
-	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
-		return err
-	}
+	go func() {
+		time.Sleep(1 * time.Minute)
+		cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
+		if err != nil {
+			c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
+		}
+
+		c.recorder.Eventf(crt, corev1.EventTypeNormal, reasonRequested, "Created new CertificateRequest resource %q", cr.Name)
+	}()
 
-	c.recorder.Eventf(crt, corev1.EventTypeNormal, reasonRequested, "Created new CertificateRequest resource %q", cr.Name)
 	if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
 		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried. %w", err)
 	}

```

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The feature to create certificate requests with the name being a function of certificate name and revision has been introduced under the feature flag "StableCertificateRequestName" and it is disabled by default. This helps to prevent the error "multiple CertificateRequests were found for the 'next' revision...". 
```
