### PR TITLE
Bump golang to latest version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -38,7 +38,7 @@ KUBEBUILDER_ASSETS_VERSION=1.25.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.4
+VENDORED_GO_VERSION := 1.19.5
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
See [announcement tweet](https://twitter.com/golang/status/1612879466757296132)

One of the [fixed issues](https://github.com/golang/go/issues/57556) is potentially relevant to cert-manager but we've not seen any failures like that as far as I know so we should be OK to backport but there's likely no need to release a new version.

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade to Go 1.19.5
```
