### PR TITLE
Move custom acmesolver image above extraArgs

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
           - --leader-election-retry-period={{ .retryPeriod }}
           {{- end }}
           {{- end }}
+          {{- with .Values.acmesolver.image }}
+          - --acme-http01-solver-image={{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}
+          {{- end }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -109,9 +112,6 @@ spec:
           {{- end }}
           {{- if .Values.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ .Values.maxConcurrentChallenges }}
-          {{- end }}
-          {{- with .Values.acmesolver.image }}
-          - --acme-http01-solver-image={{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}
           {{- end }}
           ports:
           - containerPort: 9402


### PR DESCRIPTION
Since the acmesolver image has defaults (i.e. the repository is set by [default][values]), the helm chart changes introduced in #5554 will always set the `--acme-http01-solver-image` parameter.

This can break users who previously had this parameter set via the extraArgs Helm option, which was found and reported on [Slack][slack].

This commit moves the new Helm value added in #5554 above extraArgs, so that if extraArgs is set it will take precedence and nothing should change as users upgrade.

[values]: https://github.com/cert-manager/cert-manager/blob/a5d67d3a21f86fb21b8194808601da429a1c4752/deploy/charts/cert-manager/values.yaml#L504-L516
[slack]: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1672925692339849

### Kind

/kind bug

### Release Note

```release-note
Ensure extraArgs in Helm takes precedence over the new acmesolver image options
```
