### PR TITLE
Cainjector: only reconcile annotated injectables

### DIFF
--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -234,7 +234,7 @@ func isInjectable() predicate.Funcs {
 	}
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return f(e.ObjectOld)
+			return f(e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			return f(e.Object)

--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
@@ -215,32 +213,19 @@ func injectableCAFromSecretIndexer(rawObj client.Object) []string {
 	return []string{secretNameRaw}
 }
 
-// isInjectable returns predicates that determine whether an object is a
+// hasInjectableAnnotation returns predicates that determine whether an object is a
 // cainjector injectable by looking at whether it has one of the three
 // annotations used to mark injectables.
-func isInjectable() predicate.Funcs {
-	f := func(o client.Object) bool {
-		annots := o.GetAnnotations()
-		if _, ok := annots[cmapi.WantInjectAPIServerCAAnnotation]; ok {
-			return true
-		}
-		if _, ok := annots[cmapi.WantInjectAnnotation]; ok {
-			return true
-		}
-		if _, ok := annots[cmapi.WantInjectFromSecretAnnotation]; ok {
-			return true
-		}
-		return false
+func hasInjectableAnnotation(o client.Object) bool {
+	annots := o.GetAnnotations()
+	if _, ok := annots[cmapi.WantInjectAPIServerCAAnnotation]; ok {
+		return true
 	}
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return f(e.ObjectNew)
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return f(e.Object)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return f(e.Object)
-		},
+	if _, ok := annots[cmapi.WantInjectAnnotation]; ok {
+		return true
 	}
+	if _, ok := annots[cmapi.WantInjectFromSecretAnnotation]; ok {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -95,13 +95,14 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, namespace strin
 	// Registers a c/r controller for each of APIService, CustomResourceDefinition, Mutating/ValidatingWebhookConfiguration
 	// TODO: add a flag to allow users to configure which of these controllers should be registered
 	for _, setup := range injectorSetups {
-		log := ctrl.Log.WithName(setup.objType.GetName())
-		log.Info("Registering new controller")
+		log := ctrl.Log.WithValues("kind", setup.resourceName)
+		log.Info("Registering a reconciler for injectable")
 		r := &genericInjectReconciler{
-			injector:  setup.injector,
-			namespace: namespace,
-			log:       log,
-			Client:    mgr.GetClient(),
+			injector:     setup.injector,
+			namespace:    namespace,
+			resourceName: setup.resourceName,
+			log:          log,
+			Client:       mgr.GetClient(),
 			// TODO: refactor
 			sources: []caDataSource{
 				sds,
@@ -110,9 +111,10 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, namespace strin
 			},
 		}
 
-		// This code does some magic to make it possible to filter
-		// injectables by whether they have the annotations we're
-		// interested in when determining whether to trigger reconcilers
+		// Index injectable with a new field. If the injectable's CA is
+		// to be sourced from a Secret, the field's value will be the
+		// namespaced name of the Secret.
+		// This field can then be used as a field selector when listing injectables of this type.
 		secretTyp := setup.injector.NewTarget().AsObject()
 		if err := mgr.GetFieldIndexer().IndexField(ctx, secretTyp, injectFromSecretPath, injectableCAFromSecretIndexer); err != nil {
 			err := fmt.Errorf("error making injectable indexable by inject-ca-from-secret annotation: %w", err)
@@ -127,6 +129,10 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, namespace strin
 				secretToInjectable: buildSecretToInjectableFunc(setup.listType, setup.resourceName),
 			}).Map))
 		if watchCerts {
+			// Index injectable with a new field. If the injectable's CA is
+			// to be sourced from a Certificate's Secret, the field's value will be the
+			// namespaced name of the Certificate.
+			// This field can then be used as a field selector when listing injectables of this type.
 			certTyp := setup.injector.NewTarget().AsObject()
 			if err := mgr.GetFieldIndexer().IndexField(ctx, certTyp, injectFromPath, injectableCAFromIndexer); err != nil {
 				err := fmt.Errorf("error making injectable indexable by inject-ca-from path: %w", err)

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -18,6 +18,7 @@ package cainjector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -87,7 +88,8 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	certName := splitNamespacedName(certNameRaw)
 	log = log.WithValues("certificate", certName)
 	if certName.Namespace == "" {
-		log.Error(nil, "invalid certificate name: needs a namespace/ prefix")
+		err := errors.New("invalid annotation")
+		log.Error(err, "invalid certificate name: needs a namespace/ prefix")
 		// TODO: should an error be returned here to prevent the caller from proceeding?
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil
@@ -124,7 +126,8 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	// inject the CA data
 	caData, hasCAData := secret.Data[cmmeta.TLSCAKey]
 	if !hasCAData {
-		log.Error(nil, "certificate has no CA data")
+		err := errors.New("invalid CA source")
+		log.Error(err, "certificate has no CA data")
 		// don't requeue, we'll get called when the secret gets updated
 		return nil, nil
 	}
@@ -153,7 +156,8 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 	secretName := splitNamespacedName(secretNameRaw)
 	log = log.WithValues("secret", secretName)
 	if secretName.Namespace == "" {
-		log.Error(nil, "invalid secret source: missing namespace/ prefix")
+		err := errors.New("invalid annotation")
+		log.Error(err, "invalid secret source: missing namespace/ prefix")
 		// TODO: should we return error here to prevent the caller from proceeding?
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil
@@ -182,7 +186,8 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 	// inject the CA data
 	caData, hasCAData := secret.Data[cmmeta.TLSCAKey]
 	if !hasCAData {
-		log.Error(nil, "certificate has no CA data")
+		err := errors.New("invalid CA source")
+		log.Error(err, "secret contains no CA data")
 		// don't requeue, we'll get called when the secret gets updated
 		return nil, nil
 	}

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -87,7 +87,7 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	certName := splitNamespacedName(certNameRaw)
 	log = log.WithValues("certificate", certName)
 	if certName.Namespace == "" {
-		log.Error(nil, "invalid certificate name; needs a namespace/ prefix")
+		log.Error(nil, "invalid certificate name: needs a namespace/ prefix")
 		// TODO: should an error be returned here to prevent the caller from proceeding?
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil
@@ -153,7 +153,7 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 	secretName := splitNamespacedName(secretNameRaw)
 	log = log.WithValues("secret", secretName)
 	if secretName.Namespace == "" {
-		log.Error(nil, "invalid certificate name")
+		log.Error(nil, "invalid secret source: missing namespace/ prefix")
 		// TODO: should we return error here to prevent the caller from proceeding?
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil


### PR DESCRIPTION
Cainjector can inject CA data to 'injectables' that can be CRDs, Validating/MutatingWebhookConfigurations or APIServices.
Users specify the source of CA via an annotation on the injectable-
- `cert-manager.io/inject-apiserver-ca` to inject CA from kubeconfig
- `cert-manager.io/inject-ca-from-secret` to inject CA from a Secret
- `cert-manager.io/inject-ca-from` to inject CA from a cert-manager Certificate's Secret

At the moment cainjector lists and watches all resources of injectable types and trigger reconciles on all associated events. Unfortunately there is no way how to filter List/Watch on annotation and we cannot change this to labels as this would constitute a breaking change.

This PR ensures that reconciles are only triggered on events against annotated objects of injectable types. This should speed up cainjector and reduce CPU consumption (removes unnecessary work) and prevents logs being spammed with confusing errors.

To verify the bug:
1. Deploy cert-manager from latest master with `--v=5` flag for cainjector deployment
2. Observe that reconciles are triggered for various cainjector-unrelated resources that happen to be in cluster:
![reconcileall](https://user-images.githubusercontent.com/24879183/215466580-70579aca-bdaa-42bb-8f03-fb45c8aa9973.png)


To verify the fix:
1. Deploy cert-manager from latest master with `--v=5` flag for cainjector deployment
2. Observe that reconciles are only triggered for the resources with cainjector annotations (cert-manager's validating and mutating webhook configurations)
![withfilter](https://user-images.githubusercontent.com/24879183/215466923-678e902b-6788-46be-95ce-bc02c4394552.png)


As follow up work I'd also like to:
- add flags to allow users to filter which controllers should be started
- use transform functions to remove unnecessary fields from cached objects

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```

/kind cleanup
