### PR TITLE
Implement relabelings for ServiceMonitor

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -126,6 +126,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `prometheus.servicemonitor.labels` | Add custom labels to ServiceMonitor | |
 | `prometheus.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s` |
 | `prometheus.servicemonitor.honorLabels` | Enable label honoring for metrics scraped by Prometheus (see [Prometheus scrape config docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) for details). By setting `honorLabels` to `true`, Prometheus will prefer label contents given by cert-manager on conflicts. Can be used to remove the "exported_namespace" label for example.  | `false` |
+| `prometheus.servicemonitor.relabelings` | Add relabelings to ServiceMonitor. See [Prometheus RelabelConfig docs](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.RelabelConfig) | `[]` |
 | `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 | `deploymentAnnotations` | Annotations to add to the cert-manager deployment | `{}` |
 | `podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -42,4 +42,7 @@ spec:
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
     honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
+    {{- with .Values.prometheus.servicemonitor.relabelings }}
+    relabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -211,6 +211,7 @@ prometheus:
     labels: {}
     annotations: {}
     honorLabels: false
+    relabelings: []
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Organizations using Prometheus operator rely on ServiceMonitors for scraping metrics of cert-manager. Sometimes it is required to change or add additional labels to metrics. This is supported by the ServiceMonitor CR. This PR adds thhttps://github.com/cert-manager/cert-manager/issues/5215e ability for helm chart users to specify RelabelConfigs to be configured onto the ServiceMonitor included in the cert-manager helm chart.

Ticket https://github.com/cert-manager/cert-manager/issues/5215

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

/kind feature
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Allow specification of relabelings on ServiceMonitor though helm chart values.
```
