### PR TITLE
Vault test code cleanliness improvements

### DIFF
--- a/test/e2e/framework/addon/vault/proxy.go
+++ b/test/e2e/framework/addon/vault/proxy.go
@@ -65,8 +65,7 @@ func (p *proxy) init() (*vault.Client, error) {
 	cfg.Address = fmt.Sprintf("https://127.0.0.1:%d", p.listenPort)
 
 	caCertPool := x509.NewCertPool()
-	ok := caCertPool.AppendCertsFromPEM(p.vaultCA)
-	if ok == false {
+	if ok := caCertPool.AppendCertsFromPEM(p.vaultCA); !ok {
 		return nil, fmt.Errorf("error loading Vault CA bundle: %s", p.vaultCA)
 	}
 

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -75,7 +75,7 @@ type Details struct {
 	// PodNS is the namespace that the Vault pod is deployed into.
 	PodNS string
 
-	// PodSA is the service accoutn that gets auto-mounted in the Vault pod.
+	// PodSA is the service account that gets auto-mounted in the Vault pod.
 	PodSA string
 
 	// VaultCA is the CA used to sign the vault serving certificate
@@ -89,15 +89,15 @@ type Details struct {
 
 func (v *Vault) Setup(cfg *config.Config) error {
 	if v.Name == "" {
-		return fmt.Errorf("Name field must be set on Vault addon")
+		return fmt.Errorf("'Name' field must be set on Vault addon")
 	}
 	if v.Namespace == "" {
 		// TODO: in non-global instances, we could generate a new namespace just
 		// for this addon to be used from.
-		return fmt.Errorf("Namespace name must be specified")
+		return fmt.Errorf("'Namespace' name must be specified")
 	}
 	if v.Base == nil {
-		return fmt.Errorf("Base field must be set on Vault addon")
+		return fmt.Errorf("'Base' field must be set on Vault addon")
 	}
 
 	var err error

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -325,21 +325,21 @@ func SetIssuerVaultAppRoleAuth(keyName, approleName, roleId, path string) Issuer
 	}
 }
 
-func SetIssuerVaultKubernetesAuthSecret(keyName, secretServiceAccount, role, path string) IssuerModifier {
+func SetIssuerVaultKubernetesAuthSecret(secretKey, secretName, vaultRole, vaultPath string) IssuerModifier {
 	return func(iss v1.GenericIssuer) {
 		spec := iss.GetSpec()
 		if spec.Vault == nil {
 			spec.Vault = &v1.VaultIssuer{}
 		}
 		spec.Vault.Auth.Kubernetes = &v1.VaultKubernetesAuth{
-			Path: path,
+			Path: vaultPath,
 			SecretRef: cmmeta.SecretKeySelector{
-				Key: keyName,
+				Key: secretKey,
 				LocalObjectReference: cmmeta.LocalObjectReference{
-					Name: secretServiceAccount,
+					Name: secretName,
 				},
 			},
-			Role: role,
+			Role: vaultRole,
 		}
 
 	}


### PR DESCRIPTION
- inlined some functions that were used only once
- fixed some linting errors (eg. error messages should start with lowercase letter)
- I tried to make the vault test code a bit more understandable by not re-using role names as the name of the SA, secret, ...

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
