### PR TITLE
Error if the resource name is omitted, unless --all is also used.

### DIFF
--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -113,7 +113,7 @@ func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !o.All && len(args) == 0 {
-		return errors.New("certificate name(s) is/are required without the --all flag")
+		return errors.New("inform one or more Certificate resource name or use the --all flag to renew all Certificate resources")
 	}
 
 	return nil

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -112,6 +112,10 @@ func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot specify --namespace flag in conjunction with --all flag")
 	}
 
+	if !o.All && len(args) == 0 {
+		return errors.New("certificate name(s) is/are required without the --all flag")
+	}
+
 	return nil
 }
 

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -113,7 +113,7 @@ func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !o.All && len(args) == 0 {
-		return errors.New("inform one or more Certificate resource name or use the --all flag to renew all Certificate resources")
+		return errors.New("please supply one or more Certificate resource names or use the --all flag to renew all Certificate resources")
 	}
 
 	return nil

--- a/cmd/ctl/pkg/renew/renew_test.go
+++ b/cmd/ctl/pkg/renew/renew_test.go
@@ -72,6 +72,29 @@ func TestValidate(t *testing.T) {
 			},
 			expErr: true,
 		},
+		"If --namespace specified without arguments, error": {
+			options: &Options{},
+			setStringFlags: []stringFlag{
+				{name: "namespace", value: "foo"},
+			},
+			expErr: true,
+		},
+		"If --namespace specified and at least one argument, don't error": {
+			options: &Options{},
+			args:    []string{"bar"},
+			setStringFlags: []stringFlag{
+				{name: "namespace", value: "foo"},
+			},
+			expErr: false,
+		},
+		"If --namespace specified with multiple arguments, don't error": {
+			options: &Options{},
+			args:    []string{"bar", "abc"},
+			setStringFlags: []stringFlag{
+				{name: "namespace", value: "foo"},
+			},
+			expErr: false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
### Pull Request Motivation

The aim of this PR is to fix the bug reported [here](https://github.com/cert-manager/cert-manager/issues/5886). Currently, there is no validation for the scenario where the namespace is informed without a certificate list. Therefore, this PR adds a validation for this scenario:

- Error:

`cmctl renew -n application-team-1 -> Error`

- Ok

`cmctl renew -n application-team-1 service-1 -> ok`

### bug

### Release Note

```release-note
cmctl renew now prints an error message unless Certificate name(s) or --all are supplied
```

Fixes: https://github.com/cert-manager/cert-manager/issues/5886