### PR TITLE
Bump go to 1.19.5

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -38,7 +38,7 @@ KUBEBUILDER_ASSETS_VERSION=1.25.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.4
+VENDORED_GO_VERSION := 1.19.5
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

[release go1.19.5)](https://golang.google.cn/doc/devel/release#go1.19)
```
go1.19.5 (released 2023-01-10) includes fixes to the compiler, the linker, and the crypto/x509, net/http, sync/atomic, and syscall packages. See the [Go 1.19.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.5+label%3ACherryPickApproved) on our issue tracker for details.
```


```release-note
Upgrade to go 1.19.5
```
