### PR TITLE
Ensures that only one secrets cache is created for cert-manager controller

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -488,9 +488,10 @@ func (s *Solver) dns01SolverForConfig(config *cmacme.ACMEChallengeSolverDNS01) (
 // NewSolver creates a Solver which can instantiate the appropriate DNS
 // provider.
 func NewSolver(ctx *controller.Context) (*Solver, error) {
+	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
 	webhookSolvers := []webhook.Solver{
 		&webhookslv.Webhook{},
-		rfc2136.New(rfc2136.WithNamespace(ctx.Namespace)),
+		rfc2136.New(rfc2136.WithNamespace(ctx.Namespace), rfc2136.WithSecretsLister(secretsLister)),
 	}
 
 	initialized := make(map[string]webhook.Solver)

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -33,6 +33,8 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
+const SolverName = "rfc2136"
+
 type Solver struct {
 	secretLister corelisters.SecretLister
 
@@ -65,7 +67,7 @@ func New(opts ...Option) *Solver {
 }
 
 func (s *Solver) Name() string {
-	return "rfc2136"
+	return SolverName
 }
 
 func (s *Solver) Present(ch *whapi.ChallengeRequest) error {
@@ -112,7 +114,6 @@ func (s *Solver) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan s
 		factory.Start(stopCh)
 		factory.WaitForCacheSync(stopCh)
 	}
-
 	return nil
 }
 

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -100,7 +100,11 @@ func (s *Solver) CleanUp(ch *whapi.ChallengeRequest) error {
 
 func (s *Solver) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error {
 	// Only start a secrets informerfactory if it is needed (if the solver
-	// is not already initialized with a secrets lister)
+	// is not already initialized with a secrets lister) This is legacy
+	// functionality. If you have a secrets watcher already available in the
+	// caller, you probably want to use that to avoid double caching the
+	// Secrets
+	// TODO: refactor and remove this functionality
 	if s.secretLister == nil {
 		cl, err := kubernetes.NewForConfig(kubeClientConfig)
 		if err != nil {

--- a/test/acme/dns/fixture.go
+++ b/test/acme/dns/fixture.go
@@ -24,10 +24,12 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
+	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/rfc2136"
 	"github.com/cert-manager/cert-manager/test/internal/apiserver"
 )
 
@@ -42,7 +44,8 @@ func init() {
 type fixture struct {
 	// testSolver is the actual DNS solver that is under test.
 	// It is set when calling the NewFixture function.
-	testSolver webhook.Solver
+	testSolver     webhook.Solver
+	testSolverType string
 
 	resolvedFQDN            string
 	resolvedZone            string
@@ -96,7 +99,28 @@ func (f *fixture) setup(t *testing.T) func() {
 	f.clientset = cl
 
 	stopCh := make(chan struct{})
-	f.testSolver.Initialize(env.Config, stopCh)
+
+	var testSolver webhook.Solver
+	switch f.testSolverType {
+	case rfc2136.SolverName:
+		cl, err := kubernetes.NewForConfig(env.Config)
+		if err != nil {
+			t.Errorf("error initializing solver: %#+v", err)
+		}
+
+		// obtain a secret lister and start the informer factory to populate the
+		// secret cache
+		factory := informers.NewSharedInformerFactoryWithOptions(cl, time.Minute*5)
+		secretLister := factory.Core().V1().Secrets().Lister()
+		factory.Start(stopCh)
+		factory.WaitForCacheSync(stopCh)
+		testSolver = rfc2136.New(rfc2136.WithSecretsLister(secretLister))
+		f.testSolver = testSolver
+	default:
+		t.Errorf("unknown solver type: %s", f.testSolverType)
+	}
+
+	testSolver.Initialize(env.Config, stopCh)
 
 	return func() {
 		close(stopCh)

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 )
 
 // Option applies a configuration option to the test fixture being built
@@ -33,9 +31,9 @@ type Option func(*fixture)
 
 // NewFixture constructs a new *fixture, applying the given Options before
 // returning.
-func NewFixture(solver webhook.Solver, opts ...Option) *fixture {
+func NewFixture(solverType string, opts ...Option) *fixture {
 	f := &fixture{
-		testSolver: solver,
+		testSolverType: solverType,
 	}
 	for _, o := range opts {
 		o(f)

--- a/test/integration/rfc2136_dns01/provider_test.go
+++ b/test/integration/rfc2136_dns01/provider_test.go
@@ -59,7 +59,7 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 		TSIGKeyName: rfc2136TestTsigKeyName,
 	}
 
-	fixture := dns.NewFixture(&rfc2136.Solver{},
+	fixture := dns.NewFixture(rfc2136.SolverName,
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),
@@ -91,7 +91,7 @@ func TestRunSuiteNoTSIG(t *testing.T) {
 		Nameserver: server.ListenAddr(),
 	}
 
-	fixture := dns.NewFixture(&rfc2136.Solver{},
+	fixture := dns.NewFixture(rfc2136.SolverName,
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),


### PR DESCRIPTION
Fixes #5689 



<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

See #5689 for context.

Cert-manager controller was starting two `Secret`s watches resulting in all `Secret`s being cached twice.

This PR removes the redundant informer factory that was being started in the rfc2136 DNS solver and instead passes a secrets lister from the default informer factory to the solver.

### Metrics

Comparison of memory consumption improvement

#### With the current master

Create 300 `Secret`s about 1Mb each:
![master](https://user-images.githubusercontent.com/24879183/210788793-5293fa4e-0543-43f0-a214-dc4dae4b4ed4.png)

Memory spikes up to 900Mb, then stabilizes around 700Mb:
![latestmastergrafana](https://user-images.githubusercontent.com/24879183/210789016-6f012f41-3f38-44fb-b55f-ab9d372c32f0.png)

#### From this PR

Create 300 `Secret`s about 1Mb each:
![secretsnoextracache](https://user-images.githubusercontent.com/24879183/210789211-a64897fe-2a0e-492d-b183-1040bd71b4e5.png)
Memory spikes up to 450Mb, then stabilizes around 300Mb:
![secretsnocachegrafana](https://user-images.githubusercontent.com/24879183/210789369-6a34e784-d14e-40d0-b326-23fb0152c43b.png)


To observe that only one watch is started:

Start cert-manager controller with `--v=5` flag
Look at the logs and observe that `Secret`s watch is started only once:
```
I0105 10:15:42.906265       1 reflector.go:221] Starting reflector *v1.CertificateRequest (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906303       1 reflector.go:257] Listing and watching *v1.CertificateRequest from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906305       1 reflector.go:221] Starting reflector *v1.Issuer (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906310       1 reflector.go:257] Listing and watching *v1.Issuer from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906310       1 reflector.go:221] Starting reflector *v1.Pod (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906315       1 reflector.go:257] Listing and watching *v1.Pod from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906325       1 reflector.go:221] Starting reflector *v1.Secret (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906335       1 reflector.go:257] Listing and watching *v1.Secret from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906337       1 reflector.go:221] Starting reflector *v1.Ingress (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906344       1 reflector.go:257] Listing and watching *v1.Ingress from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906367       1 reflector.go:221] Starting reflector *v1.Certificate (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906375       1 reflector.go:257] Listing and watching *v1.Certificate from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906401       1 reflector.go:221] Starting reflector *v1.Order (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906408       1 reflector.go:257] Listing and watching *v1.Order from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906468       1 reflector.go:221] Starting reflector *v1.Challenge (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906473       1 reflector.go:257] Listing and watching *v1.Challenge from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906484       1 reflector.go:221] Starting reflector *v1.ClusterIssuer (10h0m0s) from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
I0105 10:15:42.906492       1 reflector.go:257] Listing and watching *v1.ClusterIssuer from k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169
```

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixes a bug where cert-manager controller was caching all Secrets twice
```

/kind bug

Signed-off-by: irbekrm <irbekrm@gmail.com>
