### PR TITLE
BUGFIX: Stricter CertificateRequest CSR webhook validation

### DIFF
--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -47,6 +47,13 @@ const (
 	// This feature gate must be used together with LiteralCertificateSubject webhook feature gate.
 	// See https://github.com/cert-manager/cert-manager/issues/3203 and https://github.com/cert-manager/cert-manager/issues/4424 for context.
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
+
+	// Owner (responsible for graduating feature through to GA): @inteon
+	// GA: v1.13
+	// DontAllowInsecureCSRUsageDefinition will prevent the webhook from allowing
+	// CertificateRequest's usages to be only defined in the CSR, while leaving
+	// the usages field empty.
+	DontAllowInsecureCSRUsageDefinition featuregate.Feature = "DontAllowInsecureCSRUsageDefinition"
 )
 
 func init() {
@@ -61,6 +68,8 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	DontAllowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
+
 	AdditionalCertificateOutputFormats: {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:          {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/api/util/kube.go
+++ b/pkg/api/util/kube.go
@@ -91,6 +91,10 @@ func KubeExtKeyUsageStrings(usage []x509.ExtKeyUsage) []certificatesv1.KeyUsage 
 
 // kubeKeyUsageString returns the cmapi.KeyUsage and "unknown" if not found
 func kubeKeyUsageString(usage x509.KeyUsage) certificatesv1.KeyUsage {
+	if usage == x509.KeyUsageDigitalSignature {
+		return certificatesv1.UsageDigitalSignature // we have two keys that map to KeyUsageDigitalSignature in our map, we should be consistent when parsing
+	}
+
 	for k, v := range keyUsagesKube {
 		if usage == v {
 			return k
@@ -102,6 +106,10 @@ func kubeKeyUsageString(usage x509.KeyUsage) certificatesv1.KeyUsage {
 
 // kubeExtKeyUsageString returns the cmapi.ExtKeyUsage and "unknown" if not found
 func kubeExtKeyUsageString(usage x509.ExtKeyUsage) certificatesv1.KeyUsage {
+	if usage == x509.ExtKeyUsageEmailProtection {
+		return certificatesv1.UsageEmailProtection // we have two keys that map to ExtKeyUsageEmailProtection in our map, we should be consistent when parsing
+	}
+
 	for k, v := range extKeyUsagesKube {
 		if usage == v {
 			return k

--- a/pkg/api/util/usages.go
+++ b/pkg/api/util/usages.go
@@ -90,10 +90,11 @@ func ExtKeyUsageStrings(usage []x509.ExtKeyUsage) []cmapi.KeyUsage {
 
 // keyUsageString returns the cmapi.KeyUsage and "unknown" if not found
 func keyUsageString(usage x509.KeyUsage) cmapi.KeyUsage {
+	if usage == x509.KeyUsageDigitalSignature {
+		return cmapi.UsageDigitalSignature // we have two keys that map to KeyUsageDigitalSignature in our map, we should be consistent when parsing
+	}
+
 	for k, v := range keyUsages {
-		if usage == x509.KeyUsageDigitalSignature {
-			return cmapi.UsageDigitalSignature // we have KeyUsageDigitalSignature twice in our array, we should be consistent when parsing
-		}
 		if usage == v {
 			return k
 		}
@@ -104,6 +105,10 @@ func keyUsageString(usage x509.KeyUsage) cmapi.KeyUsage {
 
 // extKeyUsageString returns the cmapi.ExtKeyUsage and "unknown" if not found
 func extKeyUsageString(usage x509.ExtKeyUsage) cmapi.KeyUsage {
+	if usage == x509.ExtKeyUsageEmailProtection {
+		return cmapi.UsageEmailProtection // we have two keys that map to ExtKeyUsageEmailProtection in our map, we should be consistent when parsing
+	}
+
 	for k, v := range extKeyUsages {
 		if usage == v {
 			return k

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cert-manager/cert-manager/integration-tests/framework"
@@ -100,7 +101,8 @@ func TestValidationCertificateRequests(t *testing.T) {
 					IssuerRef: cmmeta.ObjectReference{Name: "test"},
 				},
 			},
-			expectError: false,
+			expectError: true,
+			errorSuffix: "csr key usages do not match specified usages, these should match if both are set: [[]certmanager.KeyUsage[3] != []certmanager.KeyUsage[2]]",
 		},
 		"No errors on valid certificaterequest with special usages only set in spec": {
 			input: &cmapi.CertificateRequest{
@@ -111,8 +113,9 @@ func TestValidationCertificateRequests(t *testing.T) {
 				Spec: cmapi.CertificateRequestSpec{
 					Request: mustGenerateCSR(t, &cmapi.Certificate{
 						Spec: cmapi.CertificateSpec{
-							DNSNames: []string{"example.com"},
-							Usages:   []cmapi.KeyUsage{},
+							DNSNames:              []string{"example.com"},
+							Usages:                []cmapi.KeyUsage{},
+							EncodeUsagesInRequest: pointer.Bool(false),
 						},
 					}),
 					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
@@ -150,8 +153,9 @@ func TestValidationCertificateRequests(t *testing.T) {
 				Spec: cmapi.CertificateRequestSpec{
 					Request: mustGenerateCSR(t, &cmapi.Certificate{
 						Spec: cmapi.CertificateSpec{
-							DNSNames: []string{"example.com"},
-							Usages:   []cmapi.KeyUsage{},
+							DNSNames:              []string{"example.com"},
+							Usages:                []cmapi.KeyUsage{},
+							EncodeUsagesInRequest: pointer.Bool(false),
 						},
 					}),
 					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/api"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -174,6 +175,170 @@ func TestValidationCertificateRequests(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 			defer cancel()
+
+			// The default is true, but we set it here to make sure it was not changed by other tests
+			utilfeature.DefaultMutableFeatureGate.Set("DontAllowInsecureCSRUsageDefinition=true")
+
+			config, stop := framework.RunControlPlane(t, ctx)
+			defer stop()
+
+			framework.WaitForOpenAPIResourcesToBeLoaded(t, ctx, config, certGVK)
+
+			// create the object to get any errors back from the webhook
+			cl, err := client.New(config, client.Options{Scheme: api.Scheme})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = cl.Create(ctx, cert)
+			if test.expectError != (err != nil) {
+				t.Errorf("unexpected error, exp=%t got=%v",
+					test.expectError, err)
+			}
+			if test.expectError && !strings.HasSuffix(err.Error(), test.errorSuffix) {
+				t.Errorf("unexpected error suffix, exp=%s got=%s",
+					test.errorSuffix, err)
+			}
+		})
+	}
+}
+
+// TestValidationCertificateRequests_DontAllowInsecureCSRUsageDefinition_false makes sure that the
+// validation webhook keeps working as before when the DontAllowInsecureCSRUsageDefinition feature
+// gate is disabled.
+func TestValidationCertificateRequests_DontAllowInsecureCSRUsageDefinition_false(t *testing.T) {
+	tests := map[string]struct {
+		input       runtime.Object
+		errorSuffix string // is a suffix as the API server sends the whole value back in the error
+		expectError bool
+	}{
+		"No errors on valid certificaterequest with no usages set": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames: []string{"example.com"},
+						},
+					}),
+					Usages:    []cmapi.KeyUsage{},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on valid certificaterequest with special usages set": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+						},
+					}),
+					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on valid certificaterequest with special usages set only in CSR": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+						},
+					}),
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on valid certificaterequest with special usages only set in spec": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames:              []string{"example.com"},
+							Usages:                []cmapi.KeyUsage{},
+							EncodeUsagesInRequest: pointer.Bool(false),
+						},
+					}),
+					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"Errors on certificaterequest with mismatch of usages": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+						},
+					}),
+					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageCodeSigning},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: true,
+			errorSuffix: "csr key usages do not match specified usages, these should match if both are set: [[2]: \"client auth\" != \"code signing\"]",
+		},
+		"Shouldn't error when setting user info, since this will be overwritten by the mutating webhook": {
+			input: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: cmapi.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &cmapi.Certificate{
+						Spec: cmapi.CertificateSpec{
+							DNSNames:              []string{"example.com"},
+							Usages:                []cmapi.KeyUsage{},
+							EncodeUsagesInRequest: pointer.Bool(false),
+						},
+					}),
+					Usages:    []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+					Username:  "user-1",
+					Groups:    []string{"group-1", "group-2"},
+				},
+			},
+			expectError: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cert := test.input.(*cmapi.CertificateRequest)
+			cert.SetGroupVersionKind(certGVK)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+			defer cancel()
+
+			utilfeature.DefaultMutableFeatureGate.Set("DontAllowInsecureCSRUsageDefinition=false")
 
 			config, stop := framework.RunControlPlane(t, ctx)
 			defer stop()


### PR DESCRIPTION
### Pull Request Motivation

While creating https://github.com/cert-manager/cert-manager/pull/6056, we realised that the current CertificateRequest CSR webhook validation logic is too permissive:
If CertificateRequest.Usages is empty and the KeyUsages are only set as an extension in the CSR blob, the validation webhook allows this CertificateRequest to be created. However, some solutions (like approver-policy) depend on the Usages always being defined in the Usages array.

This is a quick summary of the current webhook behavior vs the new behavior:
| situation                    | before                      | after                                      |
|------------------------------|-----------------------------|--------------------------------------------|
| usages in CertReq & CSR blob | error if !=                 | error if !=                                |
| usages only in CertReq       | allow (use CertReq usages)  | allow (use CertReq usages)                 |
| usages only in CSR blob      | allow (use CSR blob usages) | error if CSR blob usages != default usages |
| no usages defined            | allow (use default usages)  | allow (use default usages)                 |

Important note: The current webhook behavior differs from our assumptions made in approver-policy & our assumptions made in our Certificate Template logic (https://github.com/cert-manager/cert-manager/blob/master/pkg/util/pki/certificatetemplate.go#L206).

Making the validation webhook stricter is always a breaking change, however I think it is justified because it makes cert-manager more secure (after this change, you can rely purely on the Usages array in the CertReq to make policy decisions). Also, there is no existing implementation that uses the CSR blob as sole source of truth for the usages. (see examples below)
[OK] csi-driver sets Usages only on CertReq: https://github.com/cert-manager/csi-driver/blob/ebe0181784d79b8514bb77a5e516ea978da4c6bd/pkg/requestgen/generator.go#L76-L95
[OK] csi-driver-spiffe sets Usages only on CertReq: https://github.com/cert-manager/csi-driver-spiffe/blob/main/internal/csi/driver/driver.go#L274-L289
[OK] istio-csr sets Usages both on CertReq and CSR blob: https://github.com/cert-manager/istio-csr/blob/main/pkg/server/server.go#L180

### Kind

/kind bug

### Release Note

```release-note
⚠️ possibly breaking: Webhook validation of CertificateRequest resources is stricter now: all KeyUsages and ExtendedKeyUsages must be defined directly in the CertificateRequest resource, the encoded CSR can never contain more usages that defined there.
```
