### PR TITLE
[release-1.10] Remove redundant secret cache

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -488,9 +488,10 @@ func (s *Solver) dns01SolverForConfig(config *cmacme.ACMEChallengeSolverDNS01) (
 // NewSolver creates a Solver which can instantiate the appropriate DNS
 // provider.
 func NewSolver(ctx *controller.Context) (*Solver, error) {
+	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
 	webhookSolvers := []webhook.Solver{
 		&webhookslv.Webhook{},
-		rfc2136.New(rfc2136.WithNamespace(ctx.Namespace)),
+		rfc2136.New(rfc2136.WithNamespace(ctx.Namespace), rfc2136.WithSecretsLister(secretsLister)),
 	}
 
 	initialized := make(map[string]webhook.Solver)

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -33,6 +33,8 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
+const SolverName = "rfc2136"
+
 type Solver struct {
 	secretLister corelisters.SecretLister
 
@@ -65,7 +67,7 @@ func New(opts ...Option) *Solver {
 }
 
 func (s *Solver) Name() string {
-	return "rfc2136"
+	return SolverName
 }
 
 func (s *Solver) Present(ch *whapi.ChallengeRequest) error {
@@ -112,7 +114,6 @@ func (s *Solver) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan s
 		factory.Start(stopCh)
 		factory.WaitForCacheSync(stopCh)
 	}
-
 	return nil
 }
 

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -100,7 +100,11 @@ func (s *Solver) CleanUp(ch *whapi.ChallengeRequest) error {
 
 func (s *Solver) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error {
 	// Only start a secrets informerfactory if it is needed (if the solver
-	// is not already initialized with a secrets lister)
+	// is not already initialized with a secrets lister) This is legacy
+	// functionality. If you have a secrets watcher already available in the
+	// caller, you probably want to use that to avoid double caching the
+	// Secrets
+	// TODO: refactor and remove this functionality
 	if s.secretLister == nil {
 		cl, err := kubernetes.NewForConfig(kubeClientConfig)
 		if err != nil {

--- a/test/acme/dns/fixture.go
+++ b/test/acme/dns/fixture.go
@@ -24,10 +24,12 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
+	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/rfc2136"
 	"github.com/cert-manager/cert-manager/test/internal/apiserver"
 )
 
@@ -42,7 +44,8 @@ func init() {
 type fixture struct {
 	// testSolver is the actual DNS solver that is under test.
 	// It is set when calling the NewFixture function.
-	testSolver webhook.Solver
+	testSolver     webhook.Solver
+	testSolverType string
 
 	resolvedFQDN            string
 	resolvedZone            string
@@ -96,7 +99,28 @@ func (f *fixture) setup(t *testing.T) func() {
 	f.clientset = cl
 
 	stopCh := make(chan struct{})
-	f.testSolver.Initialize(env.Config, stopCh)
+
+	var testSolver webhook.Solver
+	switch f.testSolverType {
+	case rfc2136.SolverName:
+		cl, err := kubernetes.NewForConfig(env.Config)
+		if err != nil {
+			t.Errorf("error initializing solver: %#+v", err)
+		}
+
+		// obtain a secret lister and start the informer factory to populate the
+		// secret cache
+		factory := informers.NewSharedInformerFactoryWithOptions(cl, time.Minute*5)
+		secretLister := factory.Core().V1().Secrets().Lister()
+		factory.Start(stopCh)
+		factory.WaitForCacheSync(stopCh)
+		testSolver = rfc2136.New(rfc2136.WithSecretsLister(secretLister))
+		f.testSolver = testSolver
+	default:
+		t.Errorf("unknown solver type: %s", f.testSolverType)
+	}
+
+	testSolver.Initialize(env.Config, stopCh)
 
 	return func() {
 		close(stopCh)

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 )
 
 // Option applies a configuration option to the test fixture being built
@@ -33,9 +31,9 @@ type Option func(*fixture)
 
 // NewFixture constructs a new *fixture, applying the given Options before
 // returning.
-func NewFixture(solver webhook.Solver, opts ...Option) *fixture {
+func NewFixture(solverType string, opts ...Option) *fixture {
 	f := &fixture{
-		testSolver: solver,
+		testSolverType: solverType,
 	}
 	for _, o := range opts {
 		o(f)

--- a/test/integration/rfc2136_dns01/provider_test.go
+++ b/test/integration/rfc2136_dns01/provider_test.go
@@ -59,7 +59,7 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 		TSIGKeyName: rfc2136TestTsigKeyName,
 	}
 
-	fixture := dns.NewFixture(&rfc2136.Solver{},
+	fixture := dns.NewFixture(rfc2136.SolverName,
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),
@@ -91,7 +91,7 @@ func TestRunSuiteNoTSIG(t *testing.T) {
 		Nameserver: server.ListenAddr(),
 	}
 
-	fixture := dns.NewFixture(&rfc2136.Solver{},
+	fixture := dns.NewFixture(rfc2136.SolverName,
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),


### PR DESCRIPTION
### Pull Request Motivation

Implements @irbekrm 's  #5691 as a backport for release-1.10

Related to #5689

### Kind

/kind bug

### Release Note

```release-note
Fixes a bug where the cert-manager controller was caching all Secrets twice
```
