### PR TITLE
[release-1.9] Bump to latest go minor version to fix vulns

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -35,7 +35,7 @@ K8S_CODEGEN_VERSION=v0.24.2
 
 KUBEBUILDER_ASSETS_VERSION=1.24.2
 
-VENDORED_GO_VERSION := 1.18.3
+VENDORED_GO_VERSION := 1.18.8
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

Go version bump to fix vulns - related to #5559 but adjusted for release-1.9 which used go 1.18

### Kind

/kind bug

### Release Note

```release-note
Upgrade to latest go minor release
```
