### PR TITLE
Removes leftover replace statement

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -28,6 +28,7 @@ github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/v4/LICENS
 github.com/cenkalti/backoff/v3,https://github.com/cenkalti/backoff/blob/v3.0.0/LICENSE,MIT
 github.com/cenkalti/backoff/v4,https://github.com/cenkalti/backoff/blob/v4.1.3/LICENSE,MIT
 github.com/cert-manager/cert-manager,https://github.com/cert-manager/cert-manager/blob/HEAD/LICENSE,Apache-2.0
+github.com/cert-manager/cert-manager/make/config/samplewebhook/sample,https://github.com/cert-manager/cert-manager/blob/HEAD/make/licenses.mk,Apache-2.0
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/azuredns/LICENSE,MIT
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/clouddns,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/clouddns/LICENSE,MIT
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/cloudflare,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/cloudflare/LICENSE,MIT

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/cert-manager/cert-manager
 
 go 1.19
 
+// Do not remove this comment:
+// please place any replace statements here at the top for visibility and add a
+// comment to it as to when it can be removed
+
+// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
+replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d
+
 require (
 	github.com/Azure/azure-sdk-for-go v67.3.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.28
@@ -253,8 +260,3 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 )
-
-replace github.com/miekg/dns v1.1.41 => github.com/miekg/dns v1.1.34
-
-// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d


### PR DESCRIPTION
This should have been removed in https://github.com/cert-manager/cert-manager/pull/4958 however looks like I forgot to do that

It was added in https://github.com/cert-manager/cert-manager/pull/4942/commits/587e02cee9fba54b1b7580e06ee2b8351072842f to keep supporting HMACMD5 algorithm for RFC2136 DNS solver's [TSIG algorithm](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/#transaction-signatures--tsig) - to avoid a breaking change. In #4958 we implemented a shim over the upstream `TSIGProvider` interface so now we can use the latest version of that module without breaking anyone.


```release-note
NONE
```

/kind cleanup
