### PR TITLE
feat: Add max-concurrent-challenges parameter to helm

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -212,6 +212,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `startupapicheck.serviceAccount.name` | Service account for the startupapicheck component to be used. If not set and `startupapicheck.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `startupapicheck.serviceAccount.annotations` | Annotations to add to the service account for the startupapicheck component |  |
 | `startupapicheck.serviceAccount.automountServiceAccountToken` | Automount API credentials for the startupapicheck Service Account | `true` |
+| `maxConcurrentChallenges` | The maximum number of challenges that can be scheduled as 'processing' at once | `60` |
 
 ### Default Security Contexts
 

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -107,6 +107,9 @@ spec:
           {{- if .Values.featureGates }}
           - --feature-gates={{ .Values.featureGates }}
           {{- end }}
+          {{- if .Values.maxConcurrentChallenges }}
+          - --max-concurrent-challenges={{ .Values.maxConcurrentChallenges }}
+          {{- end }}
           ports:
           - containerPort: 9402
             name: http-metrics

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -64,6 +64,9 @@ strategy: {}
 # controller pod & webhook pod.
 featureGates: ""
 
+# The maximum number of challenges that can be scheduled as 'processing' at once
+maxConcurrentChallenges: 60
+
 image:
   repository: quay.io/jetstack/cert-manager-controller
   # You can manage a registry with


### PR DESCRIPTION
Set the max-concurrent-challenges value with -set maxConcurrentChallenges=value when deploying with helm

Fixes: https://github.com/cert-manager/cert-manager/issues/5627

### Kind

### Release Note

```release-note
Add the `--max-concurrent-challenges` controller flag to the helm chart
```
