### PR TITLE
helm: Add option to keep CRDs when helm chart is uninstalled

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -170,7 +170,17 @@ The duration the clients should wait between attempting acquisition and renewal 
 > false
 > ```
 
-Install the cert-manager CRDs, it is recommended to not use Helm to manage the CRDs.
+This method of CRDs installation will be deprecated in future releases. It is mutually exclusive with crds.install and crds.keep=true
+#### **crds.install** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+#### **crds.keep** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
 ### Controller
 
 #### **replicaCount** ~ `number`

--- a/deploy/charts/cert-manager/templates/_preflight.tpl
+++ b/deploy/charts/cert-manager/templates/_preflight.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cert-manager.preflight" -}}
+  {{- if and (.Values.installCRDs) (or (.Values.crds.install) (.Values.crds.keep)) }}
+    {{- fail "ERROR: Cannot set both .Values.installCRDs and .Values.crds.install" }}
+  {{- end }}
+{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -67,9 +67,13 @@ global:
     # +docs:property
     # retryPeriod: 15s
 
-# Install the cert-manager CRDs, it is recommended to not use Helm to manage
-# the CRDs.
+# This method of CRDs installation will be deprecated in future releases
+# It is mutually exclusive with crds.install and crds.keep=true
 installCRDs: false
+
+crds:
+  install: false
+  keep: false
 
 # +docs:section=Controller
 

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -2,10 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -2,10 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -2,10 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.acme.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   name: challenges.acme.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1,8 +1,12 @@
+{{- include "cert-manager.preflight" . }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -3,10 +3,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   name: issuers.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -2,10 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
   labels:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -2,10 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
-  labels:
-    {{- if .Values.crds.keep }}
+  {{- if .Values.crds.keep }}
+  annotations:
     "helm.sh/resource-policy": keep
-    {{- end }}
+  {{- end }}
+  labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'


### PR DESCRIPTION
### Pull Request Motivation
Provider users the option of keeping CRD resources upon chart uninstall so that custom resources are not deleted.

### Kind
feature

### Release Note
```release-note
Helm chart can now install CRDs with 'helm.sh/resource-policy' annotation set to 'keep' to avoid uninstalling CRDs when chart is removed.
```
