### PR TITLE
[release-1.11] e2e flakiness: vault addon incorrectly using StdoutPipe

### DIFF
--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chart
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -164,16 +165,12 @@ func (c *Chart) runInstall() error {
 	}
 
 	cmd := c.buildHelmCmd(args...)
-	cmd.Stdout = nil
-	out, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	defer out.Close()
+	stdoutBuf := &bytes.Buffer{}
+	cmd.Stdout = stdoutBuf
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
-		_, err2 := io.Copy(os.Stdout, out)
+		_, err2 := io.Copy(os.Stdout, stdoutBuf)
 		if err2 != nil {
 			return fmt.Errorf("cmd.Run: %v: io.Copy: %v", err, err2)
 		}
@@ -197,19 +194,15 @@ func (c *Chart) buildHelmCmd(args ...string) *exec.Cmd {
 
 func (c *Chart) getHelmVersion() (string, error) {
 	cmd := c.buildHelmCmd("version", "--template", "{{.Client.Version}}")
-	cmd.Stdout = nil
-	out, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", err
-	}
-	defer out.Close()
+	stdoutBuf := &bytes.Buffer{}
+	cmd.Stdout = stdoutBuf
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		return "", err
 	}
 
-	outBytes, err := io.ReadAll(out)
+	outBytes, err := io.ReadAll(stdoutBuf)
 	if err != nil {
 		return "", err
 	}
@@ -220,16 +213,12 @@ func (c *Chart) getHelmVersion() (string, error) {
 // Deprovision the deployed instance of tiller-deploy
 func (c *Chart) Deprovision() error {
 	cmd := c.buildHelmCmd("delete", "--namespace", c.Namespace, c.ReleaseName)
-	cmd.Stdout = nil
-	out, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	defer out.Close()
+	stdoutBuf := &bytes.Buffer{}
+	cmd.Stdout = stdoutBuf
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
-		_, err2 := io.Copy(os.Stdout, out)
+		_, err2 := io.Copy(os.Stdout, stdoutBuf)
 		if err2 != nil {
 			return fmt.Errorf("cmd.Run: %v: io.Copy: %v", err, err2)
 		}


### PR DESCRIPTION
I'd like to backport the commit https://github.com/cert-manager/cert-manager/pull/5502/commits/ba0bb5d5030a06a00f38779fbc9feb609c41dfee that was merged to master. This commit fixes a flake that appears quite often. 

Example: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-release-1.11-e2e-v1-21/1623293794206093312

<details>

<summary>Links to the test failures, including the retried ones</summary>


- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-22-feature-gates-disabled/1605910679389212672
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-22-feature-gates-disabled/1611711112418430976
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25/1575107357778644992
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1592476906110849024
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1606251763705319424
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1606977004362534912
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1608426957869944832
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1610964282554454016
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1615314583654764544
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1618577356455153664
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1618939908171239424
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-25-feature-gates-disabled/1621114910916218880
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-26-feature-gates-disabled/1605537234168057856
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-26-feature-gates-disabled/1608075094809120768
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-26-feature-gates-disabled/1609524908134502400
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-26-feature-gates-disabled/1609887376002256896
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5629/pull-cert-manager-master-e2e-v1-25/1602318501106683904
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5632/pull-cert-manager-master-e2e-v1-25/1602260162268106752
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5637/pull-cert-manager-master-e2e-v1-25/1603072207322353664
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5637/pull-cert-manager-master-e2e-v1-25/1603346968615063552
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5639/pull-cert-manager-master-e2e-v1-26/1613468908277207040
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5644/pull-cert-manager-master-e2e-v1-26/1604869701396074496
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5655/pull-cert-manager-master-e2e-v1-26/1605226221040308224
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5660/pull-cert-manager-master-e2e-v1-22/1605314050617511936
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5660/pull-cert-manager-master-e2e-v1-26/1605557935365165056
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5660/pull-cert-manager-master-e2e-v1-26/1611415762172383232
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5691/pull-cert-manager-master-e2e-v1-21/1610981336078618624
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5691/pull-cert-manager-master-e2e-v1-21/1610992410341412864
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5693/pull-cert-manager-master-e2e-v1-26/1611376909772394496
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5703/pull-cert-manager-release-1.11-e2e-v1-26/1612403356788068352
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5706/pull-cert-manager-master-e2e-v1-26/1612521533371060224
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5724/pull-cert-manager-master-e2e-v1-26/1613971461192552448
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5736/pull-cert-manager-master-e2e-v1-21/1615768152128360448
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5736/pull-cert-manager-master-e2e-v1-22/1615768152212246528
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5736/pull-cert-manager-master-e2e-v1-26/1615767603286904832
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5754/pull-cert-manager-master-e2e-v1-26/1618585611369713664
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5754/pull-cert-manager-master-e2e-v1-26/1618603247923105792
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5766/pull-cert-manager-master-e2e-v1-26/1620315082258911232
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5766/pull-cert-manager-master-e2e-v1-26/1620372995551793152


</details>

---

For context, the Go documentation [1] mentions that `StdoutPipe` should not be used along with `Run`:

> "Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. It is thus incorrect to call Wait before all reads from the pipe have completed. For the same reason, it is incorrect to call Run when using StdoutPipe. See the example for idiomatic usage."

It seems we are using `Run`, meaning that the StdoutPipe gets closed when `Run` returns (because `Run` calls `Wait` and closes the StdoutPipe before returning).

To reproduce:

    git fetch https://github.com/cert-manager/cert-manager/commit/fa4c2cfcad79f0a8a806b71caefbf96b049533c5
    git checkout https://github.com/cert-manager/cert-manager/commit/fa4c2cfcad79f0a8a806b71caefbf96b049533c5
    go test -tags=e2e_test ./test/e2e -- -test.outputdir=$PWD/_bin/artifacts \
      -ginkgo.junit-report=junit__01.xml -ginkgo.flake-attempts=1            \
      -test.timeout=24h -ginkgo.v -test.v -ginkgo.randomize-all              \
      -ginkgo.progress -ginkgo.trace -ginkgo.slow-spec-threshold=300s        \
      --repo-root=/home/mvalais/code/cert-manager                            \
      --report-dir=/home/mvalais/code/cert-manager/_bin/artifacts            \
      --acme-dns-server=10.0.0.16 --acme-ingress-ip=10.0.0.15                \
      --acme-gateway-ip=10.0.0.14                                            \
      --ingress-controller-domain=ingress-nginx.http01.example.com           \
      --gateway-domain=gateway.http01.example.com                            \
      --feature-gates=""                                                     \
      --ginkgo.focus=".*should be ready with a valid serviceAccountRef"

Result:

    error install helm chart: cmd.Run: exit status 1: io.Copy: write /dev/stdout: copy_file_range: use of closed file

https://pkg.go.dev/os/exec#Cmd.StdoutPipe

/kind flake

```release-note
NONE
```
