### PR TITLE
Avoid logging confusing error messages for external issuers

### DIFF
--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmdoc "github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	clientv1 "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -85,6 +86,11 @@ func certificateRequestsForSecret(log logr.Logger,
 	dbg.Info("checking if self signed certificate requests reference secret")
 	var affected []*cmapi.CertificateRequest
 	for _, request := range requests {
+		if request.Spec.IssuerRef.Group != cmdoc.GroupName {
+			dbg.Info("skipping SelfSigned secret reference checks since issuer has external group", "group", request.Spec.IssuerRef.Group)
+			continue
+		}
+
 		issuerObj, err := helper.GetGenericIssuer(request.Spec.IssuerRef, request.Namespace)
 		if k8sErrors.IsNotFound(err) {
 			dbg.Info("issuer not found, skipping")

--- a/pkg/controller/certificaterequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks_test.go
@@ -225,6 +225,20 @@ func Test_certificatesRequestsForSecret(t *testing.T) {
 			},
 			expectedAffected: []*cmapi.CertificateRequest{},
 		},
+		"if issuer has different group, do nothing": {
+			existingCRs: []runtime.Object{
+				gen.CertificateRequest("a",
+					gen.SetCertificateRequestNamespace("test-namespace"),
+					gen.SetCertificateRequestAnnotations(map[string]string{
+						"cert-manager.io/private-key-secret-name": "test-secret",
+					}), gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+						Name: "a", Kind: "Keith", Group: "not-cert-manager.io",
+					}),
+				),
+			},
+			existingIssuers:  []runtime.Object{},
+			expectedAffected: []*cmapi.CertificateRequest{},
+		},
 		"should not return requests which are in a different namespace": {
 			existingCRs: []runtime.Object{
 				gen.CertificateRequest("a",


### PR DESCRIPTION
See https://github.com/cert-manager/cert-manager/issues/5601 for details.

When referring to external issuers whose kind is not "Issuer" or "ClusterIssuer" we log an error message thanks to a new check added in a [previous PR](https://github.com/cert-manager/cert-manager/pull/5336) which should only trigger for SelfSigned issuers.

The error previously looked like:

```text
"error"="invalid value \"x\" for issuerRef.kind. Must
be empty, \"Issuer\" or \"ClusterIssuer\""
```

### Kind

/kind bug

### Release Note

```release-note
Don't log errors relating to selfsigned issuer checks for external issuers
```
