### PR TITLE
Cache metadata only for pods and services

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -211,7 +211,7 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 	log.V(logf.DebugLevel).Info("starting shared informer factories")
 	ctx.SharedInformerFactory.Start(rootCtx.Done())
 	ctx.KubeSharedInformerFactory.Start(rootCtx.Done())
-	ctx.MetadataInformerFactory.Start(rootCtx.Done())
+	ctx.HTTP01ResourceMetadataInformersFactory.Start(rootCtx.Done())
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
 		ctx.GWShared.Start(rootCtx.Done())

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -211,6 +211,7 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 	log.V(logf.DebugLevel).Info("starting shared informer factories")
 	ctx.SharedInformerFactory.Start(rootCtx.Done())
 	ctx.KubeSharedInformerFactory.Start(rootCtx.Done())
+	ctx.MetadataInformerFactory.Start(rootCtx.Done())
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
 		ctx.GWShared.Start(rootCtx.Done())

--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -19,7 +19,6 @@ package informers
 import (
 	corev1 "k8s.io/api/core/v1"
 	certificatesv1 "k8s.io/client-go/informers/certificates/v1"
-	corev1informers "k8s.io/client-go/informers/core/v1"
 	networkingv1informers "k8s.io/client-go/informers/networking/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -45,8 +44,6 @@ const pleaseOpenIssue = "Please report this by opening an issue with this error 
 type KubeInformerFactory interface {
 	Start(<-chan struct{})
 	WaitForCacheSync(<-chan struct{}) map[string]bool
-	Pods() corev1informers.PodInformer
-	Services() corev1informers.ServiceInformer
 	Ingresses() networkingv1informers.IngressInformer
 	Secrets() SecretInformer
 	CertificateSigningRequests() certificatesv1.CertificateSigningRequestInformer

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -64,14 +64,6 @@ func (bf *baseFactory) WaitForCacheSync(stopCh <-chan struct{}) map[string]bool 
 	return ret
 }
 
-func (bf *baseFactory) Pods() corev1informers.PodInformer {
-	return bf.f.Core().V1().Pods()
-}
-
-func (bf *baseFactory) Services() corev1informers.ServiceInformer {
-	return bf.f.Core().V1().Services()
-}
-
 func (bf *baseFactory) Ingresses() networkingv1informers.IngressInformer {
 	return bf.f.Networking().V1().Ingresses()
 }

--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -115,14 +115,6 @@ func (bf *filteredSecretsFactory) WaitForCacheSync(stopCh <-chan struct{}) map[s
 	return caches
 }
 
-func (bf *filteredSecretsFactory) Pods() corev1informers.PodInformer {
-	return bf.typedInformerFactory.Core().V1().Pods()
-}
-
-func (bf *filteredSecretsFactory) Services() corev1informers.ServiceInformer {
-	return bf.typedInformerFactory.Core().V1().Services()
-}
-
 func (bf *filteredSecretsFactory) Ingresses() networkingv1informers.IngressInformer {
 	return bf.typedInformerFactory.Networking().V1().Ingresses()
 }

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -94,8 +94,8 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 	// we register these informers here so the HTTP01 solver has a synced
 	// cache when managing pod/service/ingress resources
-	podInformer := ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
-	serviceInformer := ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services"))
+	podInformer := ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
+	serviceInformer := ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services"))
 	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
 
 	// build a list of InformerSynced functions that will be returned by the Register method.

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -94,8 +94,8 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	secretInformer := ctx.KubeSharedInformerFactory.Secrets()
 	// we register these informers here so the HTTP01 solver has a synced
 	// cache when managing pod/service/ingress resources
-	podInformer := ctx.KubeSharedInformerFactory.Pods()
-	serviceInformer := ctx.KubeSharedInformerFactory.Services()
+	podInformer := ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
+	serviceInformer := ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services"))
 	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
 
 	// build a list of InformerSynced functions that will be returned by the Register method.

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -26,11 +26,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
@@ -44,6 +48,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmscheme "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/scheme"
 	informers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
@@ -84,6 +89,8 @@ type Context struct {
 	CMClient clientset.Interface
 	// GWClient is a GatewayAPI clientset.
 	GWClient gwclient.Interface
+	// MetadataClient is a PartialObjectMetadata client
+	MetadataClient metadata.Interface
 	// DiscoveryClient is a discovery interface. Usually set to Client.Discovery unless a fake client is in use.
 	DiscoveryClient discovery.DiscoveryInterface
 
@@ -97,6 +104,10 @@ type Context struct {
 	// SharedInformerFactory can be used to obtain shared SharedIndexInformer
 	// instances for cert-manager.io types
 	SharedInformerFactory informers.SharedInformerFactory
+
+	// MetadataInformerFactory can be used to start partial metadata
+	// informers
+	MetadataInformerFactory metadatainformer.SharedInformerFactory
 
 	// GWShared can be used to obtain SharedIndexInformer instances for
 	// gateway.networking.k8s.io types
@@ -273,6 +284,20 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 	} else {
 		kubeSharedInformerFactory = internalinformers.NewBaseKubeInformerFactory(clients.kubeClient, resyncPeriod, opts.Namespace)
 	}
+	r, err := labels.NewRequirement(cmacme.DomainLabelKey, selection.Exists, nil)
+	if err != nil {
+		panic(fmt.Errorf("internal error: failed to build label selector to filter HTTP-01 challenge resources: %w", err))
+	}
+	isHTTP01ChallengeResourceLabelSelector := labels.NewSelector().Add(*r)
+	metadataInformerFactory := metadatainformer.NewFilteredSharedInformerFactory(clients.metadataOnlyClient, resyncPeriod, opts.Namespace, func(listOptions *metav1.ListOptions) {
+		// metadataInformersFactory is at the moment only used for pods
+		// and services for http-01 challenge which can be identified by
+		// the same label keys, so it is okay to set the label selector
+		// here. If we start using it for other resources then we'll
+		// have to set the selectors on individual informers instead.
+		listOptions.LabelSelector = isHTTP01ChallengeResourceLabelSelector.String()
+
+	})
 
 	gwSharedInformerFactory := gwinformers.NewSharedInformerFactoryWithOptions(clients.gwClient, resyncPeriod, gwinformers.WithNamespace(opts.Namespace))
 
@@ -286,6 +311,7 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 			SharedInformerFactory:     sharedInformerFactory,
 			GWShared:                  gwSharedInformerFactory,
 			GatewaySolverEnabled:      clients.gatewayAvailable,
+			MetadataInformerFactory:   metadataInformerFactory,
 			ContextOptions:            opts,
 		},
 	}, nil

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -105,9 +105,9 @@ type Context struct {
 	// instances for cert-manager.io types
 	SharedInformerFactory informers.SharedInformerFactory
 
-	// MetadataInformerFactory can be used to start partial metadata
-	// informers
-	MetadataInformerFactory metadatainformer.SharedInformerFactory
+	// HTTP01ResourceMetadataInformersFactory is a metadata only informers
+	// factory with a http-01 resource label filter selector
+	HTTP01ResourceMetadataInformersFactory metadatainformer.SharedInformerFactory
 
 	// GWShared can be used to obtain SharedIndexInformer instances for
 	// gateway.networking.k8s.io types
@@ -289,7 +289,7 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 		panic(fmt.Errorf("internal error: failed to build label selector to filter HTTP-01 challenge resources: %w", err))
 	}
 	isHTTP01ChallengeResourceLabelSelector := labels.NewSelector().Add(*r)
-	metadataInformerFactory := metadatainformer.NewFilteredSharedInformerFactory(clients.metadataOnlyClient, resyncPeriod, opts.Namespace, func(listOptions *metav1.ListOptions) {
+	http01ResourceMetadataInformerFactory := metadatainformer.NewFilteredSharedInformerFactory(clients.metadataOnlyClient, resyncPeriod, opts.Namespace, func(listOptions *metav1.ListOptions) {
 		// metadataInformersFactory is at the moment only used for pods
 		// and services for http-01 challenge which can be identified by
 		// the same label keys, so it is okay to set the label selector
@@ -305,14 +305,14 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 		baseRestConfig: restConfig,
 		log:            logf.FromContext(ctx),
 		ctx: &Context{
-			RootContext:               ctx,
-			StopCh:                    ctx.Done(),
-			KubeSharedInformerFactory: kubeSharedInformerFactory,
-			SharedInformerFactory:     sharedInformerFactory,
-			GWShared:                  gwSharedInformerFactory,
-			GatewaySolverEnabled:      clients.gatewayAvailable,
-			MetadataInformerFactory:   metadataInformerFactory,
-			ContextOptions:            opts,
+			RootContext:                            ctx,
+			StopCh:                                 ctx.Done(),
+			KubeSharedInformerFactory:              kubeSharedInformerFactory,
+			SharedInformerFactory:                  sharedInformerFactory,
+			GWShared:                               gwSharedInformerFactory,
+			GatewaySolverEnabled:                   clients.gatewayAvailable,
+			HTTP01ResourceMetadataInformersFactory: http01ResourceMetadataInformerFactory,
+			ContextOptions:                         opts,
 		},
 	}, nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -344,6 +344,7 @@ func (c *ContextFactory) Build(component ...string) (*Context, error) {
 	ctx.Client = clients.kubeClient
 	ctx.CMClient = clients.cmClient
 	ctx.GWClient = clients.gwClient
+	ctx.MetadataClient = clients.metadataOnlyClient
 	ctx.DiscoveryClient = clients.kubeClient.Discovery()
 	ctx.Recorder = recorder
 

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -151,7 +151,7 @@ func (b *Builder) Init() {
 	b.KubeSharedInformerFactory = internalinformers.NewBaseKubeInformerFactory(b.Client, informerResyncPeriod, "")
 	b.SharedInformerFactory = informers.NewSharedInformerFactory(b.CMClient, informerResyncPeriod)
 	b.GWShared = gwinformers.NewSharedInformerFactory(b.GWClient, informerResyncPeriod)
-	b.MetadataInformerFactory = metadatainformer.NewFilteredSharedInformerFactory(b.MetadataClient, informerResyncPeriod, "", func(listOptions *metav1.ListOptions) {})
+	b.HTTP01ResourceMetadataInformersFactory = metadatainformer.NewFilteredSharedInformerFactory(b.MetadataClient, informerResyncPeriod, "", func(listOptions *metav1.ListOptions) {})
 	b.stopCh = make(chan struct{})
 	b.Metrics = metrics.New(logs.Log, clock.RealClock{})
 
@@ -322,7 +322,7 @@ func (b *Builder) Start() {
 	b.KubeSharedInformerFactory.Start(b.stopCh)
 	b.SharedInformerFactory.Start(b.stopCh)
 	b.GWShared.Start(b.stopCh)
-	b.MetadataInformerFactory.Start(b.stopCh)
+	b.HTTP01ResourceMetadataInformersFactory.Start(b.stopCh)
 
 	// wait for caches to sync
 	b.Sync()
@@ -338,7 +338,7 @@ func (b *Builder) Sync() {
 	if err := mustAllSync(b.GWShared.WaitForCacheSync(b.stopCh)); err != nil {
 		panic("Error waiting for GWShared to sync: " + err.Error())
 	}
-	if err := mustAllSyncGVR(b.MetadataInformerFactory.WaitForCacheSync(b.stopCh)); err != nil {
+	if err := mustAllSyncGVR(b.HTTP01ResourceMetadataInformersFactory.WaitForCacheSync(b.stopCh)); err != nil {
 		panic("Error waiting for MetadataInformerFactory to sync:" + err.Error())
 	}
 	if b.additionalSyncFuncs != nil {

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -27,8 +27,11 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	coretesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -61,12 +64,13 @@ func init() {
 type Builder struct {
 	T *testing.T
 
-	KubeObjects        []runtime.Object
-	CertManagerObjects []runtime.Object
-	GWObjects          []runtime.Object
-	ExpectedActions    []Action
-	ExpectedEvents     []string
-	StringGenerator    StringGenerator
+	KubeObjects            []runtime.Object
+	CertManagerObjects     []runtime.Object
+	GWObjects              []runtime.Object
+	PartialMetadataObjects []runtime.Object
+	ExpectedActions        []Action
+	ExpectedEvents         []string
+	StringGenerator        StringGenerator
 
 	// Clock will be the Clock set on the controller context.
 	// If not specified, the RealClock will be used.
@@ -110,10 +114,13 @@ func (b *Builder) Init() {
 	if b.StringGenerator == nil {
 		b.StringGenerator = RandStringBytes
 	}
+	scheme := metadatafake.NewTestScheme()
+	metav1.AddMetaToScheme(scheme)
 	b.requiredReactors = make(map[string]bool)
 	b.Client = kubefake.NewSimpleClientset(b.KubeObjects...)
 	b.CMClient = cmfake.NewSimpleClientset(b.CertManagerObjects...)
 	b.GWClient = gwfake.NewSimpleClientset(b.GWObjects...)
+	b.MetadataClient = metadatafake.NewSimpleMetadataClient(scheme, b.PartialMetadataObjects...)
 	b.DiscoveryClient = discoveryfake.NewDiscovery().WithServerResourcesForGroupVersion(func(groupVersion string) (*metav1.APIResourceList, error) {
 		if groupVersion == networkingv1.SchemeGroupVersion.String() {
 			return &metav1.APIResourceList{
@@ -144,6 +151,7 @@ func (b *Builder) Init() {
 	b.KubeSharedInformerFactory = internalinformers.NewBaseKubeInformerFactory(b.Client, informerResyncPeriod, "")
 	b.SharedInformerFactory = informers.NewSharedInformerFactory(b.CMClient, informerResyncPeriod)
 	b.GWShared = gwinformers.NewSharedInformerFactory(b.GWClient, informerResyncPeriod)
+	b.MetadataInformerFactory = metadatainformer.NewFilteredSharedInformerFactory(b.MetadataClient, informerResyncPeriod, "", func(listOptions *metav1.ListOptions) {})
 	b.stopCh = make(chan struct{})
 	b.Metrics = metrics.New(logs.Log, clock.RealClock{})
 
@@ -314,6 +322,7 @@ func (b *Builder) Start() {
 	b.KubeSharedInformerFactory.Start(b.stopCh)
 	b.SharedInformerFactory.Start(b.stopCh)
 	b.GWShared.Start(b.stopCh)
+	b.MetadataInformerFactory.Start(b.stopCh)
 
 	// wait for caches to sync
 	b.Sync()
@@ -328,6 +337,9 @@ func (b *Builder) Sync() {
 	}
 	if err := mustAllSync(b.GWShared.WaitForCacheSync(b.stopCh)); err != nil {
 		panic("Error waiting for GWShared to sync: " + err.Error())
+	}
+	if err := mustAllSyncGVR(b.MetadataInformerFactory.WaitForCacheSync(b.stopCh)); err != nil {
+		panic("Error waiting for MetadataInformerFactory to sync:" + err.Error())
 	}
 	if b.additionalSyncFuncs != nil {
 		cache.WaitForCacheSync(b.stopCh, b.additionalSyncFuncs...)
@@ -362,10 +374,23 @@ func mustAllSync(in map[reflect.Type]bool) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// We need two functions to parse map[reflect.Type]bool, map[string]bool
+// We need three functions to parse map[schema.GroupVersionResource bool, map[reflect.Type]bool, map[string]bool
 // arguments- we cannot use generics here as reflect.Type is not a valid map key
 // for a generic parameter because it does not implement comparable.
 func mustAllSyncString(in map[string]bool) error {
+	var errs []error
+	for t, started := range in {
+		if !started {
+			errs = append(errs, fmt.Errorf("informer for %v not synced", t))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// We need three functions to parse map[reflect.Type]bool, map[string]bool
+// arguments- we cannot use generics here as reflect.Type is not a valid map key
+// for a generic parameter because it does not implement comparable.
+func mustAllSyncGVR(in map[schema.GroupVersionResource]bool) error {
 	var errs []error
 	for t, started := range in {
 		if !started {

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -74,8 +74,8 @@ type reachabilityTest func(ctx context.Context, url *url.URL, key string, dnsSer
 func NewSolver(ctx *controller.Context) (*Solver, error) {
 	return &Solver{
 		Context:          ctx,
-		podLister:        ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
-		serviceLister:    ctx.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
+		podLister:        ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
+		serviceLister:    ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
 		ingressLister:    ctx.KubeSharedInformerFactory.Ingresses().Lister(),
 		httpRouteLister:  ctx.GWShared.Gateway().V1beta1().HTTPRoutes().Lister(),
 		testReachability: testReachability,

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -47,35 +47,36 @@ func podLabels(ch *cmacme.Challenge) map[string]string {
 	}
 }
 
-func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) (*corev1.Pod, error) {
+func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) error {
 	log := logf.FromContext(ctx).WithName("ensurePod")
 
 	log.V(logf.DebugLevel).Info("checking for existing HTTP01 solver pods")
 	existingPods, err := s.getPodsForChallenge(ctx, ch)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(existingPods) == 1 {
 		logf.WithRelatedResource(log, existingPods[0]).Info("found one existing HTTP01 solver pod")
-		return existingPods[0], nil
+		return nil
 	}
 	if len(existingPods) > 1 {
 		log.V(logf.InfoLevel).Info("multiple challenge solver pods found for challenge. cleaning up all existing pods.")
 		err := s.cleanupPods(ctx, ch)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		return nil, fmt.Errorf("multiple existing challenge solver pods found and cleaned up. retrying challenge sync")
+		return fmt.Errorf("multiple existing challenge solver pods found and cleaned up. retrying challenge sync")
 	}
 
 	log.V(logf.InfoLevel).Info("creating HTTP01 challenge solver pod")
 
-	return s.createPod(ctx, ch)
+	_, err = s.createPod(ctx, ch)
+	return err
 }
 
 // getPodsForChallenge returns a list of pods that were created to solve
 // the given challenge
-func (s *Solver) getPodsForChallenge(ctx context.Context, ch *cmacme.Challenge) ([]*corev1.Pod, error) {
+func (s *Solver) getPodsForChallenge(ctx context.Context, ch *cmacme.Challenge) ([]*metav1.PartialObjectMetadata, error) {
 	log := logf.FromContext(ctx)
 
 	podLabels := podLabels(ch)
@@ -88,19 +89,24 @@ func (s *Solver) getPodsForChallenge(ctx context.Context, ch *cmacme.Challenge) 
 		orderSelector = orderSelector.Add(*req)
 	}
 
-	podList, err := s.podLister.Pods(ch.Namespace).List(orderSelector)
+	podMetadataList, err := s.podLister.ByNamespace(ch.Namespace).List(orderSelector)
 	if err != nil {
 		return nil, err
 	}
 
-	var relevantPods []*corev1.Pod
-	for _, pod := range podList {
-		if !metav1.IsControlledBy(pod, ch) {
-			logf.WithRelatedResource(log, pod).Info("found existing solver pod for this challenge resource, however " +
+	var relevantPods []*metav1.PartialObjectMetadata
+	for _, pod := range podMetadataList {
+		// TODO: can we use a metadata lister instead?
+		p, ok := pod.(*metav1.PartialObjectMetadata)
+		if !ok {
+			return nil, fmt.Errorf("internal error: cannot cast PartialMetadata: %+#v", pod)
+		}
+		if !metav1.IsControlledBy(p, ch) {
+			logf.WithRelatedResource(log, p).Info("found existing solver pod for this challenge resource, however " +
 				"it does not have an appropriate OwnerReference referencing this challenge. Skipping it altogether.")
 			continue
 		}
-		relevantPods = append(relevantPods, pod)
+		relevantPods = append(relevantPods, p)
 	}
 
 	return relevantPods, nil

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -163,7 +163,7 @@ func TestEnsurePod(t *testing.T) {
 			scenario.builder.InitWithRESTConfig()
 			s := &Solver{
 				Context:   scenario.builder.Context,
-				podLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
+				podLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
 			}
 			s.Context.ACMEOptions = controller.ACMEOptions{
 				HTTP01SolverResourceRequestCPU:    cpuRequest,
@@ -254,7 +254,7 @@ func TestGetPodsForChallenge(t *testing.T) {
 			scenario.builder.InitWithRESTConfig()
 			s := &Solver{
 				Context:   scenario.builder.Context,
-				podLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
+				podLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
 			}
 			defer scenario.builder.Stop()
 			scenario.builder.Start()

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -18,247 +18,252 @@ package http
 
 import (
 	"context"
-	"reflect"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	coretesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller"
+	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/stretchr/testify/assert"
+	coretesting "k8s.io/client-go/testing"
 )
 
 func TestEnsurePod(t *testing.T) {
-	const createdPodKey = "createdPod"
-	tests := map[string]solverFixture{
-		"should return an existing pod if one already exists": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Token:   "token",
-					Key:     "key",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+	type testT struct {
+		builder     *testpkg.Builder
+		chal        *cmacme.Challenge
+		expectedErr bool
+	}
+	cpuRequest, err := resource.ParseQuantity("10m")
+	assert.NoError(t, err)
+	cpuLimit, err := resource.ParseQuantity("100m")
+	assert.NoError(t, err)
+	memoryRequest, err := resource.ParseQuantity("64Mi")
+	assert.NoError(t, err)
+	memoryLimit, err := resource.ParseQuantity("64Mi")
+	assert.NoError(t, err)
+	var (
+		testNamespace = "foo"
+		chal          = &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+			},
+			Spec: cmacme.ChallengeSpec{
+				DNSName: "example.com",
+				Token:   "token",
+				Key:     "key",
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+					},
+				},
+			},
+		}
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cm-acme-http-solver-",
+				Namespace:    testNamespace,
+				Labels:       podLabels(chal),
+				Annotations: map[string]string{
+					"sidecar.istio.io/inject": "false",
+				},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
+			},
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: pointer.Bool(false),
+				NodeSelector: map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+				RestartPolicy: corev1.RestartPolicyOnFailure,
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: pointer.BoolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            "acmesolver",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Args: []string{
+							fmt.Sprintf("--listen-port=%d", acmeSolverListenPort),
+							fmt.Sprintf("--domain=%s", chal.Spec.DNSName),
+							fmt.Sprintf("--token=%s", chal.Spec.Token),
+							fmt.Sprintf("--key=%s", chal.Spec.Key),
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    cpuRequest,
+								corev1.ResourceMemory: memoryRequest,
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    cpuLimit,
+								corev1.ResourceMemory: memoryLimit,
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: acmeSolverListenPort,
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
 						},
 					},
 				},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-				s.testResources[createdPodKey] = ing
-
-				// TODO: replace this with expectedActions to make sure no other actions are performed
-				// create a reactor that fails the test if a pod is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "pods", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					t.Errorf("ensurePod should not create a pod if one already exists")
-					t.Fail()
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
+		}
+		podMeta = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
 			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				createdPod := s.testResources[createdPodKey].(*corev1.Pod)
-				resp := args[0].(*corev1.Pod)
-				if resp == nil {
-					t.Errorf("unexpected pod = nil")
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(resp, createdPod) {
-					t.Errorf("Expected %v to equal %v", resp, createdPod)
-				}
+			ObjectMeta: pod.ObjectMeta,
+		}
+	)
+	tests := map[string]testT{
+		"should do nothing if pod already exists": {
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{podMeta},
+				ExpectedActions:        []testpkg.Action{},
 			},
+			chal: chal,
 		},
 		"should create a new pod if one does not exist": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Token:   "token",
-					Key:     "key",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{},
+				ExpectedActions:        []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("pods"), testNamespace, pod))},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedPod := s.Solver.buildPod(s.Challenge)
-				// create a reactor that fails the test if a pod is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "pods", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					pod := action.(coretesting.CreateAction).GetObject().(*corev1.Pod)
-					// clear pod name as we don't know it yet in the expectedPod
-					pod.Name = ""
-					if !reflect.DeepEqual(pod, expectedPod) {
-						t.Errorf("Expected %v to equal %v", pod, expectedPod)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*corev1.Pod)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected pod = nil")
-					t.Fail()
-					return
-				}
-				pods, err := s.Solver.podLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing pods: %v", err)
-					t.Fail()
-					return
-				}
-				if len(pods) != 1 {
-					t.Errorf("unexpected %d pods in lister: %+v", len(pods), pods)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(pods[0], resp) {
-					t.Errorf("Expected %v to equal %v", pods[0], resp)
-				}
-			},
+			chal: chal,
 		},
 		"should clean up if multiple pods exist": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Token:   "token",
-					Key:     "key",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{podMeta, func(p metav1.PartialObjectMetadata) *metav1.PartialObjectMetadata { p.Name = "foobar"; return &p }(*podMeta)},
+				KubeObjects:            []runtime.Object{pod, func(p corev1.Pod) *corev1.Pod { p.Name = "foobar"; return &p }(*pod)},
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), testNamespace, "foobar")),
+					testpkg.NewAction(coretesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), testNamespace, ""))},
 			},
-			Err: true,
-			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createPod(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-				_, err = s.Solver.createPod(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				pods, err := s.Solver.podLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("error listing pods: %v", err)
-					t.Fail()
-					return
-				}
-				if len(pods) != 0 {
-					t.Errorf("expected pods to have been cleaned up, but there were %d pods left", len(pods))
-				}
-			},
+			chal:        chal,
+			expectedErr: true,
 		},
 	}
-	for name, test := range tests {
+	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {
-			test.Setup(t)
-			resp, err := test.Solver.ensurePod(context.TODO(), test.Challenge)
-			if err != nil && !test.Err {
-				t.Errorf("Expected function to not error, but got: %v", err)
+			scenario.builder.T = t
+			scenario.builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:   scenario.builder.Context,
+				podLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
 			}
-			if err == nil && test.Err {
-				t.Errorf("Expected function to get an error, but got: %v", err)
+			s.Context.ACMEOptions = controller.ACMEOptions{
+				HTTP01SolverResourceRequestCPU:    cpuRequest,
+				HTTP01SolverResourceRequestMemory: memoryRequest,
+				HTTP01SolverResourceLimitsCPU:     cpuLimit,
+				HTTP01SolverResourceLimitsMemory:  memoryLimit,
+				ACMEHTTP01SolverRunAsNonRoot:      true,
 			}
-			test.Finish(t, resp, err)
+			scenario.builder.Start()
+			defer scenario.builder.Stop()
+			err := s.ensurePod(context.Background(), scenario.chal)
+			if err != nil != scenario.expectedErr {
+				t.Fatalf("unexpected error: wants err: %t, got err %v", scenario.expectedErr, err)
+
+			}
+			scenario.builder.CheckAndFinish()
 		})
+
 	}
 }
 
-func TestGetPodsForCertificate(t *testing.T) {
-	const createdPodKey = "createdPod"
-	tests := map[string]solverFixture{
-		"should return one pod that matches": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
+func TestGetPodsForChallenge(t *testing.T) {
+	type testT struct {
+		builder        *testpkg.Builder
+		chal           *cmacme.Challenge
+		wantedPodMetas []*metav1.PartialObjectMetadata
+		wantsErr       bool
+	}
+	var (
+		testNamespace = "foo"
+		chal          = &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+			},
+			Spec: cmacme.ChallengeSpec{
+				DNSName: "example.com",
+				Token:   "token",
+				Key:     "key",
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
 					},
 				},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.testResources[createdPodKey] = ing
-				s.Builder.Sync()
+		}
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName:    "cm-acme-http-solver-",
+				Namespace:       testNamespace,
+				Labels:          podLabels(chal),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
 			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				createdPod := s.testResources[createdPodKey].(*corev1.Pod)
-				resp := args[0].([]*corev1.Pod)
-				if len(resp) != 1 {
-					t.Errorf("expected one pod to be returned, but got %d", len(resp))
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(resp[0], createdPod) {
-					t.Errorf("Expected %v to equal %v", resp[0], createdPod)
-				}
+		}
+		podMeta = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
 			},
+			ObjectMeta: pod.ObjectMeta,
+		}
+		podMeta2 = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: *pod.ObjectMeta.DeepCopy(),
+		}
+	)
+	podMeta2.Labels[cmacme.DomainLabelKey] = "foo"
+	tests := map[string]testT{
+		"should return one pod that matches": {
+			chal: chal,
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{podMeta},
+			},
+			wantedPodMetas: []*metav1.PartialObjectMetadata{podMeta},
 		},
 		"should not return a pod for the same certificate but different domain": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
-			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				differentChallenge := s.Challenge.DeepCopy()
-				differentChallenge.Spec.DNSName = "notexample.com"
-				_, err := s.Solver.createPod(context.TODO(), differentChallenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].([]*corev1.Pod)
-				if len(resp) != 0 {
-					t.Errorf("expected zero pods to be returned, but got %d", len(resp))
-					t.Fail()
-					return
-				}
+			chal: chal,
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{&metav1.PartialObjectMetadata{}},
 			},
 		},
 	}
-	for name, test := range tests {
+	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {
-			test.Setup(t)
-			resp, err := test.Solver.getPodsForChallenge(context.TODO(), test.Challenge)
-			if err != nil && !test.Err {
-				t.Errorf("Expected function to not error, but got: %v", err)
+			scenario.builder.T = t
+			scenario.builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:   scenario.builder.Context,
+				podLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
 			}
-			if err == nil && test.Err {
-				t.Errorf("Expected function to get an error, but got: %v", err)
+			defer scenario.builder.Stop()
+			scenario.builder.Start()
+			gotPodMetas, err := s.getPodsForChallenge(s.RootContext, scenario.chal)
+			if err != nil != scenario.wantsErr {
+				t.Fatalf("unexpected error: wants error: %t, got error: %v", scenario.wantsErr, err)
 			}
-			test.Finish(t, resp, err)
+			assert.ElementsMatch(t, gotPodMetas, scenario.wantedPodMetas)
+			scenario.builder.CheckAndFinish()
 		})
 	}
 }

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -81,7 +81,6 @@ func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challen
 
 	var relevantServices []*metav1.PartialObjectMetadata
 	for _, service := range serviceList {
-		// TODO: can we use a metadata specific lister instead?
 		s, ok := service.(*metav1.PartialObjectMetadata)
 		if !ok {
 			return nil, fmt.Errorf("internal error: cannot cast Service PartialObjectMetadata")

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -31,34 +31,37 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-func (s *Solver) ensureService(ctx context.Context, ch *cmacme.Challenge) (*corev1.Service, error) {
+// ensureService ensures that a Service exists for the given Challenge. It
+// returns the name of the Service and error if any.
+func (s *Solver) ensureService(ctx context.Context, ch *cmacme.Challenge) (string, error) {
 	log := logf.FromContext(ctx).WithName("ensureService")
 
 	log.V(logf.DebugLevel).Info("checking for existing HTTP01 solver services for challenge")
 	existingServices, err := s.getServicesForChallenge(ctx, ch)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	if len(existingServices) == 1 {
 		logf.WithRelatedResource(log, existingServices[0]).Info("found one existing HTTP01 solver Service for challenge resource")
-		return existingServices[0], nil
+		return existingServices[0].Name, nil
 	}
 	if len(existingServices) > 1 {
 		log.V(logf.DebugLevel).Info("multiple challenge solver services found for challenge. cleaning up all existing services.")
 		err := s.cleanupServices(ctx, ch)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		return nil, fmt.Errorf("multiple existing challenge solver services found and cleaned up. retrying challenge sync")
+		return "", fmt.Errorf("multiple existing challenge solver services found and cleaned up. retrying challenge sync")
 	}
 
 	log.V(logf.DebugLevel).Info("creating HTTP01 challenge solver service")
-	return s.createService(ctx, ch)
+	svc, err := s.createService(ctx, ch)
+	return svc.Name, err
 }
 
 // getServicesForChallenge returns a list of services that were created to solve
 // http challenges for the given domain
-func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challenge) ([]*corev1.Service, error) {
+func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challenge) ([]*metav1.PartialObjectMetadata, error) {
 	log := logf.FromContext(ctx).WithName("getServicesForChallenge")
 
 	podLabels := podLabels(ch)
@@ -71,19 +74,24 @@ func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challen
 		selector = selector.Add(*req)
 	}
 
-	serviceList, err := s.serviceLister.Services(ch.Namespace).List(selector)
+	serviceList, err := s.serviceLister.ByNamespace(ch.Namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	var relevantServices []*corev1.Service
+	var relevantServices []*metav1.PartialObjectMetadata
 	for _, service := range serviceList {
-		if !metav1.IsControlledBy(service, ch) {
-			logf.WithRelatedResource(log, service).Info("found existing solver pod for this challenge resource, however " +
+		// TODO: can we use a metadata specific lister instead?
+		s, ok := service.(*metav1.PartialObjectMetadata)
+		if !ok {
+			return nil, fmt.Errorf("internal error: cannot cast Service PartialObjectMetadata")
+		}
+		if !metav1.IsControlledBy(s, ch) {
+			logf.WithRelatedResource(log, s).Info("found existing solver pod for this challenge resource, however " +
 				"it does not have an appropriate OwnerReference referencing this challenge. Skipping it altogether.")
 			continue
 		}
-		relevantServices = append(relevantServices, service)
+		relevantServices = append(relevantServices, s)
 	}
 
 	return relevantServices, nil

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -18,476 +18,229 @@ package http
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	coretesting "k8s.io/client-go/testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEnsureService(t *testing.T) {
-	const createdServiceKey = "createdService"
-	tests := map[string]solverFixture{
-		"should return an existing service if one already exists": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
+	type testT struct {
+		builder     *testpkg.Builder
+		chal        *cmacme.Challenge
+		expectedErr bool
+	}
+	var (
+		testNamespace = "foo"
+		chal          = &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+			},
+			Spec: cmacme.ChallengeSpec{
+				DNSName: "example.com",
+				Token:   "token",
+				Key:     "key",
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
 					},
 				},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				svc, err := s.Solver.createService(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-				s.testResources[createdServiceKey] = svc
-
-				// TODO: replace this with expectedActions to make sure no other actions are performed
-				// create a reactor that fails the test if a service is created
-				s.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					t.Errorf("ensureService should not create a service if one already exists")
-					t.Fail()
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
+		}
+		service = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cm-acme-http-solver-",
+				Namespace:    testNamespace,
+				Labels:       podLabels(chal),
+				Annotations: map[string]string{
+					"auth.istio.io/8089": "NONE",
+				},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
 			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				createdService := s.testResources[createdServiceKey].(*v1.Service)
-				resp := args[0].(*v1.Service)
-				if resp == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(resp, createdService) {
-					t.Errorf("Expected %v to equal %v", resp, createdService)
-				}
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						Port:       acmeSolverListenPort,
+						TargetPort: intstr.FromInt(acmeSolverListenPort),
+					},
+				},
+				Selector: podLabels(chal),
 			},
+		}
+		serviceMeta = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Service",
+			},
+			ObjectMeta: service.ObjectMeta,
+		}
+	)
+	tests := map[string]testT{
+		"should return an existing service if one already exists": {
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{serviceMeta},
+			},
+			chal: chal,
 		},
 		"should create a new service if one does not exist": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
+			builder: &testpkg.Builder{
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, service))},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
-				if err != nil {
-					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
-				}
-				// create a reactor that fails the test if a service is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
-					// clear service name as we don't know it yet in the expectedService
-					service.Name = ""
-					if !reflect.DeepEqual(service, expectedService) {
-						t.Errorf("Expected %v to equal %v", service, expectedService)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*v1.Service)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 1 {
-					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(services[0], resp) {
-					t.Errorf("Expected %v to equal %v", services[0], resp)
-				}
-			},
+			chal: chal,
 		},
 		"should clean up if multiple services exist": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{serviceMeta, func(s metav1.PartialObjectMetadata) *metav1.PartialObjectMetadata { s.Name = "foobar"; return &s }(*serviceMeta)},
+				KubeObjects:            []runtime.Object{service, func(s corev1.Service) *corev1.Service { s.Name = "foobar"; return &s }(*service)},
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, "foobar")),
+					testpkg.NewAction(coretesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, ""))},
 			},
-			Err: true,
-			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createService(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-				_, err = s.Solver.createService(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 0 {
-					t.Errorf("expected services to have been cleaned up, but there were %d services left", len(services))
-				}
-			},
-		},
-		"http-01 ingress challenge without a service type should default to NodePort": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "test.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
-			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
-				if err != nil {
-					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
-				}
-				// create a reactor that fails the test if a service is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
-					// clear service name as we don't know it yet in the expectedService
-					service.Name = ""
-					if !reflect.DeepEqual(service, expectedService) {
-						t.Errorf("Expected %v to equal %v", service, expectedService)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*v1.Service)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 1 {
-					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(services[0], resp) {
-					t.Errorf("Expected %v to equal %v", services[0], resp)
-				}
-				if services[0].Spec.Type != v1.ServiceTypeNodePort {
-					t.Errorf("Blank service type should default to NodePort, but was %q", services[0].Spec.Type)
-				}
-			},
-			Err: false,
+			chal:        chal,
+			expectedErr: true,
 		},
 		"http-01 ingress challenge with a service type specified should end up on the generated solver service": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "test.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
-								ServiceType: v1.ServiceTypeClusterIP,
-							},
-						},
-					},
-				},
+			chal: func(chal *cmacme.Challenge) *cmacme.Challenge {
+				chal.Spec.Solver.HTTP01.Ingress.ServiceType = corev1.ServiceTypeClusterIP
+				return chal
+			}(chal.DeepCopy()),
+			builder: &testpkg.Builder{
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, func(s *corev1.Service) *corev1.Service { s.Spec.Type = corev1.ServiceTypeClusterIP; return s }(service.DeepCopy())))},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
-				if err != nil {
-					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
-				}
-				// create a reactor that fails the test if a service is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
-					// clear service name as we don't know it yet in the expectedService
-					service.Name = ""
-					if !reflect.DeepEqual(service, expectedService) {
-						t.Errorf("Expected %v to equal %v", service, expectedService)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*v1.Service)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 1 {
-					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(services[0], resp) {
-					t.Errorf("Expected %v to equal %v", services[0], resp)
-				}
-				if services[0].Spec.Type != v1.ServiceTypeClusterIP {
-					t.Errorf("expected service type %q, but was %q", v1.ServiceTypeClusterIP, services[0].Spec.Type)
-				}
-			},
-			Err: false,
 		},
 		"http-01 gateway httpRoute challenge without a service type should default to NodePort": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "test.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
-						},
-					},
-				},
+			chal: func(chal *cmacme.Challenge) *cmacme.Challenge {
+				chal.Spec.Solver.HTTP01.Ingress = nil
+				chal.Spec.Solver.HTTP01.GatewayHTTPRoute = &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{}
+				return chal
+			}(chal.DeepCopy()),
+			builder: &testpkg.Builder{
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, service))},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
-				if err != nil {
-					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
-				}
-				// create a reactor that fails the test if a service is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
-					// clear service name as we don't know it yet in the expectedService
-					service.Name = ""
-					if !reflect.DeepEqual(service, expectedService) {
-						t.Errorf("Expected %v to equal %v", service, expectedService)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*v1.Service)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 1 {
-					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(services[0], resp) {
-					t.Errorf("Expected %v to equal %v", services[0], resp)
-				}
-				if services[0].Spec.Type != v1.ServiceTypeNodePort {
-					t.Errorf("Blank service type should default to NodePort, but was \"%s\"", services[0].Spec.Type)
-				}
-			},
-			Err: false,
 		},
 		"http-01 gateway httpRoute challenge with a service type specified should end up on the generated solver service": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "test.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
-								ServiceType: v1.ServiceTypeClusterIP,
-							},
-						},
-					},
-				},
+			chal: func(chal *cmacme.Challenge) *cmacme.Challenge {
+				chal.Spec.Solver.HTTP01.Ingress = nil
+				chal.Spec.Solver.HTTP01.GatewayHTTPRoute = &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
+					ServiceType: corev1.ServiceTypeClusterIP,
+				}
+				return chal
+			}(chal.DeepCopy()),
+			builder: &testpkg.Builder{
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("services"), testNamespace, func(s *corev1.Service) *corev1.Service { s.Spec.Type = corev1.ServiceTypeClusterIP; return s }(service.DeepCopy())))},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
-				if err != nil {
-					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
-				}
-				// create a reactor that fails the test if a service is created
-				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
-					// clear service name as we don't know it yet in the expectedService
-					service.Name = ""
-					if !reflect.DeepEqual(service, expectedService) {
-						t.Errorf("Expected %v to equal %v", service, expectedService)
-					}
-					return false, ret, nil
-				})
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].(*v1.Service)
-				err := args[1]
-				if resp == nil && err == nil {
-					t.Errorf("unexpected service = nil")
-					t.Fail()
-					return
-				}
-				services, err := s.Solver.serviceLister.List(labels.NewSelector())
-				if err != nil {
-					t.Errorf("unexpected error listing services: %v", err)
-					t.Fail()
-					return
-				}
-				if len(services) != 1 {
-					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(services[0], resp) {
-					t.Errorf("Expected %v to equal %v", services[0], resp)
-				}
-				if services[0].Spec.Type != v1.ServiceTypeClusterIP {
-					t.Errorf("expected service type %q, but was %q", v1.ServiceTypeClusterIP, services[0].Spec.Type)
-				}
-			},
-			Err: false,
 		},
 	}
-	for name, test := range tests {
+	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {
-			test.Setup(t)
-			resp, err := test.Solver.ensureService(context.TODO(), test.Challenge)
-			if err != nil && !test.Err {
-				t.Errorf("Expected function to not error, but got: %v", err)
+			scenario.builder.T = t
+			scenario.builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:       scenario.builder.Context,
+				serviceLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
 			}
-			if err == nil && test.Err {
-				t.Errorf("Expected function to get an error, but got: %v", err)
+			scenario.builder.Start()
+			defer scenario.builder.Stop()
+			_, err := s.ensureService(context.Background(), scenario.chal)
+			if err != nil != scenario.expectedErr {
+				t.Fatalf("unexpected error: wants err: %t, got err %v", scenario.expectedErr, err)
+
 			}
-			test.Finish(t, resp, err)
+			scenario.builder.CheckAndFinish()
 		})
+
 	}
 }
 
 func TestGetServicesForChallenge(t *testing.T) {
-	const createdServiceKey = "createdService"
-	tests := map[string]solverFixture{
+	type testT struct {
+		builder            *testpkg.Builder
+		chal               *cmacme.Challenge
+		wantedServiceMetas []*metav1.PartialObjectMetadata
+		expectedErr        bool
+	}
+	var (
+		testNamespace = "foo"
+		chal          = &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+			},
+			Spec: cmacme.ChallengeSpec{
+				DNSName: "example.com",
+				Token:   "token",
+				Key:     "key",
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+					},
+				},
+			},
+		}
+		service = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cm-acme-http-solver-",
+				Namespace:    testNamespace,
+				Labels:       podLabels(chal),
+				Annotations: map[string]string{
+					"auth.istio.io/8089": "NONE",
+				},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						Port:       acmeSolverListenPort,
+						TargetPort: intstr.FromInt(acmeSolverListenPort),
+					},
+				},
+				Selector: podLabels(chal),
+			},
+		}
+		serviceMeta = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Service",
+			},
+			ObjectMeta: service.ObjectMeta,
+		}
+	)
+	tests := map[string]testT{
 		"should return one service that matches": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
+			chal: chal,
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{serviceMeta},
 			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createService(context.TODO(), s.Challenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.testResources[createdServiceKey] = ing
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				createdService := s.testResources[createdServiceKey].(*v1.Service)
-				resp := args[0].([]*v1.Service)
-				if len(resp) != 1 {
-					t.Errorf("expected one service to be returned, but got %d", len(resp))
-					t.Fail()
-					return
-				}
-				if !reflect.DeepEqual(resp[0], createdService) {
-					t.Errorf("Expected %v to equal %v", resp[0], createdService)
-				}
-			},
-		},
-		"should not return a service for the same certificate but different domain": {
-			Challenge: &cmacme.Challenge{
-				Spec: cmacme.ChallengeSpec{
-					DNSName: "example.com",
-					Solver: cmacme.ACMEChallengeSolver{
-						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
-							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
-						},
-					},
-				},
-			},
-			PreFn: func(t *testing.T, s *solverFixture) {
-				differentChallenge := s.Challenge.DeepCopy()
-				differentChallenge.Spec.DNSName = "invaliddomain"
-				_, err := s.Solver.createService(context.TODO(), differentChallenge)
-				if err != nil {
-					t.Errorf("error preparing test: %v", err)
-				}
-
-				s.Builder.Sync()
-			},
-			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
-				resp := args[0].([]*v1.Service)
-				if len(resp) != 0 {
-					t.Errorf("expected zero services to be returned, but got %d", len(resp))
-					t.Fail()
-					return
-				}
-			},
+			wantedServiceMetas: []*metav1.PartialObjectMetadata{serviceMeta},
 		},
 	}
-	for name, test := range tests {
+	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {
-			test.Setup(t)
-			resp, err := test.Solver.getServicesForChallenge(context.TODO(), test.Challenge)
-			if err != nil && !test.Err {
-				t.Errorf("Expected function to not error, but got: %v", err)
+			scenario.builder.T = t
+			scenario.builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:       scenario.builder.Context,
+				serviceLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
 			}
-			if err == nil && test.Err {
-				t.Errorf("Expected function to get an error, but got: %v", err)
+			scenario.builder.Start()
+			defer scenario.builder.Stop()
+			gotServiceMetas, err := s.getServicesForChallenge(context.Background(), scenario.chal)
+			if err != nil != scenario.expectedErr {
+				t.Fatalf("unexpected error: wants err: %t, got err %v", scenario.expectedErr, err)
+
 			}
-			test.Finish(t, resp, err)
+			assert.ElementsMatch(t, gotServiceMetas, scenario.wantedServiceMetas)
+			scenario.builder.CheckAndFinish()
 		})
+
 	}
 }

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -145,7 +145,7 @@ func TestEnsureService(t *testing.T) {
 			scenario.builder.InitWithRESTConfig()
 			s := &Solver{
 				Context:       scenario.builder.Context,
-				serviceLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
+				serviceLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
 			}
 			scenario.builder.Start()
 			defer scenario.builder.Stop()
@@ -229,7 +229,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 			scenario.builder.InitWithRESTConfig()
 			s := &Solver{
 				Context:       scenario.builder.Context,
-				serviceLister: scenario.builder.MetadataInformerFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
+				serviceLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
 			}
 			scenario.builder.Start()
 			defer scenario.builder.Stop()


### PR DESCRIPTION
This PR ensures that cert-manager retrieves and caches metadata only Pods and Services for http-01 challenge and applies a filter to only cache relevant resources.

## Context

Currently cert-manager watches [all Pods and Services in the cluster](https://github.com/cert-manager/cert-manager/blob/master/pkg/controller/acmechallenges/controller.go#L95-L98) which causes unnecessary memory/CPU consumption when any events occur for any Pods/Services in cluster.

## Fix

This PR introduces metadata only informer factory with a filter for http-01 challenge resource filters. Pods and Services' informers get created from this factory.

## Notes

- We start a new metadata informer factory rather than using the [the one that's created for Secrets](https://github.com/cert-manager/cert-manager/blob/master/internal/informers/core_filteredsecrets.go#L154). This is because the Secrets metadata factory is wrapped together with a higher level typed factory into one factory that hides from consumers (control loops) the complexity of determining whether metada only or full data needs to be cached for the Secret and also because it is only started if the `SecretsFilteredCaching` alpha feature is on so doesn't make sense to use it for Pods and Services. I don't see any potential issues or significant overhead related to the extra factory.
- This PR changes a bunch of unit tests for http-01 challenge resources - these tests needed updating to work with this change, but also were written a long time ago and use custom functionality to determine if certain methods are called- I updated them to use the newer client-go builder mechanim for comparing expected actions (that we also use in other places)

## Metrics

I tested this by creating and labelling a bunch of Pods and Services, see [the script](https://gist.github.com/irbekrm/7d107c9b581b8a9e891dfdc30282dac1#file-pods_services-sh)

Memory and CPU consumption for cert-manage controller from current master:
![podsservicesmaster](https://user-images.githubusercontent.com/24879183/234229060-0c874970-53b0-4761-9c03-9f7b25283022.png)


Memory and CPU consumption from this PR (the script was called just after deploying cert-manager):
![podsservmeta](https://user-images.githubusercontent.com/24879183/234229354-b33eabab-962b-414b-838a-356644fecda7.png)




```release-note
Caches metadata only for filtered Pods and Services
```

/kind cleanup
