### PR TITLE
Check JKS/PKCS12 truststore in Secrets only if issuer provides the CA 

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -134,7 +134,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -156,7 +156,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -357,9 +357,10 @@ type JKSKeystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will be updated immediately.
-	// A file named `truststore.jks` will also be created in the target
-	// Secret resource, encrypted using the password stored in
-	// `passwordSecretRef` containing the issuing Certificate Authority
+	// If the issuer provided a CA certificate, a file named `truststore.jks`
+	// will also be created in the target Secret resource, encrypted using the
+	// password stored in `passwordSecretRef`
+	// containing the issuing Certificate Authority
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource
@@ -375,9 +376,10 @@ type PKCS12Keystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will be updated immediately.
-	// A file named `truststore.p12` will also be created in the target
-	// Secret resource, encrypted using the password stored in
-	// `passwordSecretRef` containing the issuing Certificate Authority
+	// If the issuer provided a CA certificate, a file named `truststore.p12` will
+	// also be created in the target Secret resource, encrypted using the
+	// password stored in `passwordSecretRef` containing the issuing Certificate
+	// Authority
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource


### PR DESCRIPTION
### Pull Request Motivation

The current policy check for keystores in Secrets creates a loop because
the truststore.jks or truststore.p12 will never exist when the issuer didn't
provide the CA certificate. This behaviour was introduced by #5597

The JKS and PKCS12 truststores are only added to the Secret
if the CA is provided by the issuer. The CertificateRequest API
reference states:

> The PEM encoded x509 certificate of the signer, also known
> as the CA (Certificate Authority). This is set on a best-effort basis by
> different issuers. If not set, the CA is assumed to be unknown/not available.


This change will only check the PKCS12/JKS truststores if the CA cert from the
issuer exists in the secret.


Fixes #5755

### Kind

/kind bug

### Release Note

```release-note
 Check JKS/PKCS12 truststore in Secrets only if issuer provides the CA
```
