### PR TITLE
Use jetstack vcert fork to properly reset on TPP error

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -15,7 +15,7 @@ github.com/Masterminds/semver/v3,https://github.com/Masterminds/semver/blob/v3.1
 github.com/Masterminds/sprig/v3,https://github.com/Masterminds/sprig/blob/v3.2.2/LICENSE.txt,MIT
 github.com/Masterminds/squirrel,https://github.com/Masterminds/squirrel/blob/v1.5.3/LICENSE.txt,MIT
 github.com/NYTimes/gziphandler,https://github.com/NYTimes/gziphandler/blob/v1.1.1/LICENSE,Apache-2.0
-github.com/Venafi/vcert/v4,https://github.com/Venafi/vcert/blob/v4.23.0/LICENSE,Apache-2.0
+github.com/Venafi/vcert/v4,https://github.com/jetstack/vcert/blob/3aa3dfd6613d/LICENSE,Apache-2.0
 github.com/akamai/AkamaiOPEN-edgegrid-golang,https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v1.2.2/LICENSE,Apache-2.0
 github.com/antlr/antlr4/runtime/Go/antlr,https://github.com/antlr/antlr4/blob/runtime/Go/antlr/v1.4.10/runtime/Go/antlr/LICENSE,BSD-3-Clause
 github.com/armon/go-metrics,https://github.com/armon/go-metrics/blob/v0.3.9/LICENSE,MIT

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.21
 	github.com/Azure/go-autorest/autorest/to v0.4.0
-	github.com/Venafi/vcert/v4 v4.23.0
+	github.com/Venafi/vcert/v4 v4.0.0-00010101000000-000000000000
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/aws/aws-sdk-go v1.44.179
 	github.com/cloudflare/cloudflare-go v0.58.1
@@ -256,3 +256,6 @@ require (
 )
 
 replace github.com/miekg/dns v1.1.41 => github.com/miekg/dns v1.1.34
+
+// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
+replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
-github.com/Venafi/vcert/v4 v4.23.0 h1:FlHqH+gVMEIDJ5Orkb9mdWaPFVx746gkIcnTfjVufR0=
-github.com/Venafi/vcert/v4 v4.23.0/go.mod h1:4Nec3twWisOdS1unpDZ93sfau9eVSDS8Ot+Ry/gg0es=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2 h1:F1j7z+/DKEsYqZNoxC6wvfmaiDneLsQOFQmuq9NADSY=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2/go.mod h1:QlXr/TrICfQ/ANa76sLeQyhAJyNR9sEcfNuZBkY9jgY=
@@ -597,6 +595,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d h1:V9SfHhSwP97N8ziqP621+qk5FJ+oMh8Lu9ttrL2/U3o=
+github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d/go.mod h1:SWmRLLPU0f2ujjVaEUssKKSxYHhznpohrPYxUpjsGFg=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=


### PR DESCRIPTION
### Pull Request Motivation

In case we send a new valid CSR to TPP after a TPP error occurred, we get the following error message: `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`

In https://github.com/cert-manager/cert-manager/pull/5674 we introduced the https://github.com/Venafi/vcert/pull/269 fix for this issue. However, we found out that this fix does often fail due in a race condition (see https://github.com/jetstack/vcert/pull/3). The race condition causes the requested CSR to get lost when calling reset too soon after requesting, resulting in the old Certificate being returned instead in a non-failure mode.

In order to fix the original issue, without having a race condition, we created https://github.com/jetstack/vcert/pull/3 which unconditionally calls the reset endpoint before requesting a certificate from TPP. This reset call will not continue if no certificate is found or if the certificate is in a non-failed state, only resetting the TPP certificate in case there was an error. We call the reset endpoint with restart=false as argument which does mean that we do not restart the issuance. Instead, we start a new issuance by requesting a new certificate after calling the reset endpoint. This solution solves the original issue and does not have any race conditions. However, it does introduce an additional HTTP call per issuance. We have not found any other solution that works as reliably as this solution, but are committed to updating our vCert fork if we find a more efficient solution that works as reliably as this solution.

### Kind

/kind bug

### Release Note

```release-note
The auto-retry mechanism added in VCert 4.23.0 and part of cert-manager 1.11.0 (#5674) has been found to be faulty. Until this issue is fixed upstream, we now use a patched version of VCert. This patch will slowdown the issuance of certificates by 9% in case of heavy load on TPP. We aim to release at an ulterior date a patch release of cert-manager to fix this slowdown.
```
