### PR TITLE
Updates cmctl to point at latest cert-manager

### DIFF
--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -12,7 +12,7 @@ go 1.20
 // or a branch name (master).
 
 require (
-	github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71
+	github.com/cert-manager/cert-manager v1.12.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2

--- a/cmd/ctl/go.sum
+++ b/cmd/ctl/go.sum
@@ -92,8 +92,8 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZ
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71 h1:jhVl/bpUSPnxglLgT5yCpqCkk1Nm9rUsi8/JAu74YCY=
-github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71/go.mod h1:6OaSRbLMjTHsMORCHbs28rCOxeNjFK3lW+58v95mGJc=
+github.com/cert-manager/cert-manager v1.12.0 h1:CWIZeWop7RwFCIKgSzsxFFGcI2nvudkOICBMDY7SKuI=
+github.com/cert-manager/cert-manager v1.12.0/go.mod h1:vRRQLs67q9PN/3SILHpiLbzuG63c4I0+q6pbppEWChs=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -9,7 +9,7 @@ replace github.com/cert-manager/cert-manager/cmd/ctl => ../../cmd/ctl/
 replace github.com/cert-manager/cert-manager/webhook-binary => ../../cmd/webhook/
 
 require (
-	github.com/cert-manager/cert-manager v1.12.0-beta.1.0.20230510114354-4959b1ce1a71
+	github.com/cert-manager/cert-manager v1.12.0
 	github.com/cert-manager/cert-manager/cmd/ctl v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.2.4
 	github.com/miekg/dns v1.1.50


### PR DESCRIPTION
This PR bumps cert-manager version in cmctl's `go.mod` file to v1.12.0. This should have been done _before_ releasing, however should not be a major issue as I cannot think of any changes that went in in cert-manager before v1.12.0-beta.1 and v1.12.0 that would have affected cmctl.

I've updated the release process notes so we don't forget it in the future https://github.com/cert-manager/website/pull/1225

```release-note
NONE
```

/kind cleanup