### PR TITLE
service account labels introduce a white line issue

### DIFF
--- a/deploy/charts/cert-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/serviceaccount.yaml
@@ -20,6 +20,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.labels }}
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Enabling workload identity requires the addition of a label to the service account. Unfortunately the current implementation adds a white line on top of the provided extra label

```yaml
apiVersion: v1
kind: ServiceAccount
automountServiceAccountToken: true
metadata:
  name: cert-manager
  namespace: cert-manager
  labels:
    app: cert-manager
    app.kubernetes.io/name: cert-manager
    app.kubernetes.io/instance: cert-manager
    app.kubernetes.io/component: "controller"
    app.kubernetes.io/version: "v1.12.2"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: cert-manager-v1.12.2
      
    azure.workload.identity/use: true
```

### Kind

bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
