### PR TITLE
Remove conflicting labels from CRDs

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: challenges.acme.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: acme.cert-manager.io

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: issuers.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -3,9 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
   labels:
-    app: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: acme.cert-manager.io


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
- Removes a conflict when deployed through ArgoCD that sets up its own `app.kubernetes.io/instance` label (https://github.com/argoproj/argo-cd/issues/6728). No need for workarounds like https://github.com/HariSekhon/Kubernetes-configs/blob/master/cert-manager/base/remove-instance-label.jsonpatch.yaml. If the `app.kubernetes.io/instance` label is set within the Helm chart then ArgoCD reports warnings like:
```
SharedResourceWarning 	CustomResourceDefinition/certificaterequests.cert-manager.io is part of applications cert-manager-production and cert-manager
```

- This small tweak also makes CRDs valid Kubernetes manifests that are trivially to deploy (see https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-46x-to-47x). But still allows them to be modified by your release process.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->
feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
