### PR TITLE
Adds ingress annotation support for alt-names

### DIFF
--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -69,6 +69,10 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		crt.Spec.CommonName = commonName
 	}
 
+	if altNames, found := ingLikeAnnotations[cmapi.AltNamesAnnotationKey]; found {
+		crt.Spec.DNSNames = strings.Split(altNames, ",")
+	}
+
 	if emailAddresses, found := ingLikeAnnotations[cmapi.EmailsAnnotationKey]; found {
 		crt.Spec.EmailAddresses = strings.Split(emailAddresses, ",")
 	}

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -55,7 +55,7 @@ func Test_translateAnnotations(t *testing.T) {
 			cmapi.SubjectStreetAddressesAnnotationKey:     `"1725 Slough Avenue, Suite 200, Scranton Business Park","1800 Slough Avenue, Suite 200, Scranton Business Park"`,
 			cmapi.SubjectPostalCodesAnnotationKey:         "ABC123",
 			cmapi.SubjectSerialNumberAnnotationKey:        "123456",
-			cmapi.AltNamesAnnotationKey:                   "example.com,test.example.com",
+			cmapi.AltNamesAnnotationKey:                   "www.example.com,example.com,test.example.com",
 		}
 	}
 
@@ -79,13 +79,13 @@ func Test_translateAnnotations(t *testing.T) {
 				a.Equal(nil, joinErr)
 				a.Equal(`"1725 Slough Avenue, Suite 200, Scranton Business Park","1800 Slough Avenue, Suite 200, Scranton Business Park"`, joinedAddresses)
 
-				splitAltNames, splitErr := cmutil.SplitWithEscapeCSV("example.com,test.example.com")
+				splitAltNames, splitErr := cmutil.SplitWithEscapeCSV("www.example.com,example.com,test.example.com")
 				a.Equal(nil, splitErr)
 				a.Equal(splitAltNames, crt.Spec.DNSNames)
 
 				joinedAltNames, joinErr := cmutil.JoinWithEscapeCSV(crt.Spec.DNSNames)
 				a.Equal(nil, joinErr)
-				a.Equal("example.com,test.example.com", joinedAltNames)
+				a.Equal("www.example.com,example.com,test.example.com", joinedAltNames)
 
 			},
 		},

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -55,6 +55,7 @@ func Test_translateAnnotations(t *testing.T) {
 			cmapi.SubjectStreetAddressesAnnotationKey:     `"1725 Slough Avenue, Suite 200, Scranton Business Park","1800 Slough Avenue, Suite 200, Scranton Business Park"`,
 			cmapi.SubjectPostalCodesAnnotationKey:         "ABC123",
 			cmapi.SubjectSerialNumberAnnotationKey:        "123456",
+			cmapi.AltNamesAnnotationKey:                   "example.com,test.example.com",
 		}
 	}
 
@@ -77,6 +78,15 @@ func Test_translateAnnotations(t *testing.T) {
 				joinedAddresses, joinErr := cmutil.JoinWithEscapeCSV(crt.Spec.Subject.StreetAddresses)
 				a.Equal(nil, joinErr)
 				a.Equal(`"1725 Slough Avenue, Suite 200, Scranton Business Park","1800 Slough Avenue, Suite 200, Scranton Business Park"`, joinedAddresses)
+
+				splitAltNames, splitErr := cmutil.SplitWithEscapeCSV("example.com,test.example.com")
+				a.Equal(nil, splitErr)
+				a.Equal(splitAltNames, crt.Spec.DNSNames)
+
+				joinedAltNames, joinErr := cmutil.JoinWithEscapeCSV(crt.Spec.DNSNames)
+				a.Equal(nil, joinErr)
+				a.Equal("example.com,test.example.com", joinedAltNames)
+
 			},
 		},
 		"success rsa private key algorithm": {

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -784,6 +784,11 @@ func (s *Suite) Define() {
 			}
 			var certName string
 			domain := e2eutil.RandomSubdomain(s.DomainSuffix)
+			altNames := strings.Join([]string{
+				e2eutil.RandomSubdomain(s.DomainSuffix),
+				e2eutil.RandomSubdomain(domain),
+				domain,
+			}, ",")
 			duration := time.Hour * 999
 			renewBefore := time.Hour * 111
 			revisionHistoryLimit := pointer.Int32(7)
@@ -805,6 +810,7 @@ func (s *Suite) Define() {
 					"cert-manager.io/issuer-kind":                 issuerRef.Kind,
 					"cert-manager.io/issuer-group":                issuerRef.Group,
 					"cert-manager.io/common-name":                 domain,
+					"cert-manager.io/alt-names":                   altNames,
 					"cert-manager.io/duration":                    duration.String(),
 					"cert-manager.io/renew-before":                renewBefore.String(),
 					"cert-manager.io/revision-history-limit":      strconv.FormatInt(int64(*revisionHistoryLimit), 10),
@@ -828,6 +834,7 @@ func (s *Suite) Define() {
 					"cert-manager.io/issuer-kind":                 issuerRef.Kind,
 					"cert-manager.io/issuer-group":                issuerRef.Group,
 					"cert-manager.io/common-name":                 domain,
+					"cert-manager.io/alt-names":                   altNames,
 					"cert-manager.io/duration":                    duration.String(),
 					"cert-manager.io/renew-before":                renewBefore.String(),
 					"cert-manager.io/revision-history-limit":      strconv.FormatInt(int64(*revisionHistoryLimit), 10),
@@ -857,7 +864,7 @@ func (s *Suite) Define() {
 			err = f.Helper().ValidateCertificate(
 				cert,
 				func(certificate *cmapi.Certificate, _ *corev1.Secret) error {
-					Expect(certificate.Spec.DNSNames).To(ConsistOf(domain))
+					Expect(certificate.Spec.DNSNames).To(ConsistOf(strings.Split(altNames, ",")))
 					Expect(certificate.Spec.CommonName).To(Equal(domain))
 					Expect(certificate.Spec.Duration.Duration).To(Equal(duration))
 					Expect(certificate.Spec.RenewBefore.Duration).To(Equal(renewBefore))

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -785,9 +785,9 @@ func (s *Suite) Define() {
 			var certName string
 			domain := e2eutil.RandomSubdomain(s.DomainSuffix)
 			altNames := strings.Join([]string{
+				domain,
 				e2eutil.RandomSubdomain(s.DomainSuffix),
 				e2eutil.RandomSubdomain(domain),
-				domain,
 			}, ",")
 			duration := time.Hour * 999
 			renewBefore := time.Hour * 111


### PR DESCRIPTION
### Pull Request Motivation

Add support for ingress annotation controlling Certificate SAN DNS names. Fixes #5897 .

### Kind

/kind feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add support for ingress annotation cert-manager.io/alt-names
```
