### PR TITLE
Fix update-licenses make target

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -61,7 +61,9 @@ verify-crds: | $(NEEDS_GO) $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 	./hack/check-crds.sh $(GO) $(CONTROLLER-GEN) $(YQ)
 
 .PHONY: update-licenses
-update-licenses: LICENSES cmd/acmesolver/LICENSES cmd/cainjector/LICENSES cmd/ctl/LICENSES cmd/controller/LICENSES cmd/webhook/LICENSES test/integration/LICENSES test/e2e/LICENSES
+update-licenses:
+	rm -rf LICENSES cmd/acmesolver/LICENSES cmd/cainjector/LICENSES cmd/ctl/LICENSES cmd/controller/LICENSES cmd/webhook/LICENSES test/integration/LICENSES test/e2e/LICENSES
+	$(MAKE) LICENSES cmd/acmesolver/LICENSES cmd/cainjector/LICENSES cmd/ctl/LICENSES cmd/controller/LICENSES cmd/webhook/LICENSES test/integration/LICENSES test/e2e/LICENSES
 
 .PHONY: update-crds
 update-crds: generate-test-crds patch-crds


### PR DESCRIPTION
The make target now removes all the LICENSES files before generating them, ensuring us they are all regenerated

### Pull Request Motivation

In https://github.com/cert-manager/cert-manager/pull/5880, we made some major changes to our go.mod setup. We also changed the LICENSES generation logic. The `update-licenses` is causing problems now however, because it does not always update all the LICENSES files. The verify-licenses returns an error in CI, but the `update-licenses` target does not fix the issue as would be expected.

see https://github.com/cert-manager/cert-manager/pull/5931 and https://github.com/cert-manager/cert-manager/pull/5828 as examples of the target not working.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
