### PR TITLE
helm: add support for TLS configuration and application protocol

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -521,6 +521,10 @@ Optionally set the IP family policy for the controller Service to configure dual
 
 Optionally set the IP families for the controller Service that should be supported, in the order in which they should be applied to ClusterIP. Can be IPv4 and/or IPv6.
 
+#### **serviceAppProtocol** ~ `string`
+
+Optionally set the application protocol to use for the controller Service.
+
 #### **podDnsPolicy** ~ `string`
 
 Pod DNS policy.  
@@ -751,6 +755,20 @@ endpointAdditionalProperties:
 
 
 
+#### **prometheus.servicemonitor.scheme** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+The explicit scheme for metrics scraping.
+#### **prometheus.servicemonitor.tlsConfig** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+TLS configuration for metrics scraping.
 #### **prometheus.podmonitor.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -27,8 +27,8 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
-{{- if .Values.prometheus.servicemonitor.appProtocol }}
-    appProtocol: {{ .Values.prometheus.servicemonitor.appProtocol }}
+{{- if .Values.serviceAppProtocol }}
+    appProtocol: {{ .Values.serviceAppProtocol }}
 {{- end }}
     port: 9402
     name: tcp-prometheus-servicemonitor

--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -27,6 +27,9 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
+{{- if .Values.prometheus.servicemonitor.appProtocol }}
+    appProtocol: {{ .Values.prometheus.servicemonitor.appProtocol }}
+{{- end }}
     port: 9402
     name: tcp-prometheus-servicemonitor
     targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -60,4 +60,13 @@ spec:
     {{- with .Values.prometheus.servicemonitor.endpointAdditionalProperties }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.prometheus.servicemonitor.scheme }}
+    scheme: {{ .Values.prometheus.servicemonitor.scheme }}
+{{- end }}
+{{- if .Values.prometheus.servicemonitor.tlsConfig }}
+    tlsConfig:
+      {{- with .Values.prometheus.servicemonitor.tlsConfig }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -138,6 +138,9 @@
         "serviceAnnotations": {
           "$ref": "#/$defs/helm-values.serviceAnnotations"
         },
+        "serviceAppProtocol": {
+          "$ref": "#/$defs/helm-values.serviceAppProtocol"
+        },
         "serviceIPFamilies": {
           "$ref": "#/$defs/helm-values.serviceIPFamilies"
         },
@@ -1254,6 +1257,10 @@
     "helm-values.serviceAnnotations": {
       "description": "Optional annotations to add to the controller Service.",
       "type": "object"
+    },
+    "helm-values.serviceAppProtocol": {
+      "description": "Optionally set the application protocol to use for the controller Service.",
+      "type": "string"
     },
     "helm-values.serviceIPFamilies": {
       "description": "Optionally set the IP families for the controller Service that should be supported, in the order in which they should be applied to ClusterIP. Can be IPv4 and/or IPv6.",

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1109,11 +1109,17 @@
         "prometheusInstance": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.prometheusInstance"
         },
+        "scheme": {
+          "$ref": "#/$defs/helm-values.prometheus.servicemonitor.scheme"
+        },
         "scrapeTimeout": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.scrapeTimeout"
         },
         "targetPort": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.targetPort"
+        },
+        "tlsConfig": {
+          "$ref": "#/$defs/helm-values.prometheus.servicemonitor.tlsConfig"
         }
       },
       "type": "object"
@@ -1162,6 +1168,11 @@
       "description": "Specifies the `prometheus` label on the created ServiceMonitor. This is used when different Prometheus instances have label selectors matching different ServiceMonitors.",
       "type": "string"
     },
+    "helm-values.prometheus.servicemonitor.scheme": {
+      "default": "",
+      "description": "The explicit scheme for metrics scraping.",
+      "type": "string"
+    },
     "helm-values.prometheus.servicemonitor.scrapeTimeout": {
       "default": "30s",
       "description": "The timeout before a metrics scrape fails.",
@@ -1171,6 +1182,11 @@
       "default": 9402,
       "description": "The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics.",
       "type": "number"
+    },
+    "helm-values.prometheus.servicemonitor.tlsConfig": {
+      "default": {},
+      "description": "TLS configuration for metrics scraping.",
+      "type": "object"
     },
     "helm-values.replicaCount": {
       "default": 1,

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -349,6 +349,10 @@ podLabels: {}
 # +docs:property
 # serviceIPFamilies: []
 
+# Optionally set the application protocol to use for the controller Service.
+# +docs:property
+# serviceAppProtocol: ""
+
 # Optional DNS settings. These are useful if you have a public and private DNS zone for
 # the same domain on Route 53. The following is an example of ensuring
 # cert-manager can access an ingress or DNS TXT records at all times.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -542,6 +542,12 @@ prometheus:
     # +docs:property
     endpointAdditionalProperties: {}
 
+    # The explicit scheme for metrics scraping.
+    scheme: ""
+
+    # TLS configuration for metrics scraping.
+    tlsConfig: {}
+
   # Note that you can not enable both PodMonitor and ServiceMonitor as they are mutually exclusive. Enabling both will result in an error.
   podmonitor:
     # Create a PodMonitor to add cert-manager to Prometheus.


### PR DESCRIPTION
### Pull Request Motivation
👋🏾 Hey there! 

This project provides tons of value, I was hoping to contribute this little bit back, if it makes sense and makes others' lives easier. Metrics scraping of cert-manager can be difficult when using something like Istio.

There are two pieces here, broken down by commit:

1. The built-in `ServiceMonitor` creation is awesome, but if scaping prometheus metrics over mTLS, we can't configure the monitor with those settings. The [CRD already supports](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.Endpoint) this, so we just need to expose those in the helm-chart to forward on to the resource. To be extra careful, these default to empty, though I think we could technically make the `scheme: http` without breaking anything.
2. Istio makes [certain traffic management decisions](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) based on the detected protocol. It uses the `port` name by default to  do this (e.g. `http-web` is detected as http, whereas `tcp-web` would be detected as raw tcp). Normally this isn't a huge deal, but when negotiating protocol upgrades or other edge-ish cases, Istio will handle things in not-so-user-friendly ways, and often cause one end of the connection to get closed incorrectly. Luckily, K8S has an API to expose this in a non-breaking way: [appProtocol](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol). This is supported since `1.20`, so it should fit the `1.11` cert-manager release. Though again, defaulted in helm to be empty just in case. This one _could_ be hard-coded, but leaves the flexibility up in the future in case cert-manager were to ever expose ways in which it'd like to expose metrics outside of HTTP.

### Kind
feature


### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
helm-chart: Prometheus ServiceMonitor resource can now be configured with TLS Configuration and Application Protocol.
```
