### PR TITLE
Enable Alpha & Beta features in local e2e and update comments

### DIFF
--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -45,6 +45,7 @@ const (
 	// alpha: v1.7.0
 	//
 	// AdditionalCertificateOutputFormats enable output additional format
+	// See https://github.com/cert-manager/cert-manager/blob/master/design/20220118.server-side-apply.md#feature-gate
 	AdditionalCertificateOutputFormats featuregate.Feature = "AdditionalCertificateOutputFormats"
 
 	// alpha: v1.8.0
@@ -95,9 +96,14 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalGatewayAPISupport:                    {Default: false, PreRelease: featuregate.Alpha},
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
-	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},
 	StableCertificateRequestName:                     {Default: false, PreRelease: featuregate.Alpha},
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
-	SecretsFilteredCaching:                           {Default: false, PreRelease: featuregate.Alpha},
+	// We plan to graduate this feature to Beta in v1.13 after we moved all controllers to use ServerSideApply.
+	// We already know that the feature is reasonably correct & stable thanks to enabling it in our e2e tests for a while.
+	// More info about criteria: https://github.com/cert-manager/cert-manager/blob/master/design/20220118.server-side-apply.md#feature-gate
+	ServerSideApply: {Default: false, PreRelease: featuregate.Alpha},
+	// We plan to graduate this feature to Beta in v1.13 after we gathered some User feedback.
+	// More info about criteria: https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#graduation-criteria
+	SecretsFilteredCaching: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -77,7 +77,7 @@ flake_attempts=1
 ginkgo_skip=
 ginkgo_focus=
 
-feature_gates=AdditionalCertificateOutputFormats=true,ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,LiteralCertificateSubject=true
+feature_gates=AllAlpha=true,AllBeta=true
 
 artifacts="./$BINDIR/artifacts"
 


### PR DESCRIPTION
This PR enables all Alpha & Beta features in our e2e tests ( the -feature-gates-disabled tests will still test the other setups ).
Also, the PR adds some more comments next to our feature gates to clarify what the roadmap looks like.

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

/kind feature

### Release Note

```release-note
Enable SSA and SecretsFilteredCaching by default
```
