### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/cmd/acmesolver/go.mod
+++ b/cmd/acmesolver/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/acmesolver-binary
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 

--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cainjector-binary
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/controller-binary
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 

--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cmctl-binary
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/webhook-binary
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager
 
-go 1.19
+go 1.20
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -52,7 +52,7 @@ KUBEBUILDER_ASSETS_VERSION=1.26.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.6
+VENDORED_GO_VERSION := 1.20.3
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/e2e-tests
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/integration-tests
 
-go 1.19
+go 1.20
 
 replace github.com/cert-manager/cert-manager => ../../
 


### PR DESCRIPTION
Upgrading to Go 1.20 as a way of testing #5968 which will be triggered here by the changes to all the `go.mod` files.

/kind cleanup

```release-note
Upgrade to Go 1.20
```
