### PR TITLE
make: the kubebuilder 1.26.0 hash for linux/amd64 changed

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -374,7 +374,7 @@ $(K8S_CODEGEN_TOOLS_DOWNLOADS): $(BINDIR)/downloaded/tools/%-gen@$(K8S_CODEGEN_V
 # You can use ./hack/latest-kubebuilder-shas.sh <version> to get latest SHAs for a particular version of kubebuilder tools #
 ############################
 
-KUBEBUILDER_TOOLS_linux_amd64_SHA256SUM=0467f408d9ce38bd6188270a34a5e97207a310b53bfd1e44982d44bb177d147c
+KUBEBUILDER_TOOLS_linux_amd64_SHA256SUM=e4aa555f4f23f031f89128aaf8eae60e305e1f4fadec2db5731b2415d1a8957d
 KUBEBUILDER_TOOLS_darwin_amd64_SHA256SUM=7ff8022a4022e76d2e7450db97232c0be77567064d8c116100d910e9b7b510d1
 KUBEBUILDER_TOOLS_darwin_arm64_SHA256SUM=9483d95d1f53907b9bbe9deb0642b7731c5aa122a4598b5759fa77c50102b797
 


### PR DESCRIPTION
As mentioned in https://github.com/cert-manager/cert-manager/pull/5711#issuecomment-1416193485, the kubebuilder tarball for linux/amd64 seems to have been changed.

Because of it, the periodic job [ci-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-make-test/1622544090765725696) has been failing since Feb 03 01:31:58

To check that this fix works, run the following:

```bash
rm -f _bin/downloaded/tools/kubebuilder_tools_1.26.0_linux_amd64.tar.gz
make _bin/downloaded/tools/kube-apiserver@1.26.0_linux_amd64 HOST_ARCH=amd64 HOST_OS=linux
```

/kind cleanup

```release-note
NONE
```

NOTE: I don't think this fix needs to be backported since the `make test` command is only run in our master periodics and our PR jobs, but not in the release-1.10 and release-1.11 jobs.