### PR TITLE
Report controller-manager as unhealthy if leader election has failed to renew the lease but process is wedged

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -134,6 +134,7 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 	}
 	healthzServer := healthz.NewServer(opts.HealthzLeaderElectionTimeout)
 	g.Go(func() error {
+		log.V(logf.InfoLevel).Info("starting healthz server", "address", healthzListener.Addr())
 		return healthzServer.Start(rootCtx, healthzListener)
 	})
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -156,7 +156,7 @@ const (
 	defaultMaxConcurrentChallenges   = 60
 
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
-	defaultHealthzServerAddress           = "127.0.0.1:10257"
+	defaultHealthzServerAddress           = "0.0.0.0:10257"
 	// This default value is the same as used in Kubernetes controller-manager.
 	// See:
 	// https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kube-controller-manager/app/controllermanager.go#L202-L209

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -156,7 +156,7 @@ const (
 	defaultMaxConcurrentChallenges   = 60
 
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
-	defaultHealthzServerAddress           = "0.0.0.0:10257"
+	defaultHealthzServerAddress           = "0.0.0.0:9403"
 	// This default value is the same as used in Kubernetes controller-manager.
 	// See:
 	// https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kube-controller-manager/app/controllermanager.go#L202-L209

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.1.0
 	k8s.io/apimachinery v0.26.3
+	k8s.io/apiserver v0.26.3
 	k8s.io/client-go v0.26.3
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 )
@@ -158,7 +159,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.3 // indirect
 	k8s.io/apiextensions-apiserver v0.26.3 // indirect
-	k8s.io/apiserver v0.26.3 // indirect
 	k8s.io/component-base v0.26.3 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-aggregator v0.26.3 // indirect

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -106,6 +106,13 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |
 | `topologySpreadConstraints` | Topology spread constraints for pod assignment | `[]` |
+| `livenessProbe.enabled` | Enable or disable the liveness probe for the controller container in the controller Pod. See https://cert-manager.io/docs/installation/best-practice/ to learn about when you might want to enable this livenss probe. | `false` |
+| `livenessProbe.initialDelaySeconds` | The liveness probe initial delay (in seconds) | `10` |
+| `livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |
+| `livenessProbe.timeoutSeconds` | The liveness probe timeout (in seconds) | `10` |
+| `livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |
+| `livenessProbe.successThreshold` | The liveness probe success threshold | `1` |
+| `livenessProbe.failureThreshold` | The liveness probe failure threshold | `8` |
 | `ingressShim.defaultIssuerName` | Optional default issuer to use for ingress resources |  |
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -163,7 +163,6 @@ spec:
           # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
           livenessProbe:
             httpGet:
-              host: 127.0.0.1
               port: 10257
               path: /livez
               scheme: HTTP

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -158,6 +158,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          # LivenessProbe settings are based on those used for the Kubernetes
+          # controller-manager. See:
+          # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              port: 10257
+              path: /livez
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 8
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -161,6 +161,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+
+          {{- with .Values.livenessProbe }}
+          {{- if .enabled }}
           # LivenessProbe settings are based on those used for the Kubernetes
           # controller-manager. See:
           # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
@@ -169,11 +172,13 @@ spec:
               port: http-healthz
               path: /livez
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 15
-            successThreshold: 1
-            failureThreshold: 8
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -126,6 +126,9 @@ spec:
           - containerPort: 9402
             name: http-metrics
             protocol: TCP
+          - containerPort: 9403
+            name: http-healthz
+            protocol: TCP
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -163,7 +166,7 @@ spec:
           # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
           livenessProbe:
             httpGet:
-              port: 10257
+              port: http-healthz
               path: /livez
               scheme: HTTP
             initialDelaySeconds: 10

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -251,6 +251,22 @@ tolerations: []
 #         app.kubernetes.io/component: controller
 topologySpreadConstraints: []
 
+# LivenessProbe settings for the controller container of the controller Pod.
+#
+# Disabled by default, because the controller has a leader election mechanism
+# which should cause it to exit if it is unable to renew its leader election
+# record.
+# LivenessProbe durations and thresholds are based on those used for the Kubernetes
+# controller-manager. See:
+# https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 15
+  successThreshold: 1
+  failureThreshold: 8
+
 webhook:
   replicaCount: 1
   timeoutSeconds: 10

--- a/pkg/healthz/doc.go
+++ b/pkg/healthz/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package healthz provides an HTTP server which responds to HTTP liveness probes
+// and performs health checks.
+//
+// Currently it only checks that the LeaderElector has an up to date LeaderElectionRecord.
+// Normally the parent process should exit if the LeaderElectionRecord is stale,
+// but it is possible that the process is prevented from exiting by a bug,
+// in which case this check will fail, the liveness probe will fail and then the
+// Kubelet will restart the process.
+// See the following issue and PR to understand how this problem was solved in
+// Kubernetes:
+// * [kube-controller-manager becomes deadlocked but still passes healthcheck](https://github.com/kubernetes/kubernetes/issues/70819)
+// * [Report KCM as unhealthy if leader election is wedged](https://github.com/kubernetes/kubernetes/pull/70971)
+
+package healthz

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/client-go/tools/leaderelection"
+)
+
+const (
+	// Copied from pkg/metrics/metrics.go
+	healthzServerReadTimeout    = 8 * time.Second
+	healthzServerWriteTimeout   = 8 * time.Second
+	healthzServerMaxHeaderBytes = 1 << 20 // 1 MiB
+)
+
+// Server responds to HTTP requests to a /livez endpoint and responds with an
+// error if the LeaderElector has exited or has not observed the
+// LeaderElectionRecord for a given amount of time.
+type Server struct {
+	server *http.Server
+	// LeaderHealthzAdaptor is public so that it can be retrieved by the caller
+	// and used as the value for `LeaderElectionConfig.Watchdog` when
+	// initializing the LeaderElector.
+	LeaderHealthzAdaptor *leaderelection.HealthzAdaptor
+}
+
+// NewServer creates a new healthz.Server.
+// The supplied leaderElectionHealthzAdaptorTimeout controls how long after the
+// leader lease time, the leader election will be considered to have failed.
+func NewServer(leaderElectionHealthzAdaptorTimeout time.Duration) *Server {
+	leaderHealthzAdaptor := leaderelection.NewLeaderHealthzAdaptor(leaderElectionHealthzAdaptorTimeout)
+	mux := http.NewServeMux()
+	healthz.InstallLivezHandler(mux, leaderHealthzAdaptor)
+	return &Server{
+		server: &http.Server{
+			ReadTimeout:    healthzServerReadTimeout,
+			WriteTimeout:   healthzServerWriteTimeout,
+			MaxHeaderBytes: healthzServerMaxHeaderBytes,
+			Handler:        mux,
+		},
+		LeaderHealthzAdaptor: leaderHealthzAdaptor,
+	}
+}
+
+// Start makes the server listen on the supplied socket, until the supplied
+// context is cancelled, after which the server will gracefully shutdown and Start will
+// exit.
+// The server is given 5 seconds to shutdown gracefully.
+func (o *Server) Start(ctx context.Context, l net.Listener) error {
+	var g errgroup.Group
+	g.Go(func() error {
+		if err := o.server.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		<-ctx.Done()
+		// allow a timeout for graceful shutdown
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return o.server.Shutdown(shutdownCtx)
+	})
+	return g.Wait()
+}

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,359 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init" // add command line flags
+
+	"github.com/cert-manager/cert-manager/pkg/healthz"
+)
+
+const (
+	localIdentity   = "local-node"
+	remoteIdentity  = "remote-node"
+	lockDescription = "fake-resource-lock"
+)
+
+// TestHealthzLivez checks the responses of the `/livez` endpoint.
+//
+// These tests are intended to demonstrate that the LeaderElectionHealthzAdaptor
+// does indeed cause the `/livez` endpoint to return errors if the healthz
+// server continues to run after the LeaderElector go-routine has exited.
+func TestHealthzLivez(t *testing.T) {
+
+	type input struct {
+		leaderElectionEnabled bool
+		resourceLock          *fakeResourceLock
+		onNewLeaderHook       func(in *input)
+	}
+
+	type output struct {
+		responseBody string
+		responseCode int
+	}
+
+	type testCase struct {
+		name string
+		in   input
+		out  output
+	}
+
+	tests := []testCase{
+		{
+			// OK: when leader-election is disabled (--leader-elect=false) the leader
+			// election healthz adaptor always returns OK.
+			//
+			// LeaderElectionHealthzAdaptor.Check returns nil if its
+			// LeaderElector pointer has not been set.
+			// See https://github.com/kubernetes/client-go/blob/8cbca742aebe24b24f7f4e32fd999942fa9133e8/tools/leaderelection/healthzadaptor.go#L43-L52
+			name: "ok-leader-election-disabled",
+			in: input{
+				leaderElectionEnabled: false,
+				resourceLock:          nil,
+			},
+			out: output{
+				responseBody: "ok",
+				responseCode: http.StatusOK,
+			},
+		},
+		{
+			// OK: when the local node is leader and has updated the leader
+			// election record.
+			name: "ok-local-leader",
+			in: input{
+				leaderElectionEnabled: true,
+				resourceLock: &fakeResourceLock{
+					record: &resourcelock.LeaderElectionRecord{
+						HolderIdentity: localIdentity,
+					},
+				},
+			},
+			out: output{
+				responseBody: "ok",
+				responseCode: http.StatusOK,
+			},
+		},
+		{
+			// OK: when a remote node is leader and has updated the leader
+			// election record.
+			//
+			// LeaderElect.Check always succeeds when another node has the
+			// leader lock.
+			// See https://github.com/kubernetes/client-go/blob/8cbca742aebe24b24f7f4e32fd999942fa9133e8/tools/leaderelection/leaderelection.go#L385-L399
+			name: "ok-remote-leader",
+			in: input{
+				leaderElectionEnabled: true,
+				resourceLock: &fakeResourceLock{
+					record: &resourcelock.LeaderElectionRecord{
+						HolderIdentity: remoteIdentity,
+					},
+				},
+			},
+			out: output{
+				responseBody: "ok",
+				responseCode: http.StatusOK,
+			},
+		},
+		{
+			// Failure: when update starts to fail after the local node has once
+			// acquired the leader election lock.
+			//
+			// This is intended to simulate the situation where the
+			// LeaderElector go-routine has exited, but the parent process is
+			// wedged and has not exited.
+			// In this situation, the /livez endpoint responds with an error,
+			// because the LeaderElectionHealthzAdaptor still has a reference to
+			// the no-longer running LeaderElector and its last state.
+			//
+			// Start LeaderElector without a LeaderElectionRecord, wait for the
+			// record to be created, and then when LeaderElector calls the
+			// OnNewLeader callback, set the fakeResourceLock to return an error
+			// when Update is called.
+			// This persistent error causes `LeaderElector.renew` to exit and
+			// causes LeaderElector.Run to exit after the `RenewDeadline`.
+			//
+			// The LeaderElection go-routine will exit but the healthz server
+			// will continue running.
+			name: "fail-delayed-update-error",
+			in: input{
+				leaderElectionEnabled: true,
+				resourceLock: &fakeResourceLock{
+					record: nil,
+				},
+				onNewLeaderHook: func(in *input) {
+					in.resourceLock.updateError = fmt.Errorf("simulated-delayed-update-error")
+				},
+			},
+			out: output{
+				responseBody: "internal server error: failed election to renew leadership on lease \n",
+				responseCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			// Failure: when the local node attempts to acquire the lease but fails to update
+			// the leader election record.
+			//
+			// Like the fail-delayed-update-error test, this is intended to
+			// cause the LeaderElector to exit, leaving the healthz server
+			// running and querying the last state of the exited LeaderElector.
+			//
+			// In this simulation, there is already a LeaderElectionRecord belonging to the local node,
+			// and the update is simulated to fail on the first attempt.
+			//
+			// TODO(wallrj): This test may be redundant because it has the same
+			// effect as `fail-delayed-update-error`, in causing the running
+			// LeaderElector to exit.
+			name: "fail-immediate-update-error",
+			in: input{
+				leaderElectionEnabled: true,
+				resourceLock: &fakeResourceLock{
+					record: &resourcelock.LeaderElectionRecord{
+						HolderIdentity: localIdentity,
+					},
+					updateError: fmt.Errorf("simulated-update-error"),
+				},
+			},
+			out: output{
+				responseBody: "internal server error: failed election to renew leadership on lease \n",
+				responseCode: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			log, ctx := ktesting.NewTestContext(t)
+
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+
+			l, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+
+			livezURL := "http://" + l.Addr().String() + "/livez/leaderElection"
+
+			const leaderElectionHealthzAdaptorTimeout = time.Millisecond
+			s := healthz.NewServer(leaderElectionHealthzAdaptorTimeout)
+
+			g, gCTX := errgroup.WithContext(ctx)
+
+			leaderElected := make(chan struct{})
+
+			if tc.in.leaderElectionEnabled {
+				const (
+					leaseDuration = 500 * time.Millisecond
+					renewDeadline = 400 * time.Millisecond
+					retryPeriod   = 300 * time.Millisecond
+				)
+
+				log.Info(
+					"Starting leader election go-routine",
+					"leaseDuration", leaseDuration,
+					"renewDeadline", renewDeadline,
+					"retryPeriod", retryPeriod,
+				)
+				g.Go(func() error {
+					defer log.Info("Leader election go-routine finished")
+					leaderelection.RunOrDie(gCTX, leaderelection.LeaderElectionConfig{
+						LeaseDuration: leaseDuration,
+						RenewDeadline: renewDeadline,
+						RetryPeriod:   retryPeriod,
+						Callbacks: leaderelection.LeaderCallbacks{
+							OnStartedLeading: func(context.Context) {
+								log.Info("leaderelection.LeaderCallbacks.OnStartedLeading")
+							},
+							OnStoppedLeading: func() {
+								log.Info("leaderelection.LeaderCallbacks.OnStoppedLeading")
+							},
+							OnNewLeader: func(identity string) {
+								log.Info("leaderelection.LeaderCallbacks.OnNewLeader", "identity", identity)
+								if tc.in.onNewLeaderHook != nil {
+									tc.in.onNewLeaderHook(&tc.in)
+								}
+								close(leaderElected)
+							},
+						},
+						Lock:     tc.in.resourceLock,
+						WatchDog: s.LeaderHealthzAdaptor,
+					})
+					return nil
+				})
+			}
+
+			log.Info("Starting healthz server go-routine")
+			g.Go(func() error {
+				defer log.Info("Healthz server go-routine finished")
+				return s.Start(gCTX, l)
+			})
+
+			if tc.in.leaderElectionEnabled {
+				log.Info("Waiting for a LeaderElector to know the current leader before polling liveness endpoint")
+				<-leaderElected
+			}
+
+			const (
+				pollingInterval = 500 * time.Millisecond
+				pollingTimeout  = 3 * time.Second
+			)
+			log.Info(
+				"Polling liveness endpoint",
+				"url", livezURL,
+				"interval", pollingInterval,
+				"timeout", pollingTimeout,
+			)
+			var (
+				lastResponseCode int
+				lastResponseBody string
+			)
+			assert.Eventually(t, func() bool {
+				resp, err := http.Get(livezURL)
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, resp.Body.Close())
+				}()
+				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				require.NoError(t, err)
+
+				lastResponseCode = resp.StatusCode
+				lastResponseBody = string(bodyBytes)
+
+				log.Info("liveness-probe", "response-code", lastResponseCode, "response-body", lastResponseBody)
+
+				return tc.out.responseCode == lastResponseCode && tc.out.responseBody == lastResponseBody
+			}, pollingTimeout, pollingInterval)
+
+			assert.Equal(t, tc.out.responseBody, lastResponseBody)
+			assert.Equal(t, tc.out.responseCode, lastResponseCode)
+			cancel()
+			require.NoError(t, g.Wait())
+		})
+	}
+}
+
+// fakeResourceLock implements resourcelock.Interface sufficiently to simulate:
+// * successful acquisition of the leader election lock by the local node,
+// * current possession of the leader election lock by a remote node, and
+// * failures in leader election which cause the `LeaderElection.Run` function to exit.
+//
+// The intention is to be able to test the behavior of the
+// LeaderElectionHealthzAdaptor under those circumstances.
+type fakeResourceLock struct {
+	record      *resourcelock.LeaderElectionRecord
+	getError    error
+	updateError error
+}
+
+func (o *fakeResourceLock) Identity() string {
+	return localIdentity
+}
+
+func (o *fakeResourceLock) Describe() string {
+	return lockDescription
+}
+
+func (o *fakeResourceLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	klog.FromContext(ctx).WithName("fakeResourceLock").Info("Get")
+	if o.getError != nil {
+		return nil, nil, o.getError
+	}
+	if o.record == nil {
+		err := errors.NewNotFound(schema.ParseGroupResource("configmap"), "foo")
+		return nil, nil, err
+	}
+	lerByte, err := json.Marshal(*o.record)
+	if err != nil {
+		return nil, nil, err
+	}
+	return o.record, lerByte, nil
+}
+
+func (o *fakeResourceLock) Create(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	klog.FromContext(ctx).WithName("fakeResourceLock").Info("Create")
+	o.record = &ler
+	return nil
+}
+
+func (o *fakeResourceLock) Update(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	klog.FromContext(ctx).WithName("fakeResourceLock").Info("Update")
+	o.record = &ler
+	return o.updateError
+}
+
+func (o *fakeResourceLock) RecordEvent(_ string) {}
+
+var _ resourcelock.Interface = &fakeResourceLock{}

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -46,12 +46,12 @@ const (
 	lockDescription = "fake-resource-lock"
 )
 
-// TestHealthzLivez checks the responses of the `/livez` endpoint.
+// TestHealthzLivezLeaderElection checks the responses of the `/livez/leaderElection` endpoint.
 //
 // These tests are intended to demonstrate that the LeaderElectionHealthzAdaptor
 // does indeed cause the `/livez` endpoint to return errors if the healthz
 // server continues to run after the LeaderElector go-routine has exited.
-func TestHealthzLivez(t *testing.T) {
+func TestHealthzLivezLeaderElection(t *testing.T) {
 
 	type input struct {
 		leaderElectionEnabled bool


### PR DESCRIPTION
Added a  /livez endpoint which reports the leaderElection status and fails if leader election record has not been observed for `leader-election-lease-timeout + leader-election-healthz-adaptor-timeout`.

A livenessProbe has been added to the controller container of the controller Pod,
which is disabled by default, because we do not actually know of any bugs in the controller which would cause it hang.
A failure in the renewal of the leader election should always result in the controller process exiting.
But in case such a bug does occur in the field, the user now has the ability to turn on the liveness probe.

They can also configure the durations and thresholds, using Helm chart values, because the default values were arbitrarily based on those used in the Kubernetes controller-manager.
The user can not change the endpoint or scheme.

The problem is described in the Kubernetes code as follows::

> If we are more than timeout seconds after the lease duration that is past the timeout
> on the lease renew. Time to start reporting ourselves as unhealthy. We should have
> died but conditions like deadlock can prevent this. (See #70819)

-- https://github.com/kubernetes/client-go/blob/6c596fdbc11ce7779ee320c6a11df44c5d516d54/tools/leaderelection/leaderelection.go#L388-L390

You can test the `/livez` endpoint locally as follows:

```
$ go run ./cmd/controller/ --kubeconfig ~/.kube/config -v2
I0426 13:09:48.719637    6184 start.go:75] cert-manager "msg"="starting controller" "git-commit"="" "version"="canary"
I0426 13:09:48.719695    6184 controller.go:249] cert-manager/controller/build-context "msg"="configured acme dns01 nameservers" "nameservers"=["172.21.240.1:53"]
I0426 13:09:48.721581    6184 controller.go:71] cert-manager/controller "msg"="enabled controllers: [certificaterequests-approver certificaterequests-issuer-acme certificaterequests-issuer-ca certificaterequests-issuer-selfsigned certificaterequests-issuer-vault certificaterequests-issuer-venafi certificates-issuing certificates-key-manager certificates-metrics certificates-readiness certificates-request-manager certificates-revision-manager certificates-trigger challenges clusterissuers ingress-shim issuers orders]"
I0426 13:09:48.746489    6184 controller.go:92] cert-manager/controller "msg"="starting metrics server" "address"={"IP":"::","Port":9402,"Zone":""}
I0426 13:09:48.758497    6184 controller.go:144] cert-manager/controller "msg"="starting leader election"
I0426 13:09:48.758524    6184 controller.go:137] cert-manager/controller "msg"="starting healthz server" "address"={"IP":"::","Port":9403,"Zone":""}
I0426 13:09:48.759230    6184 leaderelection.go:248] attempting to acquire leader lease kube-system/cert-manager-controller...
```

```
$ curl http://localhost:9403/livez
ok

$ curl http://localhost:9403/livez?verbose
[+]leaderElection ok
livez check passed

$ curl http://localhost:9403/livez/leaderElection
ok
```


Unit-test output

<details>

<summary>$ go test ./pkg/healthz/... -count 1  -v -timeout 5s -run TestHealthzLivez -test.parallel 1</summary>

```
=== RUN   TestHealthzLivez
=== RUN   TestHealthzLivez/ok-leader-election-disabled
=== PAUSE TestHealthzLivez/ok-leader-election-disabled
=== RUN   TestHealthzLivez/ok-local-leader
=== PAUSE TestHealthzLivez/ok-local-leader
=== RUN   TestHealthzLivez/ok-remote-leader
=== PAUSE TestHealthzLivez/ok-remote-leader
=== RUN   TestHealthzLivez/fail-delayed-update-error
=== PAUSE TestHealthzLivez/fail-delayed-update-error
=== RUN   TestHealthzLivez/fail-immediate-update-error
=== PAUSE TestHealthzLivez/fail-immediate-update-error
=== CONT  TestHealthzLivez/ok-leader-election-disabled
    healthz_test.go:258: I0426 08:11:45.579866] Starting healthz server go-routine
    healthz_test.go:273: I0426 08:11:45.579983] Polling liveness endpoint url="http://127.0.0.1:37657/livez/leaderElection" interval="500ms" timeout="3s"
    healthz_test.go:295: I0426 08:11:46.082124] liveness-probe response-code=200 response-body="ok"
    healthz_test.go:261: I0426 08:11:46.082434] Healthz server go-routine finished
=== CONT  TestHealthzLivez/fail-delayed-update-error
    healthz_test.go:224: I0426 08:11:46.085151] Starting leader election go-routine leaseDuration="500ms" renewDeadline="400ms" retryPeriod="300ms"
    healthz_test.go:258: I0426 08:11:46.085298] Starting healthz server go-routine
    healthz_test.go:265: I0426 08:11:46.085317] Waiting for a LeaderElector to know the current leader before polling liveness endpoint
I0426 08:11:46.085396  132590 leaderelection.go:248] attempting to acquire leader lease fake-resource-lock...
    healthz_test.go:330: I0426 08:11:46.085438] fakeResourceLock: Get
    healthz_test.go:346: I0426 08:11:46.085478] fakeResourceLock: Create
I0426 08:11:46.085495  132590 leaderelection.go:258] successfully acquired lease fake-resource-lock
    healthz_test.go:330: I0426 08:11:46.085544] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:46.085629] fakeResourceLock: Update
    healthz_test.go:244: I0426 08:11:46.085660] leaderelection.LeaderCallbacks.OnNewLeader identity="local-node"
    healthz_test.go:273: I0426 08:11:46.085681] Polling liveness endpoint url="http://127.0.0.1:39897/livez/leaderElection" interval="500ms" timeout="3s"
    healthz_test.go:238: I0426 08:11:46.085699] leaderelection.LeaderCallbacks.OnStartedLeading
    healthz_test.go:330: I0426 08:11:46.387008] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:46.387362] fakeResourceLock: Update
E0426 08:11:46.387425  132590 leaderelection.go:367] Failed to update lock: simulated-delayed-update-error
    healthz_test.go:295: I0426 08:11:46.588518] liveness-probe response-code=500 response-body=<
                internal server error: failed election to renew leadership on lease
         >
I0426 08:11:46.588615  132590 leaderelection.go:283] failed to renew lease fake-resource-lock: timed out waiting for the condition
    healthz_test.go:241: I0426 08:11:46.588633] leaderelection.LeaderCallbacks.OnStoppedLeading
    healthz_test.go:254: I0426 08:11:46.588659] Leader election go-routine finished
    healthz_test.go:261: I0426 08:11:46.588837] Healthz server go-routine finished
=== CONT  TestHealthzLivez/fail-immediate-update-error
    healthz_test.go:224: I0426 08:11:46.593058] Starting leader election go-routine leaseDuration="500ms" renewDeadline="400ms" retryPeriod="300ms"
    healthz_test.go:258: I0426 08:11:46.593157] Starting healthz server go-routine
    healthz_test.go:265: I0426 08:11:46.593171] Waiting for a LeaderElector to know the current leader before polling liveness endpoint
I0426 08:11:46.593203  132590 leaderelection.go:248] attempting to acquire leader lease fake-resource-lock...
    healthz_test.go:330: I0426 08:11:46.593258] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:46.593301] fakeResourceLock: Update
E0426 08:11:46.593315  132590 leaderelection.go:367] Failed to update lock: simulated-update-error
    healthz_test.go:244: I0426 08:11:46.593357] leaderelection.LeaderCallbacks.OnNewLeader identity="local-node"
    healthz_test.go:273: I0426 08:11:46.593375] Polling liveness endpoint url="http://127.0.0.1:40745/livez/leaderElection" interval="500ms" timeout="3s"
    healthz_test.go:330: I0426 08:11:47.051654] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:47.051827] fakeResourceLock: Update
E0426 08:11:47.051863  132590 leaderelection.go:367] Failed to update lock: simulated-update-error
    healthz_test.go:295: I0426 08:11:47.095706] liveness-probe response-code=200 response-body="ok"
    healthz_test.go:330: I0426 08:11:47.506867] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:47.507013] fakeResourceLock: Update
E0426 08:11:47.507039  132590 leaderelection.go:367] Failed to update lock: simulated-update-error
    healthz_test.go:295: I0426 08:11:47.593814] liveness-probe response-code=200 response-body="ok"
    healthz_test.go:330: I0426 08:11:48.057822] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:48.058008] fakeResourceLock: Update
E0426 08:11:48.058049  132590 leaderelection.go:367] Failed to update lock: simulated-update-error
    healthz_test.go:295: I0426 08:11:48.094018] liveness-probe response-code=500 response-body=<
                internal server error: failed election to renew leadership on lease
         >
    healthz_test.go:241: I0426 08:11:48.094329] leaderelection.LeaderCallbacks.OnStoppedLeading
    healthz_test.go:254: I0426 08:11:48.094361] Leader election go-routine finished
    healthz_test.go:261: I0426 08:11:48.094429] Healthz server go-routine finished
=== CONT  TestHealthzLivez/ok-remote-leader
    healthz_test.go:224: I0426 08:11:48.099083] Starting leader election go-routine leaseDuration="500ms" renewDeadline="400ms" retryPeriod="300ms"
    healthz_test.go:258: I0426 08:11:48.099156] Starting healthz server go-routine
    healthz_test.go:265: I0426 08:11:48.099165] Waiting for a LeaderElector to know the current leader before polling liveness endpoint
I0426 08:11:48.099187  132590 leaderelection.go:248] attempting to acquire leader lease fake-resource-lock...
    healthz_test.go:330: I0426 08:11:48.099193] fakeResourceLock: Get
    healthz_test.go:244: I0426 08:11:48.099250] leaderelection.LeaderCallbacks.OnNewLeader identity="remote-node"
    healthz_test.go:273: I0426 08:11:48.099261] Polling liveness endpoint url="http://127.0.0.1:33821/livez/leaderElection" interval="500ms" timeout="3s"
    healthz_test.go:330: I0426 08:11:48.434431] fakeResourceLock: Get
    healthz_test.go:295: I0426 08:11:48.601111] liveness-probe response-code=200 response-body="ok"
    healthz_test.go:241: I0426 08:11:48.601248] leaderelection.LeaderCallbacks.OnStoppedLeading
    healthz_test.go:254: I0426 08:11:48.601287] Leader election go-routine finished
    healthz_test.go:261: I0426 08:11:48.601484] Healthz server go-routine finished
=== CONT  TestHealthzLivez/ok-local-leader
    healthz_test.go:224: I0426 08:11:48.606357] Starting leader election go-routine leaseDuration="500ms" renewDeadline="400ms" retryPeriod="300ms"
    healthz_test.go:258: I0426 08:11:48.606499] Starting healthz server go-routine
    healthz_test.go:265: I0426 08:11:48.606518] Waiting for a LeaderElector to know the current leader before polling liveness endpoint
I0426 08:11:48.606603  132590 leaderelection.go:248] attempting to acquire leader lease fake-resource-lock...
    healthz_test.go:330: I0426 08:11:48.606671] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:48.606743] fakeResourceLock: Update
I0426 08:11:48.606792  132590 leaderelection.go:258] successfully acquired lease fake-resource-lock
    healthz_test.go:244: I0426 08:11:48.606859] leaderelection.LeaderCallbacks.OnNewLeader identity="local-node"
    healthz_test.go:238: I0426 08:11:48.606896] leaderelection.LeaderCallbacks.OnStartedLeading
    healthz_test.go:273: I0426 08:11:48.606927] Polling liveness endpoint url="http://127.0.0.1:42065/livez/leaderElection" interval="500ms" timeout="3s"
    healthz_test.go:330: I0426 08:11:48.606956] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:48.607036] fakeResourceLock: Update
    healthz_test.go:330: I0426 08:11:48.907663] fakeResourceLock: Get
    healthz_test.go:352: I0426 08:11:48.907988] fakeResourceLock: Update
    healthz_test.go:295: I0426 08:11:49.108833] liveness-probe response-code=200 response-body="ok"
    healthz_test.go:241: I0426 08:11:49.108982] leaderelection.LeaderCallbacks.OnStoppedLeading
    healthz_test.go:254: I0426 08:11:49.109015] Leader election go-routine finished
    healthz_test.go:261: I0426 08:11:49.109167] Healthz server go-routine finished
--- PASS: TestHealthzLivez (0.00s)
    --- PASS: TestHealthzLivez/ok-leader-election-disabled (0.50s)
    --- PASS: TestHealthzLivez/fail-delayed-update-error (0.51s)
    --- PASS: TestHealthzLivez/fail-immediate-update-error (1.51s)
    --- PASS: TestHealthzLivez/ok-remote-leader (0.51s)
    --- PASS: TestHealthzLivez/ok-local-leader (0.51s)
PASS
ok      github.com/cert-manager/cert-manager/pkg/healthz        3.549s
```

</details>

xref: 
 * https://github.com/cert-manager/cert-manager/pull/5670
 * https://github.com/cert-manager/cert-manager/issues/5889
 * https://github.com/kubernetes/kubernetes/issues/70819

```release-note
The cert-manager controller container of the controller Pod now has a /livez endpoint and a default liveness probe, which fails if leader election has been lost and for some reason the process has not exited. The liveness probe is disabled by default.
```
