### PR TITLE
Clean up cached Secret resources

### DIFF
--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -164,9 +164,11 @@ type filteredSecretInformer struct {
 
 func (f *filteredSecretInformer) Informer() Informer {
 	typedInformer := f.typedInformerFactory.InformerFor(&corev1.Secret{}, f.newTyped)
-	// TODO: set any possible transforms
+
 	metadataInformer := f.metadataInformerFactory.ForResource(secretsGVR).Informer()
-	// TODO: set transform on metadataInformer to remove last applied annotation etc
+	if err := metadataInformer.SetTransform(partialMetadataRemoveAll); err != nil {
+		panic(fmt.Sprintf("internal error: error setting transfomer on the metadata informer: %v", err))
+	}
 	return &informer{
 		typedInformer:    typedInformer,
 		metadataInformer: metadataInformer,

--- a/internal/informers/transfomers.go
+++ b/internal/informers/transfomers.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.TransformFunc = partialMetadataRemoveAll
+
+// partialMetadataRemoveAll implements a cache.TransformFunc that removes
+// labels, annotations and managed
+// fields from PartialObjectMetadata.
+func partialMetadataRemoveAll(obj interface{}) (interface{}, error) {
+	partialMeta, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("internal error: cannot cast object %#+v to PartialObjectMetadata", obj)
+	}
+	partialMeta.Annotations = nil
+	partialMeta.ManagedFields = nil
+	partialMeta.Labels = nil
+	return partialMeta, nil
+}


### PR DESCRIPTION
## Description

This PR uses [client-go transform functions mechanism](https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#transform-functions) to clean up labels, annotations and managed fields from partial metadata `Secret`s. This is okay as partial metadata `Secret`s are only cached to pre-determine if a `Secret` identified by name and namespace exists.

## Notes

When we start using server-side apply in GA, we should also be able to remove the last applied annotation from cached typed `Secret`s without risking to delete it from the cluster object when cert-manager re-applies the `Secret` (i.e a `Certificate` `Secret` that was originally applied by user)

## Metrics

A rough measurement of performance changes in a cluster with 200 cert-manager unrelated `Secret`s and [`SecretsFilteredCaching` feature gate](#5824 ) on (these `Secret`s would be stored as partial metadata)

Latest master cert-manager controller pod when 200 `Secret`s with a last applied annotation get created:
![transformmaster](https://user-images.githubusercontent.com/24879183/233306291-a8ca31ee-dba8-48cd-9fd5-735666faaff3.png)

cert-manager controller from this PR when 200 `Secret`s with a last applied annotation get created:
![transformtransform](https://user-images.githubusercontent.com/24879183/233306472-5159f93a-ce22-4dd7-acee-8123af2b4a00.png)

There is a short increase in CPU consumption when the transform functions run, but I think that this is worth it as overall we reduce the memory consumption proportionally to the number of objects.




```release-note
Ensures that annotations, labels and managed fields are not cached for partial metadata `Secret`s.
```

/kind cleanup

Related PRs:
- #5824 
