### PR TITLE
Fix upstream-tags sort order

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -59,7 +59,7 @@ unit-test: | $(NEEDS_GOTESTSUM)
 
 .PHONY: setup-integration-tests
 setup-integration-tests: test/integration/versionchecker/testdata/test_manifests.tar templated-crds
-	@$(eval GIT_TAGS_FILE := $(BINDIR)/scratch/git/upstream-tags.txt)
+	@$(eval GIT_TAGS_FILE := $(BINDIR)/scratch/git/upstream-tags.1.txt)
 	@echo -e "\033[0;33mLatest known tag for integration tests is $(shell tail -1 $(GIT_TAGS_FILE)); if that seems out-of-date,\npull latest tags, run 'rm $(GIT_TAGS_FILE)' and retest\033[0m"
 
 .PHONY: integration-test
@@ -131,9 +131,9 @@ test/integration/versionchecker/testdata/test_manifests.tar: $(BINDIR)/scratch/o
 	tar --append -f $(BINDIR)/scratch/versionchecker-test-manifests.tar -C $(BINDIR)/scratch ./$(RELEASE_VERSION).yaml
 	cp $(BINDIR)/scratch/versionchecker-test-manifests.tar $@
 
-$(BINDIR)/scratch/oldcrds.tar: $(BINDIR)/scratch/git/upstream-tags.txt | $(BINDIR)/scratch/oldcrds
-	@# First, download the CRDs for all releases listed in upstream-tags.txt
-	<$(BINDIR)/scratch/git/upstream-tags.txt xargs -I% -P5 \
+$(BINDIR)/scratch/oldcrds.tar: $(BINDIR)/scratch/git/upstream-tags.1.txt | $(BINDIR)/scratch/oldcrds
+	@# First, download the CRDs for all releases listed in upstream-tags
+	<$(BINDIR)/scratch/git/upstream-tags.1.txt xargs -I% -P5 \
 		./hack/fetch-old-crd.sh \
 		"https://github.com/cert-manager/cert-manager/releases/download/%/cert-manager.yaml" \
 		$(BINDIR)/scratch/oldcrds/%.yaml


### PR DESCRIPTION
### Pull Request Motivation

Currently on master, upstream-tags.txt will use whatever ordering git uses by default, which at least on my system is lexicographic and not version aware. There's a `git ls-remote` argument to sort by version, which is what we actually want.

I'd seen this weirdness for a while and I finally dug into it.

I also added a version to upstream-tags so we can force a new invocation of `git ls-remote` on every checkout when we make a change like this. I can't imagine we'll have to change this file often but it seems good to force a new version this time.

The `--sort` flag is available at least as far back as [April 2019](https://git-scm.com/docs/git-ls-remote/2.24.0) (and probably older but I don't see a reason to dig any deeper).

#### Before this PR

`upstream-tags.txt`:

```text
v1.0.0
v1.0.0-alpha.0
v1.0.0-alpha.1
v1.0.0-beta.0
v1.0.0-beta.1
v1.0.1
v1.0.2
v1.0.3
v1.0.4
...
v1.10.0
...
v1.12.0-alpha.1
v1.2.0
...
v1.9.0
v1.9.0-alpha.0
v1.9.0-beta.0
v1.9.0-beta.1
v1.9.1
v1.9.2
v1.9.2-beta.0
```

#### After this PR

`upstream-tags.1.txt`:

```text
v1.0.0
...
v1.9.0
v1.9.0-alpha.0
v1.9.0-beta.0
v1.9.0-beta.1
v1.9.1
v1.9.2
v1.9.2-beta.0
...
v1.11.0
v1.11.0-alpha.0
v1.11.0-alpha.1
v1.11.0-alpha.2
v1.11.0-beta.0
v1.11.0-beta.1
v1.11.1-beta.0
v1.12.0-alpha.0
v1.12.0-alpha.1
```

### Kind

/kind bug

### Release Note

```release-note
Fix ordering of remote git tags when preparing integration tests
```
