### PR TITLE
Use logging library with json support in cmctl (part 1)

### DIFF
--- a/internal/cmd/util/exit.go
+++ b/internal/cmd/util/exit.go
@@ -23,7 +23,10 @@ import (
 
 // SetExitCode sets the exit code to 1 if the error is not a context.Canceled error.
 func SetExitCode(err error) {
-	if (err != nil) && !errors.Is(err, context.Canceled) {
+	if (err != nil) && errors.Is(err, context.DeadlineExceeded) {
+		errorExitCodeChannel <- 124 // Indicate that there was a timeout error
+	} else if (err != nil) && !errors.Is(err, context.Canceled) {
 		errorExitCodeChannel <- 1 // Indicate that there was an error
 	}
+	// If the context was canceled, we don't need to set the exit code
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -68,31 +68,31 @@ func InitLogs() {
 	log.SetFlags(0)
 }
 
+func AddFlagsNonDeprecated(opts *logs.Options, fs *pflag.FlagSet) {
+	var allFlags pflag.FlagSet
+	logsapi.AddFlags(opts, &allFlags)
+
+	allFlags.VisitAll(func(f *pflag.Flag) {
+		switch f.Name {
+		case "logging-format", "log-flush-frequency", "v", "vmodule":
+			fs.AddFlag(f)
+		}
+	})
+}
+
 func AddFlags(opts *logs.Options, fs *pflag.FlagSet) {
-	{
-		var allFlags flag.FlagSet
-		klog.InitFlags(&allFlags)
+	var allFlags flag.FlagSet
+	klog.InitFlags(&allFlags)
 
-		allFlags.VisitAll(func(f *flag.Flag) {
-			switch f.Name {
-			case "add_dir_header", "alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size",
-				"logtostderr", "one_output", "skip_headers", "skip_log_headers", "stderrthreshold":
-				fs.AddGoFlag(f)
-			}
-		})
-	}
+	allFlags.VisitAll(func(f *flag.Flag) {
+		switch f.Name {
+		case "add_dir_header", "alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size",
+			"logtostderr", "one_output", "skip_headers", "skip_log_headers", "stderrthreshold":
+			fs.AddGoFlag(f)
+		}
+	})
 
-	{
-		var allFlags pflag.FlagSet
-		logsapi.AddFlags(opts, &allFlags)
-
-		allFlags.VisitAll(func(f *pflag.Flag) {
-			switch f.Name {
-			case "logging-format", "log-flush-frequency", "v", "vmodule":
-				fs.AddFlag(f)
-			}
-		})
-	}
+	AddFlagsNonDeprecated(opts, fs)
 }
 
 func ValidateAndApply(opts *logs.Options) error {

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"regexp"
 
-	errors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -32,10 +31,10 @@ import (
 )
 
 var (
-	ErrCertManagerCRDsNotFound   = errors.New("the cert-manager CRDs are not yet installed on the Kubernetes API server")
-	ErrWebhookServiceFailure     = errors.New("the cert-manager webhook service is not created yet")
-	ErrWebhookDeploymentFailure  = errors.New("the cert-manager webhook deployment is not ready yet")
-	ErrWebhookCertificateFailure = errors.New("the cert-manager webhook CA bundle is not injected yet")
+	ErrCertManagerCRDsNotFound   = fmt.Errorf("the cert-manager CRDs are not yet installed on the Kubernetes API server")
+	ErrWebhookServiceFailure     = fmt.Errorf("the cert-manager webhook service is not created yet")
+	ErrWebhookDeploymentFailure  = fmt.Errorf("the cert-manager webhook deployment is not ready yet")
+	ErrWebhookCertificateFailure = fmt.Errorf("the cert-manager webhook CA bundle is not injected yet")
 )
 
 const (
@@ -62,14 +61,14 @@ type cmapiChecker struct {
 // New returns a cert-manager API checker
 func New(restcfg *rest.Config, scheme *runtime.Scheme, namespace string) (Interface, error) {
 	if err := cmapi.AddToScheme(scheme); err != nil {
-		return nil, errors.Wrap(err, "while configuring scheme")
+		return nil, fmt.Errorf("while configuring scheme: %w", err)
 	}
 
 	cl, err := client.New(restcfg, client.Options{
 		Scheme: scheme,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "while creating client")
+		return nil, fmt.Errorf("while creating client: %w", err)
 	}
 
 	return &cmapiChecker{
@@ -99,31 +98,9 @@ func (o *cmapiChecker) Check(ctx context.Context) error {
 	}
 
 	if err := o.client.Create(ctx, cert); err != nil {
-		return &ApiCheckError{
-			SimpleError:     translateToSimpleError(err),
-			UnderlyingError: err,
-		}
+		return err
 	}
 	return nil
-}
-
-type ApiCheckError struct {
-	SimpleError     error
-	UnderlyingError error
-}
-
-func (e *ApiCheckError) Error() string {
-	// If no simple error exists, print underlying error
-	if e.SimpleError == nil {
-		return e.UnderlyingError.Error()
-	}
-	return fmt.Sprintf("%v (%v)", e.SimpleError.Error(), e.UnderlyingError.Error())
-}
-
-// If no simple error exists, this function will return nil
-// which indicates that the error is not unwrappable
-func (e *ApiCheckError) Unwrap() error {
-	return e.SimpleError
 }
 
 // This translateToSimpleError function detects errors based on the error message.
@@ -137,18 +114,19 @@ func (e *ApiCheckError) Unwrap() error {
 // - Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.38.90:443: connect: connection refused
 // ErrWebhookCertificateFailure:
 // - Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "cert-manager-webhook-ca")
-func translateToSimpleError(err error) error {
+func TranslateToSimpleError(err error) error {
 	s := err.Error()
 
-	if regexErrCertManagerCRDsNotFound.MatchString(s) {
+	switch {
+	case regexErrCertManagerCRDsNotFound.MatchString(s):
 		return ErrCertManagerCRDsNotFound
-	} else if regexErrWebhookServiceFailure.MatchString(s) {
+	case regexErrWebhookServiceFailure.MatchString(s):
 		return ErrWebhookServiceFailure
-	} else if regexErrWebhookDeploymentFailure.MatchString(s) {
+	case regexErrWebhookDeploymentFailure.MatchString(s):
 		return ErrWebhookDeploymentFailure
-	} else if regexErrWebhookCertificateFailure.MatchString(s) {
+	case regexErrWebhookCertificateFailure.MatchString(s):
 		return ErrWebhookCertificateFailure
+	default:
+		return nil
 	}
-
-	return nil
 }

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -103,7 +103,7 @@ func (o *cmapiChecker) Check(ctx context.Context) error {
 	return nil
 }
 
-// This translateToSimpleError function detects errors based on the error message.
+// TranslateToSimpleError detects errors based on the error message.
 // It tries to map these error messages to a better understandable error message that
 // explains what is wrong. If it cannot create a simple error, it will return nil.
 // ErrCertManagerCRDsNotFound:

--- a/pkg/util/versionchecker/versionchecker.go
+++ b/pkg/util/versionchecker/versionchecker.go
@@ -18,9 +18,9 @@ package versionchecker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -32,17 +32,10 @@ import (
 const certificatesCertManagerCrdName = "certificates.cert-manager.io"
 const certificatesCertManagerOldCrdName = "certificates.certmanager.k8s.io"
 
-var certManagerLabelSelector = map[string]string{
-	"app.kubernetes.io/instance": "cert-manager",
-}
-var certManagerOldLabelSelector = map[string]string{
-	"release": "cert-manager",
-}
-
 var (
-	ErrCertManagerCRDsNotFound  = errors.New("the cert-manager CRDs are not yet installed on the Kubernetes API server")
-	ErrVersionNotDetected       = errors.New("could not detect the cert-manager version")
-	ErrMultipleVersionsDetected = errors.New("detect multiple different cert-manager versions")
+	ErrCertManagerCRDsNotFound  = fmt.Errorf("the cert-manager CRDs are not yet installed on the Kubernetes API server")
+	ErrVersionNotDetected       = fmt.Errorf("could not detect the cert-manager version")
+	ErrMultipleVersionsDetected = fmt.Errorf("detect multiple different cert-manager versions")
 )
 
 type Version struct {


### PR DESCRIPTION
### Pull Request Motivation

Continuation of what we started in https://github.com/cert-manager/cert-manager/pull/5828.
Changes cmctl to use the logging library used in all our other components.

**NOTE**: I had to split this PR into 2 parts: [part 1](https://github.com/cert-manager/cert-manager/pull/6108) and [part 2](https://github.com/cert-manager/cert-manager/pull/6119) because cmctl uses a pinned cert-manager version. This PR contains all the changes to cert-manager/cert-manager.

### Kind

/kind cleanup

### Release Note

I added the release note in [part 2](https://github.com/cert-manager/cert-manager/pull/6119).
```release-note
NONE
```
