### PR TITLE
feat: added custom endpoint override flag for http solver

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -283,7 +283,8 @@ func buildControllerContextFactory(ctx context.Context, opts *options.Controller
 			ACMEHTTP01SolverRunAsNonRoot:      ACMEHTTP01SolverRunAsNonRoot,
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-			HTTP01SolverNameservers: opts.ACMEHTTP01SolverNameservers,
+			HTTP01SolverNameservers:  opts.ACMEHTTP01SolverNameservers,
+			HTTP01SolverHostEndpoint: opts.ACMEHTTP01SolverHostEndpoint,
 
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.DNS01CheckRetryPeriod,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -83,6 +83,8 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverRunAsNonRoot          bool
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 	ACMEHTTP01SolverNameservers []string
+	// Overrides the host endpoint to perform HTTP01 checks on.
+	ACMEHTTP01SolverHostEndpoint string
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
@@ -148,6 +150,8 @@ const (
 
 	// default time period to wait between checking DNS01 and HTTP01 challenge propagation
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+
+	defaultACMEHTTP01SolverHostEndpoint = ""
 )
 
 var (
@@ -242,6 +246,7 @@ func NewControllerOptions() *ControllerOptions {
 		DefaultIssuerGroup:                defaultTLSACMEIssuerGroup,
 		DefaultAutoCertificateAnnotations: defaultAutoCertificateAnnotations,
 		ACMEHTTP01SolverNameservers:       []string{},
+		ACMEHTTP01SolverHostEndpoint:      defaultACMEHTTP01SolverHostEndpoint,
 		DNS01RecursiveNameservers:         []string{},
 		DNS01RecursiveNameserversOnly:     defaultDNS01RecursiveNameserversOnly,
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
@@ -320,6 +325,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		[]string{}, "A list of comma separated dns server endpoints used for "+
 			"ACME HTTP01 check requests. This should be a list containing host and "+
 			"port, for example 8.8.8.8:53,8.8.4.4:53")
+
+	fs.StringVar(&s.ACMEHTTP01SolverHostEndpoint, "acme-http01-solver-host-endpoint", defaultACMEHTTP01SolverHostEndpoint, ""+
+		"Allows to override the endpoint of the ACME HTTP01 challenge solver pods without changing the host. "+
+		"This is useful when there are issues in carrying out the ACME HTTP01 challenge in internal networks that do not implement a hairpin NAT.")
 
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -177,6 +177,9 @@ type ACMEOptions struct {
 	// for ACME HTTP01 validations.
 	HTTP01SolverNameservers []string
 
+	// HTTP01SolverHostEndpoint defines the override endpoint of the ACME pod
+	HTTP01SolverHostEndpoint string
+
 	// DNS01CheckAuthoritative is a flag for controlling if auth nss are used
 	// for checking propagation of an RR. This is the ideal scenario
 	DNS01CheckAuthoritative bool

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -35,9 +35,9 @@ import (
 // countReachabilityTestCalls is a wrapper function that allows us to count the number
 // of calls to a reachabilityTest.
 func countReachabilityTestCalls(counter *int, t reachabilityTest) reachabilityTest {
-	return func(ctx context.Context, url *url.URL, key string, dnsServers []string, userAgent string) error {
+	return func(ctx context.Context, url *url.URL, key string, dnsServers []string, hostEndpoint, userAgent string) error {
 		*counter++
-		return t(ctx, url, key, dnsServers, userAgent)
+		return t(ctx, url, key, dnsServers, hostEndpoint, userAgent)
 	}
 }
 
@@ -51,14 +51,14 @@ func TestCheck(t *testing.T) {
 	tests := []testT{
 		{
 			name: "should pass",
-			reachabilityTest: func(context.Context, *url.URL, string, []string, string) error {
+			reachabilityTest: func(context.Context, *url.URL, string, []string, string, string) error {
 				return nil
 			},
 			expectedErr: false,
 		},
 		{
 			name: "should error",
-			reachabilityTest: func(context.Context, *url.URL, string, []string, string) error {
+			reachabilityTest: func(context.Context, *url.URL, string, []string, string, string) error {
 				return fmt.Errorf("failed")
 			},
 			expectedErr: true,
@@ -176,7 +176,7 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 
 	for _, tt := range tests {
 		atomic.StoreInt32(&dnsServerCalled, 0)
-		err = testReachability(context.Background(), u, key, tt.dnsServers, "cert-manager-test")
+		err = testReachability(context.Background(), u, key, tt.dnsServers, "", "cert-manager-test")
 		switch {
 		case err == nil:
 			t.Errorf("Expected error for testReachability, but got none")


### PR DESCRIPTION
### Pull Request Motivation

A potential solution for issue https://github.com/cert-manager/cert-manager/issues/1292. There is currently no clean way to validate the http endpoint of a domain that's inaccessible to a Kubernetes cluster due to NAT hairpinning or other networking restrictions.

This PR will allow the target domain to be changed in order to successfully check if an ACME HTTP01 challenge is ready via the solver ingress. This works by allowing the user to set a flag `--acme-http01-solver-host-endpoint` to the internal DNS name of your ingress (such as `traefik.traefik.svc.cluster.local`) by keeping the `Host` header as the original domain being validated so ingress routing is not affected.

### Kind

/kind feature

### Release Note

```release-note
Added the flag --acme-http01-solver-host-endpoint in order to override the endpoint of the ACME HTTP01 challenge solver pods without changing the host.
```