### PR TITLE
Controller partial metadata

### DIFF
--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -213,8 +213,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -226,7 +226,7 @@ import (
 // its current readiness/state by applying policy functions to it.
 type Gatherer struct {
 	CertificateRequestLister cmlisters.CertificateRequestLister
-	SecretLister             corelisters.SecretLister
+	SecretLister             internalinformers.SecretLister
 }
 
 // DataForCertificate returns the secret as well as the "current" and "next"

--- a/internal/controller/certificates/policies/gatherer_test.go
+++ b/internal/controller/certificates/policies/gatherer_test.go
@@ -168,7 +168,7 @@ func TestDataForCertificate(t *testing.T) {
 			// type by registering a fake handler.
 			noop := cache.ResourceEventHandlerFuncs{AddFunc: func(obj interface{}) {}}
 			test.builder.SharedInformerFactory.Certmanager().V1().CertificateRequests().Informer().AddEventHandler(noop)
-			test.builder.KubeSharedInformerFactory.Core().V1().Secrets().Informer().AddEventHandler(noop)
+			test.builder.KubeSharedInformerFactory.Secrets().Informer().AddEventHandler(noop)
 
 			// Even though we are only relying on listers in this unit test
 			// and do not use the informer event handlers, we still need to
@@ -212,7 +212,7 @@ func TestDataForCertificate(t *testing.T) {
 
 			g := &Gatherer{
 				CertificateRequestLister: test.builder.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister(),
-				SecretLister:             test.builder.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+				SecretLister:             test.builder.KubeSharedInformerFactory.Secrets().Lister(),
 			}
 
 			ctx := logf.NewContext(context.Background(), logf.WithResource(log, test.givenCert))

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -70,6 +70,17 @@ const (
 	// This feature will add BasicConstraints section with CA field defaulting to false; CA field will be set true if the Certificate resource spec has isCA as true
 	// Github Issue: https://github.com/cert-manager/cert-manager/issues/5539
 	UseCertificateRequestBasicConstraints featuregate.Feature = "UseCertificateRequestBasicConstraints"
+
+	// Owner: @irbekrm
+	// Alpha v1.12
+	// SecretsFilteredCaching reduces controller's memory consumption by
+	// filtering which Secrets are cached in full using
+	// `controller.cert-manager.io/fao` label. By default all Certificate
+	// Secrets are labelled with controller.cert-manager.io/fao label. Users
+	// can also label other Secrets, such as issuer credentials Secrets that
+	// they know cert-manager will need access to to speed up issuance.
+	// See https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md
+	SecretsFilteredCaching featuregate.Feature = "SecretsFilteredCaching"
 )
 
 func init() {
@@ -88,4 +99,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},
 	StableCertificateRequestName:                     {Default: false, PreRelease: featuregate.Alpha},
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
+	SecretsFilteredCaching:                           {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	certificatesv1 "k8s.io/client-go/informers/certificates/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	networkingv1informers "k8s.io/client-go/informers/networking/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// This file contains common informers functionality such as shared interfaces
+// The interfaces defined here are mostly a subset of similar interfaces upstream.
+// Defining our own instead of reusing the upstream ones allows us to:
+// - create smaller interfaces that don't have methods that our control loops don't need (thus avoiding to define unnecessary methods in implementations)
+// - swap embedded upstream interfaces for our own ones
+
+var secretsGVR = corev1.SchemeGroupVersion.WithResource("secrets")
+
+const pleaseOpenIssue = "Please report this by opening an issue with this error and cert-manager controller logs and stack trace https://github.com/cert-manager/cert-manager/issues/new/choose"
+
+// KubeSharedInformerFactory represents a subset of methods in
+// informers.sharedInformerFactory. It allows us to use a wrapper around
+// informers.sharedInformerFactory to enforce particular custom informers for
+// certain types, for example a filtered informer for Secrets If you need to
+// start watching a new core type, add a method that returns an informer for
+// that type here. If you don't need special filters, make it return an informer
+// from baseFactory
+type KubeInformerFactory interface {
+	Start(<-chan struct{})
+	WaitForCacheSync(<-chan struct{}) map[string]bool
+	Pods() corev1informers.PodInformer
+	Services() corev1informers.ServiceInformer
+	Ingresses() networkingv1informers.IngressInformer
+	Secrets() SecretInformer
+	CertificateSigningRequests() certificatesv1.CertificateSigningRequestInformer
+}
+
+// SecretInformer is like client-go SecretInformer
+// https://github.com/kubernetes/client-go/blob/release-1.26/informers/core/v1/secret.go#L35-L40
+// but embeds our own interfaces with a smaller subset of methods.
+type SecretInformer interface {
+	// Informer ensures that an Informer has been initialized and returns the initialized informer.
+	Informer() Informer
+	// Lister returns a lister for the initialized informer. It will also ensure that the informer exists.
+	Lister() SecretLister
+}
+
+// SecretLister is a subset of client-go SecretLister functionality https://github.com/kubernetes/client-go/blob/release-1.26/listers/core/v1/secret.go#L28-L37
+type SecretLister interface {
+	// Secrets returns a namespace secrets getter/lister
+	Secrets(namespace string) corev1listers.SecretNamespaceLister
+}
+
+// Informer is a subset of client-go SharedIndexInformer https://github.com/kubernetes/client-go/blob/release-1.26/tools/cache/shared_informer.go#L35-L211
+type Informer interface {
+	// AddEventHadler allows reconcile loop to register an event handler so
+	// it gets triggered when the informer has a new event
+	AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
+	// HasSynced returns true if the informer's cache has synced (at least
+	// one LIST has been performed)
+	HasSynced() bool
+}

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -43,7 +43,7 @@ type baseFactory struct {
 
 func NewBaseKubeInformerFactory(client kubernetes.Interface, resync time.Duration, namespace string) KubeInformerFactory {
 	return &baseFactory{
-		f: kubeinformers.NewSharedInformerFactory(client, resync),
+		f: kubeinformers.NewSharedInformerFactoryWithOptions(client, resync, kubeinformers.WithNamespace(namespace)),
 		// namespace is set to a non-empty value if cert-manager
 		// controller is scoped to a single namespace via --namespace
 		// flag

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	certificatesv1 "k8s.io/client-go/informers/certificates/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	networkingv1informers "k8s.io/client-go/informers/networking/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// This file contains an implementation of core informers that wraps the core
+// upstream informers without any custom modifications
+
+// baseFactory is an implementation of KubeSharedInformerFactory that returns
+// standard upstream informer functionality
+type baseFactory struct {
+	f kubeinformers.SharedInformerFactory
+	// namespace is set if cert-manager controller is scoped to a single
+	// namespace
+	namespace string
+}
+
+func NewBaseKubeInformerFactory(client kubernetes.Interface, resync time.Duration, namespace string) KubeInformerFactory {
+	return &baseFactory{
+		f: kubeinformers.NewSharedInformerFactory(client, resync),
+		// namespace is set to a non-empty value if cert-manager
+		// controller is scoped to a single namespace via --namespace
+		// flag
+		namespace: namespace,
+	}
+}
+
+func (bf *baseFactory) Start(stopCh <-chan struct{}) {
+	bf.f.Start(stopCh)
+}
+
+func (bf *baseFactory) WaitForCacheSync(stopCh <-chan struct{}) map[string]bool {
+	ret := make(map[string]bool)
+	cacheSyncs := bf.f.WaitForCacheSync(stopCh)
+	for key, val := range cacheSyncs {
+		ret[key.String()] = val
+	}
+	return ret
+}
+
+func (bf *baseFactory) Pods() corev1informers.PodInformer {
+	return bf.f.Core().V1().Pods()
+}
+
+func (bf *baseFactory) Services() corev1informers.ServiceInformer {
+	return bf.f.Core().V1().Services()
+}
+
+func (bf *baseFactory) Ingresses() networkingv1informers.IngressInformer {
+	return bf.f.Networking().V1().Ingresses()
+}
+
+func (bf *baseFactory) Secrets() SecretInformer {
+	return &baseSecretInformer{
+		f:         bf.f,
+		namespace: bf.namespace,
+	}
+}
+
+func (bf *baseFactory) CertificateSigningRequests() certificatesv1.CertificateSigningRequestInformer {
+	return bf.f.Certificates().V1().CertificateSigningRequests()
+}
+
+var _ SecretInformer = &baseSecretInformer{}
+
+// baseSecretInformer is an implementation of SecretInformer that only uses
+// upstream client-go functionality
+type baseSecretInformer struct {
+	f         kubeinformers.SharedInformerFactory
+	informer  cache.SharedIndexInformer
+	namespace string
+}
+
+func (bsi *baseSecretInformer) Informer() Informer {
+	bsi.informer = bsi.f.InformerFor(&corev1.Secret{}, bsi.new)
+	return bsi.informer
+}
+
+func (bsi *baseSecretInformer) Lister() SecretLister {
+	return corev1listers.NewSecretLister(bsi.f.InformerFor(&corev1.Secret{}, bsi.new).GetIndexer())
+}
+
+func (bsi *baseSecretInformer) new(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return corev1informers.NewSecretInformer(client, bsi.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+}

--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	kubeinformers "k8s.io/client-go/informers"
+	certificatesv1 "k8s.io/client-go/informers/certificates/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	internalinterfaces "k8s.io/client-go/informers/internalinterfaces"
+	networkingv1informers "k8s.io/client-go/informers/networking/v1"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
+	"k8s.io/client-go/metadata/metadatalister"
+	"k8s.io/client-go/tools/cache"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+)
+
+// This file contains all the functionality for implementing core informers with a filter for Secrets
+// https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md
+var (
+	isCertManageSecretLabelSelector     labels.Selector
+	isNotCertManagerSecretLabelSelector labels.Selector
+)
+
+func init() {
+	r, err := labels.NewRequirement(cmapi.PartOfCertManagerControllerLabelKey, selection.Equals, []string{"true"})
+	if err != nil {
+		panic(fmt.Errorf("internal error: failed to build label selector to filter cert-manager secrets: %w", err))
+	}
+	isCertManageSecretLabelSelector = labels.NewSelector().Add(*r)
+
+	r, err = labels.NewRequirement(cmapi.PartOfCertManagerControllerLabelKey, selection.DoesNotExist, make([]string, 0))
+	if err != nil {
+		panic(fmt.Errorf("internal error: failed to build label selector to filter non-cert-manager secrets: %w", err))
+	}
+	isNotCertManagerSecretLabelSelector = labels.NewSelector().Add(*r)
+}
+
+type filteredSecretsFactory struct {
+	typedInformerFactory    kubeinformers.SharedInformerFactory
+	metadataInformerFactory metadatainformer.SharedInformerFactory
+	client                  kubernetes.Interface
+	namespace               string
+	ctx                     context.Context
+}
+
+func NewFilteredSecretsKubeInformerFactory(ctx context.Context, typedClient kubernetes.Interface, metadataClient metadata.Interface, resync time.Duration, namespace string) KubeInformerFactory {
+	return &filteredSecretsFactory{
+		typedInformerFactory: kubeinformers.NewSharedInformerFactory(typedClient, resync),
+		metadataInformerFactory: metadatainformer.NewFilteredSharedInformerFactory(metadataClient, resync, namespace, func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = isNotCertManagerSecretLabelSelector.String()
+
+		}),
+		// namespace is set to a non-empty value if cert-manager
+		// controller is scoped to a single namespace via --namespace
+		// flag
+		namespace: namespace,
+		client:    typedClient,
+		// Go recommends to not store context in
+		// structs, but here we have no other way as we need to use root context inside
+		// Get whose signature is defined upstream and does not accept context
+		ctx: ctx,
+	}
+}
+
+func (bf *filteredSecretsFactory) Start(stopCh <-chan struct{}) {
+	bf.typedInformerFactory.Start(stopCh)
+	bf.metadataInformerFactory.Start(stopCh)
+}
+
+func (bf *filteredSecretsFactory) WaitForCacheSync(stopCh <-chan struct{}) map[string]bool {
+	caches := make(map[string]bool)
+	typedCaches := bf.typedInformerFactory.WaitForCacheSync(stopCh)
+	partialMetaCaches := bf.metadataInformerFactory.WaitForCacheSync(stopCh)
+	// We have to cast the keys into string type. It is not possible to
+	// create a generic type here as neither of the types returned by
+	// WaitForCacheSync are valid map key arguments in generics- they aren't
+	// comparable types.
+	for key, val := range typedCaches {
+		caches[key.String()] = val
+	}
+	for key, val := range partialMetaCaches {
+		caches[key.String()] = val
+	}
+	return caches
+}
+
+func (bf *filteredSecretsFactory) Pods() corev1informers.PodInformer {
+	return bf.typedInformerFactory.Core().V1().Pods()
+}
+
+func (bf *filteredSecretsFactory) Services() corev1informers.ServiceInformer {
+	return bf.typedInformerFactory.Core().V1().Services()
+}
+
+func (bf *filteredSecretsFactory) Ingresses() networkingv1informers.IngressInformer {
+	return bf.typedInformerFactory.Networking().V1().Ingresses()
+}
+
+func (bf *filteredSecretsFactory) CertificateSigningRequests() certificatesv1.CertificateSigningRequestInformer {
+	return bf.typedInformerFactory.Certificates().V1().CertificateSigningRequests()
+}
+
+func (bf *filteredSecretsFactory) Secrets() SecretInformer {
+	f := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+		return corev1informers.NewFilteredSecretInformer(client, bf.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = isCertManageSecretLabelSelector.String()
+		})
+	}
+	return &filteredSecretInformer{
+		typedInformerFactory:    bf.typedInformerFactory,
+		metadataInformerFactory: bf.metadataInformerFactory,
+		namespace:               bf.namespace,
+		typedClient:             bf.client.CoreV1(),
+		newTyped:                f,
+		ctx:                     bf.ctx,
+	}
+}
+
+// filteredSecretInformer is an implementation of SecretInformer that uses two
+// caches (typed and metadata) to list and watch Secrets
+type filteredSecretInformer struct {
+	typedInformerFactory    kubeinformers.SharedInformerFactory
+	metadataInformerFactory metadatainformer.SharedInformerFactory
+	typedClient             typedcorev1.SecretsGetter
+	newTyped                internalinterfaces.NewInformerFunc
+
+	namespace string
+	// Go recommends to not store context in
+	// structs, but here we have no other way as we need to use root context inside
+	// Get whose signature is defined upstream and does not accept context
+	ctx context.Context
+}
+
+func (f *filteredSecretInformer) Informer() Informer {
+	typedInformer := f.typedInformerFactory.InformerFor(&corev1.Secret{}, f.newTyped)
+	// TODO: set any possible transforms
+	metadataInformer := f.metadataInformerFactory.ForResource(secretsGVR).Informer()
+	// TODO: set transform on metadataInformer to remove last applied annotation etc
+	return &informer{
+		typedInformer:    typedInformer,
+		metadataInformer: metadataInformer,
+	}
+}
+
+func (f *filteredSecretInformer) Lister() SecretLister {
+	typedLister := corev1listers.NewSecretLister(f.typedInformerFactory.InformerFor(&corev1.Secret{}, f.newTyped).GetIndexer())
+	metadataLister := metadatalister.New(f.metadataInformerFactory.ForResource(secretsGVR).Informer().GetIndexer(), secretsGVR)
+	return &secretLister{
+		typedClient:           f.typedClient,
+		namespace:             f.namespace,
+		typedLister:           typedLister,
+		partialMetadataLister: metadataLister,
+		ctx:                   f.ctx,
+	}
+}
+
+// informer is an implementation of Informer interface
+type informer struct {
+	typedInformer    cache.SharedIndexInformer
+	metadataInformer cache.SharedIndexInformer
+}
+
+func (i *informer) HasSynced() bool {
+	return i.typedInformer.HasSynced() && i.metadataInformer.HasSynced()
+}
+
+func (i *informer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	_, err := i.metadataInformer.AddEventHandler(handler)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.typedInformer.AddEventHandler(handler)
+	return nil, err
+}
+
+// secretLister is an implementation of SecretLister with a namespaced lister
+// that knows how to do conditional GET/LIST of Secrets using a combination of
+// typed and metadata cache and kube apiserver
+type secretLister struct {
+	namespace             string
+	partialMetadataLister metadatalister.Lister
+	typedLister           corev1listers.SecretLister
+	typedClient           typedcorev1.SecretsGetter
+	// TODO: add link
+	// Go recommends to not store context in
+	// structs, but here we have no other way as we need to use root context inside
+	// Get whose signature is defined upstream and does not accept context
+	ctx context.Context
+}
+
+func (sl *secretLister) Secrets(namespace string) corev1listers.SecretNamespaceLister {
+	return &secretNamespaceLister{
+		namespace:             namespace,
+		partialMetadataLister: sl.partialMetadataLister,
+		typedLister:           sl.typedLister,
+		typedClient:           sl.typedClient,
+		ctx:                   sl.ctx,
+	}
+}
+
+var _ corev1listers.SecretNamespaceLister = &secretNamespaceLister{}
+
+// secretNamespaceLister is an implementation of
+// corelisters.SecretNamespaceLister
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/listers/core/v1/secret.go#L62-L72.
+// It knows how to get and list Secrets using typed and partial metadata caches
+// and kube apiserver. It looks for Secrets in both caches, if the Secret is
+// found in metadata cache, it will retrieve it from kube apiserver.
+type secretNamespaceLister struct {
+	namespace             string
+	partialMetadataLister metadatalister.Lister
+	typedLister           corev1listers.SecretLister
+	typedClient           typedcorev1.SecretsGetter
+	// TODO: add link
+	// Go recommends to not store context in
+	// structs, but here we have no other way as we need to use root context inside
+	// Get whose signature is defined upstream and does not accept context
+	ctx context.Context
+}
+
+func (snl *secretNamespaceLister) Get(name string) (*corev1.Secret, error) {
+	log := logf.FromContext(snl.ctx)
+	log = log.WithValues("secret", name, "namespace", snl.namespace)
+	// TODO: debug print
+	log.Info("Getting secret from cache")
+	var secretFoundInTypedCache, secretFoundInMetadataCache bool
+	secret, err := snl.typedLister.Secrets(snl.namespace).Get(name)
+	if err == nil {
+		secretFoundInTypedCache = true
+	}
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "error getting secret from typed cache")
+		return nil, fmt.Errorf("error retrieving secret from the typed cache: %w", err)
+	}
+	_, partialMetadataGetErr := snl.partialMetadataLister.Namespace(snl.namespace).Get(name)
+	if partialMetadataGetErr == nil {
+		// TODO: debug line
+		log.Info("Secret found in partial metadata cache, getting it from kube apiserver")
+		secretFoundInMetadataCache = true
+	}
+
+	if partialMetadataGetErr != nil && !apierrors.IsNotFound(partialMetadataGetErr) {
+		return nil, fmt.Errorf("error retrieving object from partial object metadata cache: %w", err)
+	}
+
+	if secretFoundInMetadataCache && secretFoundInTypedCache {
+		// TODO: this error message should be made into something that makes sense to users if they see it
+		log.Info(fmt.Sprintf("warning: possible internal error: stale cache: secret found both in typed cache and in partial cache: %s", pleaseOpenIssue), "secret name")
+		return snl.typedClient.Secrets(snl.namespace).Get(snl.ctx, name, metav1.GetOptions{})
+	}
+
+	if secretFoundInTypedCache {
+		// TODO: remove debug line
+		log.Info("secret found in typed cache, returning the cached version")
+		return secret, nil
+	}
+
+	if secretFoundInMetadataCache {
+		return snl.typedClient.Secrets(snl.namespace).Get(snl.ctx, name, metav1.GetOptions{})
+	}
+
+	// TODO: debug line
+	log.Info("secret neither in typed nor metadata cache")
+	// TODO: we want to return apierrors.ErrNotFound here, but which one?
+	return nil, partialMetadataGetErr
+}
+
+func (snl *secretNamespaceLister) List(selector labels.Selector) ([]*corev1.Secret, error) {
+	log := logf.FromContext(snl.ctx)
+	log = log.WithValues("secrets namespace", snl.namespace, "secrets selector", selector.String())
+	matchingSecretsMap := make(map[string]*corev1.Secret)
+	typedSecrets, err := snl.typedLister.List(selector)
+	if err != nil {
+		log.Error(err, "error listing Secrets from typed cache")
+		return nil, err
+	}
+	for _, secret := range typedSecrets {
+		key := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}.String()
+		matchingSecretsMap[key] = secret
+	}
+	metadataSecrets, err := snl.partialMetadataLister.List(selector)
+	if err != nil {
+		log.Error(err, "error listing Secrets from metadata only cache")
+		return nil, err
+	}
+	for _, secretMeta := range metadataSecrets {
+		unstructuredObj, err := objectToUnstructured(secretMeta)
+		if err != nil {
+			log.Error(err, "error converting runtime object to unstructured")
+			return nil, err
+		}
+		name := unstructuredObj.GetName()
+		key := types.NamespacedName{Namespace: snl.namespace, Name: name}.String()
+		if _, ok := matchingSecretsMap[key]; ok {
+			log.Info(fmt.Sprintf("warning: possible internal error: stale cache: secret found both in typed cache and in partial cache: %s", pleaseOpenIssue), "secret name", name)
+			// do nothing- use object from typed cache
+		}
+		secret, err := snl.typedClient.Secrets(snl.namespace).Get(snl.ctx, name, metav1.GetOptions{})
+		if err != nil {
+			log.Error(err, "error retrieving secret from kube apiserver", "secret name", name)
+			return nil, err
+		}
+		matchingSecretsMap[key] = secret
+	}
+
+	matchingSecrets := make([]*corev1.Secret, 0)
+	for _, val := range matchingSecretsMap {
+		matchingSecrets = append(matchingSecrets, val)
+	}
+	return matchingSecrets, nil
+}
+
+func objectToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	unstructuredContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{}
+	u.SetUnstructuredContent(unstructuredContent)
+	u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+	return u, nil
+}

--- a/internal/informers/core_filteredsecrets_test.go
+++ b/internal/informers/core_filteredsecrets_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/metadata/metadatalister"
+)
+
+func Test_secretNamespaceLister_Get(t *testing.T) {
+
+	var (
+		data       = []byte("foo")
+		testSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo",
+			},
+			Data: map[string][]byte{"foo": data},
+		}
+	)
+	tests := map[string]struct {
+		namespace             string
+		name                  string
+		partialMetadataLister metadatalister.Lister
+		typedLister           corev1listers.SecretLister
+		typedClient           typedcorev1.SecretsGetter
+		want                  *corev1.Secret
+		wantErr               bool
+	}{
+		"if querying typed cache returns an error that is not 'not found' error, return the error": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return nil, errors.New("some error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"if querying metadata cache returns an error that is not a 'not found' error, return the error": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return nil, nil
+					},
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				NamespaceLister: FakeMetadataNamespaceLister{
+					FakeGet: func(string) (*metav1.PartialObjectMetadata, error) {
+						return nil, errors.New("some error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"if Secret found in typed cache, return it from there": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return testSecret, nil
+					},
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				NamespaceLister: FakeMetadataNamespaceLister{
+					FakeGet: func(string) (*metav1.PartialObjectMetadata, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "foo")
+					},
+				},
+			},
+			want: testSecret,
+		},
+		"if Secret found in metadata cache, return it from kube apiserver": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "foo")
+					},
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				NamespaceLister: FakeMetadataNamespaceLister{
+					FakeGet: func(string) (*metav1.PartialObjectMetadata, error) {
+						return &metav1.PartialObjectMetadata{}, nil
+					},
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return testSecret, nil
+						},
+					}
+				},
+			},
+			want: testSecret,
+		},
+		"if Secret found in both caches, return it from kube apiserver": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return &corev1.Secret{}, nil
+					},
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				NamespaceLister: FakeMetadataNamespaceLister{
+					FakeGet: func(string) (*metav1.PartialObjectMetadata, error) {
+						return &metav1.PartialObjectMetadata{}, nil
+					},
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return testSecret, nil
+						},
+					}
+				},
+			},
+			want: testSecret,
+		},
+		"if Secret found in metadata cache, but querying kube apiserver errors, return the error": {
+			namespace: "foo",
+			name:      "foo",
+			typedLister: FakeSecretLister{
+				NamespaceLister: FakeSecretNamespaceLister{
+					FakeGet: func(string) (*corev1.Secret, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "foo")
+					},
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				NamespaceLister: FakeMetadataNamespaceLister{
+					FakeGet: func(string) (*metav1.PartialObjectMetadata, error) {
+						return &metav1.PartialObjectMetadata{}, nil
+					},
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return nil, errors.New("some error")
+						},
+					}
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			snl := &secretNamespaceLister{
+				namespace:             scenario.namespace,
+				partialMetadataLister: scenario.partialMetadataLister,
+				typedLister:           scenario.typedLister,
+				typedClient:           scenario.typedClient,
+				ctx:                   context.Background(),
+			}
+			got, err := snl.Get(name)
+			if (err != nil) != scenario.wantErr {
+				t.Errorf("secretNamespaceLister.Get() error = %v, wantErr %v", err, scenario.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, scenario.want) {
+				t.Errorf("secretNamespaceLister.Get() = %v, want %v", got, scenario.want)
+			}
+		})
+	}
+}
+
+func Test_secretNamespaceLister_List(t *testing.T) {
+
+	var (
+		someData     = []byte("foobar")
+		someSelector = labels.Everything()
+		secretFoo    = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo",
+			},
+			Data: map[string][]byte{"someKey": someData},
+		}
+		secretFoo2 = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo",
+			},
+			Data: map[string][]byte{"someOtherKey": someData},
+		}
+		secretBar = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "bar",
+			},
+			Data: map[string][]byte{"someKey": someData},
+		}
+		secretFooMeta = metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foo",
+			},
+		}
+	)
+	tests := map[string]struct {
+		namespace             string
+		partialMetadataLister metadatalister.Lister
+		typedLister           corev1listers.SecretLister
+		typedClient           typedcorev1.SecretsGetter
+		want                  []*corev1.Secret
+		wantErr               bool
+	}{
+		"if listing Secrets from typed cache errors out then return the error": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return nil, errors.New("some error")
+				},
+			},
+			wantErr: true,
+		},
+		"if listing Secrets from metadata cache errors out then return the error": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return nil, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return nil, errors.New("some error")
+				},
+			},
+			wantErr: true,
+		},
+		"if no Secrets are found within either cache, don't return any": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return nil, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return nil, nil
+				},
+			},
+			want: make([]*corev1.Secret, 0),
+		},
+		"if some Secrets are found in typed cache, return those": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return []*corev1.Secret{&secretBar, &secretFoo}, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return nil, nil
+				},
+			},
+			want: []*corev1.Secret{&secretBar, &secretFoo},
+		},
+		"if a Secret is found in metadata only cache, return it from kube apiserver": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return nil, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return []*metav1.PartialObjectMetadata{&secretFooMeta}, nil
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return &secretFoo, nil
+						},
+					}
+				},
+			},
+			want: []*corev1.Secret{&secretFoo},
+		},
+		"if matching non-duplicate Secrets are found in both caches, return them": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return []*corev1.Secret{&secretBar}, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return []*metav1.PartialObjectMetadata{&secretFooMeta}, nil
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return &secretFoo, nil
+						},
+					}
+				},
+			},
+			want: []*corev1.Secret{&secretFoo, &secretBar},
+		},
+		"if matching Secrets are found in both caches with some duplicates, then returned the duplicates from kube apiserver": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return []*corev1.Secret{&secretFoo2}, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return []*metav1.PartialObjectMetadata{&secretFooMeta}, nil
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return &secretFoo, nil
+						},
+					}
+				},
+			},
+			want: []*corev1.Secret{&secretFoo},
+		},
+		"if a Secret is found in metadata only cache, but querying kube apiserver errors, return the error": {
+
+			namespace: "foo",
+			typedLister: FakeSecretLister{
+				FakeList: func(labels.Selector) ([]*corev1.Secret, error) {
+					return nil, nil
+				},
+			},
+			partialMetadataLister: FakeMetadataLister{
+				FakeList: func(labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+					return []*metav1.PartialObjectMetadata{&secretFooMeta}, nil
+				},
+			},
+			typedClient: FakeSecretsGetter{
+				FakeSecrets: func(string) typedcorev1.SecretInterface {
+					return FakeSecretInterface{
+						FakeGet: func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+							return nil, errors.New("some error")
+						},
+					}
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			snl := &secretNamespaceLister{
+				namespace:             scenario.namespace,
+				partialMetadataLister: scenario.partialMetadataLister,
+				typedLister:           scenario.typedLister,
+				typedClient:           scenario.typedClient,
+				ctx:                   context.Background(),
+			}
+			got, err := snl.List(someSelector)
+			if (err != nil) != scenario.wantErr {
+				t.Errorf("secretNamespaceLister.List() error = %v, wantErr %v", err, scenario.wantErr)
+				return
+			}
+			assert.ElementsMatch(t, got, scenario.want)
+		})
+	}
+}

--- a/internal/informers/fakes.go
+++ b/internal/informers/fakes.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	applyconfigcorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/metadata/metadatalister"
+)
+
+// FakeSecretLister is a fake of SecretLister
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/listers/core/v1/secret.go#L28-L37
+type FakeSecretLister struct {
+	NamespaceLister FakeSecretNamespaceLister
+	FakeList        func(labels.Selector) ([]*corev1.Secret, error)
+}
+
+func (fsl FakeSecretLister) List(selector labels.Selector) ([]*corev1.Secret, error) {
+	return fsl.FakeList(selector)
+}
+
+func (fsl FakeSecretLister) Secrets(namespace string) corev1listers.SecretNamespaceLister {
+	return fsl.NamespaceLister
+}
+
+// FakeSecretNamespaceLister is a fake of SecretNamespaceLister
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/listers/core/v1/secret.go#L62-L72.
+type FakeSecretNamespaceLister struct {
+	FakeList func(labels.Selector) ([]*corev1.Secret, error)
+	FakeGet  func(string) (*corev1.Secret, error)
+}
+
+func (fsnl FakeSecretNamespaceLister) List(selector labels.Selector) ([]*corev1.Secret, error) {
+	return fsnl.FakeList(selector)
+}
+
+func (fsnl FakeSecretNamespaceLister) Get(name string) (*corev1.Secret, error) {
+	return fsnl.FakeGet(name)
+}
+
+// FakeMetadataLister is a fake of metadata Lister
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/metadata/metadatalister/interface.go#L24-L32
+type FakeMetadataLister struct {
+	FakeList        func(labels.Selector) ([]*metav1.PartialObjectMetadata, error)
+	FakeGet         func(string) (*metav1.PartialObjectMetadata, error)
+	NamespaceLister metadatalister.NamespaceLister
+}
+
+func (fml FakeMetadataLister) List(selector labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+	return fml.FakeList(selector)
+}
+
+func (fml FakeMetadataLister) Get(name string) (*metav1.PartialObjectMetadata, error) {
+	return fml.FakeGet(name)
+}
+
+func (fml FakeMetadataLister) Namespace(string) metadatalister.NamespaceLister {
+	return fml.NamespaceLister
+}
+
+// FakeMetadataNamespaceLister is a fake of metadata NamespaceLister
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/metadata/metadatalister/interface.go#L34-L40
+type FakeMetadataNamespaceLister struct {
+	FakeList func(labels.Selector) ([]*metav1.PartialObjectMetadata, error)
+	FakeGet  func(string) (*metav1.PartialObjectMetadata, error)
+}
+
+func (fmnl FakeMetadataNamespaceLister) List(selector labels.Selector) ([]*metav1.PartialObjectMetadata, error) {
+	return fmnl.FakeList(selector)
+}
+
+func (fmnl FakeMetadataNamespaceLister) Get(name string) (*metav1.PartialObjectMetadata, error) {
+	return fmnl.FakeGet(name)
+}
+
+// FakeSecretsGetter is a fake of corev1 SecretsGetter
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/kubernetes/typed/core/v1/secret.go#L33-L37
+type FakeSecretsGetter struct {
+	FakeSecrets func(string) typedcorev1.SecretInterface
+}
+
+func (fsg FakeSecretsGetter) Secrets(namespace string) typedcorev1.SecretInterface {
+	return fsg.FakeSecrets(namespace)
+}
+
+// FakeSecretInterface is a fake of corev1 SecretInterface
+// https://github.com/kubernetes/client-go/blob/0382bf0f53b2294d4ac448203718f0ba774a477d/kubernetes/typed/core/v1/secret.go#L39-L50
+type FakeSecretInterface struct {
+	FakeGet  func(context.Context, string, metav1.GetOptions) (*corev1.Secret, error)
+	FakeList func(context.Context, metav1.ListOptions) (*corev1.SecretList, error)
+}
+
+func (fsi FakeSecretInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+	return fsi.FakeGet(ctx, name, opts)
+}
+func (fsi FakeSecretInterface) List(ctx context.Context, opts metav1.ListOptions) (*corev1.SecretList, error) {
+	return fsi.FakeList(ctx, opts)
+}
+
+func (fsi FakeSecretInterface) Create(ctx context.Context, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {
+	panic("not implemented")
+}
+
+func (fsi FakeSecretInterface) Update(ctx context.Context, secret *corev1.Secret, opts metav1.UpdateOptions) (*corev1.Secret, error) {
+	panic("not implemented")
+}
+func (fsi FakeSecretInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	panic("not implemented")
+}
+func (fsi FakeSecretInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	panic("not implemeted")
+}
+func (fsi FakeSecretInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+func (fsi FakeSecretInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *corev1.Secret, err error) {
+	panic("not implemented")
+}
+func (fsi FakeSecretInterface) Apply(ctx context.Context, secret *applyconfigcorev1.SecretApplyConfiguration, opts metav1.ApplyOptions) (result *corev1.Secret, err error) {
+	panic("not implemented")
+}

--- a/internal/informers/fakes.go
+++ b/internal/informers/fakes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2023 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/vault/fake/vault.go
+++ b/internal/vault/fake/vault.go
@@ -20,14 +20,13 @@ package fake
 import (
 	"time"
 
-	corelisters "k8s.io/client-go/listers/core/v1"
-
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 // Vault is a mock implementation of the Vault interface
 type Vault struct {
-	NewFn                           func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)
+	NewFn                           func(string, internalinformers.SecretLister, cmapi.GenericIssuer) (*Vault, error)
 	SignFn                          func([]byte, time.Duration) ([]byte, []byte, error)
 	IsVaultInitializedAndUnsealedFn func() error
 }
@@ -43,7 +42,7 @@ func New() *Vault {
 		},
 	}
 
-	v.NewFn = func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error) {
+	v.NewFn = func(string, internalinformers.SecretLister, cmapi.GenericIssuer) (*Vault, error) {
 		return v, nil
 	}
 
@@ -64,13 +63,13 @@ func (v *Vault) WithSign(certPEM, caPEM []byte, err error) *Vault {
 }
 
 // WithNew sets the fake Vault's New function.
-func (v *Vault) WithNew(f func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)) *Vault {
+func (v *Vault) WithNew(f func(string, internalinformers.SecretLister, cmapi.GenericIssuer) (*Vault, error)) *Vault {
 	v.NewFn = f
 	return v
 }
 
 // New call NewFn and returns a pointer to the fake Vault.
-func (v *Vault) New(ns string, sl corelisters.SecretLister, iss v1.GenericIssuer) (*Vault, error) {
+func (v *Vault) New(ns string, sl internalinformers.SecretLister, iss cmapi.GenericIssuer) (*Vault, error) {
 	_, err := v.NewFn(ns, sl, iss)
 	if err != nil {
 		return nil, err

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -31,9 +31,9 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/utils/pointer"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -43,7 +43,7 @@ var _ Interface = &Vault{}
 
 // ClientBuilder is a function type that returns a new Interface.
 // Can be used in tests to create a mock signer of Vault certificate requests.
-type ClientBuilder func(namespace string, _ func(ns string) CreateToken, _ corelisters.SecretLister, _ v1.GenericIssuer) (Interface, error)
+type ClientBuilder func(namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer) (Interface, error)
 
 // Interface implements various high level functionality related to connecting
 // with a Vault server, verifying its status and signing certificate request for
@@ -67,7 +67,7 @@ type CreateToken func(ctx context.Context, saName string, req *authv1.TokenReque
 // Vault client.
 type Vault struct {
 	createToken   CreateToken // Uses the same namespace as below.
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 	issuer        v1.GenericIssuer
 	namespace     string
 
@@ -93,7 +93,7 @@ type Vault struct {
 // secrets lister.
 // Returned errors may be network failures and should be considered for
 // retrying.
-func New(namespace string, createTokenFn func(ns string) CreateToken, secretsLister corelisters.SecretLister, issuer v1.GenericIssuer) (Interface, error) {
+func New(namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer) (Interface, error) {
 	v := &Vault{
 		createToken:   createTokenFn(namespace),
 		secretsLister: secretsLister,

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -213,7 +213,7 @@ comma = ,
 
 # Helm's "--set" interprets commas, which means we want to escape commas
 # for "--set featureGates". That's why we have "\$(comma)".
-feature_gates_controller := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% ValidateCAA=% ExperimentalCertificateSigningRequestControllers=% ExperimentalGatewayAPISupport=% ServerSideApply=% LiteralCertificateSubject=% UseCertificateRequestBasicConstraints=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
+feature_gates_controller := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% ValidateCAA=% ExperimentalCertificateSigningRequestControllers=% ExperimentalGatewayAPISupport=% ServerSideApply=% LiteralCertificateSubject=% UseCertificateRequestBasicConstraints=% SecretsFilteredCaching=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 feature_gates_webhook := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% LiteralCertificateSubject=%,   $(subst $(comma),$(space),$(FEATURE_GATES))))
 feature_gates_cainjector := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -19,8 +19,14 @@ package v1
 const (
 
 	// Common label keys added to resources
-
-	// Label key that indicates that a resource is of interest to cert-manager controller
+	// Label key that indicates that a resource is of interest to
+	// cert-manager controller By default this is set on
+	// certificate.spec.secretName secret as well as on the temporary
+	// private key Secret. If using SecretsFilteredCaching feature, you
+	// might want to set this (with a value of 'true') to any other Secrets
+	// that cert-manager controller needs to read, such as issuer
+	// credentials Secrets.
+	// See https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#risks-and-mitigations
 	PartOfCertManagerControllerLabelKey = "controller.cert-manager.io/fao"
 
 	// Common annotation keys added to resources

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -23,11 +23,11 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
@@ -50,7 +50,7 @@ type controller struct {
 	challengeLister     cmacmelisters.ChallengeLister
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
-	secretLister        corelisters.SecretLister
+	secretLister        internalinformers.SecretLister
 
 	// ACME challenge solvers are instantiated once at the time of controller
 	// construction.
@@ -91,12 +91,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// obtain references to all the informers used by this controller
 	challengeInformer := ctx.SharedInformerFactory.Acme().V1().Challenges()
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
-	secretInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 	// we register these informers here so the HTTP01 solver has a synced
 	// cache when managing pod/service/ingress resources
-	podInformer := ctx.KubeSharedInformerFactory.Core().V1().Pods()
-	serviceInformer := ctx.KubeSharedInformerFactory.Core().V1().Services()
-	ingressInformer := ctx.KubeSharedInformerFactory.Networking().V1().Ingresses()
+	podInformer := ctx.KubeSharedInformerFactory.Pods()
+	serviceInformer := ctx.KubeSharedInformerFactory.Services()
+	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
 
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -22,16 +22,14 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/informers"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -54,7 +52,7 @@ type controller struct {
 	challengeLister     cmacmelisters.ChallengeLister
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
-	secretLister        corelisters.SecretLister
+	secretLister        internalinformers.SecretLister
 
 	// used for testing
 	clock clock.Clock

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -72,22 +72,13 @@ type controller struct {
 
 	// scheduledWorkQueue holds items to be re-queued after a period of time.
 	scheduledWorkQueue scheduler.ScheduledWorkQueue
-
-	// logger to be used by this controller
-	log logr.Logger
 }
 
 // NewController constructs an orders controller using the provided options.
 func NewController(
 	log logr.Logger,
-	cmClient cmclient.Interface,
-	kubeInformerFactory informers.SharedInformerFactory,
-	cmInformerFactory cminformers.SharedInformerFactory,
-	accountRegistry accounts.Getter,
-	recorder record.EventRecorder,
-	clock clock.Clock,
+	ctx *controllerpkg.Context,
 	isNamespaced bool,
-	fieldManager string,
 ) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
 
 	// Create a queue used to queue up Orders to be processed.
@@ -97,13 +88,13 @@ func NewController(
 	)
 
 	// Create a scheduledWorkQueue to schedule Orders for re-processing.
-	scheduledWorkQueue := scheduler.NewScheduledWorkQueue(clock, queue.Add)
+	scheduledWorkQueue := scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add)
 
 	// Obtain references to all the informers used by this controller.
-	orderInformer := cmInformerFactory.Acme().V1().Orders()
-	issuerInformer := cmInformerFactory.Certmanager().V1().Issuers()
-	challengeInformer := cmInformerFactory.Acme().V1().Challenges()
-	secretInformer := kubeInformerFactory.Core().V1().Secrets()
+	orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders()
+	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
+	challengeInformer := ctx.SharedInformerFactory.Acme().V1().Challenges()
+	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 
 	// Build a list of InformerSynced functions. The controller will only begin
 	// processing items once all of these informers have synced.
@@ -124,7 +115,7 @@ func NewController(
 	// register event handlers and obtain a lister for ClusterIssuers.
 	var clusterIssuerLister cmlisters.ClusterIssuerLister
 	if !isNamespaced {
-		clusterIssuerInformer := cmInformerFactory.Certmanager().V1().ClusterIssuers()
+		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
 		mustSync = append(mustSync, clusterIssuerInformer.Informer().HasSynced)
 		clusterIssuerLister = clusterIssuerInformer.Lister()
 		// register handler function for clusterissuer resources
@@ -145,7 +136,7 @@ func NewController(
 	})
 
 	return &controller{
-		clock:               clock,
+		clock:               ctx.Clock,
 		queue:               queue,
 		scheduledWorkQueue:  scheduledWorkQueue,
 		orderLister:         orderLister,
@@ -154,10 +145,10 @@ func NewController(
 		secretLister:        secretLister,
 		clusterIssuerLister: clusterIssuerLister,
 		helper:              issuer.NewHelper(issuerLister, clusterIssuerLister),
-		recorder:            recorder,
-		cmClient:            cmClient,
-		accountRegistry:     accountRegistry,
-		fieldManager:        fieldManager,
+		recorder:            ctx.Recorder,
+		cmClient:            ctx.CMClient,
+		accountRegistry:     ctx.AccountRegistry,
+		fieldManager:        ctx.FieldManager,
 	}, queue, mustSync
 
 }
@@ -215,14 +206,8 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 
 	ctrl, queue, mustSync := NewController(
 		log,
-		ctx.CMClient,
-		ctx.KubeSharedInformerFactory,
-		ctx.SharedInformerFactory,
-		ctx.ACMEOptions.AccountRegistry,
-		ctx.Recorder,
-		ctx.Clock,
+		ctx,
 		isNamespaced,
-		ctx.FieldManager,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -45,7 +45,7 @@ type controller struct {
 func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	cmShared := ctx.SharedInformerFactory
 
-	ingressInformer := ctx.KubeSharedInformerFactory.Networking().V1().Ingresses()
+	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
 	c.ingressLister = ingressInformer.Lister()
 
 	log := logf.FromContext(ctx.RootContext, ControllerName)

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -46,7 +46,7 @@ type signingFn func([]*x509.Certificate, crypto.Signer, *x509.Certificate) (pki.
 
 type CA struct {
 	issuerOptions controllerpkg.IssuerOptions
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	reporter *crutil.Reporter
 
@@ -67,7 +67,7 @@ func init() {
 func NewCA(ctx *controllerpkg.Context) certificaterequests.Issuer {
 	return &CA{
 		issuerOptions:     ctx.IssuerOptions,
-		secretsLister:     ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister:     ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:          crutil.NewReporter(ctx.Clock, ctx.Recorder),
 		templateGenerator: pki.GenerateTemplateFromCertificateRequest,
 		signingFn:         pki.SignCSRTemplate,

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
@@ -72,7 +72,7 @@ type Controller struct {
 	// we need to wait for Secrets to be synced to avoid a situation where CA issuer's Secret
 	// is not yet in cached at a time when issuance is attempted,
 	// more details at https://github.com/cert-manager/cert-manager/issues/5216
-	secretLister corelisters.SecretLister
+	secretLister internalinformers.SecretLister
 
 	queue workqueue.RateLimitingInterface
 
@@ -132,7 +132,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// create a queue used to queue up items to be processed
 	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), componentName)
 
-	secretsInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
 	c.issuerLister = issuerInformer.Lister()
 	c.secretLister = secretsInformer.Lister()

--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -45,9 +45,9 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 ) func(obj any) {
 	return func(obj any) {
 		log := log.WithName("handleSecretReference")
-		secret, ok := obj.(*corev1.Secret)
+		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {
-			log.Error(nil, "object is not a secret")
+			log.Error(nil, "object is not a secret", "object", obj)
 			return
 		}
 		log = logf.WithResource(log, secret)

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	vaultinternal "github.com/cert-manager/cert-manager/internal/vault"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -42,7 +42,7 @@ const (
 type Vault struct {
 	issuerOptions controllerpkg.IssuerOptions
 	createTokenFn func(ns string) vaultinternal.CreateToken
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 	reporter      *crutil.Reporter
 
 	vaultClientBuilder vaultinternal.ClientBuilder
@@ -64,7 +64,7 @@ func NewVault(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		createTokenFn: func(ns string) vaultinternal.CreateToken {
 			return ctx.Client.CoreV1().ServiceAccounts(ns).CreateToken
 		},
-		secretsLister:      ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister:      ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:           crutil.NewReporter(ctx.Clock, ctx.Recorder),
 		vaultClientBuilder: vaultinternal.New,
 	}

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -31,17 +31,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	internalvault "github.com/cert-manager/cert-manager/internal/vault"
 	fakevault "github.com/cert-manager/cert-manager/internal/vault/fake"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -518,7 +518,7 @@ func runTest(t *testing.T, test testT) {
 	vault := NewVault(test.builder.Context).(*Vault)
 
 	if test.fakeVault != nil {
-		vault.vaultClientBuilder = func(ns string, _ func(ns string) internalvault.CreateToken, sl corelisters.SecretLister,
+		vault.vaultClientBuilder = func(ns string, _ func(ns string) internalvault.CreateToken, sl internalinformers.SecretLister,
 			iss cmapi.GenericIssuer) (internalvault.Interface, error) {
 			return test.fakeVault.New(ns, sl, iss)
 		}
@@ -526,7 +526,7 @@ func runTest(t *testing.T, test testT) {
 
 	controller := certificaterequests.New(
 		apiutil.IssuerVault,
-		func(*controller.Context) certificaterequests.Issuer { return vault },
+		func(*controllerpkg.Context) certificaterequests.Issuer { return vault },
 	)
 
 	if _, _, err := controller.Register(test.builder.Context); err != nil {

--- a/pkg/controller/certificaterequests/venafi/venafi.go
+++ b/pkg/controller/certificaterequests/venafi/venafi.go
@@ -23,10 +23,10 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
@@ -47,7 +47,7 @@ const (
 
 type Venafi struct {
 	issuerOptions controllerpkg.IssuerOptions
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 	reporter      *crutil.Reporter
 	cmClient      clientset.Interface
 
@@ -68,7 +68,7 @@ func init() {
 func NewVenafi(ctx *controllerpkg.Context) certificaterequests.Issuer {
 	return &Venafi{
 		issuerOptions: ctx.IssuerOptions,
-		secretsLister: ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:      crutil.NewReporter(ctx.Clock, ctx.Recorder),
 		clientBuilder: venaficlient.New,
 		metrics:       ctx.Metrics,

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -36,11 +36,12 @@ import (
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client"
@@ -822,7 +823,7 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	if test.fakeClient != nil {
-		v.clientBuilder = func(namespace string, secretsLister corelisters.SecretLister,
+		v.clientBuilder = func(namespace string, secretsLister internalinformers.SecretLister,
 			issuer cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (client.Interface, error) {
 			return test.fakeClient, nil
 		}
@@ -830,7 +831,7 @@ func runTest(t *testing.T, test testT) {
 
 	controller := certificaterequests.New(
 		apiutil.IssuerVenafi,
-		func(*controller.Context) certificaterequests.Issuer { return v },
+		func(*controllerpkg.Context) certificaterequests.Issuer { return v },
 	)
 	controller.Register(test.builder.Context)
 	test.builder.Start()

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -27,10 +27,10 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
 	"github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -45,7 +45,7 @@ var (
 // SecretsManager creates and updates secrets with certificate and key data.
 type SecretsManager struct {
 	secretClient coreclient.SecretsGetter
-	secretLister corelisters.SecretLister
+	secretLister internalinformers.SecretLister
 
 	// fieldManager is the manager name used for the Apply operations on Secrets.
 	fieldManager string
@@ -67,7 +67,7 @@ type SecretData struct {
 // when the corresponding Certificate is deleted.
 func NewSecretsManager(
 	secretClient coreclient.SecretsGetter,
-	secretLister corelisters.SecretLister,
+	secretLister internalinformers.SecretLister,
 	fieldManager string,
 	enableSecretOwnerReferences bool,
 ) *SecretsManager {

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -819,7 +819,7 @@ func Test_getCertificateSecret(t *testing.T) {
 
 			s := SecretsManager{
 				secretClient: builder.Client.CoreV1(),
-				secretLister: builder.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+				secretLister: builder.KubeSharedInformerFactory.Secrets().Lister(),
 				fieldManager: "cert-manager-test",
 			}
 

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -27,9 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -38,11 +35,11 @@ import (
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -67,7 +64,7 @@ type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, err
 type controller struct {
 	certificateLister        cmlisters.CertificateLister
 	certificateRequestLister cmlisters.CertificateRequestLister
-	secretLister             corelisters.SecretLister
+	secretLister             internalinformers.SecretLister
 	recorder                 record.EventRecorder
 	clock                    clock.Clock
 

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -93,23 +93,16 @@ type controller struct {
 
 func NewController(
 	log logr.Logger,
-	kubeClient kubernetes.Interface,
-	client cmclient.Interface,
-	factory informers.SharedInformerFactory,
-	cmFactory cminformers.SharedInformerFactory,
-	recorder record.EventRecorder,
-	clock clock.Clock,
-	certificateControllerOptions controllerpkg.CertificateOptions,
-	fieldManager string,
+	ctx *controllerpkg.Context,
 ) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
 
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
-	certificateInformer := cmFactory.Certmanager().V1().Certificates()
-	certificateRequestInformer := cmFactory.Certmanager().V1().CertificateRequests()
-	secretsInformer := factory.Core().V1().Secrets()
+	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
+	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
+	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 
 	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
 	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
@@ -136,23 +129,23 @@ func NewController(
 	}
 
 	secretsManager := internal.NewSecretsManager(
-		kubeClient.CoreV1(), secretsInformer.Lister(),
-		fieldManager, certificateControllerOptions.EnableOwnerRef,
+		ctx.Client.CoreV1(), secretsInformer.Lister(),
+		ctx.FieldManager, ctx.CertificateOptions.EnableOwnerRef,
 	)
 
 	return &controller{
 		certificateLister:        certificateInformer.Lister(),
 		certificateRequestLister: certificateRequestInformer.Lister(),
 		secretLister:             secretsInformer.Lister(),
-		client:                   client,
-		recorder:                 recorder,
-		clock:                    clock,
+		client:                   ctx.CMClient,
+		recorder:                 ctx.Recorder,
+		clock:                    ctx.Clock,
 		secretsUpdateData:        secretsManager.UpdateData,
 		postIssuancePolicyChain: policies.NewSecretPostIssuancePolicyChain(
-			certificateControllerOptions.EnableOwnerRef,
-			fieldManager,
+			ctx.CertificateOptions.EnableOwnerRef,
+			ctx.FieldManager,
 		),
-		fieldManager:         fieldManager,
+		fieldManager:         ctx.FieldManager,
 		localTemporarySigner: pki.GenerateLocallySignedTemporaryCertificate,
 	}, queue, mustSync
 }
@@ -468,16 +461,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
-	ctrl, queue, mustSync := NewController(log,
-		ctx.Client,
-		ctx.CMClient,
-		ctx.KubeSharedInformerFactory,
-		ctx.SharedInformerFactory,
-		ctx.Recorder,
-		ctx.Clock,
-		ctx.CertificateOptions,
-		ctx.FieldManager,
-	)
+	ctrl, queue, mustSync := NewController(log, ctx)
 	c.controller = ctrl
 
 	return queue, mustSync, nil

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -28,20 +28,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -64,7 +62,7 @@ var (
 
 type controller struct {
 	certificateLister cmlisters.CertificateLister
-	secretLister      corelisters.SecretLister
+	secretLister      internalinformers.SecretLister
 	client            cmclient.Interface
 	coreClient        kubernetes.Interface
 	recorder          record.EventRecorder

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -21,11 +21,9 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/metrics"

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -26,19 +26,17 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -60,7 +58,7 @@ type controller struct {
 	policyChain              policies.Chain
 	certificateLister        cmlisters.CertificateLister
 	certificateRequestLister cmlisters.CertificateRequestLister
-	secretLister             corelisters.SecretLister
+	secretLister             internalinformers.SecretLister
 	client                   cmclient.Interface
 	gatherer                 *policies.Gatherer
 	// policyEvaluator builds Ready condition of a Certificate based on policy evaluation

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -31,19 +31,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -66,7 +64,7 @@ var (
 type controller struct {
 	certificateLister        cmlisters.CertificateLister
 	certificateRequestLister cmlisters.CertificateRequestLister
-	secretLister             corelisters.SecretLister
+	secretLister             internalinformers.SecretLister
 	client                   cmclient.Interface
 	recorder                 record.EventRecorder
 	clock                    clock.Clock

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -58,13 +58,13 @@ type revision struct {
 	types.NamespacedName
 }
 
-func NewController(log logr.Logger, client cmclient.Interface, cmFactory cminformers.SharedInformerFactory) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
-	certificateInformer := cmFactory.Certmanager().V1().Certificates()
-	certificateRequestInformer := cmFactory.Certmanager().V1().CertificateRequests()
+	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
+	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 
 	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
 	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
@@ -84,7 +84,7 @@ func NewController(log logr.Logger, client cmclient.Interface, cmFactory cminfor
 	return &controller{
 		certificateLister:        certificateInformer.Lister(),
 		certificateRequestLister: certificateRequestInformer.Lister(),
-		client:                   client,
+		client:                   ctx.CMClient,
 	}, queue, mustSync
 }
 
@@ -205,7 +205,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
-	ctrl, queue, mustSync := NewController(log, ctx.CMClient, ctx.SharedInformerFactory)
+	ctrl, queue, mustSync := NewController(log, ctx)
 	c.controller = ctrl
 
 	return queue, mustSync, nil

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -35,7 +35,6 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -27,8 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -37,11 +35,11 @@ import (
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
@@ -68,7 +66,7 @@ const (
 type controller struct {
 	certificateLister        cmlisters.CertificateLister
 	certificateRequestLister cmlisters.CertificateRequestLister
-	secretLister             corelisters.SecretLister
+	secretLister             internalinformers.SecretLister
 	client                   cmclient.Interface
 	recorder                 record.EventRecorder
 	scheduledWorkQueue       scheduler.ScheduledWorkQueue

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -82,7 +82,7 @@ func controllerBuilder() *certificatesigningrequests.Controller {
 	return certificatesigningrequests.New(apiutil.IssuerACME, NewACME,
 		func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.RateLimitingInterface) ([]cache.InformerSynced, error) {
 			orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
-			csrLister := ctx.KubeSharedInformerFactory.Certificates().V1().CertificateSigningRequests().Lister()
+			csrLister := ctx.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 
 			orderInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
 				WorkFunc: controllerpkg.HandleOwnedResourceNamespacedFunc(

--- a/pkg/controller/certificatesigningrequests/ca/ca.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca.go
@@ -26,9 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -52,7 +52,7 @@ type signingFn func([]*x509.Certificate, crypto.Signer, *x509.Certificate) (pki.
 // or ClusterIssuer
 type CA struct {
 	issuerOptions controllerpkg.IssuerOptions
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	certClient certificatesclient.CertificateSigningRequestInterface
 
@@ -78,7 +78,7 @@ func init() {
 func NewCA(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 	return &CA{
 		issuerOptions:     ctx.IssuerOptions,
-		secretsLister:     ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister:     ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		certClient:        ctx.Client.CertificatesV1().CertificateSigningRequests(),
 		fieldManager:      ctx.FieldManager,
 		recorder:          ctx.Recorder,

--- a/pkg/controller/certificatesigningrequests/controller.go
+++ b/pkg/controller/certificatesigningrequests/controller.go
@@ -128,7 +128,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
 
 	// obtain references to all the informers used by this controller
-	csrInformer := ctx.KubeSharedInformerFactory.Certificates().V1().CertificateSigningRequests()
+	csrInformer := ctx.KubeSharedInformerFactory.CertificateSigningRequests()
 
 	// build a list of InformerSynced functions that will be returned by the
 	// Register method. The controller will only begin processing items once all

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks.go
@@ -48,9 +48,9 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 ) func(obj any) {
 	return func(obj any) {
 		log := log.WithName("handleSecretReference")
-		secret, ok := obj.(*corev1.Secret)
+		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {
-			log.Error(nil, "object is not a secret")
+			log.Error(nil, "object is not a secret", "object", obj)
 			return
 		}
 		log = logf.WithResource(log, secret)

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
@@ -120,7 +120,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 			defer builder.Stop()
 			builder.Init()
 
-			lister := builder.Context.KubeSharedInformerFactory.Certificates().V1().CertificateSigningRequests().Lister()
+			lister := builder.Context.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 			helper := issuer.NewHelper(
 				builder.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 				builder.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
@@ -330,7 +330,7 @@ func Test_certificatesRequestsForSecret(t *testing.T) {
 			defer builder.Stop()
 			builder.Init()
 
-			lister := builder.Context.KubeSharedInformerFactory.Certificates().V1().CertificateSigningRequests().Lister()
+			lister := builder.Context.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 			helper := issuer.NewHelper(
 				builder.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 				builder.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -27,9 +27,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	internalvault "github.com/cert-manager/cert-manager/internal/vault"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -51,7 +51,7 @@ type signingFn func(*x509.Certificate, *x509.Certificate, crypto.PublicKey, inte
 type Vault struct {
 	issuerOptions controllerpkg.IssuerOptions
 	kclient       kubernetes.Interface
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	recorder record.EventRecorder
 
@@ -74,7 +74,7 @@ func NewVault(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 	return &Vault{
 		issuerOptions: ctx.IssuerOptions,
 		kclient:       ctx.Client,
-		secretsLister: ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		recorder:      ctx.Recorder,
 		certClient:    ctx.Client.CertificatesV1().CertificateSigningRequests(),
 		clientBuilder: internalvault.New,

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -30,17 +30,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	internalvault "github.com/cert-manager/cert-manager/internal/vault"
 	fakevault "github.com/cert-manager/cert-manager/internal/vault/fake"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -129,7 +129,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -190,7 +190,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -234,7 +234,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
 				return fakevault.New(), nil
 			},
 			builder: &testpkg.Builder{
@@ -296,7 +296,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
 				return fakevault.New().WithSign(nil, nil, errors.New("sign error")), nil
 			},
 			builder: &testpkg.Builder{
@@ -357,7 +357,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ corelisters.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
 				return fakevault.New().WithSign([]byte("signed-cert"), []byte("signing-ca"), nil), nil
 			},
 			builder: &testpkg.Builder{
@@ -436,7 +436,7 @@ func TestProcessItem(t *testing.T) {
 
 			controller := certificatesigningrequests.New(
 				apiutil.IssuerVault,
-				func(*controller.Context) certificatesigningrequests.Signer { return vault },
+				func(*controllerpkg.Context) certificatesigningrequests.Signer { return vault },
 			)
 			controller.Register(test.builder.Context)
 			test.builder.Start()

--- a/pkg/controller/certificatesigningrequests/venafi/venafi.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi.go
@@ -27,9 +27,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	experimentalapi "github.com/cert-manager/cert-manager/pkg/apis/experimental/v1alpha1"
@@ -53,7 +53,7 @@ const (
 // Issuer or ClusterIssuer
 type Venafi struct {
 	issuerOptions controllerpkg.IssuerOptions
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 	certClient    certificatesclient.CertificateSigningRequestInterface
 	recorder      record.EventRecorder
 
@@ -76,7 +76,7 @@ func init() {
 func NewVenafi(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 	return &Venafi{
 		issuerOptions: ctx.IssuerOptions,
-		secretsLister: ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		certClient:    ctx.Client.CertificatesV1().CertificateSigningRequests(),
 		recorder:      ctx.Recorder,
 		clientBuilder: venaficlient.New,

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -33,15 +33,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -154,7 +154,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -196,7 +196,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -242,7 +242,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{}, nil
 			},
 			builder: &testpkg.Builder{
@@ -310,7 +310,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{}, nil
 			},
 			builder: &testpkg.Builder{
@@ -378,7 +378,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", venaficlient.ErrCustomFieldsType{Type: "test-type"}
@@ -449,7 +449,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", errors.New("generic error")
@@ -520,7 +520,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "test-pickup-id", nil
@@ -582,7 +582,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrCertificatePending{}
@@ -633,7 +633,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrRetrieveCertificateTimeout{}
@@ -684,7 +684,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, errors.New("generic error")
@@ -735,7 +735,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte("garbage"), nil
@@ -808,7 +808,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ corelisters.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte(fmt.Sprintf("%s%s", certBundle.ChainPEM, certBundle.CAPEM)), nil
@@ -895,7 +895,7 @@ func TestProcessItem(t *testing.T) {
 
 			controller := certificatesigningrequests.New(
 				apiutil.IssuerVenafi,
-				func(*controller.Context) certificatesigningrequests.Signer { return venafi },
+				func(*controllerpkg.Context) certificatesigningrequests.Signer { return venafi },
 			)
 			controller.Register(test.builder.Context)
 			test.builder.Start()

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -20,13 +20,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -36,7 +35,7 @@ import (
 
 type controller struct {
 	clusterIssuerLister cmlisters.ClusterIssuerLister
-	secretLister        corelisters.SecretLister
+	secretLister        internalinformers.SecretLister
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
@@ -75,7 +74,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	// obtain references to all the informers used by this controller
 	clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
-	secretInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.
 	mustSync := []cache.InformerSynced{

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -105,11 +105,9 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 func (c *controller) secretDeleted(obj interface{}) {
 	log := c.log.WithName("secretDeleted")
 
-	var secret *corev1.Secret
-	var ok bool
-	secret, ok = obj.(*corev1.Secret)
+	secret, ok := controllerpkg.ToSecret(obj)
 	if !ok {
-		log.Error(nil, "object was not a Secret object")
+		log.Error(nil, "object is not a secret", "object", obj)
 		return
 	}
 	log = logf.WithResource(log, secret)

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -267,7 +267,12 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 
 	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(clients.cmClient, resyncPeriod, informers.WithNamespace(opts.Namespace))
 
-	kubeSharedInformerFactory := internalinformers.NewBaseKubeInformerFactory(clients.kubeClient, resyncPeriod, opts.Namespace)
+	var kubeSharedInformerFactory internalinformers.KubeInformerFactory
+	if utilfeature.DefaultFeatureGate.Enabled(feature.SecretsFilteredCaching) {
+		kubeSharedInformerFactory = internalinformers.NewFilteredSecretsKubeInformerFactory(ctx, clients.kubeClient, clients.metadataOnlyClient, resyncPeriod, opts.Namespace)
+	} else {
+		kubeSharedInformerFactory = internalinformers.NewBaseKubeInformerFactory(clients.kubeClient, resyncPeriod, opts.Namespace)
+	}
 
 	gwSharedInformerFactory := gwinformers.NewSharedInformerFactoryWithOptions(clients.gwClient, resyncPeriod, gwinformers.WithNamespace(opts.Namespace))
 

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -99,14 +99,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 // TODO: replace with generic handleObject function (like Navigator)
 func (c *controller) secretDeleted(obj interface{}) {
 	log := c.log.WithName("secretDeleted")
-
-	var secret *corev1.Secret
-	var ok bool
-	secret, ok = obj.(*corev1.Secret)
+	secret, ok := controllerpkg.ToSecret(obj)
 	if !ok {
-		log.Error(nil, "object was not a secret object")
+		log.Error(nil, "object is not a secret", "object", obj)
 		return
 	}
+
 	log = logf.WithResource(log, secret)
 	issuers, err := c.issuersForSecret(secret)
 	if err != nil {

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -20,13 +20,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -36,7 +35,7 @@ import (
 
 type controller struct {
 	issuerLister cmlisters.IssuerLister
-	secretLister corelisters.SecretLister
+	secretLister internalinformers.SecretLister
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
@@ -71,7 +70,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	// obtain references to all the informers used by this controller
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
-	secretInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.
 	mustSync := []cache.InformerSynced{

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -199,3 +199,24 @@ func BuildAnnotationsToCopy(allAnnotations map[string]string, prefixes []string)
 	}
 	return filteredAnnotations
 }
+
+func ToSecret(obj interface{}) (*corev1.Secret, bool) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		meta, ok := obj.(*metav1.PartialObjectMetadata)
+		if !ok || meta.GroupVersionKind() != corev1.SchemeGroupVersion.WithKind("Secret") {
+			// TODO: I wasn't able to get GVK from PartialMetadata,
+			// however perhaps this should be possible and then we
+			// could verify that this really is a Secret. At the
+			// moment this is okay as there is no path how any
+			// reconcile loop would receive PartialObjectMetadata
+			// for any other type.
+			return nil, false
+		}
+		secret = &corev1.Secret{}
+		secret.SetName(meta.Name)
+		secret.SetNamespace(meta.Namespace)
+	}
+	return secret, true
+
+}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -205,7 +205,7 @@ func ToSecret(obj interface{}) (*corev1.Secret, bool) {
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		meta, ok := obj.(*metav1.PartialObjectMetadata)
-		if !ok || meta.GroupVersionKind() != corev1.SchemeGroupVersion.WithKind("Secret") {
+		if !ok {
 			// TODO: I wasn't able to get GVK from PartialMetadata,
 			// however perhaps this should be possible and then we
 			// could verify that this really is a Secret. At the

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 
 	core "k8s.io/client-go/kubernetes/typed/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -68,7 +68,7 @@ func New(ctx *controller.Context, issuer v1.GenericIssuer) (issuer.Interface, er
 		return nil, fmt.Errorf("acme config may not be empty")
 	}
 
-	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
+	secretsLister := ctx.KubeSharedInformerFactory.Secrets().Lister()
 
 	a := &Acme{
 		issuer:                   issuer,
@@ -90,7 +90,7 @@ func New(ctx *controller.Context, issuer v1.GenericIssuer) (issuer.Interface, er
 type keyFromSecretFunc func(ctx context.Context, namespace, name, keyName string) (crypto.Signer, error)
 
 // newKeyFromSecret returns an implementation of keyFromSecretFunc for a secrets lister.
-func newKeyFromSecret(secretLister corelisters.SecretLister) keyFromSecretFunc {
+func newKeyFromSecret(secretLister internalinformers.SecretLister) keyFromSecretFunc {
 	return func(ctx context.Context, namespace, name, keyName string) (crypto.Signer, error) {
 		return kube.SecretTLSKeyRef(ctx, secretLister, namespace, name, keyName)
 	}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 	whapi "github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -70,7 +70,7 @@ type dnsProviderConstructors struct {
 // the certificate, and configures it based on the referenced issuer.
 type Solver struct {
 	*controller.Context
-	secretLister            corev1listers.SecretLister
+	secretLister            internalinformers.SecretLister
 	dnsProviderConstructors dnsProviderConstructors
 	webhookSolvers          map[string]webhook.Solver
 }
@@ -488,7 +488,7 @@ func (s *Solver) dns01SolverForConfig(config *cmacme.ACMEChallengeSolverDNS01) (
 // NewSolver creates a Solver which can instantiate the appropriate DNS
 // provider.
 func NewSolver(ctx *controller.Context) (*Solver, error) {
-	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
+	secretsLister := ctx.KubeSharedInformerFactory.Secrets().Lister()
 	webhookSolvers := []webhook.Solver{
 		&webhookslv.Webhook{},
 		rfc2136.New(rfc2136.WithNamespace(ctx.Namespace), rfc2136.WithSecretsLister(secretsLister)),
@@ -511,7 +511,7 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 
 	return &Solver{
 		Context:      ctx,
-		secretLister: ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		dnsProviderConstructors: dnsProviderConstructors{
 			clouddns.NewDNSProvider,
 			cloudflare.NewDNSProviderCredentials,

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -27,6 +27,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	restclient "k8s.io/client-go/rest"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	whapi "github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ import (
 const SolverName = "rfc2136"
 
 type Solver struct {
-	secretLister corelisters.SecretLister
+	secretLister internalinformers.SecretLister
 	// options to apply when the lister gets initialized
 	initOpts []Option
 
@@ -54,7 +55,7 @@ func WithNamespace(ns string) Option {
 	}
 }
 
-func WithSecretsLister(secretLister corelisters.SecretLister) Option {
+func WithSecretsLister(secretLister internalinformers.SecretLister) Option {
 	return func(s *Solver) {
 		s.secretLister = secretLister
 	}

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -102,7 +102,7 @@ func buildFakeSolver(b *test.Builder, dnsProviders dnsProviderConstructors) *Sol
 	b.InitWithRESTConfig()
 	s := &Solver{
 		Context:                 b.Context,
-		secretLister:            b.Context.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretLister:            b.Context.KubeSharedInformerFactory.Secrets().Lister(),
 		dnsProviderConstructors: dnsProviders,
 	}
 	b.Start()

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -74,9 +74,9 @@ type reachabilityTest func(ctx context.Context, url *url.URL, key string, dnsSer
 func NewSolver(ctx *controller.Context) (*Solver, error) {
 	return &Solver{
 		Context:          ctx,
-		podLister:        ctx.KubeSharedInformerFactory.Core().V1().Pods().Lister(),
-		serviceLister:    ctx.KubeSharedInformerFactory.Core().V1().Services().Lister(),
-		ingressLister:    ctx.KubeSharedInformerFactory.Networking().V1().Ingresses().Lister(),
+		podLister:        ctx.KubeSharedInformerFactory.Pods().Lister(),
+		serviceLister:    ctx.KubeSharedInformerFactory.Services().Lister(),
+		ingressLister:    ctx.KubeSharedInformerFactory.Ingresses().Lister(),
 		httpRouteLister:  ctx.GWShared.Gateway().V1beta1().HTTPRoutes().Lister(),
 		testReachability: testReachability,
 		requiredPasses:   5,

--- a/pkg/issuer/ca/ca.go
+++ b/pkg/issuer/ca/ca.go
@@ -17,8 +17,7 @@ limitations under the License.
 package ca
 
 import (
-	corelisters "k8s.io/client-go/listers/core/v1"
-
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
@@ -31,7 +30,7 @@ import (
 type CA struct {
 	*controller.Context
 	issuer        v1.GenericIssuer
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	// Namespace in which to read resources related to this Issuer from.
 	// For Issuers, this will be the namespace of the Issuer.
@@ -40,7 +39,7 @@ type CA struct {
 }
 
 func NewCA(ctx *controller.Context, issuer v1.GenericIssuer) (issuer.Interface, error) {
-	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
+	secretsLister := ctx.KubeSharedInformerFactory.Secrets().Lister()
 
 	return &CA{
 		Context:           ctx,

--- a/pkg/issuer/selfsigned/selfsigned.go
+++ b/pkg/issuer/selfsigned/selfsigned.go
@@ -17,8 +17,7 @@ limitations under the License.
 package selfsigned
 
 import (
-	corelisters "k8s.io/client-go/listers/core/v1"
-
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
@@ -30,11 +29,11 @@ type SelfSigned struct {
 	*controller.Context
 	issuer v1.GenericIssuer
 
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 }
 
 func NewSelfSigned(ctx *controller.Context, issuer v1.GenericIssuer) (issuer.Interface, error) {
-	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
+	secretsLister := ctx.KubeSharedInformerFactory.Secrets().Lister()
 
 	return &SelfSigned{
 		Context:       ctx,

--- a/pkg/issuer/vault/vault.go
+++ b/pkg/issuer/vault/vault.go
@@ -17,8 +17,7 @@ limitations under the License.
 package vault
 
 import (
-	corelisters "k8s.io/client-go/listers/core/v1"
-
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	vaultinternal "github.com/cert-manager/cert-manager/internal/vault"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -31,7 +30,7 @@ type Vault struct {
 	*controller.Context
 	issuer v1.GenericIssuer
 
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	// Namespace in which to read resources related to this Issuer from.
 	// For Issuers, this will be the namespace of the Issuer.
@@ -44,7 +43,7 @@ type Vault struct {
 
 // NewVault returns a new Vault
 func NewVault(ctx *controller.Context, issuer v1.GenericIssuer) (issuer.Interface, error) {
-	secretsLister := ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister()
+	secretsLister := ctx.KubeSharedInformerFactory.Secrets().Lister()
 
 	return &Vault{
 		Context:           ctx,

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -30,8 +30,8 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/venafi/cloud"
 	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
 	"github.com/go-logr/logr"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
@@ -45,7 +45,7 @@ const (
 	defaultAPIKeyKey = "api-key"
 )
 
-type VenafiClientBuilder func(namespace string, secretsLister corelisters.SecretLister,
+type VenafiClientBuilder func(namespace string, secretsLister internalinformers.SecretLister,
 	issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger) (Interface, error)
 
 // Interface implements a Venafi client
@@ -64,7 +64,7 @@ type Venafi struct {
 	// For Issuers, this will be the namespace of the Issuer.
 	// For ClusterIssuers, this will be the cluster resource namespace.
 	namespace     string
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	vcertClient connector
 	tppClient   *tpp.Connector
@@ -85,7 +85,7 @@ type connector interface {
 
 // New constructs a Venafi client Interface. Errors may be network errors and
 // should be considered for retrying.
-func New(namespace string, secretsLister corelisters.SecretLister, issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger) (Interface, error) {
+func New(namespace string, secretsLister internalinformers.SecretLister, issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger) (Interface, error) {
 	cfg, err := configForIssuer(issuer, secretsLister, namespace)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func New(namespace string, secretsLister corelisters.SecretLister, issuer cmapi.
 
 // configForIssuer will convert a cert-manager Venafi issuer into a vcert.Config
 // that can be used to instantiate an API client.
-func configForIssuer(iss cmapi.GenericIssuer, secretsLister corelisters.SecretLister, namespace string) (*vcert.Config, error) {
+func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.SecretLister, namespace string) (*vcert.Config, error) {
 	venCfg := iss.GetSpec().Venafi
 	switch {
 	case venCfg.TPP != nil:

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -47,7 +48,7 @@ func checkZone(t *testing.T, zone string, cnf *vcert.Config) {
 	}
 }
 
-func generateSecretLister(s *corev1.Secret, err error) corelisters.SecretLister {
+func generateSecretLister(s *corev1.Secret, err error) internalinformers.SecretLister {
 	return &testlisters.FakeSecretLister{
 		SecretsFn: func(string) corelisters.SecretNamespaceLister {
 			return &testlisters.FakeSecretNamespaceLister{
@@ -214,7 +215,7 @@ func TestConfigForIssuerT(t *testing.T) {
 
 type testConfigForIssuerT struct {
 	iss           cmapi.GenericIssuer
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	expectedErr bool
 

--- a/pkg/issuer/venafi/setup_test.go
+++ b/pkg/issuer/venafi/setup_test.go
@@ -27,10 +27,9 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 
-	corelisters "k8s.io/client-go/listers/core/v1"
-
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client"
 	internalvenafifake "github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/fake"
@@ -41,12 +40,12 @@ import (
 func TestSetup(t *testing.T) {
 	baseIssuer := gen.Issuer("test-issuer")
 
-	failingClientBuilder := func(string, corelisters.SecretLister,
+	failingClientBuilder := func(string, internalinformers.SecretLister,
 		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
 		return nil, errors.New("this is an error")
 	}
 
-	failingPingClient := func(string, corelisters.SecretLister,
+	failingPingClient := func(string, internalinformers.SecretLister,
 		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
@@ -55,7 +54,7 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
-	pingClient := func(string, corelisters.SecretLister,
+	pingClient := func(string, internalinformers.SecretLister,
 		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
@@ -64,7 +63,7 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
-	verifyCredentialsClient := func(string, corelisters.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+	verifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return nil
@@ -75,7 +74,7 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
-	failingVerifyCredentialsClient := func(string, corelisters.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+	failingVerifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return nil
@@ -169,7 +168,7 @@ func (s *testSetupT) runTest(t *testing.T) {
 
 	v := &Venafi{
 		resourceNamespace: "test-namespace",
-		Context: &controller.Context{
+		Context: &controllerpkg.Context{
 			Recorder: rec,
 		},
 		issuer:        s.iss,

--- a/pkg/issuer/venafi/venafi.go
+++ b/pkg/issuer/venafi/venafi.go
@@ -19,15 +19,13 @@ package venafi
 import (
 	"github.com/go-logr/logr"
 
-	corelisters "k8s.io/client-go/listers/core/v1"
-
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/metrics"
 )
 
 // Venafi is a implementation of govcert library to manager certificates from TPP or Venafi Cloud
@@ -35,7 +33,7 @@ type Venafi struct {
 	issuer cmapi.GenericIssuer
 	*controller.Context
 
-	secretsLister corelisters.SecretLister
+	secretsLister internalinformers.SecretLister
 
 	// Namespace in which to read resources related to this Issuer from.
 	// For Issuers, this will be the namespace of the Issuer.
@@ -44,15 +42,13 @@ type Venafi struct {
 
 	clientBuilder client.VenafiClientBuilder
 
-	metrics *metrics.Metrics
-
 	log logr.Logger
 }
 
 func NewVenafi(ctx *controller.Context, issuer cmapi.GenericIssuer) (issuer.Interface, error) {
 	return &Venafi{
 		issuer:            issuer,
-		secretsLister:     ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
+		secretsLister:     ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		resourceNamespace: ctx.IssuerOptions.ResourceNamespace(issuer),
 		clientBuilder:     client.New,
 		Context:           ctx,

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -22,8 +22,8 @@ import (
 	"crypto/x509"
 
 	corev1 "k8s.io/api/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
+	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/errors"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -32,7 +32,7 @@ import (
 // SecretTLSKeyRef will decode a PKCS1/SEC1 (in effect, a RSA or ECDSA) private key stored in a
 // secret with 'name' in 'namespace'. It will read the private key data from the secret
 // entry with name 'keyName'.
-func SecretTLSKeyRef(ctx context.Context, secretLister corelisters.SecretLister, namespace, name, keyName string) (crypto.Signer, error) {
+func SecretTLSKeyRef(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name, keyName string) (crypto.Signer, error) {
 	secret, err := secretLister.Secrets(namespace).Get(name)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func SecretTLSKeyRef(ctx context.Context, secretLister corelisters.SecretLister,
 // SecretTLSKey will decode a PKCS1/SEC1 (in effect, a RSA or ECDSA) private key stored in a
 // secret with 'name' in 'namespace'. It will read the private key data from the secret
 // entry with name 'keyName'.
-func SecretTLSKey(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) (crypto.Signer, error) {
+func SecretTLSKey(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name string) (crypto.Signer, error) {
 	return SecretTLSKeyRef(ctx, secretLister, namespace, name, corev1.TLSPrivateKeyKey)
 }
 
@@ -69,7 +69,7 @@ func ParseTLSKeyFromSecret(secret *corev1.Secret, keyName string) (crypto.Signer
 	return key, keyBytes, nil
 }
 
-func SecretTLSCertChain(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) ([]*x509.Certificate, error) {
+func SecretTLSCertChain(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name string) ([]*x509.Certificate, error) {
 	secret, err := secretLister.Secrets(namespace).Get(name)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func SecretTLSCertChain(ctx context.Context, secretLister corelisters.SecretList
 // SecretTLSKeyPairAndCA returns the X.509 certificate chain and private key of
 // the leaf certificate contained in the target Secret. If the ca.crt field exists
 // on the Secret, it is parsed and added to the end of the certificate chain.
-func SecretTLSKeyPairAndCA(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) ([]*x509.Certificate, crypto.Signer, error) {
+func SecretTLSKeyPairAndCA(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name string) ([]*x509.Certificate, crypto.Signer, error) {
 	certs, key, err := SecretTLSKeyPair(ctx, secretLister, namespace, name)
 	if err != nil {
 		return nil, nil, err
@@ -114,7 +114,7 @@ func SecretTLSKeyPairAndCA(ctx context.Context, secretLister corelisters.SecretL
 	return append(certs, ca), key, nil
 }
 
-func SecretTLSKeyPair(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) ([]*x509.Certificate, crypto.Signer, error) {
+func SecretTLSKeyPair(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name string) ([]*x509.Certificate, crypto.Signer, error) {
 	secret, err := secretLister.Secrets(namespace).Get(name)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +141,7 @@ func SecretTLSKeyPair(ctx context.Context, secretLister corelisters.SecretLister
 	return cert, key, nil
 }
 
-func SecretTLSCert(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) (*x509.Certificate, error) {
+func SecretTLSCert(ctx context.Context, secretLister internalinformers.SecretLister, namespace, name string) (*x509.Certificate, error) {
 	certs, err := SecretTLSCertChain(ctx, secretLister, namespace, name)
 	if err != nil {
 		return nil, err

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -118,17 +118,27 @@ func TestAcmeOrdersController(t *testing.T) {
 		},
 	}
 
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock: clock.RealClock{},
+			ACMEOptions: controllerpkg.ACMEOptions{
+				AccountRegistry: accountRegistry,
+			},
+		},
+
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-orders-test",
+	}
+
 	// Create a new orders controller.
 	ctrl, queue, mustSync := acmeorders.NewController(
 		logf.Log,
-		cmCl,
-		factory,
-		cmFactory,
-		accountRegistry,
-		framework.NewEventRecorder(t),
-		clock.RealClock{},
+		&controllerContext,
 		false,
-		"cert-manager-test",
 	)
 	c := controllerpkg.NewController(
 		ctx,

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates/requestmanager"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates/revisionmanager"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates/trigger"
-	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -320,23 +320,36 @@ func runAllControllers(t *testing.T, ctx context.Context, config *rest.Config) f
 	log := logf.Log
 	clock := clock.RealClock{}
 	metrics := metrics.New(log, clock)
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Metrics: metrics,
+			Clock:   clock,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-issuing-test",
+	}
 
-	revCtrl, revQueue, revMustSync := revisionmanager.NewController(log, cmCl, cmFactory)
+	// TODO: set field mananager before calling each of those- is that what we do in actual code?
+	revCtrl, revQueue, revMustSync := revisionmanager.NewController(log, &controllerContext)
 	revisionManager := controllerpkg.NewController(ctx, "revisionmanager_controller", metrics, revCtrl.ProcessItem, revMustSync, nil, revQueue)
 
-	readyCtrl, readyQueue, readyMustSync := readiness.NewController(log, cmCl, factory, cmFactory, policies.NewReadinessPolicyChain(clock), pki.RenewalTime, readiness.BuildReadyConditionFromChain, "readiness")
+	readyCtrl, readyQueue, readyMustSync := readiness.NewController(log, &controllerContext, policies.NewReadinessPolicyChain(clock), pki.RenewalTime, readiness.BuildReadyConditionFromChain)
 	readinessManager := controllerpkg.NewController(ctx, "readiness_controller", metrics, readyCtrl.ProcessItem, readyMustSync, nil, readyQueue)
 
-	issueCtrl, issueQueue, issueMustSync := issuing.NewController(log, kubeClient, cmCl, factory, cmFactory, &testpkg.FakeRecorder{}, clock, controllerpkg.CertificateOptions{}, "issuing")
+	issueCtrl, issueQueue, issueMustSync := issuing.NewController(log, &controllerContext)
 	issueManager := controllerpkg.NewController(ctx, "issuing_controller", metrics, issueCtrl.ProcessItem, issueMustSync, nil, issueQueue)
 
-	reqCtrl, reqQueue, reqMustSync := requestmanager.NewController(log, cmCl, factory, cmFactory, &testpkg.FakeRecorder{}, clock, controllerpkg.CertificateOptions{}, "requestmanager")
+	reqCtrl, reqQueue, reqMustSync := requestmanager.NewController(log, &controllerContext)
 	requestManager := controllerpkg.NewController(ctx, "requestmanager_controller", metrics, reqCtrl.ProcessItem, reqMustSync, nil, reqQueue)
 
-	keyCtrl, keyQueue, keyMustSync := keymanager.NewController(log, cmCl, kubeClient, factory, cmFactory, &testpkg.FakeRecorder{}, "keymanager")
+	keyCtrl, keyQueue, keyMustSync := keymanager.NewController(log, &controllerContext)
 	keyManager := controllerpkg.NewController(ctx, "keymanager_controller", metrics, keyCtrl.ProcessItem, keyMustSync, nil, keyQueue)
 
-	triggerCtrl, triggerQueue, triggerMustSync := trigger.NewController(log, cmCl, factory, cmFactory, &testpkg.FakeRecorder{}, clock, policies.NewTriggerPolicyChain(clock).Evaluate, "trigger")
+	triggerCtrl, triggerQueue, triggerMustSync := trigger.NewController(log, &controllerContext, policies.NewTriggerPolicyChain(clock).Evaluate)
 	triggerManager := controllerpkg.NewController(ctx, "trigger_controller", metrics, triggerCtrl.ProcessItem, triggerMustSync, nil, triggerQueue)
 
 	return framework.StartInformersAndControllers(t, factory, cmFactory, revisionManager, requestManager, keyManager, triggerManager, readinessManager, issueManager)

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -69,10 +69,20 @@ func TestIssuingController(t *testing.T) {
 	controllerOptions := controllerpkg.CertificateOptions{
 		EnableOwnerRef: true,
 	}
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-issuing-test",
+	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient,
-		cmCl, factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
-		controllerOptions, "cert-manage-certificates-issuing-test")
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
 	c := controllerpkg.NewController(
 		ctx,
 		"issuing_test",
@@ -275,10 +285,20 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 	controllerOptions := controllerpkg.CertificateOptions{
 		EnableOwnerRef: true,
 	}
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-issuing-test",
+	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient,
-		cmCl, factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
-		controllerOptions, "cert-manage-certificates-issuing-test")
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
 	c := controllerpkg.NewController(
 		ctx,
 		"issuing_test",
@@ -490,10 +510,20 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	controllerOptions := controllerpkg.CertificateOptions{
 		EnableOwnerRef: true,
 	}
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-issuing-test",
+	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient,
-		cmCl, factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
-		controllerOptions, "cert-manage-certificates-issuing-test")
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
 	c := controllerpkg.NewController(
 		ctx,
 		"issuing_test",
@@ -726,7 +756,20 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		EnableOwnerRef: true,
 	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient, cmCl, factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{}, controllerOptions, "cert-manager-issuing-test")
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-issuing-test",
+	}
+
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
 	c := controllerpkg.NewController(
 		ctx,
 		"issuing_test",
@@ -949,10 +992,19 @@ func Test_IssuingController_OwnerRefernece(t *testing.T) {
 	controllerOptions := controllerpkg.CertificateOptions{
 		EnableOwnerRef: false,
 	}
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, kubeClient, cmClient,
-		factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
-		controllerOptions, fieldManager,
-	)
+	controllerContext := controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmClient,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: fieldManager,
+	}
+	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
 	c := controllerpkg.NewController(ctx, fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
 	stopControllerNoOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
 	defer func() {
@@ -1036,10 +1088,19 @@ func Test_IssuingController_OwnerRefernece(t *testing.T) {
 	kubeClient, factory, cmClient, cmFactory = framework.NewClients(t, config)
 	stopControllerNoOwnerRef = nil
 	controllerOptions.EnableOwnerRef = true
-	ctrl, queue, mustSync = issuing.NewController(logf.Log, kubeClient, cmClient,
-		factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{},
-		controllerOptions, fieldManager,
-	)
+	controllerContext = controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmClient,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock:              clock.RealClock{},
+			CertificateOptions: controllerOptions,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: fieldManager,
+	}
+	ctrl, queue, mustSync = issuing.NewController(logf.Log, &controllerContext)
 	c = controllerpkg.NewController(ctx, fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
 	stopControllerOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
 	defer stopControllerOwnerRef()

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -95,7 +95,14 @@ func TestMetricsController(t *testing.T) {
 		}
 	}()
 
-	ctrl, queue, mustSync := controllermetrics.NewController(factory, cmFactory, metricsHandler)
+	controllerContext := controllerpkg.Context{
+		KubeSharedInformerFactory: factory,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Metrics: metricsHandler,
+		},
+	}
+	ctrl, queue, mustSync := controllermetrics.NewController(&controllerContext)
 	c := controllerpkg.NewController(
 		ctx,
 		"metrics_test",

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -53,7 +53,12 @@ func TestRevisionManagerController(t *testing.T) {
 	// Build, instantiate and run the revision manager controller.
 	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
 
-	ctrl, queue, mustSync := revisionmanager.NewController(logf.Log, cmCl, cmFactory)
+	controllerContext := controllerpkg.Context{
+		CMClient:              cmCl,
+		SharedInformerFactory: cmFactory,
+	}
+
+	ctrl, queue, mustSync := revisionmanager.NewController(logf.Log, &controllerContext)
 
 	c := controllerpkg.NewController(
 		ctx,

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -69,9 +69,18 @@ func TestTriggerController(t *testing.T) {
 		t.Fatal(err)
 	}
 	shouldReissue := policies.NewTriggerPolicyChain(fakeClock).Evaluate
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory,
-		cmFactory, framework.NewEventRecorder(t), fakeClock, shouldReissue,
-		"cert-manage-certificates-trigger-test")
+	controllerContext := &controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock: fakeClock,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-trigger-test",
+	}
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shouldReissue)
 	c := controllerpkg.NewController(
 		ctx,
 		"trigger_test",
@@ -165,10 +174,19 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	controllerContext := &controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock: fakeClock,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-trigger-test",
+	}
 	// Start the trigger controller
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory,
-		cmFactory, framework.NewEventRecorder(t), fakeClock, shoudReissue,
-		"cert-manage-certificates-trigger-test")
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shoudReissue)
 	c := controllerpkg.NewController(
 		logf.NewContext(ctx, logf.Log, "trigger_controller_RenewNearExpiry"),
 		"trigger_test",
@@ -251,8 +269,20 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 		},
 	}
 
+	controllerContext := &controllerpkg.Context{
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		ContextOptions: controllerpkg.ContextOptions{
+			Clock: fakeClock,
+		},
+		Recorder:     framework.NewEventRecorder(t),
+		FieldManager: "cert-manager-certificates-trigger-test",
+	}
+
 	// Start the trigger controller
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, shoudReissue, "cert-manger-certificates-trigger-test")
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shoudReissue)
 	c := controllerpkg.NewController(
 		logf.NewContext(ctx, logf.Log, "trigger_controller_RenewNearExpiry"),
 		"trigger_test",


### PR DESCRIPTION
This PR is an implementation of controller's memory consumption reduction design https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md.

It ensures that only `Secret`s labelled with `controller.cert-manager.io/fao` label are cached in full. For the rest of the `Secret`s only partial metadata is cached.

Implementation:

- refactors current core informer's factory used in cert-manager controller to allow to provide a custom implementation
- Adds a new alpha `SecretsFilteredCaching` feature for which a custom implementatin of core informers factory is used that:
  - wraps a 'concrete' informers factory
  - also wraps a partial metadata informers factory
  - for `Secret`s spin up two informers, one for `Secret` types that only watches `Secret`s with `controller.cert-manager.io/fao` label, one for `Secret` partial metadata that only watches `Secret`s _without` `controller.cert-manager.io/fao` label
  - for `Secret`s create a custom lister that retrieves `Secret`s either from kube apiserver or typed cache depending on whether it's found in typed cache or in partial metadata cache

The informerfactory refactor allows to implement this feature in such a way that an engineer who adds a new control loop and wants to use `Secret`s informers/listers do not need to worry about it- they just consume the informers and listers in the same way as before, the custom implementation exists at a layer below.

## Metrics

### Controller memory consumption in a cluster with 300 non-cert-manager `Secret`s each about 1MB in size
This is the same test as in https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#cluster-with-large-cert-manager-unrelated-secrets

#### cert-manager from this PR

![partial300now](https://user-images.githubusercontent.com/24879183/226613684-750d5283-408f-4123-96e4-4973d93fae6a.png)

#### cert-manager from current master

![latestmaster300now](https://user-images.githubusercontent.com/24879183/226642510-55f0b4b5-f2f8-4a9d-b43f-9c01be4eba8c.png)



### Issuing 500 certificates from 10 CA issuers with unlabelled CA cert `Secret`s

#### cert-manager from this PR

issuance time:

![partialmanycertsnow](https://user-images.githubusercontent.com/24879183/226633469-e3c39b17-21e8-49e9-852c-08144a465e29.png)

#### cert-manager from current master

issuance time:

![mastermanycertsnow](https://user-images.githubusercontent.com/24879183/226635686-a2f754e4-2a91-467b-aca2-c141483d4391.png)

We can see that the issuance time in this case is slightly slower. Users could improve that by labelling the CA issuers' CA `Secret`s.


Related PRs:

- https://github.com/cert-manager/cert-manager/pull/5660 labels all Certificate Secrets with  `controller.cert-manager.io/fao` label
- 
Next steps:
- when this PR merges, I will add additional cleanup (via [transform functions](https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#transform-functions)) for the cached metadata to remove 'last applied' label etc that should further reduce memory consumption 
- ultimately I would like to be able to document the amount of memory required for controller pod


### Release Note

```release-note
Filters Secret caching to ensure only relevant Secrets are cached in full. This should reduce controller's memory consumption in clusters with a large number of cert-manager unrelated `Secret` resources. The filtering functionality is currently placed behind `SecretsFilteredCaching` feature flag.
The filtering mechanism might, in some cases, slightly slow down issuance or cause additional requests to kube apiserver, because unlabelled `Secret`s that cert-manager controller needs will now be retrieved from kube apiserver instead of being cached locally. To prevent this from happening, users can label all issuer `Secret`s with `controller.cert-manager.io/fao: true` label.
```
/cc @SpectralHiss


Fixes #4722 