### PR TITLE
Adds kube 1.27 kind image

### DIFF
--- a/hack/latest-kind-images.sh
+++ b/hack/latest-kind-images.sh
@@ -69,6 +69,10 @@ LATEST_125_DIGEST=$(crane digest $KIND_IMAGE_REPO:$LATEST_125_TAG)
 LATEST_126_TAG=v1.26.0
 LATEST_126_DIGEST=sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
+# k8s 1.27 is manually added to ensure that we use the exact documented tag as per kind recommendation
+LATEST_127_TAG=v1.27.1
+LATEST_127_DIGEST=sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09
+
 cat << EOF > ./make/kind_images.sh
 # Copyright 2022 The cert-manager Authors.
 #
@@ -96,6 +100,9 @@ KIND_IMAGE_K8S_125=$KIND_IMAGE_REPO@$LATEST_125_DIGEST
 # Manually set - see hack/latest-kind-images.sh for details
 KIND_IMAGE_K8S_126=$KIND_IMAGE_REPO@$LATEST_126_DIGEST
 
+# Manually set- see hack/latest-kind-images.sh for details
+KIND_IMAGE_K8S_127=$KIND_IMAGE_REPO@$LATEST_127_DIGEST
+
 # $KIND_IMAGE_REPO:$LATEST_120_TAG
 KIND_IMAGE_SHA_K8S_120=$LATEST_120_DIGEST
 
@@ -118,6 +125,10 @@ KIND_IMAGE_SHA_K8S_125=$LATEST_125_DIGEST
 # $KIND_IMAGE_REPO:$LATEST_126_TAG
 KIND_IMAGE_SHA_K8S_126=$LATEST_126_DIGEST
 
+# Manually set - see hack/latest-kind-images.sh for details
+# $KIND_IMAGE_REPO:$LATEST_127_TAG
+KIND_IMAGE_SHA_K8S_127=$LATEST_127_DIGEST
+
 # note that these 'full' digests should be avoided since not all tools support them
 # prefer KIND_IMAGE_K8S_*** instead
 KIND_IMAGE_FULL_K8S_120=$KIND_IMAGE_REPO:$LATEST_120_TAG@$LATEST_120_DIGEST
@@ -129,6 +140,8 @@ KIND_IMAGE_FULL_K8S_125=$KIND_IMAGE_REPO:$LATEST_125_TAG@$LATEST_125_DIGEST
 
 # Manually set - see hack/latest-kind-images.sh for details
 KIND_IMAGE_FULL_K8S_126=$KIND_IMAGE_REPO:$LATEST_126_TAG@$LATEST_126_DIGEST
+
+KIND_IMAGE_FULL_K8S_127=$KIND_IMAGE_REPO:$LATEST_127_TAG@$LATEST_127_DIGEST
 
 EOF
 

--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -111,6 +111,7 @@ case "$k8s_version" in
 1.24*) image=$KIND_IMAGE_FULL_K8S_124 ;;
 1.25*) image=$KIND_IMAGE_FULL_K8S_125 ;;
 1.26*) image=$KIND_IMAGE_FULL_K8S_126 ;;
+1.27*) image=$KIND_IMAGE_FULL_K8S_127 ;;
 v*) printf "${red}${redcross}Error${end}: Kubernetes version must be given without the leading 'v'\n" >&2 && exit 1 ;;
 *) printf "${red}${redcross}Error${end}: unsupported Kubernetes version ${yel}${k8s_version}${end}\n" >&2 && exit 1 ;;
 esac

--- a/make/kind_images.sh
+++ b/make/kind_images.sh
@@ -24,6 +24,9 @@ KIND_IMAGE_K8S_125=docker.io/kindest/node@sha256:00d3f5314cc35327706776e95b2f8e5
 # Manually set - see hack/latest-kind-images.sh for details
 KIND_IMAGE_K8S_126=docker.io/kindest/node@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
+# Manually set- see hack/latest-kind-images.sh for details
+KIND_IMAGE_K8S_127=docker.io/kindest/node@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09
+
 # docker.io/kindest/node:v1.20.15
 KIND_IMAGE_SHA_K8S_120=sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
 
@@ -46,6 +49,10 @@ KIND_IMAGE_SHA_K8S_125=sha256:00d3f5314cc35327706776e95b2f8e504198ce59ac545d0200
 # docker.io/kindest/node:v1.26.0
 KIND_IMAGE_SHA_K8S_126=sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
+# Manually set - see hack/latest-kind-images.sh for details
+# docker.io/kindest/node:v1.27.1
+KIND_IMAGE_SHA_K8S_127=sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09
+
 # note that these 'full' digests should be avoided since not all tools support them
 # prefer KIND_IMAGE_K8S_*** instead
 KIND_IMAGE_FULL_K8S_120=docker.io/kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
@@ -57,4 +64,6 @@ KIND_IMAGE_FULL_K8S_125=docker.io/kindest/node:v1.25.8@sha256:00d3f5314cc3532770
 
 # Manually set - see hack/latest-kind-images.sh for details
 KIND_IMAGE_FULL_K8S_126=docker.io/kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
+KIND_IMAGE_FULL_K8S_127=docker.io/kindest/node:v1.27.1@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09
 


### PR DESCRIPTION
cert-manager v1.11 will be supported for a couple more months so it makes sense for 1.11 to support Kubernetes 1.27.

This PR adds Kuberentes 1.27 kind image. The 1.27 tests were already added to cert-manager 1.11 periodics in https://github.com/jetstack/testing/pull/883

```release-note
NONE
```
/kind cleanup