### PR TITLE
Make KeyUsage and BasicConstraints Critical extensions in the CSR blob

### DIFF
--- a/pkg/util/pki/basicconstraints.go
+++ b/pkg/util/pki/basicconstraints.go
@@ -35,7 +35,7 @@ type basicConstraints struct {
 
 // Adapted from x509.go
 func MarshalBasicConstraints(isCA bool, maxPathLen *int) (pkix.Extension, error) {
-	ext := pkix.Extension{Id: OIDExtensionBasicConstraints}
+	ext := pkix.Extension{Id: OIDExtensionBasicConstraints, Critical: true}
 
 	// A value of -1 causes encoding/asn1 to omit the value as desired.
 	maxPathLenValue := -1

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -410,8 +410,9 @@ func TestGenerateCSR(t *testing.T) {
 	}
 	defaultExtraExtensions := []pkix.Extension{
 		{
-			Id:    OIDExtensionKeyUsage,
-			Value: asn1KeyUsage,
+			Id:       OIDExtensionKeyUsage,
+			Value:    asn1KeyUsage,
+			Critical: true,
 		},
 	}
 
@@ -421,8 +422,9 @@ func TestGenerateCSR(t *testing.T) {
 	}
 	ipsecExtraExtensions := []pkix.Extension{
 		{
-			Id:    OIDExtensionKeyUsage,
-			Value: asn1KeyUsage,
+			Id:       OIDExtensionKeyUsage,
+			Value:    asn1KeyUsage,
+			Critical: true,
 		},
 		{
 			Id:    OIDExtensionExtendedKeyUsage,
@@ -506,8 +508,9 @@ func TestGenerateCSR(t *testing.T) {
 				Subject:            pkix.Name{CommonName: "example.org"},
 				ExtraExtensions: []pkix.Extension{
 					{
-						Id:    OIDExtensionKeyUsage,
-						Value: asn1KeyUsageWithCa,
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1KeyUsageWithCa,
+						Critical: true,
 					},
 				},
 			},
@@ -522,12 +525,14 @@ func TestGenerateCSR(t *testing.T) {
 				Subject:            pkix.Name{CommonName: "example.org"},
 				ExtraExtensions: []pkix.Extension{
 					{
-						Id:    OIDExtensionKeyUsage,
-						Value: asn1KeyUsage,
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1KeyUsage,
+						Critical: true,
 					},
 					{
-						Id:    OIDExtensionBasicConstraints,
-						Value: basicConstraintsWithoutCA,
+						Id:       OIDExtensionBasicConstraints,
+						Value:    basicConstraintsWithoutCA,
+						Critical: true,
 					},
 				},
 			},
@@ -543,12 +548,14 @@ func TestGenerateCSR(t *testing.T) {
 				Subject:            pkix.Name{CommonName: "example.org"},
 				ExtraExtensions: []pkix.Extension{
 					{
-						Id:    OIDExtensionKeyUsage,
-						Value: asn1KeyUsageWithCa,
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1KeyUsageWithCa,
+						Critical: true,
 					},
 					{
-						Id:    OIDExtensionBasicConstraints,
-						Value: basicConstraintsWithCA,
+						Id:       OIDExtensionBasicConstraints,
+						Value:    basicConstraintsWithCA,
+						Critical: true,
 					},
 				},
 			},
@@ -658,8 +665,9 @@ func Test_buildKeyUsagesExtensionsForCertificate(t *testing.T) {
 			crt:  &cmapi.Certificate{},
 			want: []pkix.Extension{
 				{
-					Id:    OIDExtensionKeyUsage,
-					Value: asn1DefaultKeyUsage,
+					Id:       OIDExtensionKeyUsage,
+					Value:    asn1DefaultKeyUsage,
+					Critical: true,
 				},
 			},
 			wantErr: false,
@@ -673,8 +681,9 @@ func Test_buildKeyUsagesExtensionsForCertificate(t *testing.T) {
 			},
 			want: []pkix.Extension{
 				{
-					Id:    OIDExtensionKeyUsage,
-					Value: asn1DefaultKeyUsage,
+					Id:       OIDExtensionKeyUsage,
+					Value:    asn1DefaultKeyUsage,
+					Critical: true,
 				},
 				{
 					Id:    OIDExtensionExtendedKeyUsage,
@@ -692,8 +701,9 @@ func Test_buildKeyUsagesExtensionsForCertificate(t *testing.T) {
 			},
 			want: []pkix.Extension{
 				{
-					Id:    OIDExtensionKeyUsage,
-					Value: asn1DefaultKeyUsage,
+					Id:       OIDExtensionKeyUsage,
+					Value:    asn1DefaultKeyUsage,
+					Critical: true,
 				},
 				{
 					Id:    OIDExtensionExtendedKeyUsage,

--- a/pkg/util/pki/keyusage.go
+++ b/pkg/util/pki/keyusage.go
@@ -128,7 +128,7 @@ func reverseBitsInAByte(in byte) byte {
 
 // Adapted from x509.go
 func MarshalKeyUsage(usage x509.KeyUsage) (pkix.Extension, error) {
-	ext := pkix.Extension{Id: OIDExtensionKeyUsage}
+	ext := pkix.Extension{Id: OIDExtensionKeyUsage, Critical: true}
 
 	var a [2]byte
 	a[0] = reverseBitsInAByte(byte(usage))


### PR DESCRIPTION
Based on upstream x509, these extensions should be critical.
https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/crypto/x509/x509.go;l=1351
https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/crypto/x509/x509.go;l=1314
https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/crypto/x509/x509.go;l=1332

This change is not a major change, it will only change what the CSRs look like.
For the certificate itself, we set the KeyUsage field on the *x509.Certificate struct and use golang to encode these extensions. Golang does always encode KeyUsage and BasicConstraints as Critical extensions in Certificates.

### Kind

/kind bug

### Release Note

```release-note
⚠️ potentially breaking ⚠️: The KeyUsage and BasicConstraints extensions will now be encoded as critical in the CertificateRequest's CSR blob.
```
