### PR TITLE
Ensure _bin/scratch exists before attempting to update licenses

### DIFF
--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -47,7 +47,7 @@ $(BINDIR)/scratch/cert-manager.licenses_notice: $(BINDIR)/scratch/license-footno
 # to commit a go.work file to the repository root for reasons given in:
 # https://github.com/cert-manager/cert-manager/pull/5935
 LICENSES_GO_WORK := $(BINDIR)/scratch/LICENSES.go.work
-$(LICENSES_GO_WORK):
+$(LICENSES_GO_WORK): $(BINDIR)/scratch
 	$(MAKE) go-workspace GOWORK=$(abspath $@)
 
 LICENSES $(BINDIR)/scratch/LATEST-LICENSES: export GOWORK=$(abspath $(LICENSES_GO_WORK))


### PR DESCRIPTION
`make update-licenses` fails if `_bin/scratch` does not exist.

This PR ensurse that `_bin/scratch` is created if it does not exist like we do in all other make targets

```release-note
NONE
```

/kind cleanup
