### PR TITLE
Static e2e test build

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -150,7 +150,7 @@ $(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test
 ## Here's an example of how you might run a subset of the end-to-end tests
 ## which only require cert-manager to be installed:
 ##
-##  ./e2e --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
+##  ./_bin/test/e2e.test --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
 ##
 ## @category Development
 e2e-build: $(BINDIR)/test/e2e.test

--- a/make/test.mk
+++ b/make/test.mk
@@ -128,7 +128,7 @@ e2e-ci: | $(NEEDS_GO)
 	make/e2e-ci.sh
 
 $(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test
-	$(GINKGO) build --tags e2e_test test/e2e
+	CGO_ENABLED=0 $(GINKGO) build --tags e2e_test test/e2e
 	mv test/e2e/e2e.test $(BINDIR)/test/e2e.test
 
 .PHONY: e2e-build

--- a/make/test.mk
+++ b/make/test.mk
@@ -128,7 +128,7 @@ e2e-ci: | $(NEEDS_GO)
 	make/e2e-ci.sh
 
 $(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test
-	CGO_ENABLED=0 $(GINKGO) build --tags e2e_test test/e2e
+	CGO_ENABLED=0 $(GINKGO) build --ldflags="-w -s" --trimpath --tags e2e_test test/e2e
 	mv test/e2e/e2e.test $(BINDIR)/test/e2e.test
 
 .PHONY: e2e-build


### PR DESCRIPTION
I wasn't able to use the CGO compiled e2e.test binary on RedHat Enterprise Linux in 
 * https://github.com/cert-manager/cert-manager-olm/pull/94

This compiles the `e2e.test` binary statically and also reduces the size of the binary by stripping debugging symbols.

```
$ ./_bin/test/e2e.test --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
Running Suite: cert-manager e2e suite - /home/richard/projects/cert-manager/cert-manager
========================================================================================
Random Seed: 1687867131

Will run 44 of 777 specs
"hashicorp" already exists with the same configuration, skipping
Release "chart-vault-vault" does not exist. Installing it now.
NAME: chart-vault-vault
LAST DEPLOYED: Tue Jun 27 12:58:53 2023
NAMESPACE: e2e-vault
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named chart-vault-vault. To learn more about the release, try:

  $ helm status chart-vault-vault
  $ helm get manifest chart-vault-vault
```

...but as you can see, there is another problem because the standalone binary expects that a custom Hashicorp vault image to be present in the target cluster...

```
$ kubectl get pod --namespace e2e-vault
NAME                  READY   STATUS              RESTARTS   AGE
chart-vault-vault-0   0/1     ErrImageNeverPull   0          37s
```

I'll address that in another PR:

```diffdiff --git a/test/e2e/e2e.go b/test/e2e/e2e.go
index 49049f91e..b75422f36 100644
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -40,7 +40,7 @@ var isGinkgoProcessNumberOne = false
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
        addon.InitGlobals(cfg)

-       isGinkgoProcessNumberOne = true
+       // isGinkgoProcessNumberOne = true

        // We first setup the global addons, but do not provision them yet.
        // This is because we need to transfer the data from ginkgo process #1

```

```
$ ./_bin/test/e2e.test --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
Running Suite: cert-manager e2e suite - /home/richard/projects/cert-manager/cert-manager
========================================================================================
Random Seed: 1687867356

Will run 44 of 777 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••••SSS••••••••••••••[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:
goroutine 551 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x65
sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/log/log.go:59 +0xbd
sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc000453600, {0x1e3a51f, 0x14})
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/log/deleg.go:147 +0x4c
github.com/go-logr/logr.Logger.WithName({{0x20fd498, 0xc000453600}, 0x0}, {0x1e3a51f?, 0xc001391d98?})
        github.com/go-logr/logr@v1.2.4/logr.go:336 +0x46
sigs.k8s.io/controller-runtime/pkg/client.newClient(0xc000af3b00, {0x0, 0xc0002f68c0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/client.go:115 +0xb4
sigs.k8s.io/controller-runtime/pkg/client.New(0x1e55359?, {0x0, 0xc0002f68c0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/client.go:101 +0x85
github.com/cert-manager/cert-manager/test/framework.(*Framework).BeforeEach(0xc0004350e0)
        github.com/cert-manager/cert-manager@v0.0.0-00010101000000-000000000000/test/framework/framework.go:145 +0x355
github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0xa4074e, 0xc000a5de00})
        github.com/onsi/ginkgo/v2@v2.9.5/internal/node.go:463 +0x1b
github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
        github.com/onsi/ginkgo/v2@v2.9.5/internal/suite.go:863 +0x98
created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode
        github.com/onsi/ginkgo/v2@v2.9.5/internal/suite.go:850 +0xd65
••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 23 of 777 Specs in 39.346 seconds
SUCCESS! -- 23 Passed | 0 Failed | 0 Pending | 754 Skipped
PASS
```

```release-note
NONE
```
