### PR TITLE
Directly import cert-manager in cmctl

### DIFF
--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -2,13 +2,20 @@ module github.com/cert-manager/cert-manager/cmctl-binary
 
 go 1.20
 
-replace github.com/cert-manager/cert-manager => ../../
-
 // remove this once controller-runtime v0.15.0 is released
 replace sigs.k8s.io/controller-runtime v0.14.6 => sigs.k8s.io/controller-runtime v0.13.1-0.20230503134813-2e57de78ba00
 
+// Note on cert-manager versioning:
+// Because cmctl and the core cert-manager module live in the same repository, but cmctl depends on a specific
+// cert-manager version (rather than using replace statements or a go.work file), there's a need to be able
+// to update cert-manager, then update cmctl to point to that new version.
+// This means that it's not always possible to use a "nice" tagged version of cert-manager and the version
+// might look messy.
+// To update the cert-manager version, use "go get github.com/cert-manager/cert-manager@X", where X could be a commit SHA
+// or a branch name (master).
+
 require (
-	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000
+	github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2

--- a/cmd/ctl/go.sum
+++ b/cmd/ctl/go.sum
@@ -92,6 +92,8 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZ
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71 h1:jhVl/bpUSPnxglLgT5yCpqCkk1Nm9rUsi8/JAu74YCY=
+github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71/go.mod h1:6OaSRbLMjTHsMORCHbs28rCOxeNjFK3lW+58v95mGJc=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -21,7 +21,7 @@ ci-presubmit: verify-imports verify-errexit verify-boilerplate verify-codegen ve
 
 .PHONY: verify-modules
 verify-modules: | $(NEEDS_CMREL)
-	$(CMREL) validate-gomod --path $(shell pwd)
+	$(CMREL) validate-gomod --path $(shell pwd) --direct-import-modules github.com/cert-manager/cert-manager/cmctl-binary --no-dummy-modules github.com/cert-manager/cert-manager/integration-tests
 
 .PHONY: verify-imports
 verify-imports: | $(NEEDS_GOIMPORTS)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -30,7 +30,7 @@ TOOLS += kubectl=v1.27.1
 TOOLS += kind=v0.18.0
 TOOLS += controller-gen=v0.12.0
 TOOLS += cosign=v1.12.1
-TOOLS += cmrel=c35ba39e591f1e5150525ca0fef222beb719de8c
+TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
 TOOLS += release-notes=v0.14.0
 TOOLS += goimports=v0.1.12
 TOOLS += go-licenses=v1.6.0

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -12,7 +12,7 @@ replace github.com/cert-manager/cert-manager/webhook-binary => ../../cmd/webhook
 replace sigs.k8s.io/controller-runtime v0.14.6 => sigs.k8s.io/controller-runtime v0.13.1-0.20230503134813-2e57de78ba00
 
 require (
-	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000
+	github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71
 	github.com/cert-manager/cert-manager/cmctl-binary v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.2.4
 	github.com/miekg/dns v1.1.50


### PR DESCRIPTION
### Pull Request Motivation

Related to #6047 and #6041

This PR depended on https://github.com/cert-manager/release/pull/127 , which has now merged.

We want to preserve the ability for other projects to import cmctl as a module. This implies that we can't have a local filesystem replacement for the core cert-manager module in cmctl, and that cmctl must depend on an explicitly specified version of cert-manager.

Eventually we'd like cmctl to be moved to its own repo, but that's too much work right now.

Since the integration tests depend on cmctl, they also pick up an actual version of cert-manager in their go.mod file from this change. That shouldn't matter, since they still have a replace statement for cert-manager.

### Kind

/kind feature

### Release Note

```release-note
Enable cmctl to be imported by third parties
```
