### PR TITLE
[release-1.11] cherry-pick of disabling APF controller in webhook

### DIFF
--- a/pkg/acme/webhook/cmd/server/start.go
+++ b/pkg/acme/webhook/cmd/server/start.go
@@ -23,8 +23,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
 	whapi "github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
@@ -124,6 +127,13 @@ func (o WebhookServerOptions) Config() (*apiserver.Config, error) {
 // RunWebhookServer creates a new apiserver, registers an API Group for each of
 // the configured solvers and runs the new apiserver.
 func (o WebhookServerOptions) RunWebhookServer(stopCh <-chan struct{}) error {
+	// extension apiserver does not need priority and fairness.
+	// TODO: this is a short term fix; when APF graduates we will need to
+	// find another way. Alternatives are either to find a way how to
+	// disable APF controller (without the feature gate), run the controller
+	// (create RBAC and ensure required resources are installed) or do some
+	// bigger refactor of this project that could solve the problem
+	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.APIPriorityAndFairness)))
 	config, err := o.Config()
 	if err != nil {
 		return err


### PR DESCRIPTION
This was meant to be a cherry-pick of #6085 , but that had a merge conflict, so I had to create a separate PR against release-1.11 https://github.com/cert-manager/cert-manager/pull/6085#issuecomment-1557408517

I have checked that the APF gets disabled as expected using samplewebhook (`make e2e-setup-samplewebhook`)

I will cut actual patch releases for 1.11 and 1.12 with this change once we get c/r 0.15 so I can put that into 1.12 patch.

```release-note
API Priority and Fairness controller is now disabled in extension apiserver for DNS webhook implementation.
```
/kind cleanup