### PR TITLE
Remove service links from http solver pod

### DIFF
--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -188,7 +188,8 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			NodeSelector: map[string]string{
 				"kubernetes.io/os": "linux",
 			},
-			RestartPolicy: corev1.RestartPolicyOnFailure,
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			EnableServiceLinks: pointer.Bool(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: pointer.BoolPtr(s.ACMEOptions.ACMEHTTP01SolverRunAsNonRoot),
 				SeccompProfile: &corev1.SeccompProfile{

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -77,6 +77,7 @@ func TestEnsurePod(t *testing.T) {
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.Bool(false),
+				EnableServiceLinks:           pointer.Bool(false),
 				NodeSelector: map[string]string{
 					"kubernetes.io/os": "linux",
 				},


### PR DESCRIPTION
### Pull Request Motivation

The PR disables the automatic service link injection and fixes https://github.com/cert-manager/cert-manager/issues/6142.
The service link injection is not recommended by k8s and the solver does not need them anyway.

### Kind

bug

### Release Note

```release-note
Fixes a bug that caused the http solver pod to be in crash loop in a cluster with lot of services.
```
