### PR TITLE
Use a temporary go.work file when running go-licenses

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -458,6 +458,7 @@ update-base-images: $(BINDIR)/tools/crane
 
 .PHONY: tidy
 ## Run "go mod tidy" on each module in this repo
+## @category Development
 tidy:
 	go mod tidy
 	cd cmd/acmesolver && go mod tidy
@@ -469,7 +470,10 @@ tidy:
 	cd test/e2e && go mod tidy
 
 .PHONY: go-workspace
+go-workspace: export GOWORK?=$(abspath go.work)
+## Create a go.work file in the repository root (or GOWORK)
+## @category Development
 go-workspace:
-	@rm -f go.work
+	@rm -f $(GOWORK)
 	go work init
 	go work use . ./cmd/acmesolver ./cmd/cainjector ./cmd/controller ./cmd/ctl ./cmd/webhook ./test/integration ./test/e2e


### PR DESCRIPTION
Without a go.work file, `go-licenses` is unable to discover the LICENSE file and dependencies of github.com/cert-manager/cert-manager when it is pointed at `./cmd/controller`, for example.
It does not follow the replace statements in the `go.mod` file of each of the binaries.

Adding a `go.work` file allows it to work,  and presumably a `go.work` file was present when the current LICENSES files were generated and committed to the repository...or they were generated and committed before the introduction of the per-binary go.mod files.

~~The `make verify-licenses` target has been succeeding in CI thus far because the `_bin/scratch/LATEST-LICENSES*` files -- against which it compares the checked in LICENSES files -- are also cached in CI and are only updated when the respective `go.mod` or `go.sum` file changes. These must have been generated in the presence of a `go.work` file...presumably before it was removed in #5935.~~
-- Actually, I've realised that the reason is that the [pull-cert-manager-master-license only runs when `go.mod` changes](https://github.com/jetstack/testing/blob/438f15998e9095900a8e3e7151f659c0c4438e5a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml#L370-L403)

In #5962 I made a change to `cmd/controller/go.mod` which resulted in the regeneration of `_bin/scratch/LATEST-LICENSES-controller` in the absence of a go.work file and `make verify-licenses` then failed.

So since we have decided not to commit a go.work file to the repository, I've made a change here to create a go.work file in a non-standard temporary location and use it only when running `go-licenses`.

Example failures:
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5961/pull-cert-manager-master-license/1648593128208207872 in #5961
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5970/pull-cert-manager-master-license/1649061664697356288 in #5970

Example success (using this fix):
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5962/pull-cert-manager-master-license/1649054110504194048 after I rebased #5962 on top of this PR
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/5969/pull-cert-manager-master-license/1649056433360080896 in #5969 which is based on this PR

Fixes: #5964 
 * #5964

/kind bug

```release-note
NONE
```
