### PR TITLE
Ensures that certificate.spec.secretName and temporary private key Secrets are labelled

### DIFF
--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -433,6 +433,29 @@ func SecretTemplateMismatchesSecretManagedFields(fieldManager string) Func {
 	}
 }
 
+func SecretBaseLabelsAreMissing(input Input) (string, string, bool) {
+	// If certificate has not been issued yet or is in invalid state, do not attempt to update metadata
+	if len(input.Secret.Data[corev1.TLSCertKey]) > 0 {
+		var err error
+		_, err = pki.DecodeX509CertificateBytes(input.Secret.Data[corev1.TLSCertKey])
+		if err != nil {
+			// This case should never happen as it should always be caught by the
+			// secretPublicKeysMatch function beforehand, but handle it just in case.
+			return InvalidCertificate, fmt.Sprintf("Failed to decode stored certificate: %v", err), true
+		}
+	}
+
+	// check if Secret has the base labels. Currently there is only one base label
+	if input.Secret.Labels == nil {
+		return SecretBaseLabelsMissing, fmt.Sprintf("missing base label %s", cmapi.PartOfCertManagerControllerLabelKey), true
+	}
+	if _, ok := input.Secret.Labels[cmapi.PartOfCertManagerControllerLabelKey]; !ok {
+		return SecretBaseLabelsMissing, fmt.Sprintf("missing base label %s", cmapi.PartOfCertManagerControllerLabelKey), true
+	}
+
+	return "", "", false
+}
+
 // SecretAdditionalOutputFormatsDataMismatch validates that the Secret has the
 // expected Certificate AdditionalOutputFormats.
 // Returns true (violation) if AdditionalOutputFormat(s) are present and any of

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -388,6 +388,10 @@ func SecretTemplateMismatchesSecretManagedFields(fieldManager string) Func {
 			managedAnnotations = managedAnnotations.Delete(k)
 		}
 
+		// Remove the base label from the managed Labels so we can
+		// compare 1 to 1 against the SecretTemplate
+		managedLabels.Delete(cmapi.PartOfCertManagerControllerLabelKey)
+
 		// Check early for Secret Template being nil, and whether managed
 		// labels/annotations are not.
 		if input.Certificate.Spec.SecretTemplate == nil {

--- a/internal/controller/certificates/policies/constants.go
+++ b/internal/controller/certificates/policies/constants.go
@@ -48,6 +48,11 @@ const (
 	// SecretTemplate is not reflected on the target Secret, either by having
 	// extra, missing, or wrong Annotations or Labels.
 	SecretTemplateMismatch string = "SecretTemplateMismatch"
+
+	// SecretBaseLabelsMissing is a policy violation whereby the Secret is
+	// missing labels that should have been added by cert-manager
+	SecretBaseLabelsMissing string = "SecretBaseLabelsMissing"
+
 	// AdditionalOutputFormatsMismatch is a policy violation whereby the
 	// Certificate's AdditionalOutputFormats is not reflected on the target
 	// Secret, either by having extra, missing, or wrong values.

--- a/internal/controller/certificates/policies/policies.go
+++ b/internal/controller/certificates/policies/policies.go
@@ -101,6 +101,7 @@ func NewSecretPostIssuancePolicyChain(ownerRefEnabled bool, fieldManager string)
 		SecretOwnerReferenceManagedFieldMismatch(ownerRefEnabled, fieldManager),
 		SecretOwnerReferenceValueMismatch(ownerRefEnabled),
 		SecretKeystoreFormatMatchesSpec,
+		SecretBaseLabelsAreMissing,
 	}
 }
 

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -16,8 +16,15 @@ limitations under the License.
 
 package v1
 
-// Common annotation keys added to resources.
 const (
+
+	// Common label keys added to resources
+
+	// Label key that indicates that a resource is of interest to cert-manager controller
+	PartOfCertManagerControllerLabelKey = "controller.cert-manager.io/fao"
+
+	// Common annotation keys added to resources
+
 	// Annotation key for DNS subjectAltNames.
 	AltNamesAnnotationKey = "cert-manager.io/alt-names"
 

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -165,6 +165,8 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 		secret.Labels = make(map[string]string)
 	}
 
+	secret.Labels[cmapi.PartOfCertManagerControllerLabelKey] = "true"
+
 	if crt.Spec.SecretTemplate != nil {
 		for k, v := range crt.Spec.SecretTemplate.Labels {
 			secret.Labels[k] = v

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -137,7 +137,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:  strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey: strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: []byte("test-key"),
@@ -172,7 +172,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.AltNamesAnnotationKey: strings.Join(baseCertBundle.Cert.DNSNames, ","), cmapi.IPSANAnnotationKey: strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey: strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{corev1.TLSCertKey: baseCertBundle.CertBytes, corev1.TLSPrivateKeyKey: []byte("test-key"), cmmeta.TLSCAKey: []byte("test-ca")}).
 						WithType(corev1.SecretTypeTLS).
 						WithOwnerReferences(&applymetav1.OwnerReferenceApplyConfiguration{
@@ -191,7 +191,7 @@ func Test_SecretsManager(t *testing.T) {
 			expectedErr: false,
 		},
 
-		"if secret does exist, update existing Secret and leave custom annotations, with owner disabled": {
+		"if secret does exist, update existing Secret and leave custom annotations and labels, with owner disabled": {
 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
 			certificate:        baseCertBundle.Certificate,
 			existingSecret: &corev1.Secret{
@@ -199,7 +199,7 @@ func Test_SecretsManager(t *testing.T) {
 					Namespace:   gen.DefaultTestNamespace,
 					Name:        "output",
 					Annotations: map[string]string{"my-custom": "annotation"},
-					Labels:      map[string]string{},
+					Labels:      map[string]string{"my-custom": "label"},
 				},
 				Data: map[string][]byte{corev1.TLSCertKey: []byte("foo"), corev1.TLSPrivateKeyKey: []byte("foo"), cmmeta.TLSCAKey: []byte("foo")},
 				Type: corev1.SecretTypeTLS,
@@ -218,7 +218,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: []byte("test-key"),
@@ -235,7 +235,7 @@ func Test_SecretsManager(t *testing.T) {
 			},
 			expectedErr: false,
 		},
-		"if secret does exist, update existing Secret and leave custom annotations, with owner enabled": {
+		"if secret does exist, update existing Secret and leave custom annotations and labels, with owner enabled": {
 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
 			certificate:        baseCertBundle.Certificate,
 			existingSecret: &corev1.Secret{
@@ -243,7 +243,7 @@ func Test_SecretsManager(t *testing.T) {
 					Namespace:   gen.DefaultTestNamespace,
 					Name:        "output",
 					Annotations: map[string]string{"my-custom": "annotation"},
-					Labels:      map[string]string{},
+					Labels:      map[string]string{"my-custom": "label"},
 				},
 				Data: map[string][]byte{corev1.TLSCertKey: []byte("foo"), corev1.TLSPrivateKeyKey: []byte("foo"), cmmeta.TLSCAKey: []byte("foo")},
 				Type: corev1.SecretTypeTLS,
@@ -263,7 +263,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: []byte("test-key"),
@@ -286,7 +286,7 @@ func Test_SecretsManager(t *testing.T) {
 			expectedErr: false,
 		},
 
-		"if secret does not exist, create new Secret using the secret template": {
+		"if secret does exist, update existing Secret and add annotations set in secretTemplate": {
 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
 			certificate:        baseCertWithSecretTemplate,
 			existingSecret: &corev1.Secret{
@@ -294,7 +294,7 @@ func Test_SecretsManager(t *testing.T) {
 					Namespace:   gen.DefaultTestNamespace,
 					Name:        "output",
 					Annotations: map[string]string{"my-custom": "annotation"},
-					Labels:      map[string]string{},
+					Labels:      map[string]string{"my-custom": "label"},
 				},
 				Data: map[string][]byte{corev1.TLSCertKey: []byte("foo"), corev1.TLSPrivateKeyKey: []byte("foo"), cmmeta.TLSCAKey: []byte("foo")},
 				Type: corev1.SecretTypeTLS,
@@ -315,7 +315,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(map[string]string{"template": "label"}).
+						WithLabels(map[string]string{"template": "label", cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: []byte("test-key"),
@@ -333,7 +333,54 @@ func Test_SecretsManager(t *testing.T) {
 			expectedErr: false,
 		},
 
-		"if secret does exist, update existing Secret and add annotations set in secretTemplate": {
+		"if secret does exist, ensure that any missing base labels and annotations are added": {
+			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
+			certificate:        baseCertWithSecretTemplate,
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   gen.DefaultTestNamespace,
+					Name:        "output",
+					Annotations: map[string]string{"my-custom": "annotation"},
+					Labels:      map[string]string{"my-custom": "label"},
+				},
+				Data: map[string][]byte{corev1.TLSCertKey: []byte("foo"), corev1.TLSPrivateKeyKey: []byte("foo"), cmmeta.TLSCAKey: []byte("foo")},
+				Type: corev1.SecretTypeTLS,
+			},
+			secretData: SecretData{Certificate: baseCertBundle.CertBytes, CA: []byte("test-ca"), PrivateKey: []byte("test-key")},
+			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
+				return func(_ context.Context, gotCnf *applycorev1.SecretApplyConfiguration, gotOpts metav1.ApplyOptions) (*corev1.Secret, error) {
+					expCnf := applycorev1.Secret("output", gen.DefaultTestNamespace).
+						WithAnnotations(
+							map[string]string{
+								"template":               "annotation",
+								"my-custom":              "annotation-from-secret",
+								cmapi.CertificateNameKey: "test", cmapi.IssuerGroupAnnotationKey: "foo.io",
+								cmapi.IssuerKindAnnotationKey: "Issuer", cmapi.IssuerNameAnnotationKey: "ca-issuer",
+
+								cmapi.CommonNameAnnotationKey: baseCertBundle.Cert.Subject.CommonName,
+								cmapi.AltNamesAnnotationKey:   strings.Join(baseCertBundle.Cert.DNSNames, ","),
+								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
+								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
+							}).
+						WithLabels(map[string]string{"template": "label", cmapi.PartOfCertManagerControllerLabelKey: "true"}).
+						WithData(map[string][]byte{
+							corev1.TLSCertKey:       baseCertBundle.CertBytes,
+							corev1.TLSPrivateKeyKey: []byte("test-key"),
+							cmmeta.TLSCAKey:         []byte("test-ca"),
+						}).
+						WithType(corev1.SecretTypeTLS)
+					assert.Equal(t, expCnf, gotCnf)
+
+					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					assert.Equal(t, expOpts, gotOpts)
+
+					return nil, nil
+				}
+			},
+			expectedErr: false,
+		},
+
+		"if secret does not exist, create new Secret using the secret template": {
 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
 			certificate:        baseCertWithSecretTemplate,
 			existingSecret:     nil,
@@ -354,7 +401,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(map[string]string{"template": "label"}).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true", "template": "label"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: []byte("test-key"),
@@ -395,7 +442,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:                   baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey:             baseCertBundle.PrivateKeyBytes,
@@ -432,7 +479,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:                           baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey:                     baseCertBundle.PrivateKeyBytes,
@@ -469,7 +516,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:                           baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey:                     baseCertBundle.PrivateKeyBytes,
@@ -500,6 +547,9 @@ func Test_SecretsManager(t *testing.T) {
 					Annotations: map[string]string{
 						"my-custom": "annotation",
 					},
+					Labels: map[string]string{
+						"my-custom": "label",
+					},
 				},
 				Data: map[string][]byte{
 					corev1.TLSCertKey:                           []byte("foo"),
@@ -524,7 +574,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:       baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey: baseCertBundle.PrivateKeyBytes,
@@ -553,6 +603,9 @@ func Test_SecretsManager(t *testing.T) {
 					Annotations: map[string]string{
 						"my-custom": "annotation",
 					},
+					Labels: map[string]string{
+						"my-custom": "label",
+					},
 				},
 				Data: map[string][]byte{
 					corev1.TLSCertKey:                           []byte("foo"),
@@ -577,7 +630,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:                   baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey:             baseCertBundle.PrivateKeyBytes,
@@ -607,6 +660,9 @@ func Test_SecretsManager(t *testing.T) {
 					Annotations: map[string]string{
 						"my-custom": "annotation",
 					},
+					Labels: map[string]string{
+						"my-custom": "label",
+					},
 				},
 				Data: map[string][]byte{
 					corev1.TLSCertKey:                           []byte("foo"),
@@ -631,7 +687,7 @@ func Test_SecretsManager(t *testing.T) {
 								cmapi.IPSANAnnotationKey:      strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
 								cmapi.URISANAnnotationKey:     strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
 							}).
-						WithLabels(make(map[string]string)).
+						WithLabels(map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}).
 						WithData(map[string][]byte{
 							corev1.TLSCertKey:                           baseCertBundle.CertBytes,
 							corev1.TLSPrivateKeyKey:                     baseCertBundle.PrivateKeyBytes,

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -128,7 +128,7 @@ func NewController(
 var isNextPrivateKeyLabelSelector labels.Selector
 
 func init() {
-	r, err := labels.NewRequirement("cert-manager.io/next-private-key", selection.Equals, []string{"true"})
+	r, err := labels.NewRequirement(cmapi.IsNextPrivateKeySecretLabelKey, selection.Equals, []string{"true"})
 	if err != nil {
 		panic(err)
 	}
@@ -351,7 +351,8 @@ func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.C
 			Name:            name,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},
 			Labels: map[string]string{
-				"cert-manager.io/next-private-key": "true",
+				cmapi.IsNextPrivateKeySecretLabelKey:      "true",
+				cmapi.PartOfCertManagerControllerLabelKey: "true",
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -82,7 +82,8 @@ func TestProcessItem(t *testing.T) {
 			Namespace: namespace,
 			Name:      name,
 			Labels: map[string]string{
-				cmapi.IsNextPrivateKeySecretLabelKey: "true",
+				cmapi.IsNextPrivateKeySecretLabelKey:      "true",
+				cmapi.PartOfCertManagerControllerLabelKey: "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(&cmapi.Certificate{
@@ -181,7 +182,7 @@ func TestProcessItem(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace:       "testns",
 							GenerateName:    "test-",
-							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true", cmapi.PartOfCertManagerControllerLabelKey: "true"},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
 						},
 						Data: map[string][]byte{"tls.key": nil},
@@ -211,7 +212,7 @@ func TestProcessItem(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace:       "testns",
 							Name:            "fixed-name",
-							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true", cmapi.PartOfCertManagerControllerLabelKey: "true"},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
 						},
 						Data: map[string][]byte{"tls.key": nil},
@@ -243,7 +244,7 @@ func TestProcessItem(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace:       "testns",
 							Name:            "fixed-name",
-							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true", cmapi.PartOfCertManagerControllerLabelKey: "true"},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
 						},
 						Data: map[string][]byte{"tls.key": nil},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

See #5639 for context.

In order to make it possible to filter `Secret` resources that cert-manager is interested in, for example to filter which `Secret`s are cached, it would be great if cert-manager would label those `Secret` resources. Adding the labels now would make it easier for us to implement caching improvements that use the new labels in a future release as at a point when users upgrade to a version of cert-manager with caching improvements their resources should already be labelled (assuming that they upgrade one minor release at a time as per our recommendation).

This PR:

- adds a new `controller.cert-manager.io/fao` label to cert-manager API
- ensures that all `Secret`s referenced in `certificate.spec.secretName` as well as temporary private key `Secret`s created during issuance are labelled with the new label
- ensures that if when a `Certificate` is reconciled and its `cert.spec.secretName` `Secret` is found to not have the label, it will be added even if this happens outside issuance. (This will ensure that when cert-manager starts up it will label all unlabelled `Certificate` `Secret`s).

`certificate.spec.secretName`  `Secret` labelling works in the same way as it currently does with our annotations where any non-annotated `certificate.spec.secretName` `Secret` will get the annotations applied no matter whether the `Secret` was originally created by cert-manager or user and this will happen as soon as the `Certificate` is synced (so in practice when the cert-manager controller starts).

This is how the new label looks:
![secretsannots](https://user-images.githubusercontent.com/24879183/211072071-cc1ec630-0cf5-4e14-a601-878b6ef2fe79.png)



### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
`certificate.spec.secretName` Secrets will now be labelled with `controller.cert-manager.io/fao` label
```

I've tested with 1.26 (w&w/o SSA), 1.21, 1.22(w&w/o SSA) that
- when a new `certificate.spec.secretName` Secret gets created the label gets applied
- when a user created`certificate.spec.secretName` Secret exists in cluster with some custom labels and a `Certificate` referencing it gets applied, the new label gets added and the existing ones are preserved (this is the same behaviour as currently with cert-manager annotations)
- the new label gets applied to temporary private key Secrets

I've also tested that upgrading to this PR results in label being added to existing `Secret`s and downgrading results in it being removed.

/kind cleanup
