### PR TITLE
Remove VCert fork dependency replace statement

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -9,7 +9,7 @@ github.com/Azure/go-autorest/logger,https://github.com/Azure/go-autorest/blob/lo
 github.com/Azure/go-autorest/tracing,https://github.com/Azure/go-autorest/blob/tracing/v0.6.0/tracing/LICENSE,Apache-2.0
 github.com/Azure/go-ntlmssp,https://github.com/Azure/go-ntlmssp/blob/cb9428e4ac1e/LICENSE,MIT
 github.com/NYTimes/gziphandler,https://github.com/NYTimes/gziphandler/blob/v1.1.1/LICENSE,Apache-2.0
-github.com/Venafi/vcert/v4,https://github.com/jetstack/vcert/blob/3aa3dfd6613d/LICENSE,Apache-2.0
+github.com/Venafi/vcert/v4,https://github.com/Venafi/vcert/blob/69f417ae176d/LICENSE,Apache-2.0
 github.com/akamai/AkamaiOPEN-edgegrid-golang,https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v1.2.2/LICENSE,Apache-2.0
 github.com/antlr/antlr4/runtime/Go/antlr,https://github.com/antlr/antlr4/blob/runtime/Go/antlr/v1.4.10/runtime/Go/antlr/LICENSE,BSD-3-Clause
 github.com/asaskevich/govalidator,https://github.com/asaskevich/govalidator/blob/21a406dcc535/LICENSE,MIT

--- a/cmd/controller/LICENSES
+++ b/cmd/controller/LICENSES
@@ -8,7 +8,7 @@ github.com/Azure/go-autorest/autorest/validation,https://github.com/Azure/go-aut
 github.com/Azure/go-autorest/logger,https://github.com/Azure/go-autorest/blob/logger/v0.2.1/logger/LICENSE,Apache-2.0
 github.com/Azure/go-autorest/tracing,https://github.com/Azure/go-autorest/blob/tracing/v0.6.0/tracing/LICENSE,Apache-2.0
 github.com/Azure/go-ntlmssp,https://github.com/Azure/go-ntlmssp/blob/cb9428e4ac1e/LICENSE,MIT
-github.com/Venafi/vcert/v4,https://github.com/jetstack/vcert/blob/3aa3dfd6613d/LICENSE,Apache-2.0
+github.com/Venafi/vcert/v4,https://github.com/Venafi/vcert/blob/69f417ae176d/LICENSE,Apache-2.0
 github.com/akamai/AkamaiOPEN-edgegrid-golang,https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v1.2.2/LICENSE,Apache-2.0
 github.com/aws/aws-sdk-go,https://github.com/aws/aws-sdk-go/blob/v1.44.179/LICENSE.txt,Apache-2.0
 github.com/aws/aws-sdk-go/internal/sync/singleflight,https://github.com/aws/aws-sdk-go/blob/v1.44.179/internal/sync/singleflight/LICENSE,BSD-3-Clause

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
-	github.com/Venafi/vcert/v4 v4.23.0 // indirect
+	github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d // indirect
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2 // indirect
 	github.com/aws/aws-sdk-go v1.44.179 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -153,6 +153,3 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.2.0 // indirect
 )
-
-// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d

--- a/cmd/controller/go.sum
+++ b/cmd/controller/go.sum
@@ -65,6 +65,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d h1:xrCoQD8VjB+Q7FGPGq20rLeT0C1pjim2qUUv5buQGC4=
+github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d/go.mod h1:4Nec3twWisOdS1unpDZ93sfau9eVSDS8Ot+Ry/gg0es=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2 h1:F1j7z+/DKEsYqZNoxC6wvfmaiDneLsQOFQmuq9NADSY=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2/go.mod h1:QlXr/TrICfQ/ANa76sLeQyhAJyNR9sEcfNuZBkY9jgY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -329,8 +331,6 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d h1:V9SfHhSwP97N8ziqP621+qk5FJ+oMh8Lu9ttrL2/U3o=
-github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d/go.mod h1:SWmRLLPU0f2ujjVaEUssKKSxYHhznpohrPYxUpjsGFg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,12 @@ go 1.20
 // please place any replace statements here at the top for visibility and add a
 // comment to it as to when it can be removed
 
-// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d
-
 require (
 	github.com/Azure/azure-sdk-for-go v67.3.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.21
 	github.com/Azure/go-autorest/autorest/to v0.4.0
-	github.com/Venafi/vcert/v4 v4.23.0
+	github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/aws/aws-sdk-go v1.44.179
 	github.com/cpu/goacmedns v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d h1:xrCoQD8VjB+Q7FGPGq20rLeT0C1pjim2qUUv5buQGC4=
+github.com/Venafi/vcert/v4 v4.24.1-0.20230703183014-69f417ae176d/go.mod h1:4Nec3twWisOdS1unpDZ93sfau9eVSDS8Ot+Ry/gg0es=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2 h1:F1j7z+/DKEsYqZNoxC6wvfmaiDneLsQOFQmuq9NADSY=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2/go.mod h1:QlXr/TrICfQ/ANa76sLeQyhAJyNR9sEcfNuZBkY9jgY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -354,8 +356,6 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d h1:V9SfHhSwP97N8ziqP621+qk5FJ+oMh8Lu9ttrL2/U3o=
-github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d/go.mod h1:SWmRLLPU0f2ujjVaEUssKKSxYHhznpohrPYxUpjsGFg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 
+	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
@@ -49,6 +50,31 @@ func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, custo
 	if err != nil {
 		return "", err
 	}
+
+	// If the connector is TPP, we unconditionally reset any prior failed enrollment
+	// so that we don't get stuck with "Fix any errors, and then click Retry."
+	// (60% of the time) or "WebSDK CertRequest" (40% of the time).
+	//
+	// It would be preferable to only reset when necessary to avoid the extra
+	// call. We tried that in https://github.com/Venafi/vcert/pull/269. It turns
+	// out that calling "request" followed by "reset(restart=true)" causes a
+	// race in TPP.
+	//
+	// Unconditionally resetting isn't optimal, but "reset(restart=false)" is
+	// lightweight. We haven't verified that it doesn't slow things down on
+	// large TPP instances.
+	//
+	// Note that resetting won't affect the existing certificate if one was
+	// already issued.
+	tppConnector, isTPP := v.vcertClient.(*tpp.Connector)
+	if isTPP {
+		err := tppConnector.ResetCertificate(vreq, false)
+		notFoundErr := &tpp.ErrCertNotFound{}
+		if err != nil && !errors.As(err, &notFoundErr) {
+			return "", err
+		}
+	}
+
 	return v.vcertClient.RequestCertificate(vreq)
 }
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -103,7 +103,4 @@ require (
 
 replace github.com/miekg/dns v1.1.41 => github.com/miekg/dns v1.1.34
 
-// remove this once https://github.com/jetstack/vcert/pull/3 is merged upstream
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d
-
 replace github.com/cert-manager/cert-manager => ../../


### PR DESCRIPTION
### Pull Request Motivation

Thanks to https://github.com/Venafi/vcert/pull/295, we do not longer need the fork.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
