### PR TITLE
Set the Vault namespace using vault SDK client methods instead of using raw request object

### DIFF
--- a/internal/vault/fake/client.go
+++ b/internal/vault/fake/client.go
@@ -64,7 +64,3 @@ func (c *Client) Token() string {
 func (c *Client) RawRequest(r *vault.Request) (*vault.Response, error) {
 	return c.RawRequestFn(r)
 }
-
-func (c *Client) Sys() *vault.Sys {
-	return nil
-}

--- a/internal/vault/fake/vault.go
+++ b/internal/vault/fake/vault.go
@@ -20,7 +20,6 @@ package fake
 import (
 	"time"
 
-	vault "github.com/hashicorp/vault/api"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -78,11 +77,6 @@ func (v *Vault) New(ns string, sl corelisters.SecretLister, iss v1.GenericIssuer
 	}
 
 	return v, nil
-}
-
-// Sys returns an empty `vault.Sys`.
-func (v *Vault) Sys() *vault.Sys {
-	return new(vault.Sys)
 }
 
 // IsVaultInitializedAndUnsealed always returns nil

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -45,10 +45,8 @@ type ClientBuilder func(namespace string, secretsLister corelisters.SecretLister
 // Interface implements various high level functionality related to connecting
 // with a Vault server, verifying its status and signing certificate request for
 // Vault's certificate.
-// TODO: Sys() is duplicated here and in Client interface
 type Interface interface {
 	Sign(csrPEM []byte, duration time.Duration) (certPEM []byte, caPEM []byte, err error)
-	Sys() *vault.Sys
 	IsVaultInitializedAndUnsealed() error
 }
 
@@ -58,7 +56,6 @@ type Client interface {
 	RawRequest(r *vault.Request) (*vault.Response, error)
 	SetToken(v string)
 	Token() string
-	Sys() *vault.Sys
 }
 
 // Vault implements Interface and holds a Vault issuer, secrets lister and a
@@ -407,10 +404,6 @@ func (v *Vault) requestTokenWithKubernetesAuth(client Client, kubernetesAuth *v1
 	}
 
 	return token, nil
-}
-
-func (v *Vault) Sys() *vault.Sys {
-	return v.client.Sys()
 }
 
 func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]byte, []byte, error) {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -55,7 +55,6 @@ type Client interface {
 	NewRequest(method, requestPath string) *vault.Request
 	RawRequest(r *vault.Request) (*vault.Response, error)
 	SetToken(v string)
-	Token() string
 }
 
 // Vault implements Interface and holds a Vault issuer, secrets lister and a

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1289,3 +1289,70 @@ func TestIsVaultInitiatedAndUnsealedIntegration(t *testing.T) {
 	err = v.IsVaultInitializedAndUnsealed()
 	require.NoError(t, err)
 }
+
+// TestSignIntegration demonstrates that it interacts only with the API endpoint
+// path supplied in the Issuer resource and that it supplies the Vault namespace
+// and token to that endpoint.
+func TestSignIntegration(t *testing.T) {
+	const (
+		vaultToken     = "token1"
+		vaultNamespace = "vault-ns-1"
+		vaultPath      = "my_pki_mount/sign/my-role-name"
+	)
+
+	privatekey := generateRSAPrivateKey(t)
+	csrPEM := generateCSR(t, privatekey)
+
+	rootBundleData, err := bundlePEM(testIntermediateCa, testRootCa)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/v1/%s", vaultPath), func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, vaultNamespace, request.Header.Get("X-Vault-Namespace"), "Expected Vault namespace header for namespaced API path")
+		assert.Equal(t, vaultToken, request.Header.Get("X-Vault-Token"), "Expected the Vault token for root-only API path")
+		_, err := response.Write(rootBundleData)
+		require.NoError(t, err)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	v, err := New(
+		"k8s-ns1",
+		listers.FakeSecretListerFrom(listers.NewFakeSecretLister(),
+			listers.SetFakeSecretNamespaceListerGet(
+				&corev1.Secret{
+					Data: map[string][]byte{
+						"key1": []byte(vaultToken),
+					},
+				}, nil),
+		),
+		&cmapi.Issuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer1",
+				Namespace: "k8s-ns1",
+			},
+			Spec: v1.IssuerSpec{
+				IssuerConfig: v1.IssuerConfig{
+					Vault: &v1.VaultIssuer{
+						Server:    server.URL,
+						Path:      vaultPath,
+						Namespace: vaultNamespace,
+						Auth: cmapi.VaultAuth{
+							TokenSecretRef: &cmmeta.SecretKeySelector{
+								LocalObjectReference: cmmeta.LocalObjectReference{
+									Name: "secret1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	certPEM, caPEM, err := v.Sign(csrPEM, time.Hour)
+	require.NoError(t, err)
+	require.NotEmpty(t, certPEM)
+	require.NotEmpty(t, caPEM)
+}


### PR DESCRIPTION
This is an alternative approach to https://github.com/cert-manager/cert-manager/pull/5589, written with input from @zscholl  and @inteon . @zscholl 's description applies to this PR so I've copied it: 
> ### Pull Request Motivation
> 
> This change fixes #5563 by changing the vault client logic to instead use the vault client's functions to set the namespace, rather than passing in a new request object with custom headers.
> #### Why is this necessary?
> 
> The behavior of the vault client changed in vault api version `v1.11.0` with [this commit](https://github.com/hashicorp/vault/commit/a442461f81783cd0abec312e910e3a720ab7fd68). The impact of this change means that any headers that are set in the request object passed in to `RawRequest` are wiped out if there are no headers set in the vault client object.
> 
> Before vault API `v1.11.0` `RawRequest` respected headers that were passed in via the request argument.
> 
> The vault API dependency was upgraded in cert-manager `v1.10.0`: [39fa9f5](https://github.com/cert-manager/cert-manager/commit/39fa9f51b4d96ff54dd253cc6e655b8ad8625a21) and so anyone using this version or later will see that the namespace setting does nothing and all requests to vault go to the default root namespace.


The motivation for this alternative approach is [described in my code review comments for #5589](https://github.com/cert-manager/cert-manager/pull/5589#pullrequestreview-1189741716).

Fixes: https://github.com/cert-manager/cert-manager/issues/5563
 * https://github.com/cert-manager/cert-manager/issues/5563

Replaces: https://github.com/cert-manager/cert-manager/pull/5589

/kind bug

```release-note
Fixes a bug that caused the Vault issuer to omit the Vault namespace in requests to the Vault API.
```
