### PR TITLE
Add extraObjects to values

### DIFF
--- a/deploy/charts/cert-manager/templates/extra-list.yaml
+++ b/deploy/charts/cert-manager/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -671,3 +671,32 @@ startupapicheck:
 
   volumes: []
   volumeMounts: []
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: argocd-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "argocd"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client_id
+  #         objectName: client_id
+  #       - key: client_secret
+  #         objectName: client_secret
+  #       secretName: argocd-secrets-store
+  #       type: Opaque
+  #       labels:
+  #         app.kubernetes.io/part-of: argocd
+


### PR DESCRIPTION
### Pull Request Motivation

My motivation is so I can add Vault ExternalSecrets directly to my Application in ArgoCD, and not keep two separate applications for such simple thing. This change allows you to add extra yaml's to your cert-manager deployment.

### Kind
Feature
### Release Note
```release-note
Add possibility to add extra yaml resources to Helm deployment
```
