### PR TITLE
Remove verify-licenses from ci-presubmit

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -3,7 +3,7 @@
 ## request or change is merged.
 ##
 ## @category CI
-ci-presubmit: verify-imports verify-errexit verify-boilerplate verify-codegen verify-crds verify-licenses
+ci-presubmit: verify-imports verify-errexit verify-boilerplate verify-codegen verify-crds
 
 .PHONY: verify-imports
 verify-imports: | $(NEEDS_GOIMPORTS)
@@ -25,6 +25,9 @@ verify-boilerplate:
 	$(__PYTHON) hack/verify_boilerplate.py
 
 .PHONY: verify-licenses
+## Check that the LICENSES file is up to date; must pass before a change to go.mod can be merged
+##
+## @category CI
 verify-licenses: $(BINDIR)/scratch/LATEST-LICENSES
 	@diff $(BINDIR)/scratch/LATEST-LICENSES LICENSES >/dev/null || (echo -e "\033[0;33mLICENSES seem to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
 


### PR DESCRIPTION
### Pull Request Motivation

Since verify-licenses relies on third party servers it can flake for reasons unrelated to changes in a PR. [cmrel#111](https://github.com/cert-manager/release/pull/111) adds the ability for tests to be triggered only when a named file changes; this will remove the license check from our default "make test" in favour of the version which will be invoked only when go.mod is updated.

### Kind

/kind flake

### Release Note

```release-note
NONE
```
