### PR TITLE
Revert "automount service account tokens off by default"

### DIFF
--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -175,7 +175,6 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
 		},
 		Spec: corev1.PodSpec{
-			AutomountServiceAccountToken: pointer.Bool(false),
 			NodeSelector: map[string]string{
 				"kubernetes.io/os": "linux",
 			},


### PR DESCRIPTION
This reverts commit 954eb0d875cb79d6da8eca233ccc9267ebf1420c.

I accidentally pushed that commit to master while setting up visual studio code on a new laptop.

Apologies everyone. 

I will also look into automatically applying the necessary branch protection in the github.com/jetstack/testing repo.

```release-note
NONE
```
