### PR TITLE
Bump contour

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -315,7 +315,7 @@ e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar
 	$(HELM) upgrade \
 		--install \
 		--wait \
-		--version 7.8.1 \
+		--version 10.0.1 \
 		--namespace projectcontour \
 		--create-namespace \
 		--set contour.ingressClass.create=false \


### PR DESCRIPTION
### Pull Request Motivation

This matches the version used on the master branch at the time of this commit. This version was chosen because it was tested on master. It implies a bump of the underlying version of contour from 1.20 -> 1.23, but it seems better to use a tested version of the chart rather than a previously untested version.

This update is required because the previous version was removed from the bitnami helm chart repo. That has broken our periodics for the release-1.10 branch.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
