### PR TITLE
Webhook solver conformance bugfix

### DIFF
--- a/pkg/acme/webhook/apiserver/apiserver.go
+++ b/pkg/acme/webhook/apiserver/apiserver.go
@@ -112,7 +112,10 @@ func (c *Config) Complete() CompletedConfig {
 	return CompletedConfig{&completedCfg}
 }
 
-// New returns a new instance of AdmissionServer from the given config.
+// New returns a new instance of apiserver from the given config. Each of the
+// configured solvers will have an API GroupVersion registered with the new
+// apiserver and will have its Initialize function passed as post-start hook
+// with the server.
 func (c completedConfig) New() (*ChallengeServer, error) {
 	genericServer, err := c.GenericConfig.New("challenge-server", genericapiserver.NewEmptyDelegate()) // completion is done in Complete, no need for a second time
 	if err != nil {

--- a/pkg/acme/webhook/cmd/cmd.go
+++ b/pkg/acme/webhook/cmd/cmd.go
@@ -29,6 +29,11 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
+// RunWebhookServer creates and starts a new apiserver that acts as a external
+// webhook server for solving DNS challenges using the provided solver
+// implementations. This can be used as an entry point by external webhook
+// implementations, see
+// https://github.com/cert-manager/webhook-example/blob/899c408751425f8d0842b61c0e62fd8035d00316/main.go#L23-L31
 func RunWebhookServer(groupName string, hooks ...webhook.Solver) {
 	stopCh, exit := util.SetupExitHandler(util.GracefulShutdown)
 	defer exit() // This function might call os.Exit, so defer last

--- a/pkg/acme/webhook/cmd/server/start.go
+++ b/pkg/acme/webhook/cmd/server/start.go
@@ -97,6 +97,9 @@ func (o *WebhookServerOptions) Complete() error {
 	return nil
 }
 
+// Config creates a new webhook server config that includes generic upstream
+// apiserver options, rest client config and the Solvers configured for this
+// webhook server
 func (o WebhookServerOptions) Config() (*apiserver.Config, error) {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
@@ -118,6 +121,8 @@ func (o WebhookServerOptions) Config() (*apiserver.Config, error) {
 	return config, nil
 }
 
+// RunWebhookServer creates a new apiserver, registers an API Group for each of
+// the configured solvers and runs the new apiserver.
 func (o WebhookServerOptions) RunWebhookServer(stopCh <-chan struct{}) error {
 	config, err := o.Config()
 	if err != nil {

--- a/pkg/acme/webhook/webhook.go
+++ b/pkg/acme/webhook/webhook.go
@@ -24,7 +24,9 @@ import (
 	whapi "github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 )
 
-// Solver has the functionality to solve ACME challenges.
+// Solver has the functionality to solve ACME challenges. This interface is
+// implemented internally by RFC2136 DNS provider and by external webhook solver
+// implementations see https://github.com/cert-manager/webhook-example
 type Solver interface {
 	// Name is the name of this ACME solver as part of the API group.
 	// This must match what you configure in the ACME Issuer's DNS01 config.
@@ -41,5 +43,6 @@ type Solver interface {
 	CleanUp(ch *whapi.ChallengeRequest) error
 
 	// Initialize is called as a post-start hook when the apiserver starts.
+	// https://github.com/kubernetes/apiserver/blob/release-1.26/pkg/server/hooks.go#L32-L42
 	Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error
 }

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -37,6 +37,8 @@ const SolverName = "rfc2136"
 
 type Solver struct {
 	secretLister corelisters.SecretLister
+	// options to apply when the lister gets initialized
+	initOpts []Option
 
 	// If specified, namespace will cause the rfc2136 provider to limit the
 	// scope of the lister/watcher to a single namespace, to allow for
@@ -55,6 +57,21 @@ func WithNamespace(ns string) Option {
 func WithSecretsLister(secretLister corelisters.SecretLister) Option {
 	return func(s *Solver) {
 		s.secretLister = secretLister
+	}
+}
+
+// InitializeResetLister is a hack to make RFC2136 solver fit the Solver
+// interface. Unlike external solvers that are run as apiserver implementations,
+// this solver is created as part of challenge controller initialization. That
+// makes its Initialize method not fit the Solver interface very well as we want
+// a way to initialize the solver with the existing Secrets lister rather than a
+// new kube apiserver client. InitializeResetLister allows to reset secrets
+// lister when Initialize function is called so that a new lister can be
+// created. This is useful in tests where a kube clientset can get recreated for
+// an existing solver (which would not happen when this solver runs normally).
+func InitializeResetLister() Option {
+	return func(s *Solver) {
+		s.initOpts = []Option{func(s *Solver) { s.secretLister = nil }}
 	}
 }
 
@@ -99,12 +116,12 @@ func (s *Solver) CleanUp(ch *whapi.ChallengeRequest) error {
 }
 
 func (s *Solver) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error {
+	for _, opt := range s.initOpts {
+		opt(s)
+	}
 	// Only start a secrets informerfactory if it is needed (if the solver
 	// is not already initialized with a secrets lister) This is legacy
-	// functionality. If you have a secrets watcher already available in the
-	// caller, you probably want to use that to avoid double caching the
-	// Secrets
-	// TODO: refactor and remove this functionality
+	// functionality and is currently only used in integration tests.
 	if s.secretLister == nil {
 		cl, err := kubernetes.NewForConfig(kubeClientConfig)
 		if err != nil {

--- a/test/acme/dns/fixture.go
+++ b/test/acme/dns/fixture.go
@@ -81,6 +81,32 @@ type fixture struct {
 	propagationLimit time.Duration
 }
 
+// RunConformance will execute all conformance tests using the supplied
+// configuration These conformance tests should be run by all external DNS
+// solver webhook implementations, see
+// https://github.com/cert-manager/webhook-example
+func (f *fixture) RunConformance(t *testing.T) {
+	defer f.setup(t)()
+	t.Run("Conformance", func(t *testing.T) {
+		f.RunBasic(t)
+		f.RunExtended(t)
+	})
+}
+
+func (f *fixture) RunBasic(t *testing.T) {
+	defer f.setup(t)()
+	t.Run("Basic", func(t *testing.T) {
+		t.Run("PresentRecord", f.TestBasicPresentRecord)
+	})
+}
+
+func (f *fixture) RunExtended(t *testing.T) {
+	defer f.setup(t)()
+	t.Run("Extended", func(t *testing.T) {
+		t.Run("DeletingOneRecordRetainsOthers", f.TestExtendedDeletingOneRecordRetainsOthers)
+	})
+}
+
 func (f *fixture) setup(t *testing.T) func() {
 	f.setupLock.Lock()
 	defer f.setupLock.Unlock()
@@ -126,28 +152,4 @@ func (f *fixture) setup(t *testing.T) func() {
 		close(stopCh)
 		stopFunc()
 	}
-}
-
-// RunConformance will execute all conformance tests using the supplied
-// configuration
-func (f *fixture) RunConformance(t *testing.T) {
-	defer f.setup(t)()
-	t.Run("Conformance", func(t *testing.T) {
-		f.RunBasic(t)
-		f.RunExtended(t)
-	})
-}
-
-func (f *fixture) RunBasic(t *testing.T) {
-	defer f.setup(t)()
-	t.Run("Basic", func(t *testing.T) {
-		t.Run("PresentRecord", f.TestBasicPresentRecord)
-	})
-}
-
-func (f *fixture) RunExtended(t *testing.T) {
-	defer f.setup(t)()
-	t.Run("Extended", func(t *testing.T) {
-		t.Run("DeletingOneRecordRetainsOthers", f.TestExtendedDeletingOneRecordRetainsOthers)
-	})
 }

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 )
 
 // Option applies a configuration option to the test fixture being built

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -30,10 +31,13 @@ import (
 type Option func(*fixture)
 
 // NewFixture constructs a new *fixture, applying the given Options before
-// returning.
-func NewFixture(solverType string, opts ...Option) *fixture {
+// returning. Solver is an implementation of
+// https://github.com/cert-manager/cert-manager/blob/v1.11.0/pkg/acme/webhook/webhook.go#L27-L45
+// and could be RFC2136 solver or any of external solvers that run these
+// conformance tests.
+func NewFixture(solver webhook.Solver, opts ...Option) *fixture {
 	f := &fixture{
-		testSolverType: solverType,
+		testSolver: solver,
 	}
 	for _, o := range opts {
 		o(f)

--- a/test/integration/rfc2136_dns01/provider_test.go
+++ b/test/integration/rfc2136_dns01/provider_test.go
@@ -59,7 +59,7 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 		TSIGKeyName: rfc2136TestTsigKeyName,
 	}
 
-	fixture := dns.NewFixture(rfc2136.SolverName,
+	fixture := dns.NewFixture(rfc2136.New(rfc2136.InitializeResetLister()),
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),
@@ -91,7 +91,7 @@ func TestRunSuiteNoTSIG(t *testing.T) {
 		Nameserver: server.ListenAddr(),
 	}
 
-	fixture := dns.NewFixture(rfc2136.SolverName,
+	fixture := dns.NewFixture(rfc2136.New(rfc2136.InitializeResetLister()),
 		dns.SetResolvedZone(rfc2136TestZone),
 		dns.SetResolvedFQDN(rfc2136TestFqdn),
 		dns.SetAllowAmbientCredentials(false),


### PR DESCRIPTION
Fixes #5725 

This PR fixes DNS webhook solver conformance test bug introduced in #5691 - in that PR I changed a webhook Solver interface implentation for RFC2136 to not start a Secrets informer factory and made some associated changes to integration tests which are a bit clunky for this particular Solver implementation.
The tests are being used as conformance tests by external webhook implementations and the changes broke their tests.

This PR:
- reverts changes to tests that would affect third party solver implementations using them
- makes some changes to the RFC2136 Solver implementation to make it work in the integration test setup (which does not generally match how it would normally run, but I think this is acceptable)
- adds a bunch of comments to make it clearer which parts of the webhook solver code are going to be consumed by external webhook implementations

To reproduce the bug:

1. checkout example-webhook code from this PR that bumps cert-manager dependency to latest https://github.com/irbekrm/webhook-example/tree/bump_deps
2. run `TEST_ZONE_NAME=example.com. make test` that runs the conformance tests from cert-manager against the example webhook implementation
3. observe an error

To observe the fix:
1. checkout example-webhook code from this PR that bumps cert-manager dependency to latest https://github.com/irbekrm/webhook-example/tree/bump_deps
2. Add `replace github.com/cert-manager/cert-manager => github.com/irbekrm/cert-manager webhook_solver_conformance_bugfix` to go.mod to pull in cert-manager from this PR
3. Run `go mod tidy`
4.  run `TEST_ZONE_NAME=example.com. make test` that runs the conformance tests from cert-manager against the example webhook implementation
5. Observe no errors


<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

6. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

7. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

8. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

Once this PR merges I will open another to update example webhook deps.

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```

/kind bug
