### PR TITLE
Various ginkgo tweaks

### DIFF
--- a/make/config/lib.sh
+++ b/make/config/lib.sh
@@ -36,7 +36,18 @@ warn=
 wait=
 greencheck=
 redcross=
-if ! printenv NO_COLOR >/dev/null; then
+
+should_color() {
+	if [[ "${CI:-}" == "true" ]]; then
+		return 1
+	elif [[ "${NO_COLOR:-}" ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+if should_color >/dev/null; then
   red="\033[0;31m"
   green="\033[0;32m"
   yel="\033[0;33m"

--- a/make/e2e-ci.sh
+++ b/make/e2e-ci.sh
@@ -15,5 +15,13 @@
 # limitations under the License.
 
 set -o errexit
+
 trap 'make kind-logs' EXIT
-make --no-print-directory e2e FLAKE_ATTEMPTS=2 K8S_VERSION="$(K8S_VERSION)"
+
+# Note: We set CI here, even though it should be set by Prow, which is the cert-manager CI test runner
+# See the list of defined variables here: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+# We explicitly set CI here because it helps with local testing
+# (i.e. "I want to run the exact same e2e test that will be run in CI")
+# and because it allows us to be explicit about where it's getting set when we call "make e2e-ci"
+
+make --no-print-directory e2e FLAKE_ATTEMPTS=2 CI=true K8S_VERSION="$(K8S_VERSION)"

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -69,12 +69,18 @@ BINDIR=${BINDIR:-$_default_bindir}
 #  [5]: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1507011895024947200
 #  [6]: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1507019887451574272
 #  [7]: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1507040653668782080
+
 nodes=20
+
 flake_attempts=1
+
 ginkgo_skip=
 ginkgo_focus=
+
 feature_gates=AdditionalCertificateOutputFormats=true,ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,LiteralCertificateSubject=true
+
 artifacts="./$BINDIR/artifacts"
+
 help() {
   cat <<EOF | color ""
 Runs the end-to-end test suite against an already configured kind cluster.
@@ -170,22 +176,28 @@ if [[ "${ginkgo_args[*]}" =~ ginkgo.focus ]]; then
   ginkgo_args+=(--ginkgo.v --test.v)
 fi
 
+ginkgo_color=
+
+if ! should_color; then
+	ginkgo_color="--no-color"
+fi
+
 mkdir -p "$artifacts"
 
 export CGO_ENABLED=0
 
 trace ginkgo \
-  -tags=e2e_test \
-  -procs="$nodes" \
-  -output-dir="$artifacts" \
-  -junit-report="junit__01.xml" \
-  -flake-attempts="$flake_attempts" \
-  -timeout="24h" \
+  --tags=e2e_test \
+  --procs="$nodes" \
+  --output-dir="$artifacts" \
+  --junit-report="junit__01.xml" \
+  --flake-attempts="$flake_attempts" \
+  --timeout="1h" \
+  $ginkgo_color \
   -v \
-  -randomize-all \
-  -progress \
-  -trace \
-  -slow-spec-threshold="${GINKGO_SLOW_SPEC_THRESHOLD:-300s}" \
+  --randomize-all \
+  --trace \
+  --poll-progress-after=60s \
   ./test/e2e/ \
   -- \
   --repo-root="$PWD" \


### PR DESCRIPTION
### Pull Request Motivation

1. Remove deprecated args (progress, slow spec threshold)
2. Disable colors in CI

Deprecation notice given by Ginkgo on current tests is below:

```text
You're using deprecated Ginkgo functionality:
=============================================
  --slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo. 
This feature has proved to be more noisy than useful. 
You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
  --progress is deprecated . 
The functionality provided by --progress was confusing and is no longer needed.
Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose specs.
Or you can run with -vv to always see all node events.
Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck.
```

I don't think we care about node events really, so I only added `--poll-progress-after`.

### E2E Test Output Example

Before this PR (taken from [here](https://prow.build-infra.jetstack.net/log?container=test&id=1610294125595201536&job=pull-cert-manager-master-e2e-v1-26)):

```text
[0m[Conformance] CertificateSigningRequests [38;5;243mCertificateSigningRequest with issuer type Vault AppRole Custom Auth Path ClusterIssuer Without Root CA [38;5;10m[1mshould issue an ECDSA certificate for a single Common Name[0m
```

After this PR (taken from [here](https://prow.build-infra.jetstack.net/log?container=test&id=1610294331095126016&job=pull-cert-manager-master-e2e-v1-26)):

```text
[Conformance] CertificateSigningRequests CertificateSigningRequest with issuer type Vault AppRole Custom Auth Path ClusterIssuer Without Root CA should issue an RSA certificate for a single Common Name
```

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
