### PR TITLE
Fix webhook feature gate

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - --secure-port={{ .Values.webhook.securePort }}
           {{- end }}
           {{- if .Values.featureGates }}
-          - --feature-gates={{ .Values.featureGates }}
+          - --feature-gates={{ .Values.webhook.featureGates }}
           {{- end }}
           {{- $tlsConfig := default $config.tlsConfig "" }}
           {{ if or (not $config.tlsConfig) (and (not $tlsConfig.dynamic) (not $tlsConfig.filesystem) ) -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -70,7 +70,7 @@ podDisruptionBudget:
   # or a percentage value (e.g. 25%)
 
 # Comma separated list of feature gates that should be enabled on the
-# controller pod & webhook pod.
+# controller pod.
 featureGates: ""
 
 # The maximum number of challenges that can be scheduled as 'processing' at once
@@ -340,6 +340,10 @@ webhook:
   extraArgs: []
   # Path to a file containing a WebhookConfiguration object used to configure the webhook
   # - --config=<path-to-config-file>
+
+  # Comma separated list of feature gates that should be enabled on the
+  # webhok pod.
+  featureGates: ""
 
   resources: {}
     # requests:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -342,7 +342,7 @@ webhook:
   # - --config=<path-to-config-file>
 
   # Comma separated list of feature gates that should be enabled on the
-  # webhok pod.
+  # webhook pod.
   featureGates: ""
 
   resources: {}

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// feature contains cainjector feature gate setup code. Do not import this
+// package into any code that's shared with other components to prevent
+// overwriting other component's featue gates, see i.e
+// https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 
 import (

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// feature contains controller's feature gate setup functionality. Do not import
+// this package into any code that's shared with other components to prevent
+// overwriting other component's featue gates, see i.e
+// https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 
 import (

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// feature contains webhook's feature gate setup functionality. Do not import
+// this package into any code that's shared with other components to prevent
+// overwriting other component's featue gates, see i.e
+// https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 
 import (

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -270,7 +270,7 @@ e2e-setup-certmanager: $(BINDIR)/cert-manager.tgz $(foreach binaryname,controlle
 		--set installCRDs=true \
 		--set featureGates="$(feature_gates_controller)" \
 		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200}" \
-		--set "webhook.extraArgs={--feature-gates=$(feature_gates_webhook)}" \
+		--set webhook.featureGates="$(feature_gates_webhook)" \
 		--set "cainjector.extraArgs={--feature-gates=$(feature_gates_cainjector)}" \
 		--set "dns01RecursiveNameservers=$(SERVICE_IP_PREFIX).16:53" \
 		--set "dns01RecursiveNameserversOnly=true" \

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -349,7 +349,8 @@ func (c *controller) deleteRequestsNotMatchingSpec(ctx context.Context, crt *cma
 
 func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi.Certificate, pk crypto.Signer, nextRevision int, nextPrivateKeySecretName string) error {
 	log := logf.FromContext(ctx)
-	x509CSR, err := pki.GenerateCSR(crt)
+
+	x509CSR, err := pki.GenerateCSR(crt, pki.WithUseLiteralSubject(utilfeature.DefaultMutableFeatureGate.Enabled(feature.LiteralCertificateSubject)))
 	if err != nil {
 		log.Error(err, "Failed to generate CSR - will not retry")
 		return nil

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -29,12 +29,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 func buildCertificate(cn string, dnsNames ...string) *cmapi.Certificate {
@@ -614,10 +611,10 @@ func TestGenerateCSR(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, feature.LiteralCertificateSubject, tt.literalCertificateSubjectFeatureEnabled)()
 			got, err := GenerateCSR(
 				tt.crt,
 				WithEncodeBasicConstraintsInRequest(tt.basicConstraintsFeatureEnabled),
+				WithUseLiteralSubject(tt.literalCertificateSubjectFeatureEnabled),
 			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateCSR() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

See #6011 for context- a shared library was pulling in some code from controller's feature gate setup, which was causing the webhook's feature gates being overwritten by the controller ones because webhook was also importing the shared library.

Additionally in https://github.com/cert-manager/cert-manager/pull/5584 we started relying on this bug by passing the feature flag values previously meant for controller into webhook.

Also our docs currently list the controller feature gates for webhook (I think I will edit this by hand no matter whether this PR gets cherry-picked or not) https://cert-manager.io/docs/cli/webhook/

This PR:

- removes the references to controller feature gates in the shared PKI library that was causing the controller feature gates to overwrite the webhook feature gates
- revert functionality that was passing controller feature gates into webhook (https://github.com/cert-manager/cert-manager/pull/5584)
- adds a new field to helm values for defining webhook features


<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

## Notes

- As mentioned this is a breaking change for anyone relying on the behaviour introduced in #5584 as well as for anyone who would have passed controller features into webhook via `--feature-gates` flag

- Previously a user would have been able to pass the same set of feature gates to both webhook's and controller's ` --feature-gates` flag- if they had done that than this PR would break them.

- I am not sure if this should be cherry-picked- it is breaking, but is also a bugfix and maybe would be preferable to put it in 1.12 patch release in case that prevents some folks from starting to use the wrong helm values field to define webhook features.

## Alternatives

- refactor the feature gate setup so that it is actually not possible or at least is harder to accidentally overwrite feature gates of components. I had an alternative PR that tried to make it harder #6040 , but I think there might be better approaches that could be explored, so this PR just fixes the bug and adds some warnings to code

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixes a bug where webhook was pulling in controller's feature gates.
**Breaking**: If you deploy using helm and have `.featureGates` value set, the features defined there will no longer be passed to cert-manager webhook. Use `webhook.featureGates` field instead to define features to be enabled on webhook.
**Potentially breaking**: If you were, for some reason, passing cert-manager controller's features to webhook's `--feature-gates` flag, this will now break (unless the webhook actually has a feature by that name).
```

Fixes: #6011 

/kind bug
