### PR TITLE
apis/acme/v1: ACMEIssuer: set omitempty on optional field

### DIFF
--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -52,7 +52,7 @@ type ACMEIssuer struct {
 	// chains that has a certificate with this value as its issuer's CN
 	// +optional
 	// +kubebuilder:validation:MaxLength=64
-	PreferredChain string `json:"preferredChain"`
+	PreferredChain string `json:"preferredChain,omitempty"`
 
 	// Base64-encoded bundle of PEM CAs which can be used to validate the certificate
 	// chain presented by the ACME server.


### PR DESCRIPTION
### Pull Request Motivation

The `PreferredChain` field is marked optional in the API docs, but is required when serializing JSON. Make it optional to match.

### Kind

bug

### Release Note
Probably don't need one, but:
```release-note
Make apis/acme/v1/ACMEIssuer.PreferredChain optional in JSON serialization.
```
