### PR TITLE
Adding pre-start checks to controllers

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -191,6 +191,11 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 
 		iface, err := fn(ctxFactory)
 		if err != nil {
+			if _, ok := err.(controller.PreStartError); ok {
+				log.V(logf.InfoLevel).Info(fmt.Sprintf("not starting controller as pre-start check failed - %v", err.Error()))
+				continue
+			}
+
 			err = fmt.Errorf("error starting controller: %v", err)
 
 			cancelContext()

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -203,6 +203,7 @@ var (
 		requestmanager.ControllerName,
 		readiness.ControllerName,
 		revisionmanager.ControllerName,
+		shimgatewaycontroller.ControllerName,
 	}
 
 	experimentalCertificateSigningRequestControllers = []string{


### PR DESCRIPTION
Signed-off-by: Sathyanarayanan Saravanamuthu <sathyanarays@vmware.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
Proposing these changes as a solution to #5616. But, this is generic enough to be applicable to all controllers.

In this, we are adding a pre-start check to the controllers. If a pre-start check is defined for a controller, the check will be performed before registering the controller. If the pre-start check fails, the controller will not be registered or started. This pre-start hook in the builder will help us to check the environment including the cluster status before we start our controllers.

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
