### PR TITLE
Add support for required LDAP (rfc4514) RDNs in LiteralSubject

### DIFF
--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -944,6 +944,18 @@ func Test_validateLiteralSubject(t *testing.T) {
 			},
 			a: someAdmissionRequest,
 		},
+		"valid with a `literalSubject` containing CN with special characters, multiple DC and well-known rfc4514 and rfc5280 RDN OIDs": {
+			featureEnabled: true,
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					Subject:        &internalcmapi.X509Subject{SerialNumber: "1"},
+					LiteralSubject: "CN=James \\\"Jim\\\" Smith\\, III,DC=dc,DC=net,UID=jamessmith,STREET=La Rambla,L=Barcelona,C=Spain,O=Acme,OU=IT,OU=Admins",
+					SecretName:     "abc",
+					IssuerRef:      validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+		},
 		"invalid with a `literalSubject` without CN and no dnsNames, ipAddresses, or emailAddress": {
 			featureEnabled: true,
 			cfg: &internalcmapi.Certificate{

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -73,7 +73,7 @@ nodes=20
 flake_attempts=1
 ginkgo_skip=
 ginkgo_focus=
-feature_gates=AdditionalCertificateOutputFormats=true,ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true
+feature_gates=AdditionalCertificateOutputFormats=true,ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,LiteralCertificateSubject=true
 artifacts="./$BINDIR/artifacts"
 help() {
   cat <<EOF | color ""

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -373,6 +373,8 @@ var OIDConstants = struct {
 	Locality           []int
 	Province           []int
 	StreetAddress      []int
+	DomainComponent []int
+	UniqueIdentifier []int
 }{
 	Country:            []int{2, 5, 4, 6},
 	Organization:       []int{2, 5, 4, 10},
@@ -382,10 +384,13 @@ var OIDConstants = struct {
 	Locality:           []int{2, 5, 4, 7},
 	Province:           []int{2, 5, 4, 8},
 	StreetAddress:      []int{2, 5, 4, 9},
+	DomainComponent:    []int{0,9,2342,19200300,100,1,25},
+	UniqueIdentifier: []int{0,9,2342,19200300,100,1,1},
 }
 
 // Copied from pkix.attributeTypeNames and inverted. (Sadly it is private.)
 // Source: https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/crypto/x509/pkix/pkix.go;l=26
+// Added RDNs identifier to support rfc4514 LDAP certificates, cf https://github.com/cert-manager/cert-manager/issues/5582
 var attributeTypeNames = map[string][]int{
 	"C":            OIDConstants.Country,
 	"O":            OIDConstants.Organization,
@@ -395,6 +400,8 @@ var attributeTypeNames = map[string][]int{
 	"L":            OIDConstants.Locality,
 	"ST":           OIDConstants.Province,
 	"STREET":       OIDConstants.StreetAddress,
+	"DC": OIDConstants.DomainComponent,
+	"UID": OIDConstants.UniqueIdentifier,
 }
 
 func ParseSubjectStringToRdnSequence(subject string) (pkix.RDNSequence, error) {

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -373,8 +373,8 @@ var OIDConstants = struct {
 	Locality           []int
 	Province           []int
 	StreetAddress      []int
-	DomainComponent []int
-	UniqueIdentifier []int
+	DomainComponent    []int
+	UniqueIdentifier   []int
 }{
 	Country:            []int{2, 5, 4, 6},
 	Organization:       []int{2, 5, 4, 10},
@@ -384,8 +384,8 @@ var OIDConstants = struct {
 	Locality:           []int{2, 5, 4, 7},
 	Province:           []int{2, 5, 4, 8},
 	StreetAddress:      []int{2, 5, 4, 9},
-	DomainComponent:    []int{0,9,2342,19200300,100,1,25},
-	UniqueIdentifier: []int{0,9,2342,19200300,100,1,1},
+	DomainComponent:    []int{0, 9, 2342, 19200300, 100, 1, 25},
+	UniqueIdentifier:   []int{0, 9, 2342, 19200300, 100, 1, 1},
 }
 
 // Copied from pkix.attributeTypeNames and inverted. (Sadly it is private.)
@@ -400,8 +400,8 @@ var attributeTypeNames = map[string][]int{
 	"L":            OIDConstants.Locality,
 	"ST":           OIDConstants.Province,
 	"STREET":       OIDConstants.StreetAddress,
-	"DC": OIDConstants.DomainComponent,
-	"UID": OIDConstants.UniqueIdentifier,
+	"DC":           OIDConstants.DomainComponent,
+	"UID":          OIDConstants.UniqueIdentifier,
 }
 
 func ParseSubjectStringToRdnSequence(subject string) (pkix.RDNSequence, error) {

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -83,19 +83,20 @@ var _ = framework.CertManagerDescribe("literalsubject rdn parsing", func() {
 		pemBlock, _ := pem.Decode(crtPEM)
 		cert, err := x509.ParseCertificate(pemBlock.Bytes)
 		Expect(err).To(BeNil())
+
 		// TODO: the sequence seems to come out 'reversed' in cert.Subject.Names, investigate ordering
-		Expect(cert.Subject.Names).To(ContainElements(
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "Admins"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "IT"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 10}, Value: "Acme"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "Spain"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 7}, Value: "Barcelona"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 9}, Value: "La Rambla"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 1}, Value: "jamessmith"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "net"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "dc"},
-			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "James \"Jim\" Smith, III"},
-		))
+		Expect(cert.Subject.Names).To(Equal([]pkix.AttributeTypeAndValue{
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "Admins"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "IT"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 10}, Value: "Acme"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "Spain"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 7}, Value: "Barcelona"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 9}, Value: "La Rambla"},
+			{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 1}, Value: "jamessmith"},
+			{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "net"},
+			{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "dc"},
+			{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "James \"Jim\" Smith, III"},
+		}))
 
 	})
 })

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package certificates
 
 import (

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -1,0 +1,101 @@
+package certificates
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"time"
+
+	"github.com/cert-manager/cert-manager/internal/webhook/feature"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
+	"github.com/cert-manager/cert-manager/test/e2e/framework"
+	e2eutil "github.com/cert-manager/cert-manager/test/e2e/util"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	//. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = framework.CertManagerDescribe("literalsubject rdn parsing", func() {
+
+	const (
+		testName   = "test-literalsubject-rdn-parsing"
+		issuerName = "certificate-literalsubject-rdns"
+		secretName = testName
+	)
+
+	f := framework.NewDefaultFramework("certificate-literalsubject-rdns")
+
+	createCertificate := func(f *framework.Framework, literalSubject string) (string, *cmapi.Certificate) {
+		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
+		crt := &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: testName + "-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: cmapi.CertificateSpec{
+				SecretName: secretName,
+				PrivateKey: &cmapi.CertificatePrivateKey{RotationPolicy: cmapi.RotationPolicyAlways},
+				IssuerRef: cmmeta.ObjectReference{
+					Name: issuerName, Kind: "Issuer", Group: "cert-manager.io",
+				},
+				LiteralSubject: literalSubject,
+			},
+		}
+
+		By("creating Certificate with AdditionalOutputFormats")
+		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.Background(), crt, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Minute*2)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		return crt.Name, crt
+	}
+	BeforeEach(func() {
+		By("creating a self-signing issuer")
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}))
+		Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
+
+		By("Waiting for Issuer to become Ready")
+		err := e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName, cmapi.IssuerCondition{Type: cmapi.IssuerConditionReady, Status: cmmeta.ConditionTrue})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.Background(), issuerName, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+	})
+
+	FIt("Should create CSR reflecting most common RDNs", func() {
+		createCertificate(f, "CN=James \\\"Jim\\\" Smith\\, III,DC=dc,DC=net,UID=jamessmith,STREET=La Rambla,L=Barcelona,C=Spain,O=Acme,OU=IT,OU=Admins")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), secretName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+		Expect(secret.Data).To(HaveKey("tls.crt"))
+		crtPEM := secret.Data["tls.crt"]
+		pemBlock, _ := pem.Decode(crtPEM)
+		cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		Expect(err).To(BeNil())
+		// TODO: the sequence seems to come out 'reversed' in cert.Subject.Names, investigate ordering
+		Expect(cert.Subject.Names).To(ContainElements(
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "Admins"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "IT"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 10}, Value: "Acme"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "Spain"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 7}, Value: "Barcelona"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 9}, Value: "La Rambla"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 1}, Value: "jamessmith"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "net"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "dc"},
+			pkix.AttributeTypeAndValue{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "James \"Jim\" Smith, III"},
+		))
+
+	})
+})


### PR DESCRIPTION
* Add OID translation for mandatory DC component
* Used extensively in LDAP certificates, also required by rfc5280
* Add support for UID, mentioned in LDAP RFC
* Fix bug #5582

Signed-off-by: SpectralHiss <houssem.elfekih@jetstack.io>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add support for DC and UID in `LiteralSubject` field, all mandatory OIDs are now supported for LDAP certificates (rfc4514).
```
