### PR TITLE
Server Side Apply: Adds support for CA Injector controller

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -22,13 +22,13 @@ rules:
     verbs: ["get", "create", "update", "patch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["apiregistration.k8s.io"]
     resources: ["apiservices"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/design/20220118.server-side-apply.md
+++ b/design/20220118.server-side-apply.md
@@ -112,7 +112,7 @@ cert-manager-certificates-[issuing,trigger,keymanager,readiness]
 cert-manager-certificaterequests-[acme,approver,ca,selfsigned,vault,venafi]
 cert-manager-clusterissuers-[acme,ca,selfsigned,vault,venafi]
 cert-manager-issuers-[acme,ca,selfsigned,vault,venafi]
-cert-manager-cainjector # base field manager of cert-manager ca-injector
+cert-manager-cainjector # base field manager of cert-manager cainjector
 cert-manager-webhook # base field manager of cert-manager webhook
 cert-manager-cmctl
 ```

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -23,13 +23,18 @@ import (
 )
 
 const (
-// FeatureName will enable XYZ feature.
-// Fill this section out with additional details about the feature.
-//
-// Owner (responsible for graduating feature through to GA): @username
-// Alpha: vX.Y
-// Beta: ...
-// FeatureName featuregate.Feature = "FeatureName"
+	// FeatureName will enable XYZ feature.
+	// Fill this section out with additional details about the feature.
+	//
+	// Owner (responsible for graduating feature through to GA): @username
+	// Alpha: vX.Y
+	// Beta: ...
+	// FeatureName featuregate.Feature = "FeatureName"
+
+	// alpha: v1.12.0
+	//
+	// ServerSideApply enables the use of ServerSideApply in all API calls.
+	ServerSideApply featuregate.Feature = "ServerSideApply"
 )
 
 func init() {
@@ -43,4 +48,6 @@ func init() {
 //	utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
-var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	ServerSideApply: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -237,7 +237,7 @@ comma = ,
 # for "--set featureGates". That's why we have "\$(comma)".
 feature_gates_controller := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% ValidateCAA=% ExperimentalCertificateSigningRequestControllers=% ExperimentalGatewayAPISupport=% ServerSideApply=% LiteralCertificateSubject=% UseCertificateRequestBasicConstraints=% SecretsFilteredCaching=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 feature_gates_webhook := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% LiteralCertificateSubject=%,   $(subst $(comma),$(space),$(FEATURE_GATES))))
-feature_gates_cainjector := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
+feature_gates_cainjector := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% ServerSideApply=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 
 # Install cert-manager with E2E specific images and deployment settings.
 # The values.best-practice.yaml file is applied for compliance with the

--- a/pkg/controller/cainjector/injectables.go
+++ b/pkg/controller/cainjector/injectables.go
@@ -17,8 +17,13 @@ limitations under the License.
 package cainjector
 
 import (
+	"encoding/json"
+
 	admissionreg "k8s.io/api/admissionregistration/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	applyadmissionreg "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -61,11 +66,37 @@ type InjectTarget interface {
 	// It should be a pointer suitable for mutation.
 	AsObject() client.Object
 
+	// AsApplyObject returns this injectable as an object that only contains
+	// fields which are managed by the cainjector (CA Data) and immutable fields
+	// that must be present in Apply calls; intended for use for Apply Patch
+	// calls.
+	AsApplyObject() (client.Object, client.Patch)
+
 	// SetCA sets the CA of this target to the given certificate data (in the standard
 	// PEM format used across Kubernetes).  In cases where multiple CA fields exist per
 	// target (like admission webhook configs), all CAs are set to the given value.
 	SetCA(data []byte)
 }
+
+type ssaPatch struct {
+	patch []byte
+	err   error
+}
+
+func newSSAPatch(patch interface{}) *ssaPatch {
+	jsonPatch, err := json.Marshal(patch)
+	return &ssaPatch{patch: jsonPatch, err: err}
+}
+
+func (p *ssaPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+func (p *ssaPatch) Data(obj client.Object) ([]byte, error) {
+	return p.patch, nil
+}
+
+var _ client.Patch = &ssaPatch{}
 
 // mutatingWebhookTarget knows how to set CA data for all the webhooks
 // in a mutatingWebhookConfiguration.
@@ -76,10 +107,30 @@ type mutatingWebhookTarget struct {
 func (t *mutatingWebhookTarget) AsObject() client.Object {
 	return &t.obj
 }
+
 func (t *mutatingWebhookTarget) SetCA(data []byte) {
 	for ind := range t.obj.Webhooks {
 		t.obj.Webhooks[ind].ClientConfig.CABundle = data
 	}
+}
+
+func (t *mutatingWebhookTarget) AsApplyObject() (client.Object, client.Patch) {
+	patch := applyadmissionreg.MutatingWebhookConfiguration(t.obj.Name)
+
+	for i := range t.obj.Webhooks {
+		patch = patch.WithWebhooks(
+			applyadmissionreg.
+				MutatingWebhook().
+				WithName(t.obj.Webhooks[i].Name). // Name is used as slice key.
+				WithClientConfig(
+					&applyadmissionreg.WebhookClientConfigApplyConfiguration{
+						CABundle: t.obj.Webhooks[i].ClientConfig.CABundle,
+					},
+				),
+		)
+	}
+
+	return &t.obj, newSSAPatch(patch)
 }
 
 // validatingWebhookTarget knows how to set CA data for all the webhooks
@@ -98,6 +149,25 @@ func (t *validatingWebhookTarget) SetCA(data []byte) {
 	}
 }
 
+func (t *validatingWebhookTarget) AsApplyObject() (client.Object, client.Patch) {
+	patch := applyadmissionreg.ValidatingWebhookConfiguration(t.obj.Name)
+
+	for i := range t.obj.Webhooks {
+		patch = patch.WithWebhooks(
+			applyadmissionreg.
+				ValidatingWebhook().
+				WithName(t.obj.Webhooks[i].Name). // Name is used as slice key.
+				WithClientConfig(
+					&applyadmissionreg.WebhookClientConfigApplyConfiguration{
+						CABundle: t.obj.Webhooks[i].ClientConfig.CABundle,
+					},
+				),
+		)
+	}
+
+	return &t.obj, newSSAPatch(patch)
+}
+
 // apiServiceTarget knows how to set CA data for the CA bundle in
 // the APIService spec.
 type apiServiceTarget struct {
@@ -110,6 +180,31 @@ func (t *apiServiceTarget) AsObject() client.Object {
 
 func (t *apiServiceTarget) SetCA(data []byte) {
 	t.obj.Spec.CABundle = data
+}
+
+type apiServiceTargetPatch struct {
+	applymetav1.TypeMetaApplyConfiguration    `json:",inline"`
+	*applymetav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
+	Spec                                      *apiServiceTargetSpecPatch `json:"spec,omitempty"`
+}
+
+type apiServiceTargetSpecPatch struct {
+	CABundle []byte `json:"caBundle,omitempty"`
+}
+
+func (t *apiServiceTarget) AsApplyObject() (client.Object, client.Patch) {
+	return &t.obj, newSSAPatch(&apiServiceTargetPatch{
+		TypeMetaApplyConfiguration: *applymetav1.
+			TypeMeta().
+			WithAPIVersion(apireg.SchemeGroupVersion.String()).
+			WithKind("APIService"),
+		ObjectMetaApplyConfiguration: applymetav1.
+			ObjectMeta().
+			WithName(t.obj.Name),
+		Spec: &apiServiceTargetSpecPatch{
+			CABundle: t.obj.Spec.CABundle,
+		},
+	})
 }
 
 // crdConversionTarget knows how to set CA data for the conversion webhook in CRDs
@@ -132,4 +227,47 @@ func (t *crdConversionTarget) SetCA(data []byte) {
 		t.obj.Spec.Conversion.Webhook.ClientConfig = &apiext.WebhookClientConfig{}
 	}
 	t.obj.Spec.Conversion.Webhook.ClientConfig.CABundle = data
+}
+
+type customResourceDefinitionPatch struct {
+	applymetav1.TypeMetaApplyConfiguration    `json:",inline"`
+	*applymetav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
+	Spec                                      *customResourceDefinitionSpecPatch `json:"spec,omitempty"`
+}
+
+type customResourceDefinitionSpecPatch struct {
+	Conversion *customResourceConversionPatch `json:"conversion,omitempty"`
+}
+
+type customResourceConversionPatch struct {
+	Webhook *customResourceWebhookConversionPatch `json:"webhook,omitempty"`
+}
+
+type customResourceWebhookConversionPatch struct {
+	ClientConfig *customResourceWebhookClientConfigPatch `json:"clientConfig,omitempty"`
+}
+
+type customResourceWebhookClientConfigPatch struct {
+	CABundle []byte `json:"caBundle,omitempty"`
+}
+
+func (t *crdConversionTarget) AsApplyObject() (client.Object, client.Patch) {
+	return &t.obj, newSSAPatch(&customResourceDefinitionPatch{
+		TypeMetaApplyConfiguration: *applymetav1.
+			TypeMeta().
+			WithAPIVersion(apiext.SchemeGroupVersion.String()).
+			WithKind("CustomResourceDefinition"),
+		ObjectMetaApplyConfiguration: applymetav1.
+			ObjectMeta().
+			WithName(t.obj.Name),
+		Spec: &customResourceDefinitionSpecPatch{
+			Conversion: &customResourceConversionPatch{
+				Webhook: &customResourceWebhookConversionPatch{
+					ClientConfig: &customResourceWebhookClientConfigPatch{
+						CABundle: t.obj.Spec.Conversion.Webhook.ClientConfig.CABundle,
+					},
+				},
+			},
+		},
+	})
 }

--- a/pkg/controller/cainjector/injectables.go
+++ b/pkg/controller/cainjector/injectables.go
@@ -252,6 +252,10 @@ type customResourceWebhookClientConfigPatch struct {
 }
 
 func (t *crdConversionTarget) AsApplyObject() (client.Object, client.Patch) {
+	if t.obj.Spec.Conversion == nil || t.obj.Spec.Conversion.Webhook == nil || t.obj.Spec.Conversion.Webhook.ClientConfig == nil {
+		return &t.obj, nil
+	}
+
 	return &t.obj, newSSAPatch(&customResourceDefinitionPatch{
 		TypeMetaApplyConfiguration: *applymetav1.
 			TypeMeta().

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -31,7 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	"github.com/cert-manager/cert-manager/internal/cainjector/feature"
 	certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,8 +31,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 // This file contains logic to create reconcilers. By default a

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -125,9 +125,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// actually update with injected CA data
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
 		obj, patch := target.AsApplyObject()
-		err = r.Client.Patch(ctx, obj, patch, &client.PatchOptions{
-			Force: pointer.Bool(true), FieldManager: r.fieldManager,
-		})
+		if patch != nil {
+			err = r.Client.Patch(ctx, obj, patch, &client.PatchOptions{
+				Force: pointer.Bool(true), FieldManager: r.fieldManager,
+			})
+		}
 	} else {
 		err = r.Client.Update(ctx, target.AsObject())
 	}

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -49,7 +49,7 @@ type injectableTest struct {
 }
 
 var _ = framework.CertManagerDescribe("CA Injector", func() {
-	f := framework.NewDefaultFramework("ca-injector")
+	f := framework.NewDefaultFramework("cainjector")
 
 	issuerName := "inject-cert-issuer"
 	secretName := "serving-certs-data"


### PR DESCRIPTION
based on #4810

This PR implements Server Side Apply for the ca-injector controller when the `SeverSideApply` Feature Gate (default `disabled`) is enabled.

See  https://github.com/jetstack/cert-manager/pull/4758 for more details and design.

---

This PR adds the `--feature-gates` flag to the `ca-injector` component. A `featureGates` field has been added to the ca-injector section in the helm chart. This field gets piped down to the `ca-injector` Deployment.

The `/devel/addons/cert-manager/install.sh` script has been updated to interpret the `FEATURE_GATES_CA_INJECTOR` environment variable, which gets piped down to the `cainjector.featureGates` helm chart value. We should update the testing config to include the same feature gate options we assign for the controller component.

```release-note
ServerSideApply: The feature gate `ServerSideApply=true` configures the ca-injector controller to use Kubernetes Server Side Apply on CA Injector injectable target resources. 
```

/kind feature