### PR TITLE
feat(AzureDNS): Add support for Workload Identity

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -9,10 +9,16 @@ this directory.
 package azuredns
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
@@ -76,4 +82,120 @@ func TestInvalidAzureDns(t *testing.T) {
 
 	_, err := NewDNSProviderCredentials("invalid env", "cid", "secret", "", "", "", "", util.RecursiveNameservers, false, &v1.AzureManagedIdentity{})
 	assert.Error(t, err)
+}
+
+func populateFederatedToken(t *testing.T, filename string, content string) {
+	t.Helper()
+
+	f, err := os.Create(filename)
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	if _, err := io.WriteString(f, content); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	if err := f.Close(); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+}
+
+func TestGetAuthorizationFederatedSPT(t *testing.T) {
+	// Create a file that will be used to store a federated token
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	defer os.Remove(f.Name())
+
+	// Close the file to simplify logic within populateFederatedToken helper
+	if err := f.Close(); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	// The initial federated token is never used, so we don't care about the value yet
+	// Though, it's a requirement from adal to have a non-empty value set
+	populateFederatedToken(t, f.Name(), "random-jwt")
+
+	// Prepare environment variables adal will rely on. Skip changes for some envs if they are already defined (=live environment)
+	// Envs themselves are described here: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
+	if os.Getenv("AZURE_TENANT_ID") == "" {
+		t.Setenv("AZURE_TENANT_ID", "fakeTenantID")
+	}
+
+	if os.Getenv("AZURE_CLIENT_ID") == "" {
+		t.Setenv("AZURE_CLIENT_ID", "fakeClientID")
+	}
+
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", f.Name())
+
+	t.Run("token refresh", func(t *testing.T) {
+		// Basically, we want one token to be exchanged for the other (key and value respectively)
+		tokens := map[string]string{
+			"initialFederatedToken":   "initialAccessToken",
+			"refreshedFederatedToken": "refreshedAccessToken",
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			receivedFederatedToken := r.FormValue("client_assertion")
+			accessToken := adal.Token{AccessToken: tokens[receivedFederatedToken]}
+
+			if err := json.NewEncoder(w).Encode(accessToken); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			// Expected format: http://<server>/<tenant-ID>/oauth2/token?api-version=1.0
+			assert.Contains(t, r.RequestURI, os.Getenv("AZURE_TENANT_ID"), "URI should contain the tenant ID exposed through env variable")
+
+			assert.Equal(t, os.Getenv("AZURE_CLIENT_ID"), r.FormValue("client_id"), "client_id should match the value exposed through env variable")
+		}))
+		defer ts.Close()
+
+		ambient := true
+		env := azure.Environment{ActiveDirectoryEndpoint: ts.URL, ResourceManagerEndpoint: ts.URL}
+		managedIdentity := &v1.AzureManagedIdentity{ClientID: ""}
+
+		spt, err := getAuthorization(env, "", "", "", "", ambient, managedIdentity)
+		assert.NoError(t, err)
+
+		for federatedToken, accessToken := range tokens {
+			populateFederatedToken(t, f.Name(), federatedToken)
+			assert.NoError(t, spt.Refresh(), "Token refresh failed")
+			assert.Equal(t, accessToken, spt.Token().AccessToken, "Access token should have been set to a value returned by the webserver")
+		}
+	})
+
+	t.Run("clientID overrides through managedIdentity section", func(t *testing.T) {
+		managedIdentity := &v1.AzureManagedIdentity{ClientID: "anotherClientID"}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			accessToken := adal.Token{AccessToken: "abc"}
+
+			if err := json.NewEncoder(w).Encode(accessToken); err != nil {
+				assert.FailNow(t, err.Error())
+			}
+
+			assert.Equal(t, managedIdentity.ClientID, r.FormValue("client_id"), "client_id should match the value passed through managedIdentity section")
+		}))
+		defer ts.Close()
+
+		ambient := true
+		env := azure.Environment{ActiveDirectoryEndpoint: ts.URL, ResourceManagerEndpoint: ts.URL}
+
+		spt, err := getAuthorization(env, "", "", "", "", ambient, managedIdentity)
+		assert.NoError(t, err)
+
+		assert.NoError(t, spt.Refresh(), "Token refresh failed")
+	})
 }


### PR DESCRIPTION
### Pull Request Motivation

This PR brings support for Workload Identity to AzureDNS issuer.

There's another PR #5308, which also introduces support for Workload Identity, though it has two drawbacks:

- It doesn't handle access token renewal:
  - A federated token is renewed every hour by default (it's supposed to be re-read from disk), whereas AAD token received in exchange - every 24h.
  - `adal` doesn't read federated tokens from disk itself and doesn't expose any methods to dynamically replace `jwt`. Thus, token renewal would fail due to stale federated token;
- It supports only one Client ID:
  - As it was explained [in details](https://github.com/cert-manager/cert-manager/pull/5308#discussion_r1007280573) by @pinkfloydx33, Workload Identity supports scenarios where you map multiple MSIs to one service account, so you could have fine-grained access per each resolver.

@karlschriek, the author of that PR, does not currently have enough time to fix those, so we agreed that I'll drive it all further ([discussion](https://github.com/cert-manager/cert-manager/pull/5308#issuecomment-1305762230)).

Closes: #5085 

### Kind

/kind feature

### Release Note

```release-note
Add support for Workload Identity to AzureDNS resolver
```

### Extra information

The feature can be tested by deploying the updated image with these parameters supplied to the official helm chart:

```yaml
# Needed only if Issuer is used. ClusterIssuer has ambient flag enabled by default.
extraArgs:
  - --issuer-ambient-credentials

serviceAccount:
  annotations:
    azure.workload.identity/client-id: <YOUR-CLIENT-ID>
  labels:
    azure.workload.identity/use: "true"
```

ClientID can be overridden through `Issuer` or `ClusterIssuer`:

```yaml
[...]
    solvers:
    - dns01:
        azureDNS:
          subscriptionID: AZURE_SUBSCRIPTION_ID
          resourceGroupName: AZURE_DNS_ZONE_RESOURCE_GROUP
          hostedZoneName: AZURE_DNS_ZONE
          environment: AzurePublicCloud
          managedIdentity:
            clientID: <YOUR-CLIENT-ID>
```

```shell
Running tool: /usr/local/go/bin/go test -timeout 30s -coverprofile=/var/folders/rt/68xkylrx55j9zxpvxrggn53h0000gn/T/vscode-goTJGj6K/go-code-cover github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns

ok  	github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns	0.295s	coverage: 20.6% of statements
```