### PR TITLE
Unify semver version logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ GOFLAGS := -trimpath
 ## @category Build
 GOLDFLAGS := -w -s \
 	-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=$(RELEASE_VERSION) \
-    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)
+    -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GIT_COMMIT)
 
 include make/tools.mk
 include make/ci.mk

--- a/hack/build/version.sh
+++ b/hack/build/version.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # Changes made from the original source file, copyright Kubernetes authors:
+# https://github.com/kubernetes/kubernetes/blob/ec71e53adb6dc9f1af3662448f483f3f15971b6b/hack/lib/version.sh
 
 # Copyright 2014 The Kubernetes Authors.
 #
@@ -34,111 +35,84 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# -----------------------------------------------------------------------------
-# Version management helpers.  These functions help to set, save and load the
-# following variables:
-#
-#    KUBE_GIT_COMMIT - The git commit id corresponding to this
-#          source code.
-#    KUBE_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
-#        "dirty" indicates source code changes after the git commit id
-#        "archive" indicates the tree was produced by 'git archive'
-#    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
-#    KUBE_GIT_MAJOR - The major part of the version
-#    KUBE_GIT_MINOR - The minor component of the version
-
-export GO_PACKAGE="github.com/cert-manager/cert-manager"
-
 # Grovels through git to set a set of env variables.
-#
-# If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
-# querying git.
-# This function reads the path to cert-manager repo from a
-# REPO_PATH variable that needs to be set before calling it.
-kube::version::get_version_vars() {
-  if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
-    kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
-    return
-  fi
-
-  # If the kubernetes source was exported through git archive, then
-  # we likely don't have a git tree, but these magic values may be filled in.
-  # shellcheck disable=SC2016,SC2050
-  # Disabled as we're not expanding these at runtime, but rather expecting
-  # that another tool may have expanded these and rewritten the source (!)
-  if [[ '$Format:%%$' == "%" ]]; then
-    KUBE_GIT_COMMIT='$Format:%H$'
-    KUBE_GIT_TREE_STATE="archive"
-    # When a 'git archive' is exported, the '$Format:%D$' below will look
-    # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
-    # can be extracted from it.
-    if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
-     KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
-    fi
-  fi
-
+#    GIT_COMMIT - The git commit id corresponding to this source code.
+#    GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#      dirty" indicates source code changes after the git commit id
+#      archive" indicates the tree was produced by 'git archive'
+#    GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    GIT_MAJOR - The major part of the version
+#    GIT_MINOR - The minor component of the version
+version::get_version() {
   local git=(git --work-tree "${REPO_ROOT}")
 
-  if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
-    if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
-      # Check if the tree is dirty.  default to dirty
-      if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
-        KUBE_GIT_TREE_STATE="clean"
-      else
-        KUBE_GIT_TREE_STATE="dirty"
-      fi
+  GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null)
+
+  # Check if the tree is dirty.  default to dirty
+  if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+    GIT_TREE_STATE="clean"
+  else
+    GIT_TREE_STATE="dirty"
+  fi
+
+  # Use git describe to find the version based on tags.
+  GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null)
+
+  GIT_IS_TAGGED_RELEASE=$("${git[@]}" git describe --exact-match HEAD >/dev/null 2>&1 && echo "true" || echo "false")
+  
+  # This translates the "git describe" to an actual semver.org
+  # compatible semantic version that looks something like this:
+  #   v1.1.0-alpha.0.6+84c76d1142ea4d
+  #
+  # TODO: We continue calling this "git version" because so many
+  # downstream consumers are expecting it there.
+  #
+  # These regexes are painful enough in sed...
+  # We don't want to do them in pure shell, so disable SC2001
+  # shellcheck disable=SC2001
+  DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+  if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+    # shellcheck disable=SC2001
+    # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+    GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+  elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+    # shellcheck disable=SC2001
+    # We have distance to base tag (v1.1.0-1-gCommitHash)
+    GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+  fi
+  if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+    # git describe --dirty only considers changes to existing files, but
+    # that is problematic since new untracked .go files affect the build,
+    # so use our idea of "dirty" from git status instead.
+    GIT_VERSION+="-dirty"
+  fi
+
+  # Try to match the "git describe" output to a regex to try to extract
+  # the "major", "minor" and "patch" versions and whether this is the exact tagged
+  # version or whether the tree is between two tagged versions.
+  # Cert-manager release tag always has all three of major, minor and patch versions.
+  if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z.-]+))?(\+([0-9A-Za-z.-]+))?$ ]]; then
+    GIT_MAJOR=${BASH_REMATCH[1]}
+    GIT_MINOR=${BASH_REMATCH[2]}
+    GIT_PATCH=${BASH_REMATCH[3]}
+    IMAGE_NAME_SHORT="v${GIT_MAJOR}.${GIT_MINOR}.${GIT_PATCH}"
+    
+    GIT_SUBVERSION=${BASH_REMATCH[5]}
+    GIT_IS_PRERELEASE="false"
+    if [[ -n "$GIT_SUBVERSION" ]]; then
+      IMAGE_NAME_SHORT+="-${GIT_SUBVERSION}"
+      GIT_IS_PRERELEASE="true"
     fi
-
-    # Use git describe to find the version based on tags.
-    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
-      # This translates the "git describe" to an actual semver.org
-      # compatible semantic version that looks something like this:
-      #   v1.1.0-alpha.0.6+84c76d1142ea4d
-      #
-      # TODO: We continue calling this "git version" because so many
-      # downstream consumers are expecting it there.
-      #
-      # These regexes are painful enough in sed...
-      # We don't want to do them in pure shell, so disable SC2001
-      # shellcheck disable=SC2001
-      DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
-      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
-        # shellcheck disable=SC2001
-        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
-        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
-      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
-        # shellcheck disable=SC2001
-        # We have distance to base tag (v1.1.0-1-gCommitHash)
-        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
-      fi
-      if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
-        # git describe --dirty only considers changes to existing files, but
-        # that is problematic since new untracked .go files affect the build,
-        # so use our idea of "dirty" from git status instead.
-        KUBE_GIT_VERSION+="-dirty"
-      fi
-
-
-      # Try to match the "git describe" output to a regex to try to extract
-      # the "major", "minor" and "patch" versions and whether this is the exact tagged
-      # version or whether the tree is between two tagged versions.
-      # Cert-manager release tag always has all three of major, minor and patch versions.
-      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then
-        KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
-        KUBE_GIT_MINOR=${BASH_REMATCH[2]}
-        KUBE_GIT_PATCH=${BASH_REMATCH[3]}
-        if [[ -n "${BASH_REMATCH[4]}" ]]; then
-          KUBE_GIT_MINOR+="+"
-        fi
-      fi
-
-      # If KUBE_GIT_VERSION is not a valid Semantic Version, then refuse to build.
-      if ! [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-          echo "KUBE_GIT_VERSION should be a valid Semantic Version. Current value: ${KUBE_GIT_VERSION}"
-          echo "Please see more details here: https://semver.org"
-          exit 1
-      fi
+    
+    IMAGE_NAME_LONG="$IMAGE_NAME_SHORT"
+    if [[ -n "${BASH_REMATCH[7]}" ]]; then
+      IMAGE_NAME_LONG+="-${BASH_REMATCH[7]}"
     fi
+  else
+    # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+    echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+    echo "Please see more details here: https://semver.org"
+    exit 1
   fi
 }
 
@@ -148,54 +122,96 @@ kube::version::get_version_vars() {
 # v1.2.3.
 # If the last published releases are v1.2.3 and v1.3.0-alpha.0 it will set
 # KUBE_LAST_VERSION to v1.2.3
-# This function reads the path to cert-manager
-# repo from a REPO_PATH variable that needs to be set before calling it.
-kube::version::last_published_release() {
-    # KUBE_GIT_COMMIT get_version_vars
-    kube::version::get_version_vars
+version::last_published_release() {
+  version::list_published_releases
 
-    local git=(git --work-tree "${REPO_ROOT}")
+  local latest
 
-    # Find the last git tag which is not alpha or beta tag
-    local latest=$("${git[@]}" tag --list 'v*' | grep -v 'alpha\|beta' | tail -n1)
+  latest=$(
+    echo "$RELEASE_LIST" | \
+    grep -v 'alpha\|beta' | \
+    tail -n1
+  )
 
-
-    if [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then
-      major=${BASH_REMATCH[1]}
-      minor=${BASH_REMATCH[2]}
-      patch=${BASH_REMATCH[3]}
-      KUBE_LAST_RELEASE="v${major}.${minor}.${patch}"
-    else
-      echo "Latest found Git tag that is not alpha or beta tag is not a valid semver tag: ${latest}"
-      echo "Please see more details here: https://semver.org"
-      exit 1
-    fi
+  if [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    major=${BASH_REMATCH[1]}
+    minor=${BASH_REMATCH[2]}
+    patch=${BASH_REMATCH[3]}
+    LAST_RELEASE="v${major}.${minor}.${patch}"
+  else
+    echo "Latest found Git tag that is not alpha or beta tag is not a valid semver tag: ${latest}"
+    echo "Please see more details here: https://semver.org"
+    exit 1
+  fi
 }
 
-# Saves the environment flags to $1
-kube::version::save_version_vars() {
-  local version_file=${1-}
-  [[ -n ${version_file} ]] || {
-    echo "!!! Internal error.  No file specified in kube::version::save_version_vars"
-    return 1
-  }
+version::list_published_releases() {
+  local list
 
-  cat <<EOF >"${version_file}"
-KUBE_GIT_COMMIT='${KUBE_GIT_COMMIT-}'
-KUBE_GIT_TREE_STATE='${KUBE_GIT_TREE_STATE-}'
-KUBE_GIT_VERSION='${KUBE_GIT_VERSION-}'
-KUBE_GIT_MAJOR='${KUBE_GIT_MAJOR-}'
-KUBE_GIT_MINOR='${KUBE_GIT_MINOR-}'
+  # Lists all remote tags on the upstream, which gives tags in format:
+  # "<commit> ref/tags/<tag>". Strips commit + tag prefix, filters out tags for v1+,
+  # and manually removes v1.2.0-alpha.1, since that version's manifest contains
+  # duplicate CRD resources (2 CRDs with the same name) which in turn can cause problems
+  # with the versionchecker test.
+  list=$(
+    git ls-remote --tags --sort "version:refname" --refs "${REPO_URL}" | \
+		awk '{print $2;}' | \
+		sed 's/refs\/tags\///' | \
+		sed -n '/v1.0.0/,$p' | \
+		grep -v "v1.2.0-alpha.1"
+  )
+
+  RELEASE_LIST=$list
+}
+
+
+help() {
+  cat <<EOF
+Usage:
+    $0 version <root-of-repo>
+    $0 last-published-release <git-repo-url>
+    $0 list-published-releases <git-repo-url>
 EOF
 }
 
-# Loads up the version variables from file $1
-kube::version::load_version_vars() {
-  local version_file=${1-}
-  [[ -n ${version_file} ]] || {
-    echo "!!! Internal error.  No file specified in kube::version::load_version_vars"
-    return 1
-  }
+if [ $# -eq 2 ]; then
+  case "$1" in
+    version)
+      REPO_ROOT=$2
+      version::get_version
 
-  source "${version_file}"
-}
+      results=(
+        "GIT_COMMIT=$GIT_COMMIT"
+        "GIT_TREE_STATE=$GIT_TREE_STATE"
+        "GIT_VERSION=$GIT_VERSION"
+        "GIT_MAJOR=$GIT_MAJOR"
+        "GIT_MINOR=$GIT_MINOR"
+        "GIT_PATCH=$GIT_PATCH"
+        "GIT_SUBVERSION=$GIT_SUBVERSION"
+        "IMAGE_NAME_SHORT=$IMAGE_NAME_SHORT"
+        "IMAGE_NAME_LONG=$IMAGE_NAME_LONG"
+        "GIT_IS_PRERELEASE=$GIT_IS_PRERELEASE"
+        "GIT_IS_TAGGED_RELEASE=$GIT_IS_TAGGED_RELEASE"
+      )
+
+      echo "${results[@]}"
+
+      exit 0
+      ;;
+    last-published-release)
+      REPO_URL=$2
+      version::last_published_release
+      echo "$LAST_RELEASE"
+      exit 0
+      ;;
+    list-published-releases)
+      REPO_URL=$2
+      version::list_published_releases
+      echo "$RELEASE_LIST"
+      exit 0
+      ;;
+  esac
+fi
+
+help
+exit 1

--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -20,26 +20,24 @@ set -o pipefail
 
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 export REPO_ROOT="${SCRIPT_ROOT}/.."
-source "${REPO_ROOT}/hack/build/version.sh"
-
-kube::version::last_published_release
-
-LATEST_RELEASE="${KUBE_LAST_RELEASE}"
 
 usage_and_exit() {
-	echo "usage: $0 <path-to-helm> <path-to-kind> <path-to-ytt> <path-to-kubectl> <path-to-cmctl>" >&2
+	echo "usage: $0 <release-version> <git-commit> <last-published-release> <path-to-helm> <path-to-kind> <path-to-ytt> <path-to-kubectl> <path-to-cmctl>" >&2
 	exit 1
 }
 
-if [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ||-z "${4:-}" || -z "${5:-}" ]]; then
+if [[ -z "${1:-}" || -z "${2:-}" || -z "${3:-}" ||-z "${4:-}" || -z "${5:-}" || -z "${6:-}" || -z "${7:-}" || -z "${8:-}" ]]; then
 	usage_and_exit
 fi
 
-helm=$(realpath "$1")
-kind=$(realpath "$2")
-ytt=$(realpath "$3")
-kubectl=$(realpath "$4")
-cmctl=$(realpath "$5")
+RELEASE_VERSION="$1"
+GIT_COMMIT="$2"
+LATEST_RELEASE="$3"
+helm=$(realpath "$4")
+kind=$(realpath "$5")
+ytt=$(realpath "$6")
+kubectl=$(realpath "$7")
+cmctl=$(realpath "$8")
 
 # Set up a fresh kind cluster
 
@@ -61,7 +59,7 @@ HELM_URL="https://charts.jetstack.io"
 # cert-manager Helm chart location
 HELM_CHART="cmupgradetest/cert-manager"
 
-echo "+++ Testing upgrading from ${LATEST_RELEASE} to commit ${KUBE_GIT_COMMIT} with Helm"
+echo "+++ Testing upgrading from ${LATEST_RELEASE} to commit ${GIT_COMMIT} with Helm"
 
 # This will target the host's helm repository cache
 $helm repo add cmupgradetest $HELM_URL
@@ -130,7 +128,7 @@ $kubectl delete "namespace/${NAMESPACE}" --wait
 
 # 1. INSTALL THE LATEST PUBLISHED RELEASE WITH STATIC MANIFESTS
 
-echo "+++ Testing cert-manager upgrade from ${LATEST_RELEASE} to commit ${KUBE_GIT_COMMIT} using static manifests"
+echo "+++ Testing cert-manager upgrade from ${LATEST_RELEASE} to commit ${GIT_COMMIT} using static manifests"
 
 echo "+++ Installing cert-manager ${LATEST_RELEASE} using static manifests"
 
@@ -156,19 +154,17 @@ $kubectl wait --for=condition=Ready cert/test1 --timeout=180s
 
 MANIFEST_LOCATION=${REPO_ROOT}/_bin/yaml/cert-manager.yaml
 
-echo "+++ Installing cert-manager commit ${KUBE_GIT_COMMIT} using static manifests"
+echo "+++ Installing cert-manager commit ${GIT_COMMIT} using static manifests"
 
 # Build the static manifests
 make release-manifests
-
-RELEASE_VERSION=$(make --silent release-version)
 
 # Overwrite image tags in the static manifests and deploy.
 $ytt -f "${REPO_ROOT}/test/fixtures/upgrade/overlay/controller-ops.yaml" \
      -f "${REPO_ROOT}/test/fixtures/upgrade/overlay/cainjector-ops.yaml" \
      -f "${REPO_ROOT}/test/fixtures/upgrade/overlay/webhook-ops.yaml" \
      -f "${REPO_ROOT}/test/fixtures/upgrade/overlay/values.yaml" \
-     -f $MANIFEST_LOCATION \
+     -f "$MANIFEST_LOCATION" \
      --data-value app_version="${RELEASE_VERSION}" \
      --ignore-unknown-comments | kubectl apply -f -
 
@@ -203,4 +199,4 @@ $kubectl wait --for=condition=Ready cert/test2 --timeout=180s
 
 echo "+++ Uninstalling cert-manager"
 
-$kubectl delete -f $MANIFEST_LOCATION --wait
+$kubectl delete -f "$MANIFEST_LOCATION" --wait

--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -27,7 +27,7 @@ $(BINDIR)/scratch/license.yaml: hack/boilerplate-yaml.txt | $(BINDIR)/scratch
 # which presumably nobody will ever read or care about. Instead, just add a little footnote pointing
 # to the cert-manager repo in case anybody actually decides that they care.
 $(BINDIR)/scratch/license-footnote.yaml: | $(BINDIR)/scratch
-	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GITCOMMIT)/LICENSES" > $@
+	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GIT_COMMIT)/LICENSES" > $@
 
 $(BINDIR)/scratch/cert-manager.license: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
 	cat $^ > $@

--- a/make/release.mk
+++ b/make/release.mk
@@ -72,7 +72,7 @@ $(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDI
 	jq -n \
 		--arg releaseVersion "$(RELEASE_VERSION)" \
 		--arg buildSource "make" \
-		--arg gitCommitRef "$(GITCOMMIT)" \
+		--arg gitCommitRef "$(GIT_COMMIT)" \
 		'.releaseVersion = $$releaseVersion | .gitCommitRef = $$gitCommitRef | .buildSource = $$buildSource | .artifacts += [inputs]' $^ > $@
 
 .PHONY: release-containers

--- a/make/test.mk
+++ b/make/test.mk
@@ -164,7 +164,15 @@ e2e-build: $(BINDIR)/test/e2e.test
 
 .PHONY: test-upgrade
 test-upgrade: | $(NEEDS_HELM) $(NEEDS_KIND) $(NEEDS_YTT) $(NEEDS_KUBECTL) $(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
-	./hack/verify-upgrade.sh $(HELM) $(KIND) $(YTT) $(KUBECTL) $(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
+	./hack/verify-upgrade.sh \
+		$(RELEASE_VERSION) \
+		$(GIT_COMMIT) \
+		$(shell $(MAKE) last-published-release) \
+		$(HELM) \
+		$(KIND) \
+		$(YTT) \
+		$(KUBECTL) \
+		$(BINDIR)/cmctl/cmctl-$(HOST_OS)-$(HOST_ARCH)
 
 test/integration/versionchecker/testdata/test_manifests.tar: $(BINDIR)/scratch/oldcrds.tar $(BINDIR)/yaml/cert-manager.yaml
 	@# Remove the temp files if they exist


### PR DESCRIPTION
Currently, version number generation logic is duplicated in makefile and a bash script (make/git.mk & hack/build/version.sh).

This PR moves all version info generation into a single hack/build/version.sh file. This file now serves as our only source of truth. The hack/build/version.sh file originates from k/k but was heavily modified & simplified to better fit our usecase & build env.
```console
$ ./hack/build/version.sh
Usage:
    ./hack/build/version.sh version <root-of-repo>
    ./hack/build/version.sh last-published-release <git-repo-url>
    ./hack/build/version.sh list-published-releases <git-repo-url>
$ ./hack/build/version.sh version .
GIT_COMMIT=a9cb4e04690d552ecd17044e14f8190fa5a3519b GIT_TREE_STATE=clean GIT_VERSION=v1.12.0-beta.1.51+a9cb4e04690d55 GIT_MAJOR=1 GIT_MINOR=12 GIT_PATCH=0 GIT_SUBVERSION=beta.1.51 IMAGE_NAME_SHORT=v1.12.0-beta.1.51 IMAGE_NAME_LONG=v1.12.0-beta.1.51-a9cb4e04690d55 GIT_IS_PRERELEASE=true GIT_IS_TAGGED_RELEASE=false
$ ./hack/build/version.sh last-published-release https://github.com/cert-manager/cert-manager.git
v1.12.0
$ ./hack/build/version.sh list-published-releases https://github.com/cert-manager/cert-manager.git
v1.0.0
...
v1.12.0-beta.2
```

This is the version info in more detail:
```
GIT_COMMIT=a9cb4e04690d552ecd17044e14f8190fa5a3519b
GIT_TREE_STATE=clean
GIT_VERSION=v1.12.0-beta.1.51+a9cb4e04690d55
GIT_MAJOR=1
GIT_MINOR=12
GIT_PATCH=0
GIT_SUBVERSION=beta.1.51
IMAGE_NAME_SHORT=v1.12.0-beta.1.51
IMAGE_NAME_LONG=v1.12.0-beta.1.51-a9cb4e04690d55 # We replaced the + with - since + is not supported in an image tag.
GIT_IS_PRERELEASE=true
GIT_IS_TAGGED_RELEASE=false
```

This PR is an improved version of https://github.com/cert-manager/cert-manager/pull/5378.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
