### PR TITLE
End-to-end tests: use Vault 1.12.1 instead of the outdated Vault 1.2.3

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -15,7 +15,7 @@ K8S_VERSION := 1.24
 IMAGE_ingressnginx_amd64 := k8s.gcr.io/ingress-nginx/controller:v1.1.0@sha256:7464dc90abfaa084204176bcc0728f182b0611849395787143f6854dc6c38c85
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.7.1@sha256:aec4b029660d47aea025336150fdc2822c991f592d5170d754b6acaf158b513e
 IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.7.1@sha256:1bcec6bc854720e22f439c6dcea02fcf689f31976babcf03a449d750c2b1f34a
-IMAGE_vault_amd64 := index.docker.io/library/vault:1.2.3@sha256:b1c86c9e173f15bb4a926e4144a63f7779531c30554ac7aee9b2a408b22b2c01
+IMAGE_vault_amd64 := index.docker.io/library/vault:1.12.1@sha256:08dd1cb922624c51a5aefd4d9ce0ac5ed9688d96d8a5ad94664fa10e84702ed6
 IMAGE_bind_amd64 := docker.io/eafxx/bind:latest-9f74179f@sha256:0b8c766f5bedbcbe559c7970c8e923aa0c4ca771e62fcf8dba64ffab980c9a51
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.1.1@sha256:7dafe98c73d229bbac08067fccf9b2884c63c8e1412fe18f9986f59232cf3cb5
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.22.0@sha256:c8ee1e566340c1bfd11fc9a1a90d758bde562faecb722540207084330b300497
@@ -25,7 +25,7 @@ IMAGE_vaultretagged_amd64 := local/vault:local
 IMAGE_ingressnginx_arm64 := k8s.gcr.io/ingress-nginx/controller:v1.1.0@sha256:86be28e506653cbe29214cb272d60e7c8841ddaf530da29aa22b1b1017faa956
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.7.1@sha256:4355f1f65ea5e952886e929a15628f0c6704905035b4741c6f560378871c9335
 IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.7.1@sha256:141234fb74242155c7b843180b90ee5fb6a20c9e77598bd9c138c687059cdafd
-IMAGE_vault_arm64 := index.docker.io/library/vault:1.2.3@sha256:226a269b83c4b28ff8a512e76f1e7b707eccea012e4c3ab4c7af7fff1777ca2d
+IMAGE_vault_arm64 := $(IMAGE_vault_amd64)
 IMAGE_bind_arm64 := docker.io/eafxx/bind:latest-9f74179f@sha256:85de273f24762c0445035d36290a440e8c5a6a64e9ae6227d92e8b0b0dc7dd6d
 IMAGE_sampleexternalissuer_arm64 := # 🚧 NOT AVAILABLE FOR arm64 🚧
 IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.22.0@sha256:ca37e86e284e72b3a969c7845a56a1cfcd348f4cb75bf6312d5b11067efdd667
@@ -131,7 +131,7 @@ $(LOAD_TARGETS): load-%: % $(BINDIR)/scratch/kind-exists | $(NEEDS_KIND)
 # We don't pull using both the digest and tag because crane replaces the
 # tag with "i-was-a-digest". We still check that the downloaded image
 # matches the digest.
-$(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,sampleexternalissuer) $(call image-tar,vault) $(call image-tar,ingressnginx): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
+$(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,sampleexternalissuer) $(call image-tar,ingressnginx): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
 	@$(eval IMAGE=$(subst +,:,$*))
 	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
 	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))
@@ -140,7 +140,7 @@ $(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(
 	$(CRANE) pull $(IMAGE_WITHOUT_DIGEST) $@ --platform=linux/$(CRI_ARCH)
 
 # Same as above, except it supports multiarch images.
-$(call image-tar,kind): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
+$(call image-tar,kind) $(call image-tar,vault): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
 	@$(eval IMAGE=$(subst +,:,$*))
 	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
 	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -40,9 +40,9 @@ import (
 
 const (
 	vaultHelmChartRepo    = "https://helm.releases.hashicorp.com"
-	vaultHelmChartVersion = "0.22.0"
+	vaultHelmChartVersion = "0.22.1"
 	vaultImageRepository  = "index.docker.io/library/vault"
-	vaultImageTag         = "1.2.3@sha256:b1c86c9e173f15bb4a926e4144a63f7779531c30554ac7aee9b2a408b22b2c01"
+	vaultImageTag         = "1.12.1@sha256:08dd1cb922624c51a5aefd4d9ce0ac5ed9688d96d8a5ad94664fa10e84702ed6"
 )
 
 // Vault describes the configuration details for an instance of Vault
@@ -72,8 +72,11 @@ type Details struct {
 	// PodName is the name of the Vault pod
 	PodName string
 
-	// Namespace is the namespace vault has been deployed into
-	Namespace string
+	// PodNS is the namespace that the Vault pod is deployed into.
+	PodNS string
+
+	// PodSA is the service accoutn that gets auto-mounted in the Vault pod.
+	PodSA string
 
 	// VaultCA is the CA used to sign the vault serving certificate
 	VaultCA           []byte
@@ -273,10 +276,12 @@ func (v *Vault) Provision() error {
 			continue
 		}
 		v.details.PodName = vaultPod.Name
+		v.details.PodNS = vaultPod.Namespace
+		v.details.PodSA = vaultPod.Spec.ServiceAccountName
+
 		break
 	}
 
-	v.details.Namespace = v.Namespace
 	v.details.Host = fmt.Sprintf("https://%s:8200", "chart-vault-"+v.Name+"."+v.Namespace)
 
 	return nil

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -93,7 +93,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("creating a service account for Vault authentication")
-		err = vaultInit.CreateKubernetesRole(f.KubeClientSet, f.Namespace.Name, vaultKubernetesRoleName, vaultSecretServiceAccount)
+		err = vaultInit.CreateKubernetesRole(f.KubeClientSet, vaultKubernetesRoleName, f.Namespace.Name, vaultSecretServiceAccount)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -104,7 +104,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		vaultInit.CleanAppRole()
 
 		By("Cleaning up Kubernetes")
-		vaultInit.CleanKubernetesRole(f.KubeClientSet, f.Namespace.Name, vaultKubernetesRoleName, vaultSecretServiceAccount)
+		vaultInit.CleanKubernetesRole(f.KubeClientSet, vaultKubernetesRoleName, f.Namespace.Name, vaultSecretServiceAccount)
 
 		By("Cleaning up Vault")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())


### PR DESCRIPTION
The main reason for bumping Vault's version is because 1.2.3 is not compatible with the config parameter `disable_iss_validation`, which is needed for accommodating the future tests coming in https://github.com/cert-manager/cert-manager/pull/5502 that rely on bound tokens and static tokens.

For context, Vault 1.2.3 was released on Sep 9, 2019 ([1]) but `disable_iss_validation` was only added on July 21st, 2020 in Vault 1.5.0.

Due to a breaking change that happened in Vault 1.5.0 ([2]) in which Vault started loading the pod's token instead of using the token to be reviewed for authenticating, I had to tweak the end-to-end tests. I renamed `serviceAccountName` and `namespace` to `boundSA` and `boundNS`, since these two variables now refer to the service account of the token to be reviewed, but not the service account to be used for authenticating. The service account used for authenticating is now the pod's service account.

Alternatively, I could have prevented the service account from being mounted to the pod, but I figured that having the two service accounts separated is what most people do (although both ways are fine by me).

In order to upgrade to Vault 1.12.1, I had to change a bit how the end-to-end tests are 

[1]: https://github.com/hashicorp/vault/commit/c14bd9a2
[2]: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#150

/kind cleanup

```release-note
NONE
```
