### PR TITLE
Add --concurrent-workers flag to cert-manager controller

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -204,9 +204,7 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 		g.Go(func() error {
 			log.V(logf.InfoLevel).Info("starting controller")
 
-			// TODO: make this either a constant or a command line flag
-			workers := 5
-			return iface.Run(workers, rootCtx.Done())
+			return iface.Run(opts.NumberOfConcurrentWorkers, rootCtx.Done())
 		})
 	}
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -101,6 +101,10 @@ type ControllerOptions struct {
 
 	EnableCertificateOwnerRef bool
 
+	// The number of concurrent workers for each controller.
+	NumberOfConcurrentWorkers int
+	// MaxConcurrentChallenges determines the maximum number of challenges that can be
+	// scheduled as 'processing' at once.
 	MaxConcurrentChallenges int
 
 	// The host and port address, separated by a ':', that the Prometheus server
@@ -142,7 +146,8 @@ const (
 
 	defaultDNS01RecursiveNameserversOnly = false
 
-	defaultMaxConcurrentChallenges = 60
+	defaultNumberOfConcurrentWorkers = 5
+	defaultMaxConcurrentChallenges   = 60
 
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
@@ -246,6 +251,8 @@ func NewControllerOptions() *ControllerOptions {
 		DNS01RecursiveNameserversOnly:     defaultDNS01RecursiveNameserversOnly,
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
+		NumberOfConcurrentWorkers:         defaultNumberOfConcurrentWorkers,
+		MaxConcurrentChallenges:           defaultMaxConcurrentChallenges,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
 		EnablePprof:                       cmdutil.DefaultEnableProfiling,
 		PprofAddress:                      cmdutil.DefaultProfilerAddr,
@@ -358,6 +365,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"A prefix starting with a dash(-) specifies an annotation that shouldn't be copied. Example: '*,-kubectl.kuberenetes.io/'- all annotations"+
 		"will be copied apart from the ones where the key is prefixed with 'kubectl.kubernetes.io/'.")
 
+	fs.IntVar(&s.NumberOfConcurrentWorkers, "concurrent-workers", defaultNumberOfConcurrentWorkers, ""+
+		"The number of concurrent workers for each controller.")
 	fs.IntVar(&s.MaxConcurrentChallenges, "max-concurrent-challenges", defaultMaxConcurrentChallenges, ""+
 		"The maximum number of challenges that can be scheduled as 'processing' at once.")
 	fs.DurationVar(&s.DNS01CheckRetryPeriod, "dns01-check-retry-period", defaultDNS01CheckRetryPeriod, ""+


### PR DESCRIPTION
### Pull Request Motivation

Currently, we use the magic number 5 as the number of concurrent workers for each controller.
This is however a parameter that a lot of people might want to increase for large clusters/ lots of certificates.

see #5932 for an example of how this parameter speeds up our e2e tests

### Kind

/kind feature

### Release Note

```release-note
Added the --concurrent-workers flag that lets you control the number of concurrent workers for each of our controllers.
```
