### PR TITLE
Handle uname on linux/arm64

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -51,8 +51,11 @@ $(BINDIR)/scratch/%_VERSION: FORCE | $(BINDIR)/scratch
 # and Intel).
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 HOST_ARCH = $(shell uname -m)
+
 ifeq (x86_64, $(HOST_ARCH))
 	HOST_ARCH = amd64
+else ifeq (aarch64, $(HOST_ARCH))
+	HOST_ARCH = arm64
 endif
 
 # --silent = don't print output like progress meters


### PR DESCRIPTION
### Pull Request Motivation

On linux/arm64 `uname -m` [gives](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1676652687723599?thread_ts=1676643017.223269&cid=CDEQJ0Q8M) `aarch64`, not `arm64`.

We don't have many people doing development on linux/arm64 so this wasn't spotted, because in macOS `uname -m` gives `arm64`.

### Kind

/kind bug

### Release Note

```release-note
Fix development environment and go vendoring on Linux ARM64.
```
