### PR TITLE
Use template when generating tempdir in verify-crds

### DIFF
--- a/hack/check-crds.sh
+++ b/hack/check-crds.sh
@@ -41,7 +41,7 @@ fi
 
 echo "+++ verifying that generated CRDs are up-to-date..." >&2
 
-tmpdir="$(mktemp -d)"
+tmpdir="$(mktemp -d tmp-CHECKCRD-XXXXXXXXX --tmpdir)"
 trap 'rm -r $tmpdir' EXIT
 
 make PATCH_CRD_OUTPUT_DIR=$tmpdir patch-crds


### PR DESCRIPTION
### Pull Request Motivation

Due to [a bug in controller-gen][bug] certain paths are incorrectly split and part of these paths can be interpreted as a numeric literal, which will cause controller-gen to fail. We observe this as occasional test flakes in the "verify-crds" target, when the tmpdir starts with a zero, such as in `/tmp/tmp.0PFqFSHBID`

This commit attempts to avoid this bug by specifying a template for the tmpdir we generate when verifying CRDs which doesn't include any "." characters, which seem to be being split incorrectly.

[bug]: https://github.com/kubernetes-sigs/controller-tools/issues/734

### Kind

/kind bug

### Release Note

```release-note
Use manually specified tmpdir template when verifying CRDs
```
