### PR TITLE
Add a comment that go workspaces are required to use ko make targets

### DIFF
--- a/make/ko.mk
+++ b/make/ko.mk
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 ## Experimental tools for building and deploying cert-manager using ko to build and push Docker images.
+## You need to have go workspaces set up to use the ko make targets.
+## https://go.dev/blog/get-familiar-with-workspaces.
+## Run make go-workspaces to set up a Go workspace for this repo.
 ##
 ## Examples:
 ##


### PR DESCRIPTION
ko make targets do not work without go workspaces set up- this PR adds a comment that explains that.

In theory we could do something smart to detect if they are set up, but in practice that is probably an overkill.

```release-note
NONE
```

/kind cleanup
