### PR TITLE
Add Venafi custom field support to cert-shim

### DIFF
--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -268,5 +268,9 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		}
 	}
 
+	if venafiAnnotation, found := ingLikeAnnotations[cmapi.VenafiCustomFieldsAnnotationKey]; found {
+		metav1.SetMetaDataAnnotation(&crt.ObjectMeta, cmapi.VenafiCustomFieldsAnnotationKey, venafiAnnotation)
+	}
+
 	return nil
 }

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
+const venafiCustomField = `[
+	{"name": "field-name", "value": "field value"},
+	{"name": "field-name-2", "value": "field value 2"}]`
+
 func Test_translateAnnotations(t *testing.T) {
 	type testCase struct {
 		crt           *cmapi.Certificate
@@ -272,6 +276,16 @@ func Test_translateAnnotations(t *testing.T) {
 				tc.annotations[cmapi.SubjectStreetAddressesAnnotationKey] = "invalid csv\","
 			},
 			expectedError: errInvalidIngressAnnotation,
+		},
+		"pass venafi annotation": {
+			crt: gen.Certificate("venafi-test"),
+			annotations: map[string]string{
+				cmapi.VenafiCustomFieldsAnnotationKey: venafiCustomField,
+			},
+			check: func(a *assert.Assertions, crt *cmapi.Certificate) {
+				annotations := crt.ObjectMeta.GetAnnotations()
+				a.Equal(venafiCustomField, annotations[cmapi.VenafiCustomFieldsAnnotationKey])
+			},
 		},
 	}
 	for name, tc := range tests {


### PR DESCRIPTION
Some setups have a requirement to have custom-field annotation set on Certificate object.

This commit adds support for scraping Venafi custom-fields annotation from ingressLike objects and pass them to Certificate object.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR adds support for Venafi custom-field annotation from ingLike resources

### Kind
Feature

### Release Note

```release-note
NONE
```
