### PR TITLE
feat(chart): support probes for cert-manager and cainjector

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -100,6 +100,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `volumes` | Optional volumes for cert-manager | `[]` |
 | `volumeMounts` | Optional volume mounts for cert-manager | `[]` |
 | `resources` | CPU/memory resource requests/limits | `{}` |
+| `livenessProbe` | Define livenessProbe for cert-manager | `{}` |
+| `readinessProbe` | Define readinessProbe for cert-manager | `{}` |
 | `securityContext` | Security context for the controller pod assignment | refer to [Default Security Contexts](#default-security-contexts) |
 | `containerSecurityContext` | Security context to be set on the controller component container | refer to [Default Security Contexts](#default-security-contexts) |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
@@ -190,6 +192,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.image.repository` | cainjector image repository | `quay.io/jetstack/cert-manager-cainjector` |
 | `cainjector.image.tag` | cainjector image tag | `{{RELEASE_VERSION}}` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
+| `cainjector.livenessProbe` | Define livenessProbe for cainjector | `{}` |
+| `cainjector.readinessProbe` | Define readinessProbe for cainjector | `{}` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | refer to [Default Security Contexts](#default-security-contexts) |
 | `cainjector.containerSecurityContext` | Security context to be set on cainjector component container | refer to [Default Security Contexts](#default-security-contexts) |
 | `acmesolver.image.repository` | acmesolver image repository | `quay.io/jetstack/cert-manager-acmesolver` |

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -82,6 +82,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.cainjector.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cainjector.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.cainjector.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -117,6 +117,14 @@ spec:
           - containerPort: 9402
             name: http-metrics
             protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -124,6 +124,22 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+## Liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe: {}
+  # httpGet:
+  #   path: /
+  #   port: http-metrics
+  # initialDelaySeconds: 10
+  # periodSeconds: 5
+readinessProbe: {}
+  # httpGet:
+  #   path: /
+  #   port: http-metrics
+  # initialDelaySeconds: 10
+  # periodSeconds: 5
+
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
@@ -422,6 +438,13 @@ cainjector:
     # rollingUpdate:
     #   maxSurge: 0
     #   maxUnavailable: 1
+
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe: {}
+
+  readinessProbe: {}
 
   # Pod Security Context to be set on the cainjector component Pod
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
### Pull Request Motivation

Currently it is not possible to configure readiness and liveness probes for all created Pods, when using cert-manager Helm chart. To conform to Kubernetes best-practices provide the ability to allow configuration probes in all created Pods.

Closes https://github.com/cert-manager/cert-manager/issues/5626

### Kind

/kind feature

### Release Note

```release-note
Feature: The helm chart now supports `livenessProbe` and `readinessProbe` for the cert-manager and cainjector deployment so that the pod automatically restarts if it doesnt respond.
```
