### PR TITLE
Use high QPS, Burst, ConcurrentWorkers, ginkgo nodes values for faster e2e tests

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -247,6 +247,7 @@ e2e-setup-certmanager: $(BINDIR)/cert-manager.tgz $(foreach binaryname,controlle
 		--set startupapicheck.image.tag="$(TAG)" \
 		--set installCRDs=true \
 		--set featureGates="$(feature_gates_controller)" \
+		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200}" \
 		--set "webhook.extraArgs={--feature-gates=$(feature_gates_webhook)}" \
 		--set "cainjector.extraArgs={--feature-gates=$(feature_gates_cainjector)}" \
 		--set "dns01RecursiveNameservers=$(SERVICE_IP_PREFIX).16:53" \

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -263,7 +263,7 @@ e2e-setup-bind: $(call image-tar,bind) load-$(call image-tar,bind) $(wildcard ma
 
 .PHONY: e2e-setup-gatewayapi
 e2e-setup-gatewayapi: $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml $(BINDIR)/scratch/kind-exists $(NEEDS_KUBECTL)
-	$(KUBECTL) apply -f $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml > /dev/null
+	$(KUBECTL) apply --server-side -f $(BINDIR)/downloaded/gateway-api-$(GATEWAY_API_VERSION).yaml > /dev/null
 
 
 # v1 NGINX-Ingress by default only watches Ingresses with Ingress class
@@ -311,7 +311,7 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 		--set initImage.pullPolicy=Never \
 		kyverno kyverno/kyverno >/dev/null
 	@$(KUBECTL) create ns cert-manager >/dev/null 2>&1 || true
-	$(KUBECTL) apply -f make/config/kyverno/policy.yaml >/dev/null
+	$(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
 
 $(BINDIR)/downloaded/pebble-$(PEBBLE_COMMIT).tar.gz: | $(BINDIR)/downloaded
 	$(CURL) https://github.com/letsencrypt/pebble/archive/$(PEBBLE_COMMIT).tar.gz -o $@
@@ -387,7 +387,7 @@ e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar
 		--set envoy.service.clusterIP=${SERVICE_IP_PREFIX}.14 \
 		--set-file configInline=make/config/projectcontour/contour.yaml \
 		projectcontour bitnami/contour >/dev/null
-	$(KUBECTL) apply -f make/config/projectcontour/gateway.yaml
+	$(KUBECTL) apply --server-side -f make/config/projectcontour/gateway.yaml
 
 .PHONY: e2e-setup-sampleexternalissuer
 ifeq ($(CRI_ARCH),amd64)

--- a/make/e2e.sh
+++ b/make/e2e.sh
@@ -70,7 +70,7 @@ BINDIR=${BINDIR:-$_default_bindir}
 #  [6]: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1507019887451574272
 #  [7]: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1507040653668782080
 
-nodes=20
+nodes=40
 
 flake_attempts=1
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -122,7 +122,9 @@ e2e: $(BINDIR)/scratch/kind-exists | $(NEEDS_KUBECTL) $(NEEDS_GINKGO)
 	make/e2e.sh
 
 .PHONY: e2e-ci
-e2e-ci: e2e-setup-kind e2e-setup
+e2e-ci: | $(NEEDS_GO)
+	$(shell export HELM_BURST_LIMIT=-1)
+	$(MAKE) e2e-setup-kind e2e-setup
 	make/e2e-ci.sh
 
 $(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test

--- a/test/e2e/framework/addon/base/base.go
+++ b/test/e2e/framework/addon/base/base.go
@@ -55,6 +55,9 @@ func (b *Base) Setup(c *config.Config) error {
 		return err
 	}
 
+	kubeConfig.Burst = 9000
+	kubeConfig.QPS = 9000
+
 	kubeClientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return err

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -121,6 +121,10 @@ func (f *Framework) BeforeEach() {
 	By("Creating a kubernetes client")
 	kubeConfig, err := util.LoadConfig(f.Config.KubeConfig, f.Config.KubeContext)
 	Expect(err).NotTo(HaveOccurred())
+
+	kubeConfig.Burst = 9000
+	kubeConfig.QPS = 9000
+
 	f.KubeClientConfig = kubeConfig
 
 	f.KubeClientSet, err = kubernetes.NewForConfig(kubeConfig)

--- a/test/e2e/suite/certificaterequests/approval/approval.go
+++ b/test/e2e/suite/certificaterequests/approval/approval.go
@@ -198,6 +198,8 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 		kubeConfig, err := testutil.LoadConfig(f.Config.KubeConfig, f.Config.KubeContext)
 		Expect(err).NotTo(HaveOccurred())
 
+		kubeConfig.QPS = 9000
+		kubeConfig.Burst = 9000
 		kubeConfig.BearerToken = fmt.Sprintf("%s", token)
 		kubeConfig.CertData = nil
 		kubeConfig.KeyData = nil

--- a/test/e2e/suite/certificaterequests/approval/userinfo.go
+++ b/test/e2e/suite/certificaterequests/approval/userinfo.go
@@ -166,6 +166,8 @@ var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 		kubeConfig, err := testutil.LoadConfig(f.Config.KubeConfig, f.Config.KubeContext)
 		Expect(err).NotTo(HaveOccurred())
 
+		kubeConfig.QPS = 9000
+		kubeConfig.Burst = 9000
 		kubeConfig.BearerToken = fmt.Sprintf("%s", token)
 		kubeConfig.CertData = nil
 		kubeConfig.KeyData = nil


### PR DESCRIPTION
Reduces the e2e test duration from 30min to 16min.

```release-note
NONE
```

/kind cleanup
