### PR TITLE
Bump to latest go minor version to fix vulns

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -36,7 +36,7 @@ KUBEBUILDER_ASSETS_VERSION=1.25.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.1
+VENDORED_GO_VERSION := 1.19.3
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

There are a few vulns that've been fixed in the two new go 1.19 releases.

### Kind

/kind bug

### Release Note

```release-note
Upgrade to latest go minor release
```
