### PR TITLE
Replace deprecated wait.PollUntil and wait.Poll

### DIFF
--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -245,7 +245,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	if o.FetchCert {
 		fmt.Fprintf(o.ErrOut, "CertificateRequest %v in namespace %v has not been signed yet. Wait until it is signed...\n",
 			req.Name, req.Namespace)
-		err = wait.Poll(time.Second, o.Timeout, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, o.Timeout, false, func(ctx context.Context) (done bool, err error) {
 			req, err = o.CMClient.CertmanagerV1().CertificateRequests(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil

--- a/cmd/ctl/pkg/create/certificatesigningrequest/certificatesigningrequest.go
+++ b/cmd/ctl/pkg/create/certificatesigningrequest/certificatesigningrequest.go
@@ -263,7 +263,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	if o.FetchCert {
 		fmt.Fprintf(o.Out, "CertificateSigningRequest %s has not been signed yet. Wait until it is signed...\n", req.Name)
 
-		err = wait.Poll(time.Second, o.Timeout, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, o.Timeout, false, func(ctx context.Context) (done bool, err error) {
 			req, err = o.KubeClient.CertificatesV1().CertificateSigningRequests().Get(ctx, req.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -414,7 +414,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 }
 
 func (c *controller) waitForCertificateRequestToExist(namespace, name string) error {
-	return wait.Poll(time.Millisecond*100, time.Second*5, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*100, time.Second*5, false, func(ctx context.Context) (bool, error) {
 		_, err := c.certificateRequestLister.CertificateRequests(namespace).Get(name)
 		if apierrors.IsNotFound(err) {
 			return false, nil

--- a/test/acme/util.go
+++ b/test/acme/util.go
@@ -94,10 +94,10 @@ func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.Challeng
 	}
 }
 
-func allConditions(c ...wait.ConditionFunc) wait.ConditionFunc {
-	return func() (bool, error) {
+func allConditions(c ...wait.ConditionWithContextFunc) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		for _, fn := range c {
-			ok, err := fn()
+			ok, err := fn(ctx)
 			if err != nil || !ok {
 				return ok, err
 			}
@@ -106,23 +106,14 @@ func allConditions(c ...wait.ConditionFunc) wait.ConditionFunc {
 	}
 }
 
-func closingStopCh(t time.Duration) <-chan struct{} {
-	stopCh := make(chan struct{})
-	go func() {
-		defer close(stopCh)
-		<-time.After(t)
-	}()
-	return stopCh
-}
-
-func (f *fixture) recordHasPropagatedCheck(fqdn, value string) func() (bool, error) {
-	return func() (bool, error) {
+func (f *fixture) recordHasPropagatedCheck(fqdn, value string) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		return util.PreCheckDNS(fqdn, value, []string{f.testDNSServer}, *f.useAuthoritative)
 	}
 }
 
-func (f *fixture) recordHasBeenDeletedCheck(fqdn, value string) func() (bool, error) {
-	return func() (bool, error) {
+func (f *fixture) recordHasBeenDeletedCheck(fqdn, value string) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		msg, err := util.DNSQuery(fqdn, dns.TypeTXT, []string{f.testDNSServer}, *f.useAuthoritative)
 		if err != nil {
 			return false, err

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -321,9 +321,8 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		// TODO: we should use observedGeneration here, but currently it won't
 		// be incremented correctly in this scenario.
 		// Verify that Issuer's Ready condition remains True for 5 seconds.
-		err = wait.Poll(time.Millisecond*200, time.Second*5, func() (bool, error) {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(
-				context.TODO(), issuerName, metav1.GetOptions{})
+		err = wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*200, time.Second*5, true, func(ctx context.Context) (bool, error) {
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(ctx, issuerName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -337,6 +336,6 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			return false, nil
 		})
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(wait.ErrWaitTimeout))
+		Expect(err).To(MatchError(context.DeadlineExceeded))
 	})
 })

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -78,7 +78,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 	}
 
 	var firstReq *cmapi.CertificateRequest
-	if err := wait.Poll(time.Millisecond*500, time.Second*10, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -111,7 +111,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 	t.Log("Marked CertificateRequest as InvalidRequest")
 
 	// Wait for Certificate to be marked as Failed
-	if err := wait.Poll(time.Millisecond*500, time.Second*50, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*50, true, func(ctx context.Context) (bool, error) {
 		crt, err := cmCl.CertmanagerV1().Certificates(crt.Namespace).Get(ctx, crt.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -137,7 +137,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 	}
 
 	var secondReq *cmapi.CertificateRequest
-	if err := wait.Poll(time.Millisecond*500, time.Second*10, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -212,7 +212,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 	}
 
 	var firstReq *cmapi.CertificateRequest
-	if err := wait.Poll(time.Millisecond*500, time.Second*10, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -245,7 +245,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 	t.Log("Marked CertificateRequest as Failed")
 
 	// Wait for Certificate to be marked as Failed
-	if err := wait.Poll(time.Millisecond*500, time.Second*50, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*50, true, func(ctx context.Context) (bool, error) {
 		crt, err := cmCl.CertmanagerV1().Certificates(crt.Namespace).Get(ctx, crt.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -271,7 +271,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 	}
 
 	var secondReq *cmapi.CertificateRequest
-	if err := wait.Poll(time.Millisecond*500, time.Second*10, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -254,7 +254,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 				},
 			},
 			expRunErr:          true,
-			expErrMsg:          "error when waiting for CertificateRequest to be signed: timed out waiting for the condition",
+			expErrMsg:          "error when waiting for CertificateRequest to be signed: context deadline exceeded",
 			expNamespace:       ns1,
 			expName:            cr7Name,
 			expKeyFilename:     cr7Name + ".key",
@@ -377,7 +377,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 			// If applicable, check the file where the certificate is stored
 			// If the expected error message is the one below, we skip checking
 			// because no certificate will have been written to file
-			if test.fetchCert && test.expErrMsg != "error when waiting for CertificateRequest to be signed: timed out waiting for the condition" {
+			if test.fetchCert && test.expErrMsg != "error when waiting for CertificateRequest to be signed: context deadline exceeded" {
 				certData, err := os.ReadFile(test.expCertFilename)
 				if err != nil {
 					t.Errorf("error when reading file storing private key: %v", err)


### PR DESCRIPTION
### Pull Request Motivation

see https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#PollImmediateUntil
I plan to replace each wait function one at a time.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
