### PR TITLE
Add MaxPathLen and add EncodeBasicConstraintsInRequest option to Certificate and CertificateRequest resources

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificaterequests.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificaterequests.yaml
@@ -142,6 +142,19 @@ spec:
                   required:
                     - name
                   type: object
+                maxPathLen:
+                  description: |-
+                    Requested basic constraints maxPathLen value. Note that the issuer may choose
+                    to ignore the requested maxPathLen value, just like any other requested attribute.
+
+                    NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+                    it must have the same maxPathLen value as specified here.
+
+                    If set, maxPathLen must be a value of `0` or greater.
+                    If unset (`nil`), there is no maximum.
+                    Default value is `nil`.
+                  format: int32
+                  type: integer
                 request:
                   description: |-
                     The PEM-encoded X.509 certificate signing request to be submitted to the

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -128,6 +128,15 @@ spec:
                     type: string
                   type: array
                   x-kubernetes-list-type: atomic
+                encodeBasicConstraintsInRequest:
+                  description: |-
+                    Whether the BasicConstraints extension should be set in the encoded CSR.
+
+                    IMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature
+                    gate is set. Otherwise, the CSR will not have the BasicConstraints extension.
+                    This option defaults to true, and should only be disabled if the target
+                    issuer does not support CSRs with a X509 BasicConstraints extension.
+                  type: boolean
                 encodeUsagesInRequest:
                   description: |-
                     Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
@@ -308,6 +317,21 @@ spec:
 
                     Cannot be set if the `subject` or `commonName` field is set.
                   type: string
+                maxPathLen:
+                  description: |-
+                    Requested basic constraints maxPathLen value.
+                    The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest
+                    resources. Note that the issuer may choose to ignore the requested maxPathLen value, just
+                    like any other requested attribute.
+                    If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+                    `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+                    have a BasicConstraints extension with the provided maxPathLen value.
+
+                    If set, maxPathLen must be a value of `0` or greater.
+                    If unset (`nil`), there is no maximum.
+                    Default value is `nil`.
+                  format: int32
+                  type: integer
                 nameConstraints:
                   description: |-
                     x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.

--- a/deploy/crds/cert-manager.io_certificaterequests.yaml
+++ b/deploy/crds/cert-manager.io_certificaterequests.yaml
@@ -141,6 +141,19 @@ spec:
                 required:
                 - name
                 type: object
+              maxPathLen:
+                description: |-
+                  Requested basic constraints maxPathLen value. Note that the issuer may choose
+                  to ignore the requested maxPathLen value, just like any other requested attribute.
+
+                  NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+                  it must have the same maxPathLen value as specified here.
+
+                  If set, maxPathLen must be a value of `0` or greater.
+                  If unset (`nil`), there is no maximum.
+                  Default value is `nil`.
+                format: int32
+                type: integer
               request:
                 description: |-
                   The PEM-encoded X.509 certificate signing request to be submitted to the

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -127,6 +127,15 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              encodeBasicConstraintsInRequest:
+                description: |-
+                  Whether the BasicConstraints extension should be set in the encoded CSR.
+
+                  IMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature
+                  gate is set. Otherwise, the CSR will not have the BasicConstraints extension.
+                  This option defaults to true, and should only be disabled if the target
+                  issuer does not support CSRs with a X509 BasicConstraints extension.
+                type: boolean
               encodeUsagesInRequest:
                 description: |-
                   Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
@@ -308,6 +317,21 @@ spec:
 
                   Cannot be set if the `subject` or `commonName` field is set.
                 type: string
+              maxPathLen:
+                description: |-
+                  Requested basic constraints maxPathLen value.
+                  The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest
+                  resources. Note that the issuer may choose to ignore the requested maxPathLen value, just
+                  like any other requested attribute.
+                  If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+                  `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+                  have a BasicConstraints extension with the provided maxPathLen value.
+
+                  If set, maxPathLen must be a value of `0` or greater.
+                  If unset (`nil`), there is no maximum.
+                  Default value is `nil`.
+                format: int32
+                type: integer
               nameConstraints:
                 description: |-
                   x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -217,10 +217,26 @@ type CertificateSpec struct {
 	// The isCA value is used to set the `isCA` field on the created CertificateRequest
 	// resources. Note that the issuer may choose to ignore the requested isCA value, just
 	// like any other requested attribute.
+	// If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+	// `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+	// have a BasicConstraints extension with the provided isCA value.
 	//
 	// If true, this will automatically add the `cert sign` usage to the list
 	// of requested `usages`.
 	IsCA bool
+
+	// Requested basic constraints maxPathLen value.
+	// The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest
+	// resources. Note that the issuer may choose to ignore the requested maxPathLen value, just
+	// like any other requested attribute.
+	// If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+	// `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+	// have a BasicConstraints extension with the provided maxPathLen value.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	MaxPathLen *int
 
 	// Requested key usages and extended key usages.
 	// These usages are used to set the `usages` field on the created CertificateRequest
@@ -242,6 +258,14 @@ type CertificateSpec struct {
 	// This option defaults to true, and should only be disabled if the target
 	// issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
 	EncodeUsagesInRequest *bool
+
+	// Whether the BasicConstraints extension should be set in the encoded CSR.
+	//
+	// IMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature
+	// gate is set. Otherwise, the CSR will not have the BasicConstraints extension.
+	// This option defaults to true, and should only be disabled if the target
+	// issuer does not support CSRs with a X509 BasicConstraints extension.
+	EncodeBasicConstraintsInRequest *bool
 
 	// The maximum number of CertificateRequest revisions that are maintained in
 	// the Certificate's history. Each revision represents a single `CertificateRequest`

--- a/internal/apis/certmanager/types_certificaterequest.go
+++ b/internal/apis/certmanager/types_certificaterequest.go
@@ -126,6 +126,17 @@ type CertificateRequestSpec struct {
 	// of requested `usages`.
 	IsCA bool
 
+	// Requested basic constraints maxPathLen value. Note that the issuer may choose
+	// to ignore the requested maxPathLen value, just like any other requested attribute.
+	//
+	// NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+	// it must have the same maxPathLen value as specified here.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	MaxPathLen *int
+
 	// Requested key usages and extended key usages.
 	//
 	// NOTE: If the CSR in the `Request` field has uses the KeyUsage or

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -776,6 +776,13 @@ func autoConvert_v1_CertificateRequestSpec_To_certmanager_CertificateRequestSpec
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int)
+		**out = int(**in)
+	} else {
+		out.MaxPathLen = nil
+	}
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -796,6 +803,13 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1_CertificateRequestSpec
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = int32(**in)
+	} else {
+		out.MaxPathLen = nil
+	}
 	out.Usages = *(*[]certmanagerv1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -884,10 +898,18 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *certmanag
 		return err
 	}
 	out.IsCA = in.IsCA
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int)
+		**out = int(**in)
+	} else {
+		out.MaxPathLen = nil
+	}
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.SignatureAlgorithm = certmanager.SignatureAlgorithm(in.SignatureAlgorithm)
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.EncodeBasicConstraintsInRequest = (*bool)(unsafe.Pointer(in.EncodeBasicConstraintsInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
 	out.NameConstraints = (*certmanager.NameConstraints)(unsafe.Pointer(in.NameConstraints))
@@ -926,10 +948,18 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 		return err
 	}
 	out.IsCA = in.IsCA
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = int32(**in)
+	} else {
+		out.MaxPathLen = nil
+	}
 	out.Usages = *(*[]certmanagerv1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanagerv1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.SignatureAlgorithm = certmanagerv1.SignatureAlgorithm(in.SignatureAlgorithm)
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.EncodeBasicConstraintsInRequest = (*bool)(unsafe.Pointer(in.EncodeBasicConstraintsInRequest))
 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	out.AdditionalOutputFormats = *(*[]certmanagerv1.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
 	out.NameConstraints = (*certmanagerv1.NameConstraints)(unsafe.Pointer(in.NameConstraints))

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -163,6 +163,16 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 		}
 	}
 
+	if crt.EncodeBasicConstraintsInRequest != nil {
+		if !utilfeature.DefaultFeatureGate.Enabled(feature.UseCertificateRequestBasicConstraints) {
+			el = append(el, field.Forbidden(fldPath.Child("encodeBasicConstraintsInRequest"), "Feature gate UseCertificateRequestBasicConstraints must be enabled on the webhook to use the alpha `encodeBasicConstraintsInRequest` field"))
+		}
+	}
+
+	if crt.MaxPathLen != nil && !crt.IsCA {
+		el = append(el, field.Forbidden(fldPath.Child("maxPathLen"), "must not be set unless the certificate is a CA"))
+	}
+
 	if crt.PrivateKey != nil {
 		switch crt.PrivateKey.Algorithm {
 		case "", internalcmapi.RSAKeyAlgorithm:

--- a/internal/apis/certmanager/validation/certificaterequest.go
+++ b/internal/apis/certmanager/validation/certificaterequest.go
@@ -91,6 +91,10 @@ func ValidateCertificateRequestSpec(crSpec *cmapi.CertificateRequestSpec, fldPat
 func validateCertificateRequestSpecRequest(crSpec *cmapi.CertificateRequestSpec, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
+	if crSpec.MaxPathLen != nil && !crSpec.IsCA {
+		el = append(el, field.Forbidden(fldPath.Child("maxPathLen"), "must not be set unless the certificate is a CA"))
+	}
+
 	if len(crSpec.Request) == 0 {
 		el = append(el, field.Required(fldPath.Child("request"), "must be specified"))
 		return el
@@ -109,7 +113,7 @@ func validateCertificateRequestSpecRequest(crSpec *cmapi.CertificateRequestSpec,
 
 	_, err = pki.CertificateTemplateFromCSRPEM(
 		crSpec.Request,
-		pki.CertificateTemplateValidateAndOverrideBasicConstraints(crSpec.IsCA, nil),
+		pki.CertificateTemplateValidateAndOverrideBasicConstraints(crSpec.IsCA, crSpec.MaxPathLen),
 		pki.CertificateTemplateValidateAndOverrideKeyUsages(keyUsage, extKeyUsage),
 	)
 	if err != nil {

--- a/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -293,6 +293,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -457,6 +462,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -469,6 +479,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 	}
 	if in.EncodeUsagesInRequest != nil {
 		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EncodeBasicConstraintsInRequest != nil {
+		in, out := &in.EncodeBasicConstraintsInRequest, &out.EncodeBasicConstraintsInRequest
 		*out = new(bool)
 		**out = **in
 	}

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -3041,6 +3041,13 @@ func schema_pkg_apis_certmanager_v1_CertificateRequestSpec(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"maxPathLen": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Requested basic constraints maxPathLen value. Note that the issuer may choose to ignore the requested maxPathLen value, just like any other requested attribute.\n\nNOTE: If the CSR in the `Request` field has a BasicConstraints extension, it must have the same maxPathLen value as specified here.\n\nIf set, maxPathLen must be a value of `0` or greater. If unset (`nil`), there is no maximum. Default value is `nil`.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"usages": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -3408,6 +3415,13 @@ func schema_pkg_apis_certmanager_v1_CertificateSpec(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"maxPathLen": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Requested basic constraints maxPathLen value. The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest resources. Note that the issuer may choose to ignore the requested maxPathLen value, just like any other requested attribute. If the `UseCertificateRequestBasicConstraints` feature gate is set and the `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will have a BasicConstraints extension with the provided maxPathLen value.\n\nIf set, maxPathLen must be a value of `0` or greater. If unset (`nil`), there is no maximum. Default value is `nil`.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"usages": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -3444,6 +3458,13 @@ func schema_pkg_apis_certmanager_v1_CertificateSpec(ref common.ReferenceCallback
 					"encodeUsagesInRequest": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.\n\nThis option defaults to true, and should only be disabled if the target issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"encodeBasicConstraintsInRequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether the BasicConstraints extension should be set in the encoded CSR.\n\nIMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature gate is set. Otherwise, the CSR will not have the BasicConstraints extension. This option defaults to true, and should only be disabled if the target issuer does not support CSRs with a X509 BasicConstraints extension.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -57,6 +57,14 @@ const (
 	// See https://github.com/cert-manager/cert-manager/issues/3203 and https://github.com/cert-manager/cert-manager/issues/4424 for context.
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
 
+	// Owner: @SgtCoDFish
+	// Alpha: v1.11
+	//
+	// UseCertificateRequestBasicConstraints will add Basic Constraints section in the Extension Request of the Certificate Signing Request
+	// This feature will add BasicConstraints section with CA field defaulting to false; CA field will be set true if the Certificate resource spec has isCA as true
+	// Github Issue: https://github.com/cert-manager/cert-manager/issues/5539
+	UseCertificateRequestBasicConstraints featuregate.Feature = "UseCertificateRequestBasicConstraints"
+
 	// Owner: @inteon
 	// Beta: v1.13
 	// GA: v1.15
@@ -99,8 +107,9 @@ func init() {
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
 
-	AdditionalCertificateOutputFormats: {Default: true, PreRelease: featuregate.GA},
-	LiteralCertificateSubject:          {Default: true, PreRelease: featuregate.Beta},
-	NameConstraints:                    {Default: true, PreRelease: featuregate.Beta},
-	OtherNames:                         {Default: true, PreRelease: featuregate.Beta},
+	AdditionalCertificateOutputFormats:    {Default: true, PreRelease: featuregate.GA},
+	LiteralCertificateSubject:             {Default: true, PreRelease: featuregate.Beta},
+	NameConstraints:                       {Default: true, PreRelease: featuregate.Beta},
+	OtherNames:                            {Default: true, PreRelease: featuregate.Beta},
+	UseCertificateRequestBasicConstraints: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -270,6 +270,20 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// Requested basic constraints maxPathLen value.
+	// The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest
+	// resources. Note that the issuer may choose to ignore the requested maxPathLen value, just
+	// like any other requested attribute.
+	// If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+	// `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+	// have a BasicConstraints extension with the provided maxPathLen value.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Requested key usages and extended key usages.
 	// These usages are used to set the `usages` field on the created CertificateRequest
 	// resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
@@ -298,6 +312,15 @@ type CertificateSpec struct {
 	// issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
 	// +optional
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+
+	// Whether the BasicConstraints extension should be set in the encoded CSR.
+	//
+	// IMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature
+	// gate is set. Otherwise, the CSR will not have the BasicConstraints extension.
+	// This option defaults to true, and should only be disabled if the target
+	// issuer does not support CSRs with a X509 BasicConstraints extension.
+	// +optional
+	EncodeBasicConstraintsInRequest *bool `json:"encodeBasicConstraintsInRequest,omitempty"`
 
 	// The maximum number of CertificateRequest revisions that are maintained in
 	// the Certificate's history. Each revision represents a single `CertificateRequest`

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -146,6 +146,18 @@ type CertificateRequestSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// Requested basic constraints maxPathLen value. Note that the issuer may choose
+	// to ignore the requested maxPathLen value, just like any other requested attribute.
+	//
+	// NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+	// it must have the same maxPathLen value as specified here.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Requested key usages and extended key usages.
 	//
 	// NOTE: If the CSR in the `Request` field has uses the KeyUsage or

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -293,6 +293,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -457,6 +462,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -469,6 +479,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 	}
 	if in.EncodeUsagesInRequest != nil {
 		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EncodeBasicConstraintsInRequest != nil {
+		in, out := &in.EncodeBasicConstraintsInRequest, &out.EncodeBasicConstraintsInRequest
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/experimental/v1alpha1/types.go
+++ b/pkg/apis/experimental/v1alpha1/types.go
@@ -29,6 +29,10 @@ const (
 	// request whether the certificate should be marked as CA.
 	CertificateSigningRequestIsCAAnnotationKey = "experimental.cert-manager.io/request-is-ca"
 
+	// CertificateSigningRequestMaxPathLenAnnotationKey is the annotation key used to
+	// request a specific MaxPathLen for your CA certificate.
+	CertificateSigningRequestMaxPathLenAnnotationKey = "experimental.cert-manager.io/request-max-path-len"
+
 	// CertificateSigningRequestMinimumDuration is the minimum allowed
 	// duration that can be requested for a CertificateSigningRequest via
 	// the experimental.cert-manager.io/request-duration annotation. This

--- a/pkg/client/applyconfigurations/certmanager/v1/certificaterequestspec.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificaterequestspec.go
@@ -66,6 +66,16 @@ type CertificateRequestSpecApplyConfiguration struct {
 	// If true, this will automatically add the `cert sign` usage to the list
 	// of requested `usages`.
 	IsCA *bool `json:"isCA,omitempty"`
+	// Requested basic constraints maxPathLen value. Note that the issuer may choose
+	// to ignore the requested maxPathLen value, just like any other requested attribute.
+	//
+	// NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+	// it must have the same maxPathLen value as specified here.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
 	// Requested key usages and extended key usages.
 	//
 	// NOTE: If the CSR in the `Request` field has uses the KeyUsage or
@@ -125,6 +135,14 @@ func (b *CertificateRequestSpecApplyConfiguration) WithRequest(values ...byte) *
 // If called multiple times, the IsCA field is set to the value of the last call.
 func (b *CertificateRequestSpecApplyConfiguration) WithIsCA(value bool) *CertificateRequestSpecApplyConfiguration {
 	b.IsCA = &value
+	return b
+}
+
+// WithMaxPathLen sets the MaxPathLen field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MaxPathLen field is set to the value of the last call.
+func (b *CertificateRequestSpecApplyConfiguration) WithMaxPathLen(value int32) *CertificateRequestSpecApplyConfiguration {
+	b.MaxPathLen = &value
 	return b
 }
 

--- a/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
@@ -142,6 +142,18 @@ type CertificateSpecApplyConfiguration struct {
 	// If true, this will automatically add the `cert sign` usage to the list
 	// of requested `usages`.
 	IsCA *bool `json:"isCA,omitempty"`
+	// Requested basic constraints maxPathLen value.
+	// The maxPathLen value is used to set the `maxPathLen` field on the created CertificateRequest
+	// resources. Note that the issuer may choose to ignore the requested maxPathLen value, just
+	// like any other requested attribute.
+	// If the `UseCertificateRequestBasicConstraints` feature gate is set and the
+	// `encodeBasicConstraintsInRequest` field is not set to `false`, the encoded CSR will
+	// have a BasicConstraints extension with the provided maxPathLen value.
+	//
+	// If set, maxPathLen must be a value of `0` or greater.
+	// If unset (`nil`), there is no maximum.
+	// Default value is `nil`.
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
 	// Requested key usages and extended key usages.
 	// These usages are used to set the `usages` field on the created CertificateRequest
 	// resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
@@ -162,6 +174,13 @@ type CertificateSpecApplyConfiguration struct {
 	// This option defaults to true, and should only be disabled if the target
 	// issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+	// Whether the BasicConstraints extension should be set in the encoded CSR.
+	//
+	// IMPORTANT: This option is only available if `UseCertificateRequestBasicConstraints` feature
+	// gate is set. Otherwise, the CSR will not have the BasicConstraints extension.
+	// This option defaults to true, and should only be disabled if the target
+	// issuer does not support CSRs with a X509 BasicConstraints extension.
+	EncodeBasicConstraintsInRequest *bool `json:"encodeBasicConstraintsInRequest,omitempty"`
 	// The maximum number of CertificateRequest revisions that are maintained in
 	// the Certificate's history. Each revision represents a single `CertificateRequest`
 	// created by this Certificate, either when it was created, renewed, or Spec
@@ -330,6 +349,14 @@ func (b *CertificateSpecApplyConfiguration) WithIsCA(value bool) *CertificateSpe
 	return b
 }
 
+// WithMaxPathLen sets the MaxPathLen field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MaxPathLen field is set to the value of the last call.
+func (b *CertificateSpecApplyConfiguration) WithMaxPathLen(value int32) *CertificateSpecApplyConfiguration {
+	b.MaxPathLen = &value
+	return b
+}
+
 // WithUsages adds the given value to the Usages field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Usages field.
@@ -361,6 +388,14 @@ func (b *CertificateSpecApplyConfiguration) WithSignatureAlgorithm(value certman
 // If called multiple times, the EncodeUsagesInRequest field is set to the value of the last call.
 func (b *CertificateSpecApplyConfiguration) WithEncodeUsagesInRequest(value bool) *CertificateSpecApplyConfiguration {
 	b.EncodeUsagesInRequest = &value
+	return b
+}
+
+// WithEncodeBasicConstraintsInRequest sets the EncodeBasicConstraintsInRequest field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EncodeBasicConstraintsInRequest field is set to the value of the last call.
+func (b *CertificateSpecApplyConfiguration) WithEncodeBasicConstraintsInRequest(value bool) *CertificateSpecApplyConfiguration {
+	b.EncodeBasicConstraintsInRequest = &value
 	return b
 }
 

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -1292,6 +1292,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.meta.v1.IssuerReference
       default: {}
+    - name: maxPathLen
+      type:
+        scalar: numeric
     - name: request
       type:
         scalar: string
@@ -1367,6 +1370,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: encodeBasicConstraintsInRequest
+      type:
+        scalar: boolean
     - name: encodeUsagesInRequest
       type:
         scalar: boolean
@@ -1389,6 +1395,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: literalSubject
       type:
         scalar: string
+    - name: maxPathLen
+      type:
+        scalar: numeric
     - name: nameConstraints
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.certmanager.v1.NameConstraints

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -362,7 +362,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	x509CSR, err := pki.GenerateCSR(
 		crt,
 		pki.WithUseLiteralSubject(utilfeature.DefaultMutableFeatureGate.Enabled(feature.LiteralCertificateSubject)),
-		pki.WithEncodeBasicConstraintsInRequest(utilfeature.DefaultMutableFeatureGate.Enabled(feature.UseCertificateRequestBasicConstraints)),
+		pki.WithEncodeBasicConstraintsInRequestByDefault(utilfeature.DefaultMutableFeatureGate.Enabled(feature.UseCertificateRequestBasicConstraints)),
 		pki.WithNameConstraints(utilfeature.DefaultMutableFeatureGate.Enabled(feature.NameConstraints)),
 		pki.WithOtherNames(utilfeature.DefaultMutableFeatureGate.Enabled(feature.OtherNames)),
 	)

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -111,7 +111,7 @@ func NewForConfigAndClient(restcfg *rest.Config, httpClient *http.Client, namesp
 				},
 			},
 		},
-		pki.WithEncodeBasicConstraintsInRequest(true),
+		pki.WithEncodeBasicConstraintsInRequestByDefault(true),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("while generating CSR: %w", err)

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -22,6 +22,7 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -282,6 +283,17 @@ func CertificateTemplateFromCSRPEM(csrPEM []byte, validatorMutators ...Certifica
 	return CertificateTemplateFromCSR(csr, validatorMutators...)
 }
 
+// TODO: we should use the conversion functions in the API package to convert
+// to internal types, rather than reimplementing them here.
+func convertPointerInt32ToPointerInt(p *int32) *int {
+	if p == nil {
+		return nil
+	}
+
+	i := int(*p)
+	return &i
+}
+
 // CertificateTemplateFromCertificate will create a x509.Certificate for the given
 // Certificate resource
 func CertificateTemplateFromCertificate(crt *v1.Certificate) (*x509.Certificate, error) {
@@ -299,7 +311,7 @@ func CertificateTemplateFromCertificate(crt *v1.Certificate) (*x509.Certificate,
 	return CertificateTemplateFromCSR(
 		csr,
 		CertificateTemplateOverrideDuration(certDuration),
-		CertificateTemplateValidateAndOverrideBasicConstraints(crt.Spec.IsCA, nil),
+		CertificateTemplateValidateAndOverrideBasicConstraints(crt.Spec.IsCA, convertPointerInt32ToPointerInt(crt.Spec.MaxPathLen)),
 		CertificateTemplateValidateAndOverrideKeyUsages(keyUsage, extKeyUsage),
 	)
 }
@@ -336,10 +348,20 @@ func CertificateTemplateFromCertificateSigningRequest(csr *certificatesv1.Certif
 
 	isCA := csr.Annotations[experimentalapi.CertificateSigningRequestIsCAAnnotationKey] == "true"
 
+	var maxPathLen *int
+	maxPathLenValue, hasMaxPathLen := csr.Annotations[experimentalapi.CertificateSigningRequestMaxPathLenAnnotationKey]
+	if hasMaxPathLen {
+		integerValue, err := strconv.Atoi(maxPathLenValue)
+		if err != nil {
+			return nil, err
+		}
+		maxPathLen = &integerValue
+	}
+
 	return CertificateTemplateFromCSRPEM(
 		csr.Spec.Request,
 		CertificateTemplateOverrideDuration(duration),
-		CertificateTemplateValidateAndOverrideBasicConstraints(isCA, nil), // Override the basic constraints, but make sure they match the constraints in the CSR if present
-		CertificateTemplateValidateAndOverrideKeyUsages(ku, eku),          // Override the key usages, but make sure they match the usages in the CSR if present
+		CertificateTemplateValidateAndOverrideBasicConstraints(isCA, maxPathLen), // Override the basic constraints, but make sure they match the constraints in the CSR if present
+		CertificateTemplateValidateAndOverrideKeyUsages(ku, eku),                 // Override the key usages, but make sure they match the usages in the CSR if present
 	)
 }

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -114,20 +114,21 @@ func KeyUsagesForCertificateOrCertificateRequest(usages []v1.KeyUsage, isCA bool
 }
 
 type generateCSROptions struct {
-	EncodeBasicConstraintsInRequest bool
-	EncodeNameConstraints           bool
-	EncodeOtherNames                bool
-	UseLiteralSubject               bool
+	EncodeBasicConstraintsInRequestByDefault bool
+	EncodeNameConstraints                    bool
+	EncodeOtherNames                         bool
+	UseLiteralSubject                        bool
 }
 
 type GenerateCSROption func(*generateCSROptions)
 
-// WithEncodeBasicConstraintsInRequest determines whether the BasicConstraints
-// extension should be encoded in the CSR.
-// NOTE: this is a temporary option that will be removed in a future release.
-func WithEncodeBasicConstraintsInRequest(encode bool) GenerateCSROption {
+// WithEncodeBasicConstraintsInRequestByDefault will set the default value for
+// whether the basic constraints extension should be encoded in the CSR.
+// NOTE: we default to true and plan to remove the false option in a future
+// release.
+func WithEncodeBasicConstraintsInRequestByDefault(encode bool) GenerateCSROption {
 	return func(o *generateCSROptions) {
-		o.EncodeBasicConstraintsInRequest = encode
+		o.EncodeBasicConstraintsInRequestByDefault = encode
 	}
 }
 
@@ -155,10 +156,10 @@ func WithUseLiteralSubject(useLiteralSubject bool) GenerateCSROption {
 // to the x509.CreateCertificateRequest function.
 func GenerateCSR(crt *v1.Certificate, optFuncs ...GenerateCSROption) (*x509.CertificateRequest, error) {
 	opts := &generateCSROptions{
-		EncodeBasicConstraintsInRequest: false,
-		EncodeNameConstraints:           false,
-		EncodeOtherNames:                false,
-		UseLiteralSubject:               false,
+		EncodeBasicConstraintsInRequestByDefault: false,
+		EncodeNameConstraints:                    false,
+		EncodeOtherNames:                         false,
+		UseLiteralSubject:                        false,
 	}
 	for _, opt := range optFuncs {
 		opt(opts)
@@ -279,10 +280,11 @@ func GenerateCSR(crt *v1.Certificate, optFuncs ...GenerateCSROption) (*x509.Cert
 		}
 	}
 
-	// NOTE(@inteon): opts.EncodeBasicConstraintsInRequest is a temporary solution and will
-	// be removed/ replaced in a future release.
-	if opts.EncodeBasicConstraintsInRequest {
-		basicExtension, err := MarshalBasicConstraints(crt.Spec.IsCA, nil)
+	// NOTE(@inteon): opts.EncodeBasicConstraintsInRequestByDefault is a temporary solution and will default to true
+	// in the future. Currently, we use a feature flag to allow users to opt-in to the new behavior.
+	if (crt.Spec.EncodeBasicConstraintsInRequest == nil && opts.EncodeBasicConstraintsInRequestByDefault) ||
+		(crt.Spec.EncodeBasicConstraintsInRequest != nil && *crt.Spec.EncodeBasicConstraintsInRequest) {
+		basicExtension, err := MarshalBasicConstraints(crt.Spec.IsCA, convertPointerInt32ToPointerInt(crt.Spec.MaxPathLen))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util"
@@ -421,14 +422,15 @@ func TestGenerateCSR(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                                    string
-		crt                                     *cmapi.Certificate
-		want                                    *x509.CertificateRequest
-		wantErr                                 bool
-		literalCertificateSubjectFeatureEnabled bool
-		basicConstraintsFeatureEnabled          bool
-		nameConstraintsFeatureEnabled           bool
-		otherNamesFeatureEnabled                bool
+		name                                                   string
+		crt                                                    *cmapi.Certificate
+		want                                                   *x509.CertificateRequest
+		wantErr                                                bool
+		literalCertificateSubjectFeatureEnabled                bool
+		encodeBasicConstraintsInRequestByDefaultFeatureEnabled bool
+		basicConstraintsFeatureEnabled                         bool
+		nameConstraintsFeatureEnabled                          bool
+		otherNamesFeatureEnabled                               bool
 	}{
 		{
 			name: "Generate CSR from certificate with only DNS",
@@ -516,7 +518,7 @@ func TestGenerateCSR(t *testing.T) {
 			},
 		},
 		{
-			name: "Generate CSR from certificate with isCA not set and with UseCertificateRequestBasicConstraints flag enabled",
+			name: "Generate CSR from certificate with isCA not set and with EncodeBasicConstraintsInRequestByDefault=true and EncodeBasicConstraintsInRequest not set",
 			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org"}},
 			want: &x509.CertificateRequest{
 				Version:            0,
@@ -536,11 +538,51 @@ func TestGenerateCSR(t *testing.T) {
 				},
 				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
 			},
-			basicConstraintsFeatureEnabled: true,
+			encodeBasicConstraintsInRequestByDefaultFeatureEnabled: true,
 		},
 		{
-			name: "Generate CSR from certificate with isCA set and with UseCertificateRequestBasicConstraints flag enabled",
-			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", IsCA: true}},
+			name: "Generate CSR from certificate with EncodeBasicConstraintsInRequestByDefault=true and EncodeBasicConstraintsInRequest=false",
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", EncodeBasicConstraintsInRequest: ptr.To(false)}},
+			want: &x509.CertificateRequest{
+				Version:            0,
+				SignatureAlgorithm: x509.SHA256WithRSA,
+				PublicKeyAlgorithm: x509.RSA,
+				ExtraExtensions: []pkix.Extension{
+					{
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1DefaultKeyUsage,
+						Critical: true,
+					},
+				},
+				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
+			},
+			encodeBasicConstraintsInRequestByDefaultFeatureEnabled: true,
+		},
+		{
+			name: "Generate CSR from certificate with isCA not set and with EncodeBasicConstraintsInRequest set to true",
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", EncodeBasicConstraintsInRequest: ptr.To(true)}},
+			want: &x509.CertificateRequest{
+				Version:            0,
+				SignatureAlgorithm: x509.SHA256WithRSA,
+				PublicKeyAlgorithm: x509.RSA,
+				ExtraExtensions: []pkix.Extension{
+					{
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1DefaultKeyUsage,
+						Critical: true,
+					},
+					{
+						Id:       OIDExtensionBasicConstraints,
+						Value:    basicConstraintsGenerator(t, false),
+						Critical: true,
+					},
+				},
+				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
+			},
+		},
+		{
+			name: "Generate CSR from certificate with isCA set and with EncodeBasicConstraintsInRequest set to true",
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", IsCA: true, EncodeBasicConstraintsInRequest: ptr.To(true)}},
 			want: &x509.CertificateRequest{
 				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
@@ -559,7 +601,6 @@ func TestGenerateCSR(t *testing.T) {
 				},
 				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
 			},
-			basicConstraintsFeatureEnabled: true,
 		},
 		{
 			name: "Generate CSR from certificate with extended key usages",
@@ -859,7 +900,7 @@ func TestGenerateCSR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GenerateCSR(
 				tt.crt,
-				WithEncodeBasicConstraintsInRequest(tt.basicConstraintsFeatureEnabled),
+				WithEncodeBasicConstraintsInRequestByDefault(tt.encodeBasicConstraintsInRequestByDefaultFeatureEnabled),
 				WithNameConstraints(tt.nameConstraintsFeatureEnabled),
 				WithOtherNames(tt.otherNamesFeatureEnabled),
 				WithUseLiteralSubject(tt.literalCertificateSubjectFeatureEnabled),

--- a/test/unit/gen/csr.go
+++ b/test/unit/gen/csr.go
@@ -35,7 +35,7 @@ import (
 type CSRModifier func(*x509.CertificateRequest) error
 
 var defaultGenerateCSROptions = []pki.GenerateCSROption{
-	pki.WithEncodeBasicConstraintsInRequest(true),
+	pki.WithEncodeBasicConstraintsInRequestByDefault(true),
 	pki.WithNameConstraints(true),
 	pki.WithOtherNames(true),
 	pki.WithUseLiteralSubject(true),


### PR DESCRIPTION
### Pull Request Motivation

Adds the missing BasicConstraints options to the Certificate and CertificateRequest resources.
Implemented very similar to the existing IsCA and Usages options.

### Kind

/kind feature

### Release Note

```release-note
The Certificate and CertificateRequest resources now support setting the MaxPathLen.
```