### PR TITLE
Enable + use k8s 1.26 for e2e tests by default

### DIFF
--- a/hack/latest-kind-images.sh
+++ b/hack/latest-kind-images.sh
@@ -63,6 +63,12 @@ LATEST_123_DIGEST=$(crane digest $KIND_IMAGE_REPO:$LATEST_123_TAG)
 LATEST_124_DIGEST=$(crane digest $KIND_IMAGE_REPO:$LATEST_124_TAG)
 LATEST_125_DIGEST=$(crane digest $KIND_IMAGE_REPO:$LATEST_125_TAG)
 
+# k8s 1.26 is manually added for now, pending a wider rethink of how we can automate bumping of kind images
+# given that kind release notes say there are specific digests which should be used with specific kind releases
+
+LATEST_126_TAG=v1.26.0
+LATEST_126_DIGEST=sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
 cat << EOF > ./make/kind_images.sh
 # Copyright 2022 The cert-manager Authors.
 #
@@ -87,6 +93,9 @@ KIND_IMAGE_K8S_123=$KIND_IMAGE_REPO@$LATEST_123_DIGEST
 KIND_IMAGE_K8S_124=$KIND_IMAGE_REPO@$LATEST_124_DIGEST
 KIND_IMAGE_K8S_125=$KIND_IMAGE_REPO@$LATEST_125_DIGEST
 
+# Manually set - see hack/latest-kind-images.sh for details
+KIND_IMAGE_K8S_126=$KIND_IMAGE_REPO@$LATEST_126_DIGEST
+
 # $KIND_IMAGE_REPO:$LATEST_120_TAG
 KIND_IMAGE_SHA_K8S_120=$LATEST_120_DIGEST
 
@@ -105,6 +114,10 @@ KIND_IMAGE_SHA_K8S_124=$LATEST_124_DIGEST
 # $KIND_IMAGE_REPO:$LATEST_125_TAG
 KIND_IMAGE_SHA_K8S_125=$LATEST_125_DIGEST
 
+# Manually set - see hack/latest-kind-images.sh for details
+# $KIND_IMAGE_REPO:$LATEST_126_TAG
+KIND_IMAGE_SHA_K8S_126=$LATEST_126_DIGEST
+
 # note that these 'full' digests should be avoided since not all tools support them
 # prefer KIND_IMAGE_K8S_*** instead
 KIND_IMAGE_FULL_K8S_120=$KIND_IMAGE_REPO:$LATEST_120_TAG@$LATEST_120_DIGEST
@@ -113,6 +126,9 @@ KIND_IMAGE_FULL_K8S_122=$KIND_IMAGE_REPO:$LATEST_122_TAG@$LATEST_122_DIGEST
 KIND_IMAGE_FULL_K8S_123=$KIND_IMAGE_REPO:$LATEST_123_TAG@$LATEST_123_DIGEST
 KIND_IMAGE_FULL_K8S_124=$KIND_IMAGE_REPO:$LATEST_124_TAG@$LATEST_124_DIGEST
 KIND_IMAGE_FULL_K8S_125=$KIND_IMAGE_REPO:$LATEST_125_TAG@$LATEST_125_DIGEST
+
+# Manually set - see hack/latest-kind-images.sh for details
+KIND_IMAGE_FULL_K8S_126=$KIND_IMAGE_REPO:$LATEST_126_TAG@$LATEST_126_DIGEST
 
 EOF
 

--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -25,7 +25,7 @@ set -e
 source ./make/kind_images.sh
 
 mode=kind
-k8s_version=1.25
+k8s_version=1.26
 kind_cluster_name=kind
 
 help() {
@@ -110,6 +110,7 @@ case "$k8s_version" in
 1.23*) image=$KIND_IMAGE_FULL_K8S_123 ;;
 1.24*) image=$KIND_IMAGE_FULL_K8S_124 ;;
 1.25*) image=$KIND_IMAGE_FULL_K8S_125 ;;
+1.26*) image=$KIND_IMAGE_FULL_K8S_126 ;;
 v*) printf "${red}${redcross}Error${end}: Kubernetes version must be given without the leading 'v'\n" >&2 && exit 1 ;;
 *) printf "${red}${redcross}Error${end}: unsupported Kubernetes version ${yel}${k8s_version}${end}\n" >&2 && exit 1 ;;
 esac

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -10,7 +10,7 @@ CRI_ARCH := $(HOST_ARCH)
 
 # TODO: this version is also defaulted in ./make/cluster.sh. Make it so that it
 # is set in one place only.
-K8S_VERSION := 1.24
+K8S_VERSION := 1.26
 
 IMAGE_ingressnginx_amd64 := k8s.gcr.io/ingress-nginx/controller:v1.1.0@sha256:7464dc90abfaa084204176bcc0728f182b0611849395787143f6854dc6c38c85
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.7.1@sha256:aec4b029660d47aea025336150fdc2822c991f592d5170d754b6acaf158b513e

--- a/make/kind_images.sh
+++ b/make/kind_images.sh
@@ -21,6 +21,9 @@ KIND_IMAGE_K8S_123=docker.io/kindest/node@sha256:ef453bb7c79f0e3caba88d2067d4196
 KIND_IMAGE_K8S_124=docker.io/kindest/node@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
 KIND_IMAGE_K8S_125=docker.io/kindest/node@sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
 
+# Manually set - see hack/latest-kind-images.sh for details
+KIND_IMAGE_K8S_126=docker.io/kindest/node@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
 # docker.io/kindest/node:v1.20.15
 KIND_IMAGE_SHA_K8S_120=sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
 
@@ -39,6 +42,10 @@ KIND_IMAGE_SHA_K8S_124=sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1
 # docker.io/kindest/node:v1.25.3
 KIND_IMAGE_SHA_K8S_125=sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
 
+# Manually set - see hack/latest-kind-images.sh for details
+# docker.io/kindest/node:v1.26.0
+KIND_IMAGE_SHA_K8S_126=sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
 # note that these 'full' digests should be avoided since not all tools support them
 # prefer KIND_IMAGE_K8S_*** instead
 KIND_IMAGE_FULL_K8S_120=docker.io/kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
@@ -47,4 +54,7 @@ KIND_IMAGE_FULL_K8S_122=docker.io/kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe
 KIND_IMAGE_FULL_K8S_123=docker.io/kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
 KIND_IMAGE_FULL_K8S_124=docker.io/kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
 KIND_IMAGE_FULL_K8S_125=docker.io/kindest/node:v1.25.3@sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
+
+# Manually set - see hack/latest-kind-images.sh for details
+KIND_IMAGE_FULL_K8S_126=docker.io/kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 


### PR DESCRIPTION
### Pull Request Motivation

Adds k8s 1.26 kind images, and uses that version by default on master.

A followup, separate PR will add k8s 1.26 images for the release-1.10 branch

This was blocked behind https://github.com/cert-manager/release/pull/113 which enabled us to manually run the 1.26 e2e test on this PR.

### Kind

/kind feature

### Release Note

```release-note
Enable testing against Kubernetes 1.26 and test with Kubernetes 1.26 by default
```
