### PR TITLE
Added the ability to set volumes and volumeMounts to all pods  via helm

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -90,6 +90,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.cainjector.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -104,6 +108,10 @@ spec:
       {{- end }}
       {{- with  .Values.cainjector.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cainjector.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -92,7 +92,7 @@ spec:
           {{- end }}
           {{- with .Values.cainjector.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
           {{- with .Values.startupapicheck.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -34,6 +34,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "startupapicheck.serviceAccountName" . }}
+      {{- if hasKey .Values.startupapicheck "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.startupapicheck.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -62,6 +65,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupapicheck.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,6 +79,10 @@ spec:
       {{- end }}
       {{- with .Values.startupapicheck.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -146,10 +146,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.config }}
+          {{- if or .Values.webhook.config (gt (len .Values.webhook.volumeMounts) 0) }}
           volumeMounts:
+            {{- if .Values.webhook.config }}
             - name: config
               mountPath: /var/cert-manager/config
+            {{- end }}
+            {{- if (gt (len .Values.webhook.volumeMounts) 0) }}
+            {{- toYaml .Values.webhook.volumeMounts | nindent 10 }}
+            {{- end }}
           {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
@@ -167,9 +172,14 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.webhook.config }}
+      {{- if or .Values.webhook.config (gt (len .Values.webhook.volumes) 0) }}
       volumes:
+        {{- if .Values.webhook.config }}
         - name: config
           configMap:
             name: {{ include "webhook.fullname" . }}
+        {{- end }}
+        {{- if (gt (len .Values.webhook.volumes) 0) }}
+        {{- toYaml .Values.webhook.volumes | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -153,7 +153,7 @@ spec:
               mountPath: /var/cert-manager/config
             {{- end }}
             {{- if (gt (len .Values.webhook.volumeMounts) 0) }}
-            {{- toYaml .Values.webhook.volumeMounts | nindent 10 }}
+            {{- toYaml .Values.webhook.volumeMounts | nindent 12 }}
             {{- end }}
           {{- end }}
       {{- with .Values.webhook.nodeSelector }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -146,7 +146,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.webhook.config (gt (len .Values.webhook.volumeMounts) 0) }}
+          {{- if or .Values.webhook.config .Values.webhook.volumeMounts }}
           volumeMounts:
             {{- if .Values.webhook.config }}
             - name: config

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -152,7 +152,7 @@ spec:
             - name: config
               mountPath: /var/cert-manager/config
             {{- end }}
-            {{- if (gt (len .Values.webhook.volumeMounts) 0) }}
+            {{- if .Values.webhook.volumeMounts }}
             {{- toYaml .Values.webhook.volumeMounts | nindent 12 }}
             {{- end }}
           {{- end }}
@@ -172,14 +172,14 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.webhook.config (gt (len .Values.webhook.volumes) 0) }}
+      {{- if or .Values.webhook.config .Values.webhook.volumes }}
       volumes:
         {{- if .Values.webhook.config }}
         - name: config
           configMap:
             name: {{ include "webhook.fullname" . }}
         {{- end }}
-        {{- if (gt (len .Values.webhook.volumes) 0) }}
+        {{- if .Values.webhook.volumes }}
         {{- toYaml .Values.webhook.volumes | nindent 8 }}
         {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
@@ -15,4 +15,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "webhook.fullname" . }}
-{{- end }} 
+{{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -424,6 +424,9 @@ webhook:
       - ipBlock:
           cidr: 0.0.0.0/0
 
+  volumes: []
+  volumeMounts: []
+
 cainjector:
   enabled: true
   replicaCount: 1
@@ -511,6 +514,9 @@ cainjector:
 
   # Automounting API credentials for a particular pod
   # automountServiceAccountToken: true
+
+  volumes: []
+  volumeMounts: []
 
 acmesolver:
   image:
@@ -609,6 +615,9 @@ startupapicheck:
       helm.sh/hook-weight: "-5"
       helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
+  # Automounting API credentials for a particular pod
+  # automountServiceAccountToken: true
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -628,3 +637,6 @@ startupapicheck:
 
     # Optional additional labels to add to the startupapicheck's ServiceAccount
     # labels: {}
+
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
### Pull Request Motivation

We needed to be able to setup an explicit volume and volumeMount for the service accounts, this PR enables setting both as an array, mirroring the functionality already in place for the controller deployment

### Kind

feature

### Release Note

```release-note
Added the ability to set volumes and volumeMounts via helm variables for cainjector, webhook, and startupapicheck
```
