### PR TITLE
Add org.opencontainers.image.source OCI label to containers

### DIFF
--- a/hack/containers/Containerfile.acmesolver
+++ b/hack/containers/Containerfile.acmesolver
@@ -2,6 +2,8 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/cert-manager/cert-manager"
+
 USER 1000
 
 COPY acmesolver /app/cmd/acmesolver/acmesolver

--- a/hack/containers/Containerfile.cainjector
+++ b/hack/containers/Containerfile.cainjector
@@ -2,6 +2,8 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/cert-manager/cert-manager"
+
 USER 1000
 
 COPY cainjector /app/cmd/cainjector/cainjector

--- a/hack/containers/Containerfile.controller
+++ b/hack/containers/Containerfile.controller
@@ -2,6 +2,8 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/cert-manager/cert-manager"
+
 USER 1000
 
 COPY controller /app/cmd/controller/controller

--- a/hack/containers/Containerfile.ctl
+++ b/hack/containers/Containerfile.ctl
@@ -2,6 +2,8 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/cert-manager/cert-manager"
+
 USER 1000
 
 COPY ctl /app/cmd/ctl/ctl

--- a/hack/containers/Containerfile.webhook
+++ b/hack/containers/Containerfile.webhook
@@ -2,6 +2,8 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/cert-manager/cert-manager"
+
 USER 1000
 
 COPY webhook /app/cmd/webhook/webhook


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

I'd like to take advantage of renovate's changelog support (https://docs.renovatebot.com/modules/datasource/docker/)

To do so, the recommended way is to add the standard OCI label `org.opencontainers.image.source`.
This is useful for all sorts of tools.

A full list of pre-defined annotations is available at: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
container images are have an OCI source label
```
