### PR TITLE
Updates Gateway API test setup

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -392,7 +392,7 @@ spec:
                               additionalProperties:
                                 type: string
                             parentRefs:
-                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                               type: array
                               items:
                                 description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -427,7 +427,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -427,7 +427,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."

--- a/make/config/projectcontour/gateway.yaml
+++ b/make/config/projectcontour/gateway.yaml
@@ -1,5 +1,5 @@
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: acmesolver
 spec:
@@ -7,7 +7,7 @@ spec:
 
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: acmesolver
   namespace: projectcontour

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -207,8 +207,8 @@ e2e-setup-bind: $(call image-tar,bind) load-$(call image-tar,bind) $(wildcard ma
 	sed -e "s|{SERVICE_IP_PREFIX}|$(SERVICE_IP_PREFIX)|g" -e "s|{IMAGE}|$(IMAGE)|g" make/config/bind/*.yaml | $(KUBECTL) apply -n bind -f - >/dev/null
 
 .PHONY: e2e-setup-gatewayapi
-e2e-setup-gatewayapi: $(BINDIR)/downloaded/gateway-api@$(GATEWAY_API_VERSION) $(BINDIR)/scratch/kind-exists $(NEEDS_KUBECTL)
-	$(KUBECTL) kustomize $</*/config/crd/experimental | $(KUBECTL) apply -f - >/dev/null
+e2e-setup-gatewayapi: $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml $(BINDIR)/scratch/kind-exists $(NEEDS_KUBECTL)
+	$(KUBECTL) apply -f $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml > /dev/null
 
 
 # v1 NGINX-Ingress by default only watches Ingresses with Ingress class

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -315,7 +315,7 @@ e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar
 	$(HELM) upgrade \
 		--install \
 		--wait \
-		--version 7.8.1 \
+		--version 10.0.1 \
 		--namespace projectcontour \
 		--create-namespace \
 		--set contour.ingressClass.create=false \

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -155,21 +155,6 @@ for v in FEATURE_GATES FLAKE_ATTEMPTS NODES GINKGO_FOCUS GINKGO_SKIP ARTIFACTS; 
   fi
 done
 
-# Skip Gateway tests for Kubernetes below v1.19.
-k8s_version=$(kubectl version -oyaml | yq e '.serverVersion | .major +"."+ .minor' -)
-case "$k8s_version" in
-1.16* | 1.17* | 1.18*)
-  printf "${yel}${warn}Warning${end}: Kubernetes version ${k8s_version}, skipping Gateway tests.\n" >&2
-
-  if [[ -z "$ginkgo_skip" ]]; then
-    ginkgo_skip="Gateway"
-  else
-    # duplicates are ok
-    ginkgo_skip="${ginkgo_skip}|Gateway"
-  fi
-  ;;
-esac
-
 ginkgo_args=("$@")
 
 if [[ -n "$ginkgo_focus" ]]; then ginkgo_args+=(--ginkgo.focus="${ginkgo_focus}"); fi

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -376,13 +376,9 @@ $(BINDIR)/downloaded/tools/kubebuilder_tools_$(KUBEBUILDER_ASSETS_VERSION)_$(HOS
 
 GATEWAY_API_SHA256SUM=c45f8806883014f7f75a2084c612fc62eb00d5c1915a906f8ca5ecda5450b163
 
-$(BINDIR)/downloaded/gateway-api@$(GATEWAY_API_VERSION): $(BINDIR)/downloaded/gateway-api@$(GATEWAY_API_VERSION).tar.gz | $(BINDIR)/downloaded
-	./hack/util/checkhash.sh $< $(GATEWAY_API_SHA256SUM)
-	@mkdir -p $@
-	tar xz -C $@ -f $<
-
-$(BINDIR)/downloaded/gateway-api@$(GATEWAY_API_VERSION).tar.gz: | $(BINDIR)/downloaded
-	$(CURL) https://github.com/kubernetes-sigs/gateway-api/archive/refs/tags/$(GATEWAY_API_VERSION).tar.gz -o $@
+$(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml: | $(BINDIR)/downloaded
+	$(CURL) https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml -o $@
+	./hack/util/checkhash.sh $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml $(GATEWAY_API_SHA256SUM)
 
 #################
 # Other Targets #

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -28,7 +28,8 @@ TOOLS += yq=v4.27.5
 TOOLS += crane=v0.11.0
 TOOLS += ginkgo=$(shell awk '/ginkgo\/v2/ {print $$2}' go.mod)
 
-GATEWAY_API_VERSION=v0.5.0
+# Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
+GATEWAY_API_VERSION=v0.5.1
 
 K8S_CODEGEN_VERSION=v0.25.2
 
@@ -374,7 +375,7 @@ $(BINDIR)/downloaded/tools/kubebuilder_tools_$(KUBEBUILDER_ASSETS_VERSION)_$(HOS
 # gatewayapi #
 ##############
 
-GATEWAY_API_SHA256SUM=c45f8806883014f7f75a2084c612fc62eb00d5c1915a906f8ca5ecda5450b163
+GATEWAY_API_SHA256SUM=b84972572a104012e7fbea5651a113ac872f6ffeb0b037b4505d664383c932a3
 
 $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml: | $(BINDIR)/downloaded
 	$(CURL) https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml -o $@

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -263,7 +263,7 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
 	// cert-manager needs to know which parentRefs should be used when creating
 	// the HTTPRoute. Usually, the parentRef references a Gateway. See:
-	// https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways
+	// https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
 	ParentRefs []gwapi.ParentReference `json:"parentRefs,omitempty"`
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -400,8 +400,8 @@ func NewGateway(gatewayName, ns, secretName string, annotations map[string]strin
 					Kinds: nil,
 				},
 				Name:     "acme-solver",
-				Protocol: gwapiv1beta1.TCPProtocolType,
-				Port:     gwapiv1beta1.PortNumber(80),
+				Protocol: gwapiv1beta1.TLSProtocolType,
+				Port:     gwapiv1beta1.PortNumber(443),
 				Hostname: (*gwapiv1beta1.Hostname)(&dnsNames[0]),
 				TLS: &gwapiv1beta1.GatewayTLSConfig{
 					CertificateRefs: []gwapiv1beta1.SecretObjectReference{


### PR DESCRIPTION
Updates a couple things related to Gateway API tests:
- test setup now downloads and installs a release of [Gateway install bundle](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api) instead of downloading the whole https://github.com/kubernetes-sigs/gateway-api/ Git repo
- bumps the version of Contour chart and Gateway lib and makes a few small fixes to get it working
- ensures that `Gateway` and `GatewayClass` are created for v1beta1 Gateway API

```release-note
NONE
```

/kind test
