### PR TITLE
Honor KIND_CLUSTER_NAME for e2e-setup & clean

### DIFF
--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -26,7 +26,7 @@ source ./make/kind_images.sh
 
 mode=kind
 k8s_version=1.27
-kind_cluster_name=kind
+name=kind
 
 help() {
   cat <<EOF
@@ -68,6 +68,10 @@ while [ $# -ne 0 ]; do
     help
     exit 0
     ;;
+    # This block of code will create the variable associated the flags,
+    # $mode, $name, and $k8s_version and then set them to the value provided.
+    # E.g. "--name pinto" will create the variable named "name" set to the
+    # value "pinto"--equivalent to name="pinto"
   --mode | --name | --k8s-version)
     if [ $# -lt 2 ]; then
       echo "$1 requires an argument" >&2
@@ -93,6 +97,8 @@ while [ $# -ne 0 ]; do
   esac
   shift
 done
+
+kind_cluster_name=${name}
 
 if printenv K8S_VERSION >/dev/null && [ -n "$K8S_VERSION" ]; then
   k8s_version="$K8S_VERSION"

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -80,7 +80,7 @@ e2e-setup-kind: kind-exists
 $(BINDIR)/scratch/kind-exists: make/config/kind/cluster.yaml preload-kind-image make/cluster.sh FORCE | $(BINDIR)/scratch $(NEEDS_KIND) $(NEEDS_KUBECTL) $(NEEDS_YQ)
 	@$(eval KIND_CLUSTER_NAME ?= kind)
 	@make/cluster.sh --name $(KIND_CLUSTER_NAME)
-	@if [ "$(shell cat $@ 2>/dev/null)" != kind ]; then echo kind > $@; else touch $@; fi
+	@if [ "$(shell cat $@ 2>/dev/null)" != $(KIND_CLUSTER_NAME) ]; then echo $(KIND_CLUSTER_NAME) > $@; else touch $@; fi
 
 .PHONY: kind-exists
 kind-exists: $(BINDIR)/scratch/kind-exists


### PR DESCRIPTION
### Summary
Before this commit, regardless of what was put for KIND_CLUSTER_NAME, the name of the cluster was always "kind". Furthermore, when running make clean, only clusters named "kind" were cleaned up. With a few minor fixes, this commit solves the problem so that kind clusters with different names can be used when running tests.



### Pull Request Motivation

Before the changes proposed in this MR, when running `make KIND_CLUSTER_NAME=<name> e2e-setup-kind` the `KIND_CLUSTER_NAME` variable had no effect on the cluster name. The cluster that was stood up was always named "kind." Furthermore, if attempting to clean up the cluster `make clean` always deleted the "kind" cluster. From the [comments here](https://github.com/malovme/cert-manager/blob/master/make/e2e-setup.mk#L72-L74), we assume that the intent was to have the name of the cluster inside the `$(BINDIR)/scratch/kind-exists` file. We honor this comment in this PR

### Kind
bug 

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
