### PR TITLE
fix: maxUnavailable pdb configuration cannot be used due to default set minAvailable

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -17,7 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "cainjector"
 
-  {{- if and .Values.cainjector.podDisruptionBudget.minAvailable (not (hasKey .Values.cainjector.podDisruptionBudget "maxUnavailable")) }}
+  {{- if not (or (hasKey .Values.cainjector.podDisruptionBudget "minAvailable") (hasKey .Values.cainjector.podDisruptionBudget "maxUnavailable")) }}
+  minAvailable: 1 # Default value because minAvailable and maxUnavailable are not set
+  {{- end }}
+  {{- if hasKey .Values.cainjector.podDisruptionBudget "minAvailable" }}
   minAvailable: {{ .Values.cainjector.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if hasKey .Values.cainjector.podDisruptionBudget "maxUnavailable" }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "cainjector"
 
-  {{- with .Values.cainjector.podDisruptionBudget.minAvailable }}
+  {{- with and .Values.cainjector.podDisruptionBudget.minAvailable (not .Values.cainjector.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ . }}
   {{- end }}
   {{- with .Values.cainjector.podDisruptionBudget.maxUnavailable }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -17,8 +17,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "cainjector"
 
-  {{- with and .Values.cainjector.podDisruptionBudget.minAvailable (not .Values.cainjector.podDisruptionBudget.maxUnavailable) }}
-  minAvailable: {{ . }}
+  {{- if and .Values.cainjector.podDisruptionBudget.minAvailable (not .Values.cainjector.podDisruptionBudget.maxUnavailable) }}
+  minAvailable: {{ .Values.cainjector.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- with .Values.cainjector.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -17,10 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "cainjector"
 
-  {{- if and .Values.cainjector.podDisruptionBudget.minAvailable (not .Values.cainjector.podDisruptionBudget.maxUnavailable) }}
+  {{- if and .Values.cainjector.podDisruptionBudget.minAvailable (not (hasKey .Values.cainjector.podDisruptionBudget "maxUnavailable")) }}
   minAvailable: {{ .Values.cainjector.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.cainjector.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.cainjector.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.cainjector.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -17,7 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
 
-  {{- if and .Values.podDisruptionBudget.minAvailable (not (hasKey .Values.podDisruptionBudget "maxUnavailable")) }}
+  {{- if not (or (hasKey .Values.podDisruptionBudget "minAvailable") (hasKey .Values.podDisruptionBudget "maxUnavailable")) }}
+  minAvailable: 1 # Default value because minAvailable and maxUnavailable are not set
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -17,8 +17,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
 
-  {{- with and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
-  minAvailable: {{ . }}
+  {{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- with .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
 
-  {{- with .Values.podDisruptionBudget.minAvailable }}
+  {{- with and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ . }}
   {{- end }}
   {{- with .Values.podDisruptionBudget.maxUnavailable }}

--- a/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/poddisruptionbudget.yaml
@@ -17,10 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
 
-  {{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
+  {{- if and .Values.podDisruptionBudget.minAvailable (not (hasKey .Values.podDisruptionBudget "maxUnavailable")) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -17,7 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
 
-  {{- if and .Values.webhook.podDisruptionBudget.minAvailable (not (hasKey .Values.webhook.podDisruptionBudget "maxUnavailable")) }}
+  {{- if not (or (hasKey .Values.webhook.podDisruptionBudget "minAvailable") (hasKey .Values.webhook.podDisruptionBudget "maxUnavailable")) }}
+  minAvailable: 1 # Default value because minAvailable and maxUnavailable are not set
+  {{- end }}
+  {{- if hasKey .Values.webhook.podDisruptionBudget "minAvailable" }}
   minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if hasKey .Values.webhook.podDisruptionBudget "maxUnavailable" }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
 
-  {{- with .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- with and .Values.webhook.podDisruptionBudget.minAvailable (not .Values.webhook.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ . }}
   {{- end }}
   {{- with .Values.webhook.podDisruptionBudget.maxUnavailable }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -17,8 +17,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
 
-  {{- with and .Values.webhook.podDisruptionBudget.minAvailable (not .Values.webhook.podDisruptionBudget.maxUnavailable) }}
-  minAvailable: {{ . }}
+  {{- if and .Values.webhook.podDisruptionBudget.minAvailable (not .Values.webhook.podDisruptionBudget.maxUnavailable) }}
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- with .Values.webhook.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -17,10 +17,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
 
-  {{- if and .Values.webhook.podDisruptionBudget.minAvailable (not .Values.webhook.podDisruptionBudget.maxUnavailable) }}
+  {{- if and .Values.webhook.podDisruptionBudget.minAvailable (not (hasKey .Values.webhook.podDisruptionBudget "maxUnavailable")) }}
   minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.webhook.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.webhook.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -63,12 +63,11 @@ strategy: {}
 podDisruptionBudget:
   enabled: false
 
-  minAvailable: 1
-  # maxUnavailable: 1
-
   # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
   # or a percentage value (e.g. 25%)
-  # maxUnavailable takes precedence over minAvailable if set
+  # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+  # minAvailable: 1
+  # maxUnavailable: 1
 
 # Comma separated list of feature gates that should be enabled on the
 # controller pod.
@@ -306,12 +305,11 @@ webhook:
   podDisruptionBudget:
     enabled: false
 
-    minAvailable: 1
-    # maxUnavailable: 1
-
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
-    # maxUnavailable takes precedence over minAvailable if set
+    # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+    # minAvailable: 1
+    # maxUnavailable: 1
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -492,12 +490,11 @@ cainjector:
   podDisruptionBudget:
     enabled: false
 
-    minAvailable: 1
-    # maxUnavailable: 1
-
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
-    # maxUnavailable takes precedence over minAvailable if set
+    # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+    # minAvailable: 1
+    # maxUnavailable: 1
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -68,6 +68,7 @@ podDisruptionBudget:
 
   # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
   # or a percentage value (e.g. 25%)
+  # maxUnavailable takes precedence over minAvailable if set
 
 # Comma separated list of feature gates that should be enabled on the
 # controller pod.
@@ -310,6 +311,7 @@ webhook:
 
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
+    # maxUnavailable takes precedence over minAvailable if set
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -495,6 +497,7 @@ cainjector:
 
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
+    # maxUnavailable takes precedence over minAvailable if set
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

The new certmanager chart managed PDBs use `{{ with .minAvailable }}` and `{{ with .maxUnavailable }}` but due to the default value of `.minAvailable` you can't use `.maxUnavailable` without setting `.minAvailable` to `null`.

Because we use certmanager as a helm dependency we can't set `.minAvailable` to `null`. This is due to the helm bug where null values are not passed to dependent charts.

Because `.minAvailable: 1` is the default value I think it makes the most sense to skip setting `minAvailable` when `.maxUnavailable` is set, and not the other way around. Any other configuration is bad configuration supplied by the user which they can simply remove from the values to fix any deployment errors.

### Kind

bug 
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Allow overriding default pdb .minAvailable with .maxUnavailable without setting .minAvailable to null
```
