### PR TITLE
Upgrade to ko 0.13

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -41,7 +41,7 @@ TOOLS += ytt=v0.43.0
 TOOLS += yq=v4.27.5
 TOOLS += crane=v0.11.0
 TOOLS += ginkgo=$(shell awk '/ginkgo\/v2/ {print $$2}' go.mod)
-TOOLS += ko=v0.12.0
+TOOLS += ko=v0.13.0
 
 # Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
 GATEWAY_API_VERSION=v0.6.2
@@ -351,9 +351,9 @@ $(BINDIR)/downloaded/tools/yq@$(YQ_VERSION)_%: | $(BINDIR)/downloaded/tools
 # ko #
 ######
 
-KO_linux_amd64_SHA256SUM=05aa77182fa7c55386bd2a210fd41298542726f33bbfc9c549add3a66f7b90ad
-KO_darwin_amd64_SHA256SUM=8679d0d74fc75f24e044649c6a961dad0a3ef03bedbdece35e2f3f29eb7876af
-KO_darwin_arm64_SHA256SUM=cfef98db8ad0e1edaa483fa5c6af89eb573a8434abd372b510b89005575de702
+KO_linux_amd64_SHA256SUM=80f3e3148fabd5b839cc367ac56bb4794f90e7262b01911316c670b210b574cc
+KO_darwin_amd64_SHA256SUM=8d9daea9bcf25c790f705ea115d1c0a0193cb3d9759e937ab2959c71f88ce29c
+KO_darwin_arm64_SHA256SUM=8b6ad2ca95de9e9a5f697f6a653301ef5405a643b09bdd10628bac0f77eaadff
 
 $(BINDIR)/downloaded/tools/ko@$(KO_VERSION)_%: | $(BINDIR)/downloaded/tools
 	$(eval OS_AND_ARCH := $(subst darwin,Darwin,$*))


### PR DESCRIPTION
[ko v0.13.0 has many fixes](https://github.com/ko-build/ko/releases/tag/v0.13.0), including one for publishing the images to your local Docker daemon.
This now works properly:

```
make ko-images-push KO_REGISTRY=ko.local
```

```
$ docker images | egrep 'ko.local/cert-manager-(ctl|webhook|acmesolver|cainjector)\s+v'
ko.local/cert-manager-acmesolver                         v1.12.0-alpha.2-63-gece30e655f2c1d
2f41e9250269   16 hours ago    40.8MB
ko.local/cert-manager-cainjector                         v1.12.0-alpha.2-63-gece30e655f2c1d
2b1c44d24c98   16 hours ago    55.8MB
ko.local/cert-manager-webhook                            v1.12.0-alpha.2-63-gece30e655f2c1d
0991f36d7f25   16 hours ago    66.7MB
ko.local/cert-manager-ctl                                v1.12.0-alpha.2-63-gece30e655f2c1d
657a0d994a49   16 hours ago    73.2MB
```

(previously it created all the images with the name `ko.local`)

```release-note
NONE
```
