### PR TITLE
feat: add Prometheus ServiceMonitor relabelings, metricRelabelings & …

### DIFF
--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -42,4 +42,16 @@ spec:
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
     honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
+    {{- with .Values.prometheus.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- with .Values.prometheus.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -211,6 +211,15 @@ prometheus:
     labels: {}
     annotations: {}
     honorLabels: false
+    # -- ServiceMonitor relabel configs to apply to samples before scraping
+    ## Ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+    ## Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    metricRelabelings: []
+    # -- ServiceMonitor will add labels from the service to the Prometheus metric
+    ## Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec
+    targetLabels: []
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
### Pull Request Motivation

This PR adds labeling support for ServiceMonitor endpoints. Those labels end up on the jobs/targets, and can be used to group jobs. E.g. can add a `department` & `team` label:

```yaml
prometheus:
  enabled: true
  serviceMonitor:
    enabled: true
    relabelings:
      - targetLabel: department
        replacement: "Foo"
      - targetLabel: team
        replacement: "Bar"
```

This can then be used in Grafana dashboards to group jobs by labels (or add variables to filter):

```
group by(job) (up{team="Foo"})
```

### Kind

/kind feature

### Release Note

```release-note
Added Prometheus ServiceMonitor relabelings, metricRelabelings & targetLabels
```
