### PR TITLE
Experimental make targets for pushing images to a Docker registry and redeploying cert-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ include make/licenses.mk
 include make/e2e-setup.mk
 include make/scan.mk
 include make/legacy.mk
+include make/ko.mk
 include make/help.mk
 
 .PHONY: clean

--- a/make/ko.mk
+++ b/make/ko.mk
@@ -1,0 +1,68 @@
+## Experimental tools for building and deploying cert-manager using ko to build and push Docker images.
+##
+## Examples:
+##
+##  # Build and Push all images to an OCI registry
+##  make ko-images-push KO_REGISTRY=<my-oci-registry>
+##
+##  # Build and Push images to an OCI registry and deploy cert-manager to the current cluster in KUBECONFIG
+##  make ko-deploy-certmanager KO_REGISTRY=<my-oci-registry>
+##
+## @category Experimental/ko
+
+## (required) The OCI registry prefix to which images will be pushed by ko.
+## @category Experimental/ko
+KO_REGISTRY ?= $(error "KO_REGISTRY is a required environment variable")
+
+## (optional) The SBOM media type to use (none will disable SBOM synthesis and
+## upload, also supports: spdx, cyclonedx, go.version-m).
+## @category Experimental/ko
+KO_SBOM ?= none
+
+## (optional) Which platforms to include in the multi-arch image.
+## Format: all | <os>[/<arch>[/<variant>]][,platform]*
+## @category Experimental/ko
+KO_PLATFORM ?= linux/amd64
+
+## (optional) Which cert-manager images to build.
+## @category Experimental/ko
+KO_BINS ?= controller acmesolver cainjector webhook ctl
+
+export KOCACHE = $(BINDIR)/scratch/ko/cache
+
+KO_IMAGE_REFS = $(foreach bin,$(KO_BINS),_bin/scratch/ko/$(bin).yaml)
+$(KO_IMAGE_REFS): _bin/scratch/ko/%.yaml: FORCE | $(NEEDS_KO) $(NEEDS_YQ)
+	@mkdir -p $(dir $@)
+	@$(eval export KO_DOCKER_REPO=$(KO_REGISTRY)/cert-manager-$*)
+	$(KO) build ./cmd/$* \
+		--bare \
+		--sbom=$(KO_SBOM) \
+		--platform=$(KO_PLATFORM) \
+		--tags=$(RELEASE_VERSION) \
+		| $(YQ) 'capture("(?P<ref>(?P<repository>[^:]+):(?P<tag>[^@]+)@(?P<digest>.*))")' > $@
+
+.PHONY: ko-images-push
+## Build and push docker images to an OCI registry using ko.
+## @category Experimental/ko
+ko-images-push: $(KO_IMAGE_REFS)
+
+.PHONY: ko-deploy-cert-manager
+## Deploy cert-manager after pushing docker images to an OCI registry using ko.
+## @category Experimental/ko
+ko-deploy-certmanager: $(BINDIR)/cert-manager.tgz $(KO_IMAGE_REFS)
+	@$(eval ACME_HTTP01_SOLVER_IMAGE = $(shell $(YQ) '.repository + "@" + .digest' $(BINDIR)/scratch/ko/acmesolver.yaml))
+	$(HELM) upgrade cert-manager $< \
+		--install \
+		--create-namespace \
+		--wait \
+		--namespace cert-manager \
+		--set image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/controller.yaml)" \
+		--set image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/controller.yaml)" \
+		--set cainjector.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/cainjector.yaml)" \
+		--set cainjector.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/cainjector.yaml)" \
+		--set webhook.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/webhook.yaml)" \
+		--set webhook.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/webhook.yaml)" \
+		--set startupapicheck.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/ctl.yaml)" \
+		--set startupapicheck.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/ctl.yaml)" \
+		--set installCRDs=true \
+		--set "extraArgs={--acme-http01-solver-image=$(ACME_HTTP01_SOLVER_IMAGE)}" \

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -27,6 +27,7 @@ TOOLS += ytt=v0.43.0
 TOOLS += yq=v4.27.5
 TOOLS += crane=v0.11.0
 TOOLS += ginkgo=$(shell awk '/ginkgo\/v2/ {print $$2}' go.mod)
+TOOLS += ko=v0.12.0
 
 # Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
 GATEWAY_API_VERSION=v0.5.1
@@ -328,6 +329,25 @@ $(BINDIR)/downloaded/tools/yq@$(YQ_VERSION)_%: | $(BINDIR)/downloaded/tools
 	$(CURL) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$* -o $@
 	./hack/util/checkhash.sh $@ $(YQ_$*_SHA256SUM)
 	chmod +x $@
+
+######
+# ko #
+######
+
+KO_linux_amd64_SHA256SUM=05aa77182fa7c55386bd2a210fd41298542726f33bbfc9c549add3a66f7b90ad
+KO_darwin_amd64_SHA256SUM=8679d0d74fc75f24e044649c6a961dad0a3ef03bedbdece35e2f3f29eb7876af
+KO_darwin_arm64_SHA256SUM=cfef98db8ad0e1edaa483fa5c6af89eb573a8434abd372b510b89005575de702
+
+$(BINDIR)/downloaded/tools/ko@$(KO_VERSION)_%: | $(BINDIR)/downloaded/tools
+	$(eval OS_AND_ARCH := $(subst darwin,Darwin,$*))
+	$(eval OS_AND_ARCH := $(subst linux,Linux,$(OS_AND_ARCH)))
+	$(eval OS_AND_ARCH := $(subst amd64,x86_64,$(OS_AND_ARCH)))
+
+	$(CURL) https://github.com/ko-build/ko/releases/download/$(KO_VERSION)/ko_$(patsubst v%,%,$(KO_VERSION))_$(OS_AND_ARCH).tar.gz -o $@.tar.gz
+	./hack/util/checkhash.sh $@.tar.gz $(KO_$*_SHA256SUM)
+	tar xfO $@.tar.gz ko > $@
+	chmod +x $@
+	rm $@.tar.gz
 
 #####################
 # k8s codegen tools #


### PR DESCRIPTION
This allows me to quickly compile the code in my working directory and deploy it on any Kubernetes cluster.
On Google GKE or Azure AKS for example. 
I used it to manually test Azure specific features in the absence of any automated E2E tests on Azure.

I have used `ko` to build the images because I it uses the local go cache which allows to to very quickly create updated Docker images.
And it makes it quick and easy to compile multi-arch images, which will allow people to compile and deploy to arm Kubernetes clusters. 
The existing `e2e- setup-certmanager` target compiles linux/amd64 images only (AFAICS).

Ultimately I hope that cert-manager might switch to `ko` for building the release images, which would allow us to remove a lot of the complex build code dedicated to creating our multi-arch images, and we could take advantage of other `ko` features such as [software-bill-of-materials (SBOM) creation](https://ko.build/features/sboms/) and in future [keyless signing of the images](https://github.com/ko-build/ko/issues/357).
I've introduced `ko` in this PR in the hope that it will be more widely adopted by cert-manager in future.

Supplants #5612 
 * https://github.com/cert-manager/cert-manager/pull/5612

In https://github.com/cert-manager/cert-manager/pull/5612 I tried to do this by modifying the existing E2E test setup code, by introducing a `USE_EXISTING_CLUSTER` and a `REGISTRY` input variable to control whether the makefile would set up a Kind cluster and "load" images into it, OR publish images to an OCI registry and deploy the cert-manager Helm chart on the cluster pointed to by the current KUBECONFIG context. 
But it made the Makefile difficult to understand, it was not intuitive to use, and it was difficult to conditionally deploy kyverno (a prerequisite of the `make e2e-setup-certmanager` target).

So here I have instead added a new self contained makefile with the two targets that I need: to push images to a registry and to deploy the cert-manager helm chart to the current context cluster, referencing the pushed images.
I've put both targets in a new `Experimental/ko` category so that it's clear that the behaviour might change in future.

```
Experimental/ko:

        Experimental tools for building and deploying cert-manager using ko to build and push Docker images.
        
    KO_BINS (default: controller acmesolver cainjector webhook ctl)
        (optional) Which cert-manager images to build.
    KO_PLATFORM (default: linux/amd64)
        (optional) Which platforms to include in the multi-arch image.
        Format: all | <os>[/<arch>[/<variant>]][,platform]*
    KO_REGISTRY (default: $(error "KO_REGISTRY is a required environment variable"))
        (required) The OCI registry prefix to which images will be pushed by ko.
    KO_SBOM (default: none)
        (optional) The SBOM media type to use (none will disable SBOM synthesis and
        upload, also supports: spdx, cyclonedx, go.version-m).
    ko-deploy-cert-manager $(BINDIR)/cert-manager.tgz $(KO_IMAGE_REFS)
        Deploy cert-manager after pushing docker images to an OCI registry using ko.
    ko-images-push $(KO_IMAGE_REFS)
        Build and push docker images to an OCI registry using ko.

```


```release-note
Experimental make targets for pushing images to an OCI registry using `ko` and redeploying cert-manager to the cluster referenced by your current KUBECONFIG context.
```
