### PR TITLE
Fire event on CertificateRequest when it has not been Approved yet.

### DIFF
--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -226,6 +226,9 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
 			},
 		},
 		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -186,6 +186,9 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
 			},
 		},
 		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -211,6 +211,9 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
 			},
 		},
 		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"github.com/kr/pretty"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	// If CertificateRequest has not been approved, exit early.
 	if !apiutil.CertificateRequestIsApproved(cr) {
 		dbg.Info("certificate request has not been approved")
+		c.recorder.Event(cr, corev1.EventTypeNormal, "WaitingForApproval", "Not signing CertificateRequest until it is Approved")
 		return nil
 	}
 

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -186,8 +186,10 @@ func TestSync(t *testing.T) {
 			certificateRequest: gen.CertificateRequestFrom(baseCRNotApproved),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer, baseCR},
-				ExpectedEvents:     []string{},
-				ExpectedActions:    []testpkg.Action{},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
+				ExpectedActions: []testpkg.Action{},
 			},
 		},
 		"should update Ready condition with 'Denied' if certificate request is denied": {
@@ -376,8 +378,10 @@ func TestSync(t *testing.T) {
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer, baseCR},
-				ExpectedEvents:     []string{},
-				ExpectedActions:    []testpkg.Action{},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
+				ExpectedActions: []testpkg.Action{},
 			},
 		},
 		"should return nil (no action) if certificate request is ready and reason Issued": {

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -175,6 +175,9 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
 			},
 		},
 		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -280,6 +280,9 @@ func TestSign(t *testing.T) {
 			builder: &controllertest.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingForApproval Not signing CertificateRequest until it is Approved",
+				},
 			},
 		},
 		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {


### PR DESCRIPTION
When the default approver is disabled and an approver is not currently running, it can be not clear to uses why a request is not progressing. This can be frustrating for users are can seem like things are not working correctly.

PR updates the internal signers to fire an event on CertificateRequests which are not yet approved so is clear why the request is not progressing.

/milestone v1.11
/kind feature
/assign @irbekrm 

```release-note
Signers fire an event on CertificateRequests which have not been approved yet. Used for informational purposes so users understand why a request is not progressing.
```
