### PR TITLE
[release-1.10] Autobuild on tag push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ _bin/
 .bin/
 user.bazelrc
 *.bak
+/go.work.sum
+/go.work

--- a/gcb/build_cert_manager.yaml
+++ b/gcb/build_cert_manager.yaml
@@ -1,0 +1,37 @@
+# This cloudbuild config file is intended to be triggered when a tag is pushed to the cert-manager repo
+# and will build a cert-manager release and push to Google Cloud Storage (GCS).
+
+# The release won't be published automatically; this file just defines the build steps.
+
+# The full release and publish process is documented here:
+# https://cert-manager.io/docs/contributing/release-process/
+
+timeout: 2700s # 45m
+
+steps:
+# cert-manager relies on the git checkout to determine release version, among other things
+# By default, gcb only does a shallow clone, so we need to "unshallow" to get more details
+- name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
+
+## Build release artifacts and push to a bucket
+- name: 'eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -eu -o pipefail
+    make vendor-go
+    make CMREL_KEY="${_KMS_KEY}" RELEASE_TARGET_BUCKET="${_RELEASE_TARGET_BUCKET}" -j16 upload-release
+    echo "Wrote to ${_RELEASE_TARGET_BUCKET}"
+
+tags:
+- "cert-manager-tag-push"
+- "ref-${REF_NAME}-${COMMIT_SHA}"
+
+substitutions:
+  _KMS_KEY: "projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-signing-key/cryptoKeyVersions/1"
+  _RELEASE_TARGET_BUCKET: "cert-manager-release"
+
+options:
+  machineType: N1_HIGHCPU_32


### PR DESCRIPTION
### Pull Request Motivation

https://github.com/cert-manager/cert-manager/pull/5940 backported to release-1.10 as discussed.

Also includes a QoL gitignore fix when switching between branches with workspaces on.

NOTE: This PR also implies a change in the build image used for releases of 1.10. We originally used [this image](https://github.com/cert-manager/release/blob/c35ba39e591f1e5150525ca0fef222beb719de8c/gcb/makestage/cloudbuild.yaml#L16) and we change it here.

This is intentional. eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1 has many vulnerabilities including critical severity vulns. Someone attacking the release process using those vulns doesn't seem particularly likely, but it does seem worth updating here. Since make-dind is much more slim than bazelbuild, it seems worth using that to reduce attack surface.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
