### PR TITLE
Bump gateway-api version to 0.6.0

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -18,7 +18,7 @@ IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.7.1@sha256:1bcec6bc85472
 IMAGE_vault_amd64 := index.docker.io/library/vault:1.12.1@sha256:08dd1cb922624c51a5aefd4d9ce0ac5ed9688d96d8a5ad94664fa10e84702ed6
 IMAGE_bind_amd64 := docker.io/eafxx/bind:latest-9f74179f@sha256:0b8c766f5bedbcbe559c7970c8e923aa0c4ca771e62fcf8dba64ffab980c9a51
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.1.1@sha256:7dafe98c73d229bbac08067fccf9b2884c63c8e1412fe18f9986f59232cf3cb5
-IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.23.2@sha256:4b9ed5bfd4afd02eabc3b6235293489dbae1684d4d3dee37e982e87638a011f9
+IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.24.1@sha256:39a804ce4b896de168915ae41358932c219443fd4ceffe37296a63f9adef0597
 IMAGE_pebble_amd64 := local/pebble:local
 IMAGE_vaultretagged_amd64 := local/vault:local
 
@@ -28,7 +28,7 @@ IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.7.1@sha256:141234fb74242
 IMAGE_vault_arm64 := $(IMAGE_vault_amd64)
 IMAGE_bind_arm64 := docker.io/eafxx/bind:latest-9f74179f@sha256:85de273f24762c0445035d36290a440e8c5a6a64e9ae6227d92e8b0b0dc7dd6d
 IMAGE_sampleexternalissuer_arm64 := # 🚧 NOT AVAILABLE FOR arm64 🚧
-IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.23.2@sha256:c877e098c42d07244cc26d4d6d4743d80fe4313a69d8c775782cba93341e0099
+IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.24.1@sha256:fee2b24db85c3ed3487e0e2a325806323997171a2ed722252f8ca85d0bee919d
 IMAGE_pebble_arm64 := local/pebble:local
 IMAGE_vaultretagged_arm64 := local/vault:local
 
@@ -321,7 +321,7 @@ e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar
 	$(HELM) upgrade \
 		--install \
 		--wait \
-		--version 10.1.3 \
+		--version 11.0.0 \
 		--namespace projectcontour \
 		--create-namespace \
 		--set contour.ingressClass.create=false \

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -30,7 +30,7 @@ TOOLS += ginkgo=$(shell awk '/ginkgo\/v2/ {print $$2}' go.mod)
 TOOLS += ko=v0.12.0
 
 # Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
-GATEWAY_API_VERSION=v0.5.1
+GATEWAY_API_VERSION=v0.6.0
 
 K8S_CODEGEN_VERSION=v0.26.0
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -395,7 +395,7 @@ $(BINDIR)/downloaded/tools/kubebuilder_tools_$(KUBEBUILDER_ASSETS_VERSION)_$(HOS
 # gatewayapi #
 ##############
 
-GATEWAY_API_SHA256SUM=b84972572a104012e7fbea5651a113ac872f6ffeb0b037b4505d664383c932a3
+GATEWAY_API_SHA256SUM=7a6f00833ba23617d6b938cffc6f9cb7faddcc0997d0bd91f34614e42fe2d35d
 
 $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml: | $(BINDIR)/downloaded
 	$(CURL) https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml -o $@


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>

https://github.com/kubernetes-sigs/gateway-api/releases

Upgrade gateway-api version to 0.6.0

```release-note
Upgraded Gateway API to v0.6.0.
```