### PR TITLE
Use Version 3 for *x509.Certificate

### DIFF
--- a/internal/controller/certificates/secrets_test.go
+++ b/internal/controller/certificates/secrets_test.go
@@ -48,6 +48,7 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "another-test-issuer", Kind: "GoogleCASIssuer", Group: "my-group.hello.world"}),
 			),
 			certificate: &x509.Certificate{
+				Version: 3,
 				Subject: pkix.Name{
 					CommonName:         "cert-manager",
 					Organization:       []string{"Example Organization 1", "Example Organization 2"},
@@ -89,6 +90,7 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "another-test-issuer", Kind: "GoogleCASIssuer", Group: "my-group.hello.world"}),
 			),
 			certificate: &x509.Certificate{
+				Version: 3,
 				Subject: pkix.Name{
 					CommonName: "cert-manager",
 				},
@@ -109,6 +111,7 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "another-test-issuer", Kind: "GoogleCASIssuer", Group: "my-group.hello.world"}),
 			),
 			certificate: &x509.Certificate{
+				Version:     3,
 				IPAddresses: []net.IP{{1, 1, 1, 1}, {1, 2, 3, 4}},
 			},
 			expAnnotations: map[string]string{
@@ -127,7 +130,8 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "another-test-issuer", Kind: "GoogleCASIssuer", Group: "my-group.hello.world"}),
 			),
 			certificate: &x509.Certificate{
-				URIs: urls,
+				Version: 3,
+				URIs:    urls,
 			},
 			expAnnotations: map[string]string{
 				"cert-manager.io/certificate-name": "test-certificate",
@@ -145,6 +149,7 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "another-test-issuer", Kind: "GoogleCASIssuer", Group: "my-group.hello.world"}),
 			),
 			certificate: &x509.Certificate{
+				Version:  3,
 				DNSNames: []string{"example.com", "cert-manager.io"},
 			},
 			expAnnotations: map[string]string{

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -93,7 +93,7 @@ func TestSign(t *testing.T) {
 	}
 
 	rootTmpl := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -69,7 +69,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -83,7 +83,7 @@ func TestSign(t *testing.T) {
 	}
 
 	rootTmpl := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -71,7 +71,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -75,11 +75,9 @@ func CertificateTemplateFromCSR(csr *x509.CertificateRequest, mutators ...Certif
 	}
 
 	cert := &x509.Certificate{
-		// Version must be 2 according to RFC5280.
-		// A version value of 2 confusingly means version 3.
-		// This value isn't used by Go at the time of writing.
+		// Version must be 3 according to RFC5280.
 		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1
-		Version:            2,
+		Version:            3,
 		SerialNumber:       serialNumber,
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -726,7 +726,7 @@ func TestSignCSRTemplate(t *testing.T) {
 		pk, err := GenerateECPrivateKey(256)
 		require.NoError(t, err)
 		tmpl := &x509.Certificate{
-			Version:               2,
+			Version:               3,
 			BasicConstraintsValid: true,
 			SerialNumber:          big.NewInt(0),
 			Subject: pkix.Name{

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -255,7 +255,7 @@ func signTestCert(key crypto.Signer) *x509.Certificate {
 	}
 
 	template := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
@@ -318,6 +318,7 @@ func TestPublicKeyMatchesCertificateRequest(t *testing.T) {
 	}
 
 	template := &x509.CertificateRequest{
+		Version: 0,
 		// SignatureAlgorithm: sigAlgo,
 		Subject: pkix.Name{
 			CommonName: "cn",

--- a/pkg/util/pki/kube_test.go
+++ b/pkg/util/pki/kube_test.go
@@ -79,7 +79,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               2,
+				Version:               3,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
@@ -112,7 +112,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               2,
+				Version:               3,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
@@ -145,7 +145,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               2,
+				Version:               3,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
@@ -179,7 +179,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               2,
+				Version:               3,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,

--- a/pkg/webhook/authority/authority.go
+++ b/pkg/webhook/authority/authority.go
@@ -331,7 +331,7 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 		return err
 	}
 	cert := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,

--- a/pkg/webhook/server/tls/dynamic_source.go
+++ b/pkg/webhook/server/tls/dynamic_source.go
@@ -207,7 +207,7 @@ func (f *DynamicSource) regenerateCertificate(nextRenew chan<- time.Time) error 
 
 	// create the certificate template to be signed
 	template := &x509.Certificate{
-		Version:            2,
+		Version:            3,
 		PublicKeyAlgorithm: x509.ECDSA,
 		PublicKey:          pk.Public(),
 		DNSNames:           f.DNSNames,

--- a/pkg/webhook/server/tls/file_source_test.go
+++ b/pkg/webhook/server/tls/file_source_test.go
@@ -174,7 +174,7 @@ func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []by
 		t.Fatal(err)
 	}
 	cert := &x509.Certificate{
-		Version:               2,
+		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.RSA,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -235,7 +235,7 @@ func NewCertManagerBasicCertificateRequest(name, issuerName string, issuerKind s
 	}
 
 	csr := &x509.CertificateRequest{
-		Version:            3,
+		Version:            0,
 		SignatureAlgorithm: signatureAlgorithm,
 		PublicKeyAlgorithm: keyAlgorithm,
 		PublicKey:          sk.Public(),

--- a/test/framework/addon/vault/vault.go
+++ b/test/framework/addon/vault/vault.go
@@ -382,6 +382,7 @@ func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName 
 	ca, _ := x509.ParseCertificate(catls.Certificate[0])
 
 	cert := &x509.Certificate{
+		Version:      3,
 		SerialNumber: big.NewInt(1658),
 		Subject: pkix.Name{
 			CommonName:   dnsName,
@@ -404,6 +405,7 @@ func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName 
 
 func GenerateCA() ([]byte, []byte, error) {
 	ca := &x509.Certificate{
+		Version:      3,
 		SerialNumber: big.NewInt(1653),
 		Subject: pkix.Name{
 			Organization: []string{"cert-manager test"},

--- a/test/unit/gen/csr.go
+++ b/test/unit/gen/csr.go
@@ -96,7 +96,7 @@ func CSRWithSigner(sk crypto.Signer, mods ...CSRModifier) (csr []byte, err error
 	}
 
 	cr := &x509.CertificateRequest{
-		Version:            3,
+		Version:            0,
 		SignatureAlgorithm: signatureAlgorithm,
 		PublicKeyAlgorithm: keyAlgorithm,
 		PublicKey:          sk.Public(),


### PR DESCRIPTION
see https://github.com/cert-manager/cert-manager/blob/master/pkg/util/pki/certificatetemplate.go#L78-L81 for context
We incorrectly assumed that the golang *x509.Certificate Version field is the encoded version (which would be 2).
Based on the comment here https://cs.opensource.google/go/go/+/master:src/crypto/x509/x509.go;l=823-827, it is clear that the Version field in *x509.Certificate is the actual version value (which should be 3).

In some places, we were setting the Version of CertificateRequest to 3 too, which is incorrect and should be kept at 0 instead.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
