### PR TITLE
Use logging library with json support in cmctl (part 2)

### DIFF
--- a/internal/cmd/util/exit.go
+++ b/internal/cmd/util/exit.go
@@ -23,10 +23,24 @@ import (
 
 // SetExitCode sets the exit code to 1 if the error is not a context.Canceled error.
 func SetExitCode(err error) {
-	if (err != nil) && errors.Is(err, context.DeadlineExceeded) {
-		errorExitCodeChannel <- 124 // Indicate that there was a timeout error
-	} else if (err != nil) && !errors.Is(err, context.Canceled) {
-		errorExitCodeChannel <- 1 // Indicate that there was an error
+	switch {
+	case err == nil || errors.Is(err, context.Canceled):
+		// If the context was canceled, we don't need to set the exit code
+	case errors.Is(err, context.DeadlineExceeded):
+		SetExitCodeValue(124) // Indicate that there was a timeout error
+	default:
+		SetExitCodeValue(1) // Indicate that there was an error
 	}
-	// If the context was canceled, we don't need to set the exit code
+}
+
+// SetExitCode sets the exit code to 1 if the error is not a context.Canceled error.
+func SetExitCodeValue(code int) {
+	if code != 0 {
+		select {
+		case errorExitCodeChannel <- code:
+		default:
+			// The exit code has already been set to a non-zero value.
+		}
+	}
+	// If the exit code is 0, we don't need to set the exit code
 }

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -38,12 +38,13 @@ var (
 )
 
 const (
-	crdsMappingError  = `error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"`
+	crdsMapping1Error = `error finding the scope of the object: failed to get restmapping: failed to find API group "cert-manager.io"`
+	crdsMapping2Error = `error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"`
 	crdsNotFoundError = `the server could not find the requested resource (post certificates.cert-manager.io)`
 )
 
 var (
-	regexErrCertManagerCRDsNotFound   = regexp.MustCompile(`^(` + regexp.QuoteMeta(crdsMappingError) + `|` + regexp.QuoteMeta(crdsNotFoundError) + `)$`)
+	regexErrCertManagerCRDsNotFound   = regexp.MustCompile(`^(` + regexp.QuoteMeta(crdsMapping1Error) + `|` + regexp.QuoteMeta(crdsMapping2Error) + `|` + regexp.QuoteMeta(crdsNotFoundError) + `)$`)
 	regexErrWebhookServiceFailure     = regexp.MustCompile(`Post "(.*)": service "(.*)-webhook" not found`)
 	regexErrWebhookDeploymentFailure  = regexp.MustCompile(`Post "(.*)": (.*): connect: connection refused`)
 	regexErrWebhookCertificateFailure = regexp.MustCompile(`Post "(.*)": x509: certificate signed by unknown authority`)


### PR DESCRIPTION
### Pull Request Motivation

Continuation of what we started in https://github.com/cert-manager/cert-manager/pull/5828.
Changes cmctl to use the logging library used in all our other components.

**NOTE**: I had to split this PR into 3 parts: [part 1](https://github.com/cert-manager/cert-manager/pull/6108), [part 2](https://github.com/cert-manager/cert-manager/pull/6119) and [part 3](https://github.com/cert-manager/cert-manager/pull/6247) because cmctl uses a pinned cert-manager version. This PR contains some remaining changes to cert-manager/cert-manager.

### Kind

/kind cleanup

### Release Note

You can find the release notes in https://github.com/cert-manager/cert-manager/pull/6119

```release-note
NONE
```
