### PR TITLE
Bump supported versions of k8s mentioned in the helm chart

### DIFF
--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -3,7 +3,7 @@ name: cert-manager
 # The version and appVersion fields are set automatically by the release tool
 version: v0.1.0
 appVersion: v0.1.0
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.21.0-0"
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png


### PR DESCRIPTION
### Pull Request Motivation

This reflects the latest supported releases as of an update on 2022-12-16

See https://github.com/cert-manager/website/pull/1131

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
