### PR TITLE
Fix cainjector's namespace flag

### DIFF
--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -215,7 +215,7 @@ func (o InjectorControllerOptions) RunInjectorController(ctx context.Context) er
 	// Never retry if the controller exits cleanly.
 	g.Go(func() (err error) {
 		for {
-			err = cainjector.RegisterCertificateBased(gctx, mgr)
+			err = cainjector.RegisterCertificateBased(gctx, mgr, o.Namespace)
 			if err == nil {
 				return
 			}
@@ -234,7 +234,7 @@ func (o InjectorControllerOptions) RunInjectorController(ctx context.Context) er
 	// We do not retry this controller because it only interacts with core APIs
 	// which should always be in a working state.
 	g.Go(func() (err error) {
-		if err = cainjector.RegisterSecretBased(gctx, mgr); err != nil {
+		if err = cainjector.RegisterSecretBased(gctx, mgr, o.Namespace); err != nil {
 			return fmt.Errorf("error registering secret controller: %v", err)
 		}
 		return

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -180,8 +180,8 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 // indices.
 // The registered controllers require the cert-manager API to be available
 // in order to run.
-func RegisterCertificateBased(ctx context.Context, mgr ctrl.Manager) error {
-	cache, client, err := newIndependentCacheAndDelegatingClient(mgr)
+func RegisterCertificateBased(ctx context.Context, mgr ctrl.Manager, namespace string) error {
+	cache, client, err := newIndependentCacheAndDelegatingClient(mgr, namespace)
 	if err != nil {
 		return err
 	}
@@ -202,8 +202,8 @@ func RegisterCertificateBased(ctx context.Context, mgr ctrl.Manager) error {
 // indices.
 // The registered controllers only require the corev1 APi to be available in
 // order to run.
-func RegisterSecretBased(ctx context.Context, mgr ctrl.Manager) error {
-	cache, client, err := newIndependentCacheAndDelegatingClient(mgr)
+func RegisterSecretBased(ctx context.Context, mgr ctrl.Manager, namespace string) error {
+	cache, client, err := newIndependentCacheAndDelegatingClient(mgr, namespace)
 	if err != nil {
 		return err
 	}
@@ -226,10 +226,13 @@ func RegisterSecretBased(ctx context.Context, mgr ctrl.Manager) error {
 // cert-manager Certificates CRDs have been installed and before the CA bundles
 // have been injected into the cert-manager CRDs, by the secrets based injector,
 // which is running in a separate goroutine.
-func newIndependentCacheAndDelegatingClient(mgr ctrl.Manager) (cache.Cache, client.Client, error) {
+func newIndependentCacheAndDelegatingClient(mgr ctrl.Manager, namespace string) (cache.Cache, client.Client, error) {
 	cacheOptions := cache.Options{
 		Scheme: mgr.GetScheme(),
 		Mapper: mgr.GetRESTMapper(),
+	}
+	if namespace != "" {
+		cacheOptions.Namespace = namespace
 	}
 	ca, err := cache.New(mgr.GetConfig(), cacheOptions)
 	if err != nil {


### PR DESCRIPTION
Ensures that when cainjector has the namespace flag passed, namespaced resource caching is scoped to that namespace

Signed-off-by: irbekrm <irbekrm@gmail.com>

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->


```release-note
Fix cainjector's --namespace flag. Users who want to prevent cainjector from reading all `Secret`s and `Certificate`s in all namespaces (i.e to prevent excessive memory consumption) can now scope it to a single namespace using the --namespace flag. A cainjector that is only used as part of cert-manager installation only needs access to the cert-manager installation namespace.
```
/kind bug