### PR TITLE
fix(#5563): sets namespace using vault client methods instead of using raw request object

### DIFF
--- a/internal/vault/fake/client.go
+++ b/internal/vault/fake/client.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"errors"
 
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	vault "github.com/hashicorp/vault/api"
 )
 
@@ -61,7 +62,7 @@ func (c *Client) Token() string {
 	return c.token
 }
 
-func (c *Client) RawRequest(r *vault.Request) (*vault.Response, error) {
+func (c *Client) NamespacedRawRequest(vaultIssuer *v1.VaultIssuer, r *vault.Request) (*vault.Response, error) {
 	return c.RawRequestFn(r)
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -65,6 +65,15 @@ type vaultClientWrapper struct {
 	*vault.Client
 }
 
+// Sends a RawRequest with a Vault namespace if it exists on the issuer. When no namespace is set on the issuer or
+// if the issuer is nil, then no vault namespace header will be sent with the request.
+//
+// Certain requests cannot be successfully made with a namespace header set even if namespaces are enabled in Vault
+// Enterprise. Root only API paths will return a 404 if requested with a namespace.
+// see: https://developer.hashicorp.com/vault/docs/enterprise/namespaces#root-only-api-paths
+//
+// Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy.
+// More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
 func (w vaultClientWrapper) NamespacedRawRequest(vaultIssuer *v1.VaultIssuer, r *vault.Request) (*vault.Response, error) {
 	if vaultIssuer != nil && vaultIssuer.Namespace != "" {
 		return w.Client.WithNamespace(vaultIssuer.Namespace).RawRequest(r)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1199,11 +1199,10 @@ func TestNamespacedRequest(t *testing.T) {
 		ns = req.Header.Get("X-Vault-Namespace")
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))
-	ln := server.Listener
-	defer ln.Close()
+	defer server.Close()
 
 	config := vault.DefaultConfig()
-	config.Address = fmt.Sprintf("http://%s", ln.Addr())
+	config.Address = fmt.Sprintf("http://%s", server.Listener.Addr())
 
 	// set up a client with a namespace
 	vaultClient, err := vault.NewClient(config)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1201,7 +1201,7 @@ func TestNamespacedRequest(t *testing.T) {
 	defer server.Close()
 
 	config := vault.DefaultConfig()
-	config.Address = fmt.Sprintf("http://%s", server.Listener.Addr())
+	config.Address = server.URL
 
 	vaultClient, err := vault.NewClient(config)
 	if err != nil {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1178,7 +1178,6 @@ type testNamespacedRequestT struct {
 }
 
 func TestNamespacedRequest(t *testing.T) {
-
 	tests := map[string]testNamespacedRequestT{
 		"request should include the namespace when present on the issuer": {
 			expectedNamespace: "test-namespace",

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1203,7 +1203,6 @@ func TestNamespacedRequest(t *testing.T) {
 	config := vault.DefaultConfig()
 	config.Address = fmt.Sprintf("http://%s", server.Listener.Addr())
 
-	// set up a client with a namespace
 	vaultClient, err := vault.NewClient(config)
 	if err != nil {
 		t.Errorf("error initializing vault client: %s", err)


### PR DESCRIPTION
### Pull Request Motivation

This change fixes #5563 by changing the vault client logic to instead use the vault client's functions to set the namespace, rather than passing in a new request object with custom headers.

#### Why is this necessary?
The behavior of the vault client changed in vault api version `v1.11.0` with [this commit](https://github.com/hashicorp/vault/commit/a442461f81783cd0abec312e910e3a720ab7fd68). The impact of this change means that any headers that are set in the request object passed in to `RawRequest` are wiped out if there are no headers set in the vault client object.

Before vault API `v1.11.0` `RawRequest` respected headers that were passed in via the request argument.

The vault API dependency was upgraded in cert-manager `v1.10.0`: https://github.com/cert-manager/cert-manager/commit/39fa9f51b4d96ff54dd253cc6e655b8ad8625a21 and so anyone using this version or later will see that the namespace setting does nothing and all requests to vault go to the default root namespace.


### Kind

bug

### Release Note

```release-note
Fixed Vault namespace bug
```
