### PR TITLE
Remove obsolete bazel documentation

### DIFF
--- a/deploy/manifests/README.md
+++ b/deploy/manifests/README.md
@@ -11,17 +11,3 @@ automatically from the [official helm chart](../charts/cert-manager).
 
 When a new release of cert-manager is cut, these manifests will be
 automatically generated and published as an asset **attached to the GitHub release**.
-
-## How can I generate my own manifests?
-
-If you want to build a copy of your own manifests for testing purposes, you
-can do so using Bazel.
-
-To build the manifests, run:
-
-```bash
-$ bazel build //deploy/manifests:cert-manager.yaml
-```
-
-This will generate the static deployment manifests at
-`bazel-bin/deploy/manifests/cert-manager.yaml`.


### PR DESCRIPTION
### Pull Request Motivation

Clean up obsolete documentation. Bazel is no longer used.

### Kind


cleanup


### Release Note


```release-note
NONE
```
