### PR TITLE
digitalocean: Pass user agent string to godo client.

### DIFF
--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -38,14 +38,14 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for digitalocean.
 // The access token must be passed in the environment variable DIGITALOCEAN_TOKEN
-func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
+func NewDNSProvider(dns01Nameservers []string, userAgent string) (*DNSProvider, error) {
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
-	return NewDNSProviderCredentials(token, dns01Nameservers)
+	return NewDNSProviderCredentials(token, dns01Nameservers, userAgent)
 }
 
 // NewDNSProviderCredentials uses the supplied credentials to return a
 // DNSProvider instance configured for digitalocean.
-func NewDNSProviderCredentials(token string, dns01Nameservers []string) (*DNSProvider, error) {
+func NewDNSProviderCredentials(token string, dns01Nameservers []string, userAgent string) (*DNSProvider, error) {
 	if token == "" {
 		return nil, fmt.Errorf("DigitalOcean token missing")
 	}
@@ -55,9 +55,15 @@ func NewDNSProviderCredentials(token string, dns01Nameservers []string) (*DNSPro
 		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
 	)
 
+	clientOpts := []godo.ClientOpt{godo.SetUserAgent(userAgent)}
+	client, err := godo.New(c, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DNSProvider{
 		dns01Nameservers: dns01Nameservers,
-		client:           godo.NewClient(c),
+		client:           client,
 	}, nil
 }
 

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -45,21 +45,21 @@ func restoreEnv() {
 
 func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("DIGITALOCEAN_TOKEN", "")
-	_, err := NewDNSProviderCredentials("123", util.RecursiveNameservers)
+	_, err := NewDNSProviderCredentials("123", util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
 	restoreEnv()
 }
 
 func TestNewDNSProviderValidEnv(t *testing.T) {
 	os.Setenv("DIGITALOCEAN_TOKEN", "123")
-	_, err := NewDNSProvider(util.RecursiveNameservers)
+	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
 	restoreEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("DIGITALOCEAN_TOKEN", "")
-	_, err := NewDNSProvider(util.RecursiveNameservers)
+	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.EqualError(t, err, "DigitalOcean token missing")
 	restoreEnv()
 }
@@ -69,7 +69,7 @@ func TestDigitalOceanPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers)
+	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
 
 	err = provider.Present(doDomain, "_acme-challenge."+doDomain+".", "123d==")
@@ -83,7 +83,7 @@ func TestDigitalOceanCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 
-	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers)
+	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(doDomain, "_acme-challenge."+doDomain+".", "123d==")

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -62,7 +62,7 @@ type dnsProviderConstructors struct {
 	route53      func(accessKey, secretKey, hostedZoneID, region, role string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
 	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error)
 	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
-	digitalOcean func(token string, dns01Nameservers []string) (*digitalocean.DNSProvider, error)
+	digitalOcean func(token string, dns01Nameservers []string, userAgent string) (*digitalocean.DNSProvider, error)
 }
 
 // Solver is a solver for the acme dns01 challenge.
@@ -286,7 +286,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, issuer v1.GenericIssuer
 
 		apiToken := string(apiTokenSecret.Data[providerConfig.DigitalOcean.Token.Key])
 
-		impl, err = s.dnsProviderConstructors.digitalOcean(strings.TrimSpace(apiToken), s.DNS01Nameservers)
+		impl, err = s.dnsProviderConstructors.digitalOcean(strings.TrimSpace(apiToken), s.DNS01Nameservers, s.RESTConfig.UserAgent)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating digitalocean challenge solver: %s", err.Error())
 		}

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -151,7 +151,7 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("acmedns", host, accountJson, dns01Nameservers)
 			return nil, nil
 		},
-		digitalOcean: func(token string, dns01Nameservers []string) (*digitalocean.DNSProvider, error) {
+		digitalOcean: func(token string, dns01Nameservers []string, userAgent string) (*digitalocean.DNSProvider, error) {
 			f.call("digitalocean", token, util.RecursiveNameservers)
 			return nil, nil
 		},


### PR DESCRIPTION
### Pull Request Motivation

This PR sets a custom user agent string when initializing the godo client for the DigitalOcean issuer. It's a general best practice for clients to identify themselves. As one of the maintainers of godo, it helps us to better understand how it is being used. It should help enable DigitalOcean to better support their customers using cert-manager.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

```release-note
The DigitalOcean issuer now sets a cert-manager user agent string.
```
