### PR TITLE
Replace deprecated wait.PollImmediateUntil

### DIFF
--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -114,7 +114,7 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string, argume
 
 	// Determine the random port number that was chosen
 	var listenPort int
-	if err = wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
+	if err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		listenPort, err = srv.Port()
 		if err != nil {
 			if errors.Is(err, server.ErrNotListening) {
@@ -123,7 +123,7 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string, argume
 			return false, err
 		}
 		return true, nil
-	}, ctx.Done()); err != nil {
+	}); err != nil {
 		t.Fatalf("Failed waiting for ListenPort to be allocated (got error: %v)", err)
 	}
 

--- a/pkg/webhook/authority/authority.go
+++ b/pkg/webhook/authority/authority.go
@@ -138,19 +138,14 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 	// been  missed that could cause us to get into an idle state where the
 	// Secret resource does not exist and so the informers handler functions
 	// are not triggered.
-	if err = wait.PollImmediateUntil(time.Second*10, func() (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Second*10, true, func(ctx context.Context) (done bool, err error) {
 		if err := d.ensureCA(ctx); err != nil {
 			d.log.Error(err, "error ensuring CA")
 		}
 		// never return 'done'.
 		// this poll only ends when stopCh is closed.
 		return false, nil
-	}, ctx.Done()); err != nil {
-		// If error cause was context, return that error instead
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
+	}); err != nil {
 		return err
 	}
 

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -217,7 +217,7 @@ func TestIssuingController(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and
 	// for the signed certificate, ca, and private key stored in the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -266,7 +266,7 @@ func TestIssuingController(t *testing.T) {
 		}
 
 		return true, nil
-	}, ctx.Done())
+	})
 
 	if err != nil {
 		t.Fatalf("Failed to wait for final state: %+v", crt)
@@ -440,7 +440,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and for
 	// the signed certificate, ca, and private key stored in the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -489,7 +489,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		}
 
 		return true, nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatalf("Failed to wait for final state: %+v", crt)
 	}
@@ -658,7 +658,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and for
 	// the signed certificate, ca, and private key stored in the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -671,7 +671,10 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 		}
 
 		return true, nil
-	}, ctx.Done())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Add labels and annotations to the SecretTemplate.
 	annotations := map[string]string{"annotation-1": "abc", "annotation-2": "123"}
@@ -683,7 +686,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	}
 
 	// Wait for the Annotations and Labels to be observed on the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Secret resource, retrying: %s", err)
@@ -700,7 +703,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 			}
 		}
 		return true, nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +716,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	}
 
 	// Wait for the Annotations and Labels to be removed from the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Secret resource, retrying: %s", err)
@@ -732,7 +735,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 			}
 		}
 		return true, nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -904,7 +907,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and for
 	// the signed certificate, ca, and private key stored in the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -917,7 +920,10 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		}
 
 		return true, nil
-	}, ctx.Done())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Add additional output formats
 	crt = gen.CertificateFrom(crt, gen.SetCertificateAdditionalOutputFormats(
@@ -934,7 +940,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 	combinedPEM := append(append(pkBytes, '\n'), certPEM...)
 
 	// Wait for the additional output format values to to be observed on the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Secret resource, retrying: %s", err)
@@ -944,7 +950,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 			"ca.crt": certPEM, "tls.crt": certPEM, "tls.key": pkBytes,
 			"key.der": pkDER, "tls-combined.pem": combinedPEM,
 		}, secret.Data), nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -957,7 +963,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 	}
 
 	// Wait for the additional output formats to be removed from the Secret.
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Secret resource, retrying: %s", err)
@@ -966,7 +972,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		return reflect.DeepEqual(map[string][]byte{
 			"ca.crt": certPEM, "tls.crt": certPEM, "tls.key": pkBytes,
 		}, secret.Data), nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -150,14 +150,14 @@ func TestMetricsController(t *testing.T) {
 	}
 
 	waitForMetrics := func(expectedOutput string) {
-		err := wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+		err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 			if err := testMetrics(expectedOutput); err != nil {
 				lastErr = err
 				return false, nil
 			}
 
 			return true, nil
-		}, ctx.Done())
+		})
 		if err != nil {
 			t.Fatalf("%s: failed to wait for expected metrics to be exposed: %s", err, lastErr)
 		}

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -154,7 +154,7 @@ func TestRevisionManagerController(t *testing.T) {
 	var crs []cmapi.CertificateRequest
 
 	// Wait for 3 CertificateRequests to be deleted, and that they have the correct revisions
-	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 		requests, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -168,7 +168,7 @@ func TestRevisionManagerController(t *testing.T) {
 		crs = requests.Items
 
 		return true, nil
-	}, ctx.Done())
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -312,13 +312,13 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 				}()
 				go func() {
 					defer close(errCh)
-					err = wait.PollImmediateUntil(time.Second, func() (done bool, err error) {
-						req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).Get(pollCtx, test.inputArgs[0], metav1.GetOptions{})
+					err = wait.PollUntilContextCancel(pollCtx, time.Second, true, func(ctx context.Context) (done bool, err error) {
+						req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).Get(ctx, test.inputArgs[0], metav1.GetOptions{})
 						if err != nil {
 							return false, nil
 						}
 						return true, nil
-					}, pollCtx.Done())
+					})
 					if err != nil {
 						errCh <- fmt.Errorf("timeout when waiting for CertificateRequest to be created, error: %v", err)
 						return

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -95,7 +95,7 @@ func WaitForOpenAPIResourcesToBeLoaded(t *testing.T, ctx context.Context, config
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediateUntil(time.Second, func() (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		og := openapi.NewOpenAPIGetter(dc)
 		oapiResource, err := openapi.NewOpenAPIParser(og).Parse()
 		if err != nil {
@@ -106,7 +106,7 @@ func WaitForOpenAPIResourcesToBeLoaded(t *testing.T, ctx context.Context, config
 			return true, nil
 		}
 		return false, nil
-	}, ctx.Done())
+	})
 
 	if err != nil {
 		t.Fatal("Our GVK isn't loaded into the OpenAPI resources API after waiting for 2 minutes", err)

--- a/test/integration/webhook/dynamic_authority_test.go
+++ b/test/integration/webhook/dynamic_authority_test.go
@@ -84,7 +84,7 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 
 	cl := kubernetes.NewForConfigOrDie(config)
 	// allow the controller to provision the Secret
-	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
 		t.Errorf("Failed waiting for Secret to contain valid certificate: %v", err)
 		return
 	}
@@ -132,7 +132,7 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 
 	cl := kubernetes.NewForConfigOrDie(config)
 	// allow the controller to provision the Secret
-	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
 		t.Errorf("Failed waiting for Secret to contain valid certificate: %v", err)
 		return
 	}
@@ -143,7 +143,7 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 	}
 
 	// allow the controller to provision the Secret again
-	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
 		t.Errorf("Failed waiting for Secret to be recreated: %v", err)
 		return
 	}
@@ -152,8 +152,8 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 // authoritySecretReadyConditionFunc will check a named Secret resource and
 // check if it contains a valid CA keypair used by the authority.
 // This can be used with the `k8s.io/apimachinery/pkg/util/wait` package.
-func authoritySecretReadyConditionFunc(t *testing.T, ctx context.Context, cl kubernetes.Interface, namespace, name string) wait.ConditionFunc {
-	return func() (done bool, err error) {
+func authoritySecretReadyConditionFunc(t *testing.T, cl kubernetes.Interface, namespace, name string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (done bool, err error) {
 		s, err := cl.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			t.Logf("Secret resource %s/%s does not yet exist, waiting...", namespace, name)

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -82,7 +82,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 
 	// allow the controller 5s to provision the Secret - this is far longer
 	// than it should ever take.
-	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, func(ctx context.Context) (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -96,7 +96,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 		}
 		t.Logf("Got non-nil certificate from dynamic source")
 		return true, nil
-	}, ctx.Done()); err != nil {
+	}); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}
@@ -148,7 +148,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 	var serialNumber *big.Int
 	// allow the controller 5s to provision the Secret - this is far longer
 	// than it should ever take.
-	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, func(ctx context.Context) (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -169,7 +169,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 
 		serialNumber = x509cert.SerialNumber
 		return true, nil
-	}, ctx.Done()); err != nil {
+	}); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}
@@ -181,7 +181,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 
 	// wait for the serving certificate to have a new serial number (which
 	// indicates it has been regenerated)
-	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Millisecond*500, true, func(ctx context.Context) (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -206,7 +206,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 		}
 
 		return true, nil
-	}, ctx.Done()); err != nil {
+	}); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}


### PR DESCRIPTION
### Pull Request Motivation

see https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#PollImmediateUntil
I plan to replace each wait function one at a time.

NOTE: `wait.ErrWaitTimeout` is now deprecated and the Poll functions directly return `context.Canceled` or `context.DeadlineExceeded`.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
