### PR TITLE
Bump go to 1.19.4

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -37,7 +37,7 @@ KUBEBUILDER_ASSETS_VERSION=1.25.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.3
+VENDORED_GO_VERSION := 1.19.4
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

Fixes some [CVEs](https://twitter.com/golang/status/1600212086994370561). See [announcement](https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU).

### Kind

/kind bug

### Release Note

```release-note
Upgrade to go 1.19.4 to fix CVE-2022-41717
```
