### PR TITLE
Add GCB configuration file for building cert-manager on tag push

### DIFF
--- a/gcb/build_cert_manager.yaml
+++ b/gcb/build_cert_manager.yaml
@@ -1,0 +1,34 @@
+# This cloudbuild config file is intended to be triggered when a tag is pushed to the cert-manager repo
+# and will build a cert-manager release and push to Google Cloud Storage (GCS).
+
+# The release won't be published automatically here; this just controls the build.
+
+timeout: 2700s # 45m
+
+steps:
+# cert-manager relies on the git checkout to determine release version, among other things
+# By default, gcb only does a shallow clone, so we need to "unshallow" to get more details
+- name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
+
+## Build release artifacts and push to a bucket
+- name: 'eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -eu -o pipefail
+    make vendor-go
+    make CMREL_KEY="${_KMS_KEY}" RELEASE_TARGET_BUCKET="${_RELEASE_TARGET_BUCKET}" -j16 upload-release
+    echo "Wrote to ${_RELEASE_TARGET_BUCKET}"
+
+tags:
+- "cert-manager-tag-push"
+- "ref-${REF_NAME}-${COMMIT_SHA}"
+
+substitutions:
+  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
+  _RELEASE_TARGET_BUCKET: "cert-manager-release"
+
+options:
+  machineType: N1_HIGHCPU_32


### PR DESCRIPTION
This PR, along with a GCB trigger to be configured later, should enable the automatic build of cert-manager releases by simply pushing tags. This should in turn remove a step from the release process, enabling easier maintenance (and hopefully, easier LTS support)

### Kind

/kind feature

### Release Note

```release-note
NONE
```
