### PR TITLE
Migrate tests: higher timeout to lower the number of false-positives

### DIFF
--- a/test/integration/ctl/migrate/ctl_upgrade_migrate_test.go
+++ b/test/integration/ctl/migrate/ctl_upgrade_migrate_test.go
@@ -74,7 +74,8 @@ func newScheme() *runtime.Scheme {
 }
 
 func TestCtlUpgradeMigrate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	// This test takes about 25 seconds to run. Let's give it enough time.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// Create the control plane with the TestType conversion handlers registered
@@ -174,7 +175,7 @@ func TestCtlUpgradeMigrate(t *testing.T) {
 }
 
 func TestCtlUpgradeMigrate_FailsIfStorageVersionDoesNotEqualTargetVersion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// Create the control plane with the TestType conversion handlers registered
@@ -226,7 +227,7 @@ func TestCtlUpgradeMigrate_FailsIfStorageVersionDoesNotEqualTargetVersion(t *tes
 }
 
 func TestCtlUpgradeMigrate_SkipsMigrationIfNothingToDo(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// Create the control plane with the TestType conversion handlers registered
@@ -286,7 +287,7 @@ func TestCtlUpgradeMigrate_SkipsMigrationIfNothingToDo(t *testing.T) {
 }
 
 func TestCtlUpgradeMigrate_ForcesMigrationIfSkipStoredVersionCheckIsEnabled(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// Create the control plane with the TestType conversion handlers registered


### PR DESCRIPTION
The issue #5899 reports a flaky test. I investigated a bit and it looks like we could lower the number of false-positives by slightly adjusting the timeout period.

Below are a few builds in which the test timed out.

Test `TestCtlUpgradeMigrate`:

| Build                                                                                                                                                                                                                 | Time   |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
| [5248/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5248/pull-cert-manager-make-test/1542108385787252736)                           | 41.39s |
| [5646/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5646/pull-cert-manager-master-make-test/1603798721051496448)             | 36.25s |
| [5723/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5723/pull-cert-manager-master-make-test/1613849442845200384)             | 31.54s |
| [5324/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5324/pull-cert-manager-master-make-test/1555159193260920832)             | 32.38s |
| [5691/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5691/pull-cert-manager-master-make-test/1610971349512097792)             | 21.76s |
| [5704/pull-cert-manager-release-1.10-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5704/pull-cert-manager-release-1.10-make-test/1612456180355960832) | 32.69s |
| [5660/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5660/pull-cert-manager-master-make-test/1605313777543155712)             | 33.65s |
| [5325/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5325/pull-cert-manager-make-test/1549804384815157248)                           | 65.01s |
| [5256/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5256/pull-cert-manager-make-test/1542838272546312192)                           | 43.77s |
| [5251/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5251/pull-cert-manager-make-test/1542533681078341632)                           | 32.76s |
| [5251/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5251/pull-cert-manager-make-test/1542474955067756544)                           | 43.94s |
| [5707/pull-cert-manager-release-1.11-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5707/pull-cert-manager-release-1.11-make-test/1612530726664671232) | 32.60s |
| [5252/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5252/pull-cert-manager-make-test/1542622978053771264)                           | 39.96s |
| [5692/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5692/pull-cert-manager-master-make-test/1611040726328545280)             | 31.69s |

Test `TestCtlUpgradeMigrate_FailsIfStorageVersionDoesNotEqualTargetVersion`:

| Build                                                                                                                                                                    | Time   |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
| [5713/pull-cert-manager-release-1.10-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5713/pull-cert-manager-release-1.10-make-test/1613117045300269056) | 32.58s |
| [5684/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5684/pull-cert-manager-master-make-test/1610555679754424320)       | 31.41s |
| [5646/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5646/pull-cert-manager-master-make-test/1603716265048805376)       | 32.23s |
| [5646/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5646/pull-cert-manager-master-make-test/1603798721051496448)       | 54.40s |
| [5324/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5324/pull-cert-manager-master-make-test/1555159193260920832)       | 33.60s |
| [5325/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5325/pull-cert-manager-make-test/1549804384815157248)              | 57.23s |
| [5251/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5251/pull-cert-manager-make-test/1542533681078341632)              | 30.91s |
| [5243/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5243/pull-cert-manager-make-test/1541699980320837632)              | 45.84s |
| [5692/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5692/pull-cert-manager-master-make-test/1611040726328545280)       | 35.33s |

Test `TestCtlUpgradeMigrate_SkipsMigrationIfNothingToDo`:

| Build                                                                                                                                                                    | Time   |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
| [5663/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5663/pull-cert-manager-master-make-test/1605898374052057088) | 32.41s |
| [5684/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5684/pull-cert-manager-master-make-test/1610555679754424320) | 55.32s |
| [5646/pull-cert-manager-master-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5646/pull-cert-manager-master-make-test/1603798721051496448) | 51.04s |
| [5325/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5325/pull-cert-manager-make-test/1549804384815157248) | 34.05s |
| [5372/pull-cert-manager-release-1.8-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5372/pull-cert-manager-release-1.8-make-test/1556218452887212032) | 38.24s |
| [5251/pull-cert-manager-make-test](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5251/pull-cert-manager-make-test/1542533681078341632) | 30.24s |


/kind cleanup

```release-note
NONE
```

Closes #5899.
