### PR TITLE
Fix cleanup panic

### DIFF
--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -69,7 +69,9 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		if issuer != nil {
+			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		}
 	})
 
 	It("should obtain a signed certificate for a single domain", func() {

--- a/test/e2e/suite/issuers/venafi/tpp/setup.go
+++ b/test/e2e/suite/issuers/venafi/tpp/setup.go
@@ -46,7 +46,9 @@ var _ = TPPDescribe("properly configured Venafi TPP Issuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		if issuer != nil {
+			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		}
 	})
 
 	It("should set Ready=True accordingly", func() {


### PR DESCRIPTION
Resolves panic on cleanup that is caused by a issuer that equals nil.

This issuer equals nil because the test is being skipped.

/kind cleanup

### Release Note

```release-note
NONE
```
