### PR TITLE
:sparkles: allow setting automountServiceAccount in post-install hook

### DIFF
--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "startupapicheck.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.startupapicheck.automountServiceAccountToken }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -62,6 +63,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupapicheck.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,6 +77,10 @@ spec:
       {{- end }}
       {{- with .Values.startupapicheck.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -553,6 +553,12 @@ startupapicheck:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
+  # Additional volumes for the startupapicheck pod
+  volumes: []
+
+  # Additional volumes fro the startupapicheck container
+  volumeMounts: []
+
   # Timeout for 'kubectl check api' command
   timeout: 1m
 
@@ -608,6 +614,9 @@ startupapicheck:
       helm.sh/hook: post-install
       helm.sh/hook-weight: "-5"
       helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+  # Automount API credentials for a Service Account.
+  automountServiceAccountToken: true
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
### Pull Request Motivation

This PR adds the ability to set `automountServiceAccountToken=false`. This is a well-known requirement for `CIS`, `BSI` and `NSA` security benchmarks.

This PR allows a user to set `serviceaccount.automount=false` in conjunction with providing the correct `volumes` as well as `volumeMounts`.

#### Example use-case

With the following values you can set automount=false and inject the needed volumes/volumeMounts:

```diff
diff --git a/deploy/charts/cert-manager/values.yaml b/deploy/charts/cert-manager/values.yaml
index faf6c8cd8..f780386af 100644
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -554,10 +554,30 @@ startupapicheck:
     # runAsNonRoot: true
 
   # Additional volumes for the startupapicheck pod
-  volumes: []
+  volumes:
+  - name: serviceaccount-token
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          name: kube-root-ca.crt
+          items:
+          - key: ca.crt
+            path: ca.crt
+      - downwardAPI:
+          items:
+          - path: namespace
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
 
   # Additional volumes fro the startupapicheck container
-  volumeMounts: []
+  volumeMounts:
+  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    name: serviceaccount-token
 
   # Timeout for 'kubectl check api' command
   timeout: 1m
@@ -616,7 +636,7 @@ startupapicheck:
       helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   # Automount API credentials for a Service Account.
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 
   serviceAccount:
     # Specifies whether a service account should be created

```

### Kind
feature

### Release Note

```release-note
NONE
```
