### PR TITLE
Add Certificate Hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect

--- a/internal/controller/certificates/policies/constants.go
+++ b/internal/controller/certificates/policies/constants.go
@@ -36,6 +36,12 @@ const (
 	// SecretMismatch is a policy violation reason for a scenario where Secret's
 	// private key does not match spec.
 	SecretMismatch string = "SecretMismatch"
+	// CertificateHashMissing is a policy violation reason for a scenario where
+	// Certificate's hash does not exist on the Secret.
+	CertificateHashMissing string = "CertificateHashMissing"
+	// CertificateHashMismatch is a policy violation reason for a scenario where
+	// Certificate's hash does not match the hash of the certificate on the Secret.
+	CertificateHashMismatch string = "CertificateHashMismatch"
 	// IncorrectIssuer is a policy violation reason for a scenario where
 	// Certificate has been issued by incorrect Issuer.
 	IncorrectIssuer string = "IncorrectIssuer"

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -92,6 +92,10 @@ const (
 	// Annotation key for the 'group' of the Issuer resource.
 	IssuerGroupAnnotationKey = "cert-manager.io/issuer-group"
 
+	// Annotation key for the hash of the Certificate that created the certificate
+	// block encoded in this Secret resource.
+	CertificateHashAnnotationKey = "cert-manager.io/certificate-hash"
+
 	// Annotation key for the name of the certificate that a resource is related to.
 	CertificateNameKey = "cert-manager.io/certificate-name"
 

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -60,6 +60,7 @@ type SecretsManager struct {
 // SecretData is a structure wrapping private key, Certificate and CA data
 type SecretData struct {
 	PrivateKey, Certificate, CA         []byte
+	CertificateHash                     string
 	CertificateName                     string
 	IssuerName, IssuerKind, IssuerGroup string
 }
@@ -198,6 +199,10 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 		secret.Annotations[cmapi.IssuerNameAnnotationKey] = data.IssuerName
 		secret.Annotations[cmapi.IssuerKindAnnotationKey] = data.IssuerKind
 		secret.Annotations[cmapi.IssuerGroupAnnotationKey] = data.IssuerGroup
+	}
+
+	if data.CertificateHash != "" {
+		secret.Annotations[cmapi.CertificateHashAnnotationKey] = data.CertificateHash
 	}
 
 	secret.Labels[cmapi.PartOfCertManagerControllerLabelKey] = "true"

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -393,6 +393,11 @@ func (c *controller) issueCertificate(ctx context.Context, nextRevision int, crt
 		crt.Spec.PrivateKey = &cmapi.CertificatePrivateKey{}
 	}
 
+	certificateHash, err := utilpki.CertificateInfoHash(crt)
+	if err != nil {
+		return err
+	}
+
 	pkData, err := utilpki.EncodePrivateKey(pk, crt.Spec.PrivateKey.Encoding)
 	if err != nil {
 		return err
@@ -401,6 +406,7 @@ func (c *controller) issueCertificate(ctx context.Context, nextRevision int, crt
 		PrivateKey:      pkData,
 		Certificate:     req.Status.Certificate,
 		CA:              req.Status.CA,
+		CertificateHash: certificateHash,
 		CertificateName: crt.Name,
 		IssuerName:      req.Spec.IssuerRef.Name,
 		IssuerKind:      req.Spec.IssuerRef.Kind,

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -36,6 +36,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates/issuing/internal"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -85,6 +86,8 @@ func TestIssuingController(t *testing.T) {
 			LastTransitionTime: &metaFixedClockStart,
 		}),
 	)
+	issuingCertHash, err := utilpki.CertificateInfoHash(issuingCert)
+	require.NoError(t, err)
 
 	tests := map[string]testT{
 		"if certificate is not in Issuing state, then do nothing": {
@@ -514,6 +517,7 @@ func TestIssuingController(t *testing.T) {
 				IssuerName:      "ca-issuer",
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
+				CertificateHash: issuingCertHash,
 			},
 			expectedErr: false,
 		},
@@ -572,6 +576,7 @@ func TestIssuingController(t *testing.T) {
 				IssuerName:      "ca-issuer",
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
+				CertificateHash: issuingCertHash,
 			},
 			expectedErr: false,
 		},
@@ -629,6 +634,7 @@ func TestIssuingController(t *testing.T) {
 				IssuerName:      "ca-issuer",
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
+				CertificateHash: issuingCertHash,
 			},
 			expectedErr: false,
 		},
@@ -687,6 +693,7 @@ func TestIssuingController(t *testing.T) {
 				IssuerName:      "ca-issuer",
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
+				CertificateHash: issuingCertHash,
 			},
 			expectedErr: false,
 		},
@@ -971,6 +978,7 @@ func TestIssuingController(t *testing.T) {
 				IssuerName:      "ca-issuer",
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
+				CertificateHash: issuingCertHash,
 			},
 			expectedErr: false,
 		},

--- a/pkg/controller/certificates/issuing/secret_manager_test.go
+++ b/pkg/controller/certificates/issuing/secret_manager_test.go
@@ -43,6 +43,7 @@ func Test_ensureSecretData(t *testing.T) {
 	block, _ := pem.Decode(pk)
 	pkDER := block.Bytes
 	combinedPEM := append(append(pk, '\n'), cert...)
+	hashValue := "[UNUSED HASH VALUE]"
 
 	tests := map[string]struct {
 		// key that should be passed to ProcessItem.
@@ -89,8 +90,10 @@ func Test_ensureSecretData(t *testing.T) {
 				},
 			},
 			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret"},
-				Data:       map[string][]byte{},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+				},
+				Data: map[string][]byte{},
 			},
 			expectedAction: false,
 		},
@@ -103,7 +106,8 @@ func Test_ensureSecretData(t *testing.T) {
 				},
 			},
 			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue}},
 				Data: map[string][]byte{
 					"tls.key": pk,
 				},
@@ -119,7 +123,9 @@ func Test_ensureSecretData(t *testing.T) {
 				},
 			},
 			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+				},
 				Data: map[string][]byte{
 					"tls.cert": cert,
 				},
@@ -138,7 +144,8 @@ func Test_ensureSecretData(t *testing.T) {
 				},
 			},
 			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -172,7 +179,11 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace", Name: "test-secret",
-					Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"},
+					Annotations: map[string]string{
+						"foo":                              "bar",
+						cmapi.CertificateHashAnnotationKey: hashValue,
+					},
+					Labels: map[string]string{"abc": "123"},
 				},
 				Data: map[string][]byte{
 					"tls.crt": cert,
@@ -195,25 +206,29 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace", Name: "test-secret",
-					Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"},
+					Annotations: map[string]string{
+						"foo":                              "bar",
+						cmapi.CertificateHashAnnotationKey: hashValue,
+					},
+					Labels: map[string]string{"abc": "123"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
 						FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`{"f:metadata": {
-							"f:annotations": {
-								"f:cert-manager.io/common-name": {},
-								"f:cert-manager.io/alt-names": {},
-								"f:cert-manager.io/ip-sans": {},
-								"f:cert-manager.io/uri-sans": {},
-								"f:foo": {},
-								"f:another-annotation": {}
-							},
-							"f:labels": {
-								"f:controller.cert-manager.io/fao": {},
-								"f:abc": {},
-								"f:another-label": {}
-							}
-						}}`),
+									"f:annotations": {
+										"f:cert-manager.io/common-name": {},
+										"f:cert-manager.io/alt-names": {},
+										"f:cert-manager.io/ip-sans": {},
+										"f:cert-manager.io/uri-sans": {},
+										"f:foo": {},
+										"f:another-annotation": {}
+									},
+									"f:labels": {
+										"f:controller.cert-manager.io/fao": {},
+										"f:abc": {},
+										"f:another-label": {}
+									}
+								}}`),
 						},
 					}},
 				},
@@ -238,23 +253,27 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace", Name: "test-secret",
-					Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"},
+					Annotations: map[string]string{
+						"foo":                              "bar",
+						cmapi.CertificateHashAnnotationKey: hashValue,
+					},
+					Labels: map[string]string{"abc": "123"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: "not-cert-manager",
 						FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`{"f:metadata": {
-							"f:annotations": {
-								"f:cert-manager.io/common-name": {},
-								"f:cert-manager.io/alt-names": {},
-								"f:cert-manager.io/ip-sans": {},
-								"f:cert-manager.io/uri-sans": {},
-								"f:foo": {}
-							},
-							"f:labels": {
-								"f:controller.cert-manager.io/fao": {},
-								"f:abc": {}
-							}
-						}}`),
+									"f:annotations": {
+										"f:cert-manager.io/common-name": {},
+										"f:cert-manager.io/alt-names": {},
+										"f:cert-manager.io/ip-sans": {},
+										"f:cert-manager.io/uri-sans": {},
+										"f:foo": {}
+									},
+									"f:labels": {
+										"f:controller.cert-manager.io/fao": {},
+										"f:abc": {}
+									}
+								}}`),
 						}},
 					},
 				},
@@ -280,24 +299,27 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace", Name: "test-secret",
-					Annotations: map[string]string{"foo": "bar"},
-					Labels:      map[string]string{"abc": "123", cmapi.PartOfCertManagerControllerLabelKey: "true"},
+					Annotations: map[string]string{
+						"foo":                              "bar",
+						cmapi.CertificateHashAnnotationKey: hashValue,
+					},
+					Labels: map[string]string{"abc": "123", cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
 						FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`{"f:metadata": {
-							"f:annotations": {
-								"f:cert-manager.io/common-name": {},
-								"f:cert-manager.io/alt-names": {},
-								"f:cert-manager.io/ip-sans": {},
-								"f:cert-manager.io/uri-sans": {},
-								"f:foo": {}
-							},
-							"f:labels": {
-								"f:controller.cert-manager.io/fao": {},
-								"f:abc": {}
-							}
-						}}`),
+									"f:annotations": {
+										"f:cert-manager.io/common-name": {},
+										"f:cert-manager.io/alt-names": {},
+										"f:cert-manager.io/ip-sans": {},
+										"f:cert-manager.io/uri-sans": {},
+										"f:foo": {}
+									},
+									"f:labels": {
+										"f:controller.cert-manager.io/fao": {},
+										"f:abc": {}
+									}
+								}}`),
 						}},
 					},
 				},
@@ -324,7 +346,8 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -348,7 +371,8 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{"foo": "bar"}},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{"foo": "bar"}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -371,7 +395,10 @@ func Test_ensureSecretData(t *testing.T) {
 				},
 			},
 			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace", Name: "test-secret",
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+				},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -391,7 +418,8 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -411,7 +439,8 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -432,7 +461,8 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"}},
 				Data: map[string][]byte{
 					"tls.crt": cert,
 					"tls.key": pk,
@@ -453,31 +483,32 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
 						FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{
-								"f:metadata": {
-									"f:labels": {
-										"f:controller.cert-manager.io/fao": {}
+								{
+									"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
 									},
-									"f:annotations": {
-										"f:cert-manager.io/common-name": {},
-										"f:cert-manager.io/alt-names": {},
-										"f:cert-manager.io/ip-sans": {},
-										"f:cert-manager.io/uri-sans": {}
-									},
-									"f:ownerReferences": {
-										"k:{\"uid\":\"uid-123\"}": {}
+									"f:data": {
+										"f:tls-combined.pem": {},
+										"f:key.der": {}
 									}
-								},
-								"f:data": {
-									"f:tls-combined.pem": {},
-									"f:key.der": {}
-								}
-							}`),
+								}`),
 						},
 					}},
 				},
@@ -500,31 +531,32 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
 						FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{
-								"f:metadata": {
-									"f:labels": {
-										"f:controller.cert-manager.io/fao": {}
-									},
-									"f:annotations": {
-										"f:cert-manager.io/common-name": {},
-										"f:cert-manager.io/alt-names": {},
-										"f:cert-manager.io/ip-sans": {},
-										"f:cert-manager.io/uri-sans": {}
-									},
-									"f:ownerReferences": {
-										"k:{\"uid\":\"uid-123\"}": {}
-									}
-								},
-								"f:data": {
-									"f:tls-combined.pem": {},
-									"f:key.der": {}
-								}
-							}`),
+									{
+										"f:metadata": {
+											"f:labels": {
+												"f:controller.cert-manager.io/fao": {}
+											},
+											"f:annotations": {
+												"f:cert-manager.io/common-name": {},
+												"f:cert-manager.io/alt-names": {},
+												"f:cert-manager.io/ip-sans": {},
+												"f:cert-manager.io/uri-sans": {}
+											},
+											"f:ownerReferences": {
+												"k:{\"uid\":\"uid-123\"}": {}
+											}
+										},
+										"f:data": {
+											"f:tls-combined.pem": {},
+											"f:key.der": {}
+										}
+									}`),
 						},
 					}},
 				},
@@ -546,24 +578,25 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -579,27 +612,28 @@ func Test_ensureSecretData(t *testing.T) {
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
-					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
+					Annotations: map[string]string{cmapi.CertificateHashAnnotationKey: hashValue},
+					Labels:      map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -623,9 +657,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -634,20 +669,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -682,9 +717,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -693,20 +729,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -740,9 +776,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -751,20 +788,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -797,9 +834,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -808,20 +846,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -856,9 +894,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -867,20 +906,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -914,9 +953,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -925,20 +965,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -972,9 +1012,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -983,20 +1024,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -1029,9 +1070,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1040,20 +1082,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+									{"f:metadata": {
+										"f:labels": {
+											"f:controller.cert-manager.io/fao": {}
+										},
+										"f:annotations": {
+											"f:cert-manager.io/common-name": {},
+											"f:cert-manager.io/alt-names": {},
+											"f:cert-manager.io/ip-sans": {},
+											"f:cert-manager.io/uri-sans": {}
+										},
+										"f:ownerReferences": {
+											"k:{\"uid\":\"uid-123\"}": {}
+										}
+									}}`),
 						}},
 					},
 				},
@@ -1088,9 +1130,10 @@ func Test_ensureSecretData(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "test-namespace",
 					Annotations: map[string]string{
-						cmapi.IssuerNameAnnotationKey:  "testissuer",
-						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
-						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+						cmapi.IssuerNameAnnotationKey:      "testissuer",
+						cmapi.IssuerKindAnnotationKey:      "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey:     "group.example.com",
+						cmapi.CertificateHashAnnotationKey: hashValue,
 					},
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					OwnerReferences: []metav1.OwnerReference{
@@ -1099,20 +1142,20 @@ func Test_ensureSecretData(t *testing.T) {
 					ManagedFields: []metav1.ManagedFieldsEntry{
 						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 							Raw: []byte(`
-							{"f:metadata": {
-								"f:labels": {
-									"f:controller.cert-manager.io/fao": {}
-								},
-								"f:annotations": {
-									"f:cert-manager.io/common-name": {},
-									"f:cert-manager.io/alt-names": {},
-									"f:cert-manager.io/ip-sans": {},
-									"f:cert-manager.io/uri-sans": {}
-								},
-								"f:ownerReferences": {
-									"k:{\"uid\":\"uid-123\"}": {}
-								}
-							}}`),
+								{"f:metadata": {
+									"f:labels": {
+										"f:controller.cert-manager.io/fao": {}
+									},
+									"f:annotations": {
+										"f:cert-manager.io/common-name": {},
+										"f:cert-manager.io/alt-names": {},
+										"f:cert-manager.io/ip-sans": {},
+										"f:cert-manager.io/uri-sans": {}
+									},
+									"f:ownerReferences": {
+										"k:{\"uid\":\"uid-123\"}": {}
+									}
+								}}`),
 						}},
 					},
 				},

--- a/pkg/util/pki/internal/infohash/README.md
+++ b/pkg/util/pki/internal/infohash/README.md
@@ -1,0 +1,35 @@
+# infohash
+
+Am extendable hash &amp; comparator that tells you why the hash did not match.
+
+For example if you edit the Name field in a struct, this library will tell
+you that the hash did not match because the Name field was changed.
+
+The hash is extendable, so you can add fields to the struct without breaking
+the hash.
+
+## Space Complexity
+
+Per struct, we store a "global" hash and a "local" hash for each field.
+The global hash is 64 bits long, and the local hashes are 32 bits long.
+We use hamming codes to detect which "local" hash has changed. This requires
+us to store log2(nr_fields+1) 32 bit parity hashes instead of nr_fields 32 bit
+hashes. To store the number of fields, we use 16 bits. The total space complexity
+is therefore:
+
+```
+(16 + 64 + log2(nr_fields+1) * 32) bits
+= (10 + log2(nr_fields+1) * 4) bytes
+= (20 + log2(nr_fields+1) * 8) hex characters
+```
+
+As a rule of thumb, this library is only useful if you have at least +-7 fields,
+otherwise you can just store the hashes of each field individually.
+
+## Safety
+
+This library will detect any changes to the struct (with collision chance of 1/2^32, accounting for birthday attack).
+However, accurately detecting which field changed is only possible if only one field changed.
+If multiple fields changed, we can only detect that at least one field changed, but not which one.
+This is because we use hamming codes to detect which field changed, and hamming codes can only detect
+single field errors.

--- a/pkg/util/pki/internal/infohash/errors.go
+++ b/pkg/util/pki/internal/infohash/errors.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+import "fmt"
+
+// ErrInvalidHash is returned by Compare if the hash is invalid.
+var ErrInvalidHash = fmt.Errorf("invalid hash")
+
+// FieldChangedError is returned by Compare if the hashes indicate
+// that the fields have changed.
+type FieldChangedError struct {
+	// Change contains the field that changed and its new value.
+	// If we do know which field changed (eg. because there were
+	// multiple changes), Change will be nil.
+	Change *FieldChange
+}
+
+type FieldChange struct {
+	FieldName string
+	NewValue  interface{}
+}
+
+func (e FieldChangedError) Error() string {
+	if e.Change == nil {
+		return "field changed"
+	}
+
+	newValue := prettyPrintConfigForHash.Sprintf("%#v", e.Change.NewValue)
+
+	return "field changed: " + e.Change.FieldName + " to " + newValue
+}

--- a/pkg/util/pki/internal/infohash/hamming.go
+++ b/pkg/util/pki/internal/infohash/hamming.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+func calculateParityCodes(values []uint32) []uint32 {
+	log2NumberOfFieldsPlusOne := log2OfXPlusOne(uint32(len(values)))
+	parityCodes := make([]uint32, log2NumberOfFieldsPlusOne)
+
+	for id, field := range values {
+		for i := range parityCodes {
+			if (id+1)&(1<<i) != 0 {
+				parityCodes[i] ^= field
+			}
+		}
+	}
+
+	return parityCodes
+}
+
+func findErrorLocation(values []uint32, parityCodes []uint32) (int, error) {
+	expectedCode := calculateParityCodes(values)
+	var errorLocation uint32
+
+	if len(parityCodes) != len(expectedCode) {
+		return 0, ErrInvalidHash
+	}
+
+	for i := range parityCodes {
+		if parityCodes[i] != expectedCode[i] {
+			errorLocation |= 1 << i
+		}
+	}
+
+	if errorLocation == 0 || errorLocation > uint32(len(values)) {
+		// Could not find the error location (there is probably more than one error)
+		return -1, nil
+	}
+
+	return int(errorLocation - 1), nil
+}
+
+func log2OfXPlusOne(x uint32) uint32 {
+	var r uint32
+	for x > 0 {
+		x >>= 1
+		r += 1
+	}
+	return r
+}

--- a/pkg/util/pki/internal/infohash/hasher.go
+++ b/pkg/util/pki/internal/infohash/hasher.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+import (
+	"hash/fnv"
+	"io"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func New() Hasher {
+	return &hasher{}
+}
+
+type hasher struct {
+	fields []field
+}
+
+var _ Hasher = &hasher{}
+
+type field struct {
+	name         string
+	value        interface{}
+	defaultValue interface{}
+}
+
+func (h *hasher) WriteFieldWithDefault(name string, value interface{}, defaultValue interface{}) Hasher {
+	// Make sure that the default value is always the same type as the value.
+	if reflect.TypeOf(value) != reflect.TypeOf(defaultValue) {
+		panic("PROGRAMMING ERROR: The default value must be the same type as the value")
+	}
+
+	// Make sure we don't add too many fields. The length of the fields slice is stored in a uint16.
+	if len(h.fields) >= 65535 {
+		panic("PROGRAMMING ERROR: too many fields passed to checkHash, max is 65535")
+	}
+
+	h.fields = append(h.fields, field{name, value, defaultValue})
+	return h
+}
+
+func (h *hasher) WriteField(name string, value interface{}) Hasher {
+	return h.WriteFieldWithDefault(name, value, reflect.Zero(reflect.TypeOf(value)).Interface())
+}
+
+func (h *hasher) Sum() ([]byte, error) {
+	fullHash, fieldHashes, err := calculateAllHashes(h.fields)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldCount := uint16(len(fieldHashes))
+	fieldCountBytes := uint16ToSlice(fieldCount)
+
+	fullHashBytes := uint64ToSlice(fullHash)
+
+	parityCodes := calculateParityCodes(fieldHashes)
+	parityCodesBytes := uint32SliceToByteSlice(parityCodes)
+
+	bytes := make([]byte, 0, len(fieldCountBytes)+len(fullHashBytes)+len(parityCodesBytes))
+	bytes = append(bytes, fieldCountBytes...)
+	bytes = append(bytes, fullHashBytes...)
+	bytes = append(bytes, parityCodesBytes...)
+	return bytes, nil
+}
+
+func (h *hasher) Compare(hash []byte) error {
+	// Check that the hash is at least 10 bytes long.
+	// 2 bytes for the field count, 8 bytes for the full hash.
+	if len(hash) < 10 {
+		return ErrInvalidHash
+	}
+
+	// Check that the parity codes are a multiple of 4 bytes.
+	if len(hash[10:])%4 != 0 {
+		return ErrInvalidHash
+	}
+
+	fieldCount := uint16FromSlice(hash)
+
+	if len(h.fields) < int(fieldCount) {
+		return ErrInvalidHash
+	}
+
+	// Check that all the new field values are equal to the default values.
+	nonHashedFields := h.fields[fieldCount:]
+	if len(nonHashedFields) > 0 {
+		fullHasher1 := fnv.New64a()
+		fullHasher2 := fnv.New64a()
+		for _, info := range nonHashedFields {
+			fullHasher1.Reset()
+			fullHasher2.Reset()
+
+			if err := stablePrint(fullHasher1, info.value); err != nil {
+				return err
+			}
+
+			if err := stablePrint(fullHasher2, info.defaultValue); err != nil {
+				return err
+			}
+
+			if fullHasher1.Sum64() != fullHasher2.Sum64() {
+				return FieldChangedError{
+					Change: &FieldChange{
+						FieldName: info.name,
+						NewValue:  info.value,
+					},
+				}
+			}
+		}
+	}
+
+	// Check that all the fields in the hash are equal to the fields in the struct.
+	hashedFields := h.fields[:fieldCount]
+
+	objFullHash, objFieldHashes, err := calculateAllHashes(hashedFields)
+	if err != nil {
+		return err
+	}
+
+	fullHash := uint64FromSlice(hash[2:10])
+	if objFullHash == fullHash {
+		// Happy path, no fields have changed.
+		return nil
+	}
+
+	parityCodes := uint32SliceFromByteSlice(hash[10:])
+	location, err := findErrorLocation(objFieldHashes, parityCodes)
+	if err != nil {
+		return err
+	}
+
+	if location > 0 {
+		return FieldChangedError{
+			Change: &FieldChange{
+				FieldName: hashedFields[location].name,
+				NewValue:  hashedFields[location].value,
+			},
+		}
+	}
+
+	return FieldChangedError{}
+}
+
+func calculateAllHashes(fields []field) (uint64, []uint32, error) {
+	fieldHashes := make([]uint32, 0, len(fields))
+
+	fullHasher := fnv.New64a()
+	fieldHasher := fnv.New32a()
+	multiWriter := io.MultiWriter(fullHasher, fieldHasher)
+
+	for _, info := range fields {
+		fieldHasher.Reset()
+
+		if err := stablePrint(multiWriter, info.value); err != nil {
+			return 0, nil, err
+		}
+
+		fieldHashes = append(fieldHashes, fieldHasher.Sum32())
+	}
+
+	return fullHasher.Sum64(), fieldHashes, nil
+}
+
+func stablePrint(writer io.Writer, v interface{}) error {
+	_, err := prettyPrintConfigForHash.Fprintf(writer, "%#v", v)
+	return err
+}
+
+// The config MUST NOT be changed because that could change the result of a hash operation
+// Based on: https://github.com/kubernetes/kubernetes/blob/f7cb8a5e8a860df643e143cde54d34080372b771/staging/src/k8s.io/apimachinery/pkg/util/dump/dump.go#L47
+var prettyPrintConfigForHash = &spew.ConfigState{
+	Indent:                  " ",
+	SortKeys:                true,
+	DisableMethods:          true,
+	SpewKeys:                true,
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+}

--- a/pkg/util/pki/internal/infohash/hasher_test.go
+++ b/pkg/util/pki/internal/infohash/hasher_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestHasher_SumAndCompare(t *testing.T) {
+	tests := []struct {
+		hash1    Hasher
+		hash2    Hasher
+		expected error
+	}{
+		{
+			hash1:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			hash2:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			expected: nil,
+		},
+		{
+			hash1:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			hash2:    New().WriteField("name1", "value1").WriteField("name2", 999),
+			expected: FieldChangedError{Change: &FieldChange{FieldName: "name2", NewValue: 999}},
+		},
+		{
+			// We allow fields to be renamed
+			hash1:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			hash2:    New().WriteField("name1", "value1").WriteField("name3", 123),
+			expected: nil,
+		},
+		{
+			// We allow new fields to be added (compare will fail if the new field has a
+			// different value than the default value)
+			hash1:    New().WriteField("name1", "value1"),
+			hash2:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			expected: FieldChangedError{Change: &FieldChange{FieldName: "name2", NewValue: 123}},
+		},
+		{
+			// We allow new fields to be added (compare will succeed if the new field has the
+			// same value as the default value)
+			hash1:    New().WriteField("name1", "value1"),
+			hash2:    New().WriteField("name1", "value1").WriteField("name2", 0),
+			expected: nil,
+		},
+
+		{
+			// We cannot detect a breaking default change, so we return nil.
+			// WARNING: The user of the library should add unit tests to prevent this from happening.
+			hash1:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			hash2:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			expected: nil,
+		},
+		{
+			// We cannot detect a breaking change in the order of the fields, so we detect a changed field.
+			// WARNING: The user of the library should add unit tests to prevent this from happening.
+			hash1:    New().WriteField("name1", "value1").WriteField("name2", 123),
+			hash2:    New().WriteField("name2", 123).WriteField("name1", "value1"),
+			expected: FieldChangedError{},
+		},
+	}
+
+	for id, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("test-%d", id+1), func(t *testing.T) {
+			sum1, err := test.hash1.Sum()
+			if err != nil {
+				t.Fatalf("Expected nil, but got %v", err)
+			}
+
+			{
+				err := test.hash2.Compare(sum1)
+				// if err != nil and test.expected == nil, or if err == nil and test.expected != nil
+				if (err != nil) != (test.expected != nil) {
+					t.Fatalf("Expected %v, but got %v", test.expected, err)
+				}
+
+				// if err != nil and test.expected != nil
+				if err != nil && err.Error() != test.expected.Error() {
+					t.Fatalf("Expected %v, but got %v", test.expected, err)
+				}
+			}
+		})
+	}
+}
+
+func Test_Sum_Static(t *testing.T) {
+	sum, err := New().
+		WriteField("name1", "value1").
+		WriteField("name2", 123).
+		WriteField("name3", []byte{1, 2, 3}).
+		WriteField("name4", 123.456).
+		WriteField("name5", &struct{ aa int }{aa: 123}).
+		Sum()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hexSum := fmt.Sprintf("%x", sum)
+
+	if hexSum != "0005b9e8e77d08167637824ae2b158f389cf41b41f87" {
+		t.Fatalf("the hash has changed: %s", hexSum)
+	}
+}
+
+func Test_Sum_Length(t *testing.T) {
+	makeHashSum := func(i int) ([]byte, error) {
+		hasher := New()
+		for j := 0; j < i; j++ {
+			hasher.WriteField(fmt.Sprintf("name%d", j), true)
+		}
+		return hasher.Sum()
+	}
+
+	for i := 0; i < 128; i++ {
+		hash, err := makeHashSum(i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log2NumberOfFieldsPlusOne := int(math.Ceil(math.Log2(float64(i + 1))))
+
+		if len(hash) != (16+64+log2NumberOfFieldsPlusOne*32)/8 {
+			t.Fatalf("the hash length is wrong: %d != %d", len(hash), (64+log2NumberOfFieldsPlusOne*32)/8)
+		}
+
+		// hash length in case we would store a hash for each field:
+		// 16 + 64 + 32 * (i - 1)
+		hashForEachField := (16 + 64 + 32*math.Max(0, float64(i-1))) / 8
+
+		t.Logf("number of fields: %d, infohash length: %d bytes, per-field hash length: %f bytes, relative change: %f %%", i, len(hash), hashForEachField, 100*(float64(len(hash))-hashForEachField)/hashForEachField)
+	}
+}

--- a/pkg/util/pki/internal/infohash/interface.go
+++ b/pkg/util/pki/internal/infohash/interface.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+// Hasher can be used to hash a object.
+type Hasher interface {
+	// WriteField adds a field to the hash. Hashes can be extended
+	// with new fields without invalidating existing hashes by writing
+	// more fields, as long as the first N calls to WriteField have the same
+	// value and defaultVlaue and are called in the same order, the longer hash
+	// must than match the default values for the new fields.
+	//
+	// eg.
+	// 	hashv1_sum := New().WriteField("a", "value").WriteField("b", 2).Sum()
+	//  New().
+	//    WriteField("a", "value").
+	//    WriteField("b", 2).
+	//    WriteFieldWithDefault("c", 3, 3).
+	//    Compare(hashv1_sum) // == nil
+	//  New().
+	//    WriteField("a", "value").
+	//    WriteField("b", 2).
+	//    WriteFieldWithDefault("c", 4, 3).
+	//    Compare(hashv1_sum) // == FieldChangedError{Change: &FieldChange{FieldName: "c", NewValue: 4}}
+	//
+	WriteFieldWithDefault(name string, value interface{}, defaultValue interface{}) Hasher
+
+	// WriteField is similar to WriteFieldWithDefault, but it assumes the default
+	// value is the zero value of the type of the field.
+	WriteField(name string, value interface{}) Hasher
+
+	// Sum returns the hash of the fields written so far. It tries to
+	// be space efficient in case you want to know what field changed
+	// and the object has 7+ fields, and long field values (longer than
+	// 64 bits). Otherwise, storing the full object is probably more
+	// space efficient for your usecase.
+	// The output of Sum is a byte slice and can be compared with the
+	// Compare function. Different byte slices can still represent the
+	// same object, so it's important to use the Compare function instead
+	// of doing a byte slice comparison.
+	Sum() ([]byte, error)
+
+	// Compare returns true if the written fields match the hash. It will
+	// return true if the hashes contain the same fields, in the same order.
+	// Even if you have written more fields than the provided hash, as long as
+	// the extra fields match the default values, Compare will consider them
+	// equal.
+	// If the hashes are different, Compare will return a FieldChangedError.
+	// This error contains the name of the field that was changed and the
+	// new value. If more than one field was changed, Compare will return
+	// a FieldChangedError with an empty Change field.
+	Compare(hash []byte) error
+}

--- a/pkg/util/pki/internal/infohash/uintencode.go
+++ b/pkg/util/pki/internal/infohash/uintencode.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+func uint16FromSlice(s []byte) uint16 {
+	return uint16(0) |
+		uint16(s[1])<<0 |
+		uint16(s[0])<<8
+}
+
+func uint16ToSlice(i uint16) []byte {
+	return []byte{
+		byte(0xff & (i >> 8)),
+		byte(0xff & (i >> 0)),
+	}
+}
+
+func uint64FromSlice(s []byte) uint64 {
+	return uint64(0) |
+		uint64(s[7])<<0 |
+		uint64(s[6])<<8 |
+		uint64(s[5])<<16 |
+		uint64(s[4])<<24 |
+		uint64(s[3])<<32 |
+		uint64(s[2])<<40 |
+		uint64(s[1])<<48 |
+		uint64(s[0])<<56
+}
+
+func uint64ToSlice(i uint64) []byte {
+	return []byte{
+		byte(0xff & (i >> 56)),
+		byte(0xff & (i >> 48)),
+		byte(0xff & (i >> 40)),
+		byte(0xff & (i >> 32)),
+		byte(0xff & (i >> 24)),
+		byte(0xff & (i >> 16)),
+		byte(0xff & (i >> 8)),
+		byte(0xff & (i >> 0)),
+	}
+}
+
+func uint32SliceFromByteSlice(s []byte) []uint32 {
+	out := make([]uint32, len(s)/4)
+
+	for i := range out {
+		out[i] = uint32(s[i*4+3])<<0 |
+			uint32(s[i*4+2])<<8 |
+			uint32(s[i*4+1])<<16 |
+			uint32(s[i*4+0])<<24
+	}
+
+	return out
+}
+
+func uint32SliceToByteSlice(i []uint32) []byte {
+	out := make([]byte, len(i)*4)
+
+	for j := range i {
+		out[j*4+3] = byte(0xff & (i[j] >> 0))
+		out[j*4+2] = byte(0xff & (i[j] >> 8))
+		out[j*4+1] = byte(0xff & (i[j] >> 16))
+		out[j*4+0] = byte(0xff & (i[j] >> 24))
+	}
+
+	return out
+}

--- a/pkg/util/pki/internal/infohash/uintencode_test.go
+++ b/pkg/util/pki/internal/infohash/uintencode_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infohash
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+)
+
+func TestUint16FromSlice(t *testing.T) {
+	if uint16FromSlice([]byte{0x12, 0x34}) != 0x1234 {
+		t.Error("uint16FromSlice failed")
+	}
+}
+
+func TestUint16ToSlice(t *testing.T) {
+	if !bytes.Equal(uint16ToSlice(0x1234), []byte{0x12, 0x34}) {
+		t.Error("uint16ToSlice failed")
+	}
+}
+
+func TestUint64FromSlice(t *testing.T) {
+	if uint64FromSlice([]byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}) != 0x123456789abcdef0 {
+		t.Error("uint64FromSlice failed")
+	}
+}
+
+func TestUint64ToSlice(t *testing.T) {
+	if !bytes.Equal(uint64ToSlice(0x123456789abcdef0), []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}) {
+		t.Error("uint64ToSlice failed")
+	}
+}
+
+func TestUint32SliceFromByteSlice(t *testing.T) {
+	if !slices.Equal(uint32SliceFromByteSlice([]byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}), []uint32{0x12345678, 0x9abcdef0}) {
+		t.Error("uint32SliceFromByteSlice failed")
+	}
+}
+
+func TestUint32SliceToByteSlice(t *testing.T) {
+	if !bytes.Equal(uint32SliceToByteSlice([]uint32{0x12345678, 0x9abcdef0}), []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}) {
+		t.Error("uint32SliceToByteSlice failed")
+	}
+}

--- a/pkg/util/pki/match.go
+++ b/pkg/util/pki/match.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+
 	"fmt"
 	"net"
 	"reflect"
@@ -125,6 +126,7 @@ func ipSlicesMatch(parsedIPs []net.IP, stringIPs []string) bool {
 // and returns a list of field names on the Certificate that do not match their
 // counterpart fields on the CertificateRequest.
 // If decoding the x509 certificate request fails, an error will be returned.
+// Deprecated: use CertificateInfoHash and IsCertificateUpToDateWithInfoHash instead.
 func RequestMatchesSpec(req *cmapi.CertificateRequest, spec cmapi.CertificateSpec) ([]string, error) {
 	x509req, err := DecodeX509CertificateRequestBytes(req.Spec.Request)
 	if err != nil {

--- a/test/e2e/suite/certificates/certificatehash.go
+++ b/test/e2e/suite/certificates/certificatehash.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+var _ = framework.CertManagerDescribe("Certificate Hash", func() {
+	const (
+		certificateName = "test-hash-cert"
+		issuerName      = "certificate-hash-name"
+		secretName      = "test-hash-name"
+	)
+
+	f := framework.NewDefaultFramework("certificates-hash-name")
+	ctx := context.Background()
+
+	createCertificate := func(f *framework.Framework, name string) *cmapi.Certificate {
+		crt := &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: f.Namespace.Name,
+			},
+			Spec: cmapi.CertificateSpec{
+				CommonName: "test",
+				SecretName: secretName,
+				PrivateKey: &cmapi.CertificatePrivateKey{
+					RotationPolicy: cmapi.RotationPolicyAlways,
+				},
+				IssuerRef: cmmeta.ObjectReference{
+					Name:  issuerName,
+					Kind:  "Issuer",
+					Group: "cert-manager.io",
+				},
+			},
+		}
+
+		By("creating Certificate")
+
+		crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.Background(), crt, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		return crt
+	}
+
+	BeforeEach(func() {
+		By("creating a self-signing issuer")
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}))
+		Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
+
+		By("Waiting for Issuer to become Ready")
+		err := e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName, cmapi.IssuerCondition{Type: cmapi.IssuerConditionReady, Status: cmmeta.ConditionTrue})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.Background(), issuerName, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+	})
+
+	FIt("A newly created certificate should have a hash annotation and changes to the spec should be detected even after delting the certificate request", func() {
+		crt := createCertificate(f, certificateName)
+		var secretBytes []byte
+
+		By("Waiting for Certificate to become Ready")
+		_, err := f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has a hash annotation")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		secretBytes = secret.Data["tls.crt"]
+
+		By("Deleting the CertificateRequest")
+		Expect(f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).NotTo(HaveOccurred())
+
+		By("Deleting and recreating the Certificate")
+		Expect(f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Delete(context.Background(), crt.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+		crt = createCertificate(f, certificateName)
+
+		By("Waiting for Certificate to become Ready")
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has same hash annotation and has not been updated")
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		Expect(secret.Data["tls.crt"]).To(Equal(secretBytes))
+
+		By("Updating the Certificate spec")
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(ctx, crt.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			crt.Spec.CommonName = "test2"
+			_, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(ctx, crt, metav1.UpdateOptions{})
+			return err
+		})).NotTo(HaveOccurred())
+
+		By("Waiting for Certificate to become Ready")
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has a new hash annotation & has been updated")
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		Expect(secret.Data["tls.crt"]).NotTo(Equal(secretBytes))
+	})
+
+	It("An existing certificate without hash annotation should get a hash annotation without reissuance", func() {
+		crt := createCertificate(f, certificateName)
+		var secretBytes []byte
+
+		By("Waiting for Certificate to become Ready")
+		_, err := f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has a hash annotation")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		secretBytes = secret.Data["tls.crt"]
+
+		By("Deleting the CertificateRequest")
+		Expect(f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).NotTo(HaveOccurred())
+
+		By("Deleting and recreating the Certificate")
+		Expect(f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Delete(context.Background(), crt.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+		crt = createCertificate(f, certificateName)
+
+		By("Removing the hash annotation")
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			delete(secret.Annotations, cmapi.CertificateHashAnnotationKey)
+			_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+			return err
+		})).NotTo(HaveOccurred())
+
+		By("Waiting for Certificate to become Ready")
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has same hash annotation and has not been updated")
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		Expect(secret.Data["tls.crt"]).To(Equal(secretBytes))
+
+		By("Updating the Certificate spec")
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			crt, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Get(ctx, crt.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			crt.Spec.CommonName = "test2"
+			_, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Update(ctx, crt, metav1.UpdateOptions{})
+			return err
+		})).NotTo(HaveOccurred())
+
+		By("Waiting for Certificate to become Ready")
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(crt, time.Second*10)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("Checking that the Certificate Secret has a new hash annotation & has been updated")
+		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Annotations).To(HaveKeyWithValue(cmapi.CertificateHashAnnotationKey, Not(BeEmpty())))
+		Expect(secret.Data["tls.crt"]).NotTo(Equal(secretBytes))
+	})
+})


### PR DESCRIPTION
Replace all current matching logic with a simple Certificate Hash that can be used to detect if the Certificate resource changed after the Secret was created/ updated.

The main goal of this PR is to be able to determine if a Secret is up-to-date for the specified Certificate resource without requiring CertificateRequest resources to exist. In the long term, this logic will replace existing matching logic and simplify the change detection mechanisms.

- We cannot use the issued certificate blob in the Secret to determine if the Certificate resource is up-to-date, because the CA might have issued a Certificate that does not match the properties requested in the Certificate resource.
- Instead, we add a hash to each Secret. This hash is created when the Secret is created and is based on the Certificate that requested the certificate in the Secret. The hash also adds parity bits to detect what field changed in case we detect a change.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
