### PR TITLE
Reduce the amount of ACME calls during issuance

### DIFF
--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -36,13 +36,24 @@ type Interface interface {
 	ListCertAlternates(ctx context.Context, url string) ([]string, error)
 	WaitOrder(ctx context.Context, url string) (*acme.Order, error)
 	CreateOrderCert(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error)
+	// Accept will (in success cases) be called once per a Challenge once it
+	// has passed self-check and is ready to be verified by the ACME server.
 	Accept(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error)
 	GetChallenge(ctx context.Context, url string) (*acme.Challenge, error)
+	// GetAuthorization will be called once for each required authorization
+	// for an Order. Additionally it will be called most likely once when a
+	// Challenge has been scheduled for processing to retrieve its status.
 	GetAuthorization(ctx context.Context, url string) (*acme.Authorization, error)
+	// WaitAuthorization will, in success cases, be called once per
+	// Challenge after it has been accepted.
 	WaitAuthorization(ctx context.Context, url string) (*acme.Authorization, error)
 	Register(ctx context.Context, acct *acme.Account, prompt func(tosURL string) bool) (*acme.Account, error)
 	GetReg(ctx context.Context, url string) (*acme.Account, error)
+	// HTTP01ChallengeResponse will be called once when an cert-manager.io
+	// Challenge for an http-01 challenge type is being created.
 	HTTP01ChallengeResponse(token string) (string, error)
+	// DNS01ChallengeResponse will be called once when an cert-manager.io
+	// Challenge for an http-01 challenge type is being created.
 	DNS01ChallengeRecord(token string) (string, error)
 	Discover(ctx context.Context) (acme.Directory, error)
 	UpdateReg(ctx context.Context, a *acme.Account) (*acme.Account, error)

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -189,9 +189,14 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 
 	switch {
 	case anyChallengesFailed(challenges):
-		// TODO (@munnerz): instead of waiting for the ACME server to mark this
-		//  Order as failed, we could just mark the Order as failed as there is
-		//  no way that we will attempt and continue the order anyway.
+		// TODO (@munnerz): instead of waiting for the ACME server to
+		// mark this Order as failed, we could just mark the Order as
+		// failed as there is no way that we will attempt and continue
+		// the order anyway. This might, however, be a breaking change
+		// in edge cases where the status of the order resource in ACME
+		// server cannot be determined from challenge resource statuses
+		// correctly. Do not change this unless there is a real need for
+		// it.
 		log.V(logf.DebugLevel).Info("Update Order status as at least one Challenge has failed")
 		_, err := c.updateOrderStatusFromACMEOrder(ctx, cl, o, acmeOrder)
 		if acmeErr, ok := err.(*acmeapi.Error); ok {

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -161,6 +161,14 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 		return c.finalizeOrder(ctx, cl, o, genericIssuer)
 	}
 
+	// At this point, if no Challenges have failed or reached a final state,
+	// we can return without taking any action. This controller will resync
+	// the Order on any owned Challenge events.
+	if !anyChallengesFailed(challenges) && !allChallengesFinal(challenges) {
+		log.V(logf.DebugLevel).Info("No action taken")
+		return nil
+	}
+
 	// Note: each of the following code paths uses the ACME Order retrieved
 	// here. Be mindful when adding new code below this call to ACME server-
 	// if the new code does not need this ACME order, try to place it above

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -490,9 +490,6 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 				ExpectedActions:    []testpkg.Action{},
 			},
 			acmeClient: &acmecl.FakeACME{
-				FakeGetOrder: func(_ context.Context, url string) (*acmeapi.Order, error) {
-					return testACMEOrderPending, nil
-				},
 				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
 					// TODO: assert s = "token"
 					return "key", nil

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -206,10 +206,16 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 			return "key", nil
 		},
 	}
-	testAuthorizationChallenge, err := buildChallenge(context.TODO(), fakeHTTP01ACMECl, testIssuerHTTP01TestCom, testOrderPending, testOrderPending.Status.Authorizations[0])
+	testAuthorizationChallenge, err := buildPartialChallenge(context.TODO(), testIssuerHTTP01TestCom, testOrderPending, testOrderPending.Status.Authorizations[0])
+
 	if err != nil {
 		t.Fatalf("error building Challenge resource test fixture: %v", err)
 	}
+	key, err := fakeHTTP01ACMECl.FakeHTTP01ChallengeResponse(testAuthorizationChallenge.Spec.Token)
+	if err != nil {
+		t.Fatalf("error building Challenge resource test fixture: %v", err)
+	}
+	testAuthorizationChallenge.Spec.Key = key
 	testAuthorizationChallengeValid := testAuthorizationChallenge.DeepCopy()
 	testAuthorizationChallengeValid.Status.State = cmacme.Valid
 	testAuthorizationChallengeInvalid := testAuthorizationChallenge.DeepCopy()
@@ -338,7 +344,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 					testpkg.NewAction(coretesting.NewCreateAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge)),
 				},
 				ExpectedEvents: []string{
-					`Normal Created Created Challenge resource "testorder-2179654896" for domain "test.com"`,
+					`Normal Created Created Challenge resource "testorder-756011405" for domain "test.com"`,
 				},
 			},
 			acmeClient: &acmecl.FakeACME{

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -22,13 +22,14 @@ import (
 	"reflect"
 	"testing"
 
-	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
-	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/cert-manager/cert-manager/test/unit/gen"
 	"github.com/kr/pretty"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 func TestChallengeSpecForAuthorization(t *testing.T) {
@@ -92,7 +93,7 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 
 	tests := map[string]struct {
 		acmeClient acmecl.Interface
-		issuer     v1.GenericIssuer
+		issuer     cmapi.GenericIssuer
 		order      *cmacme.Order
 		authz      *cmacme.ACMEAuthorization
 
@@ -101,9 +102,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 	}{
 		"should override the ingress name to edit if override annotation is specified": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
 						},
@@ -139,9 +140,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should override the ingress class to edit if override annotation is specified": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
 						},
@@ -177,9 +178,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should return an error if both ingress class and name override annotations are set": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
 						},
@@ -205,9 +206,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should ignore HTTP01 override annotations if DNS01 solver is chosen": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverDNS01},
 						},
@@ -237,9 +238,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should use configured default solver when no others are present": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
 						},
@@ -264,9 +265,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should use configured default solver when no others are present but selector is non-nil": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -307,9 +308,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should use configured default solver when others do not match": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverHTTP01,
@@ -337,9 +338,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should use DNS01 solver over HTTP01 if challenge is of type DNS01": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverHTTP01,
@@ -367,9 +368,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should return an error if none match": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								nonMatchingSelectorSolver,
@@ -391,9 +392,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"uses correct solver when selector explicitly names dnsName": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverHTTP01,
@@ -421,9 +422,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"uses default solver if dnsName does not match": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverHTTP01,
@@ -451,9 +452,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if two solvers specify the same dnsName, the one with the most labels should be chosen": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								exampleComDNSNameSelectorSolver,
@@ -510,9 +511,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if one solver matches with dnsNames, and the other solver matches with labels, the dnsName solver should be chosen": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								exampleComDNSNameSelectorSolver,
@@ -558,9 +559,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		// order to ensure that this behaviour isn't just incidental
 		"if one solver matches with dnsNames, and the other solver matches with labels, the dnsName solver should be chosen (solvers listed in reverse order)": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -604,9 +605,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if one solver matches with dnsNames, and the other solver matches with 2 labels, the dnsName solver should be chosen": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								exampleComDNSNameSelectorSolver,
@@ -652,9 +653,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should choose the solver with the most labels matching if multiple match": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -723,9 +724,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should match wildcard dnsName solver if authorization has Wildcard=true": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverDNS01,
@@ -773,9 +774,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"dnsName selectors should take precedence over dnsZone selectors": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								exampleComDNSNameSelectorSolver,
@@ -812,9 +813,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"dnsName selectors should take precedence over dnsZone selectors (reversed order)": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -851,9 +852,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"should allow matching with dnsZones": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								emptySelectorSolverDNS01,
@@ -901,9 +902,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"most specific dnsZone should be selected if multiple match": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -960,9 +961,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"most specific dnsZone should be selected if multiple match (reversed)": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -1019,9 +1020,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if two solvers specify the same dnsZone, the one with the most labels should be chosen": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -1087,9 +1088,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if both solvers match dnsNames, and one also matches dnsZones, choose the one that matches dnsZones": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -1146,9 +1147,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"if both solvers match dnsNames, and one also matches dnsZones, choose the one that matches dnsZones (reversed)": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								{
@@ -1205,9 +1206,9 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 		},
 		"uses correct solver when selector explicitly names dnsName (reversed)": {
 			acmeClient: basicACMEClient,
-			issuer: &v1.Issuer{
-				Spec: v1.IssuerSpec{
-					IssuerConfig: v1.IssuerConfig{
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
 						ACME: &cmacme.ACMEIssuer{
 							Solvers: []cmacme.ACMEChallengeSolver{
 								exampleComDNSNameSelectorSolver,

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -127,7 +127,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -166,7 +165,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -233,7 +231,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeDNS01,
 				DNSName: "example.com",
 				Token:   acmeChallengeDNS01.Token,
-				Key:     "dns01",
 				Solver:  emptySelectorSolverDNS01,
 			},
 		},
@@ -261,7 +258,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  emptySelectorSolverHTTP01,
 			},
 		},
@@ -298,7 +294,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{},
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
@@ -336,7 +331,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  emptySelectorSolverHTTP01,
 			},
 		},
@@ -367,7 +361,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeDNS01,
 				DNSName: "example.com",
 				Token:   acmeChallengeDNS01.Token,
-				Key:     "dns01",
 				Solver:  emptySelectorSolverDNS01,
 			},
 		},
@@ -422,7 +415,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -453,7 +445,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "notexample.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  emptySelectorSolverHTTP01,
 			},
 		},
@@ -501,7 +492,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -560,7 +550,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -609,7 +598,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -658,7 +646,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -718,7 +705,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -772,7 +758,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				DNSName:  "example.com",
 				Wildcard: true,
 				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSNames: []string{"*.example.com"},
@@ -821,7 +806,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -861,7 +845,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -903,7 +886,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				DNSName:  "www.example.com",
 				Wildcard: true,
 				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -963,7 +945,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				DNSName:  "www.prod.example.com",
 				Wildcard: true,
 				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"prod.example.com"},
@@ -1023,7 +1004,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				DNSName:  "www.prod.example.com",
 				Wildcard: true,
 				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"prod.example.com"},
@@ -1089,7 +1069,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "www.example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -1151,7 +1130,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "www.example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -1211,7 +1189,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "www.example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -1252,7 +1229,6 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Type:    cmacme.ACMEChallengeTypeHTTP01,
 				DNSName: "example.com",
 				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
 				Solver:  exampleComDNSNameSelectorSolver,
 			},
 		},
@@ -1260,7 +1236,7 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			cs, err := challengeSpecForAuthorization(ctx, test.acmeClient, test.issuer, test.order, *test.authz)
+			cs, err := partialChallengeSpecForAuthorization(ctx, test.issuer, test.order, *test.authz)
 			if err != nil && !test.expectedError {
 				t.Errorf("expected to not get an error, but got: %v", err)
 				t.Fail()

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -60,6 +60,12 @@ func SetChallengeToken(t string) ChallengeModifier {
 	}
 }
 
+func SetChallengeKey(k string) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Key = k
+	}
+}
+
 // SetIssuer sets the challenge.spec.issuerRef field
 func SetChallengeIssuer(o cmmeta.ObjectReference) ChallengeModifier {
 	return func(c *cmacme.Challenge) {


### PR DESCRIPTION
This PR reduces the amount of calls made to ACME server during issuance.

**Problem**:

See #5867 for context.

Currently we have some redundant calls made to ACME server during issuance:

- orders controller retrieves the key for an HTTP-01/DNS-01 challenge (`HTTP01ChallengeResponse`/`DNS01ChallengeResponse` ACME call) every time when it calculates what Challenge resources should be created although in most cases it only needs the names of the Challenges [here](https://github.com/cert-manager/cert-manager/blob/v1.11.0/pkg/controller/acmeorders/sync.go#L124)

- orders controller in some cases GETs the ACME order (`GetOrder` ACME call) when it's actually not needed [here](https://github.com/cert-manager/cert-manager/blob/v1.11.0/pkg/controller/acmeorders/sync.go#L168)

**Changes in this PR**:

- ensures that the challenge key is only retrieved at the point when we know that we need to create a Challenge resource
- ensures that the ACME order is only retrieved at the point when we know that all of the following actions need it

As a result there are a few `HTTP01ChallengeResponse`/`DNS01ChallengeResponse` and `GetOrder` calls less for each DNS name during an issuance, see results for an issuance of a Certificate with 6 DNS names:

With cert-manager v1.11.0:
```
irbe@cert-manager$ cat cert-manager.log | grep "Calling"
I0329 12:56:55.690444       1 logger.go:45] cert-manager/acme-middleware "msg"="Calling AuthorizeOrder"
I0329 12:56:56.105084       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.229605       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.387722       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.497522       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.615755       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.733963       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.834454       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:56.928337       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:57.033450       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.033525       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.033583       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.034307       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.034535       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.034672       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.034822       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.035029       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.107530       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:57.178587       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.178725       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.178828       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.178895       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.178943       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.178994       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.179051       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.179475       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.181082       1 logger.go:51] cert-manager/acme-middleware "msg"="Calling GetOrder"
I0329 12:56:57.272425       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.272540       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.272624       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.272810       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.272924       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.273083       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.273196       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.273390       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse"
I0329 12:56:57.273550       1 logger.go:51] cert-manager/acme-middleware "msg"="Calling GetOrder"
I0329 12:56:58.128626       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.153202       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.180086       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.212308       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.259463       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.345306       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:56:58.466327       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization"
I0329 12:57:27.645644       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:27.759014       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:28.958473       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:29.060989       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:29.071487       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:29.115818       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:29.131838       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:29.317900       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:29.318998       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:29.447969       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:43.133586       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:43.257753       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
I0329 12:57:44.702882       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept"
I0329 12:57:44.904816       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization"
```

From this PR:
```
irbe@cert-manager$ k logs deploy/cert-manager -ncert-manager | grep Calling
I0329 16:31:45.593597       1 logger.go:105] cert-manager/acme-middleware "msg"="Calling Register" 
I0329 16:31:46.255813       1 logger.go:111] cert-manager/acme-middleware "msg"="Calling GetReg" 
I0329 16:32:07.063410       1 logger.go:45] cert-manager/acme-middleware "msg"="Calling AuthorizeOrder" 
I0329 16:32:07.913895       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.043730       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.171798       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.302158       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.432267       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.562291       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:08.724434       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:08.724500       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:08.724538       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:08.724604       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:08.724632       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:08.724704       1 logger.go:117] cert-manager/acme-middleware "msg"="Calling HTTP01ChallengeResponse" 
I0329 16:32:09.088610       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:09.111474       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:09.138329       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:09.155952       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:09.209113       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:10.071529       1 logger.go:93] cert-manager/acme-middleware "msg"="Calling GetAuthorization" 
I0329 16:32:40.677869       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:40.812032       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:41.171855       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:41.268224       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:41.290404       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:41.310259       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:41.402448       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:41.443089       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:41.654455       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:41.786924       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:52.203509       1 logger.go:81] cert-manager/acme-middleware "msg"="Calling Accept" 
I0329 16:32:52.336636       1 logger.go:99] cert-manager/acme-middleware "msg"="Calling WaitAuthorization" 
I0329 16:32:53.651775       1 logger.go:51] cert-manager/acme-middleware "msg"="Calling GetOrder" 
I0329 16:32:53.881192       1 logger.go:75] cert-manager/acme-middleware "msg"="Calling CreateOrderCert" 
I0329 16:32:57.459335       1 logger.go:51] cert-manager/acme-middleware "msg"="Calling GetOrder" 
I0329 16:32:57.592680       1 logger.go:63] cert-manager/acme-middleware "msg"="Calling ListCertAlternates" 
I0329 16:32:57.724335       1 logger.go:57] cert-manager/acme-middleware "msg"="Calling FetchCert" 
```

**Notes**:

This PR will produce `Challenge`s with different names as the `challenge.spec.key` will not be present at the time when the `Challenge` name is calculated. The rest of the spec (including the token) should be unique so this should not cause naming clashes, however users have to ensure that they don't upgrade to this cert-manager version mid-issuance as that might cause some duplicated issuances.

Related issue #5867 . This PR will definitely help with that issue- we do not know if it will fix it for all users. However reducing the number of ACME calls is an overall valuable thing

```release-note
Reduces the amount of ACME calls during an ACME certificate issuance.
**Warning**: this PR slightly changes how `Challenge` names are calculated. To avoid duplicate issuances due to `Challenge`s being recreated, ensure that there is no in-progress ACME certificate issuance when you upgrade to this version of cert-manager.
```

/kind cleanup
