### PR TITLE
Adds a note about usage of featureGates value in Helm chart to release-1.11

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -60,8 +60,11 @@ strategy: {}
   #   maxSurge: 0
   #   maxUnavailable: 1
 
-# Comma separated list of feature gates that should be enabled on the
-# controller pod & webhook pod.
+# Comma separated list of feature gates that should be enabled on the controller
+# Note: do not use this field to pass feature gate values into webhook
+# component as this behaviour relies on a bug that will be fixed in cert-manager 1.13
+# https://github.com/cert-manager/cert-manager/pull/6093
+# Use webhook.extraArgs to pass --feature-gates flag directly instead.
 featureGates: ""
 
 # The maximum number of challenges that can be scheduled as 'processing' at once


### PR DESCRIPTION
cherry-picker seems kaput https://github.com/cert-manager/cert-manager/pull/6100#issuecomment-1561169612

```release-note
NONE
```

/kind cleanup
