### PR TITLE
Adding support to elevate acme-solver pod to root during testing

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -261,6 +261,7 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 		return nil, fmt.Errorf("error parsing ACMEHTTP01SolverResourceLimitsMemory: %w", err)
 	}
 
+	ACMEHTTP01SolverRunAsNonRoot := opts.ACMEHTTP01SolverRunAsNonRoot
 	acmeAccountRegistry := accounts.NewDefaultRegistry()
 
 	ctxFactory, err := controller.NewContextFactory(ctx, controller.ContextOptions{
@@ -279,6 +280,7 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 			HTTP01SolverResourceRequestMemory: http01SolverResourceRequestMemory,
 			HTTP01SolverResourceLimitsCPU:     http01SolverResourceLimitsCPU,
 			HTTP01SolverResourceLimitsMemory:  http01SolverResourceLimitsMemory,
+			ACMEHTTP01SolverRunAsNonRoot:      ACMEHTTP01SolverRunAsNonRoot,
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 			HTTP01SolverNameservers: opts.ACMEHTTP01SolverNameservers,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -80,6 +80,7 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverResourceRequestMemory string
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
+	ACMEHTTP01SolverRunAsNonRoot          bool
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 	ACMEHTTP01SolverNameservers []string
 
@@ -155,6 +156,7 @@ var (
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
+	defaultACMEHTTP01SolverRunAsNonRoot          = true
 
 	defaultAutoCertificateAnnotations = []string{"kubernetes.io/tls-acme"}
 
@@ -310,6 +312,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceLimitsMemory, "acme-http01-solver-resource-limits-memory", defaultACMEHTTP01SolverResourceLimitsMemory, ""+
 		"Defines the resource limits Memory size when spawning new ACME HTTP01 challenge solver pods.")
+
+	fs.BoolVar(&s.ACMEHTTP01SolverRunAsNonRoot, "acme-http01-solver-run-as-non-root", defaultACMEHTTP01SolverRunAsNonRoot, ""+
+		"Defines the ability to run the http01 solver as root for troubleshooting issues")
 
 	fs.StringSliceVar(&s.ACMEHTTP01SolverNameservers, "acme-http01-solver-nameservers",
 		[]string{}, "A list of comma separated dns server endpoints used for "+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -170,6 +170,9 @@ type ACMEOptions struct {
 	// HTTP01SolverResourceLimitsMemory defines the ACME pod's resource limits Memory size
 	HTTP01SolverResourceLimitsMemory resource.Quantity
 
+	// ACMEHTTP01SolverRunAsNonRoot sets the ACME pod's ability to run as root
+	ACMEHTTP01SolverRunAsNonRoot bool
+
 	// HTTP01SolverNameservers is a list of nameservers to use when performing self-checks
 	// for ACME HTTP01 validations.
 	HTTP01SolverNameservers []string

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -180,7 +180,7 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			},
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: pointer.BoolPtr(true),
+				RunAsNonRoot: pointer.BoolPtr(s.ACMEOptions.ACMEHTTP01SolverRunAsNonRoot),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},


### PR DESCRIPTION
Signed-off-by: Corey McGalliard <cmcgalliard@redventures.com>

### Pull Request Motivation

Hey! we met at kubecon - I chatted about wanting to help contribute to this project because cert-manager been super beneficial for my team!  I grabbed a good-first-issue and here's the PR for Issue #5295 I was able to build and run this locally - but am having issues running the test suite locally. 

### Kind
feature 

### Release Note
This PR gives us the ability to allow changing acmesolver pod SecurityContext - this will be helpful to use the newer `kubectl debug ... ` commands as well as having the ability to use sidecar pods that run as root.

