### PR TITLE
Fix Scorecard Github Action not running

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Regarding an error after merging the issue #5440 

I've noticed that the Scorecard Github Action is not running with success (https://github.com/cert-manager/cert-manager/actions/runs/3345975741). Don't know for sure when it stoped working since I've tested in the forked repo, but I've upgraded the Scorecard Github Action version and tested again to fix it.

Sorry for not noticing it before.

Here is the screenshot of the action running after the version upgrade
![Screenshot 2022-10-28 14 44 36](https://user-images.githubusercontent.com/22223372/198700587-0eb20bc9-249c-49c7-a67a-ee96d4307c7e.png)

I've tested the badge refering the joycebrum/cert-manager repo (as seen in the print bellow) and it worked too.
![Screenshot 2022-10-28 14 44 15](https://user-images.githubusercontent.com/22223372/198700605-914b67ce-6c1a-489c-a227-e0063c263e3b.png)

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->
bug
### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
