### PR TITLE
[release-1.12] Use supplied context where possible

### DIFF
--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -54,15 +54,16 @@ func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger,
 		}
 		log := log.WithValues("type", config.resourceName, "secret", secretName, "certificate", *certName)
 
-		var cert cmapi.Certificate
 		// confirm that a service owns this cert
-		if err := cl.Get(context.Background(), *certName, &cert); err != nil {
+		var cert cmapi.Certificate
+		if err := cl.Get(ctx, *certName, &cert); err != nil {
 			// TODO(directxman12): check for not found error?
 			log.Error(err, "unable to fetch certificate that owns the secret")
 			return nil
 		}
+
 		objs := config.listType.DeepCopyObject().(client.ObjectList)
-		if err := cl.List(context.Background(), objs, client.MatchingFields{injectFromPath: certName.String()}); err != nil {
+		if err := cl.List(ctx, objs, client.MatchingFields{injectFromPath: certName.String()}); err != nil {
 			log.Error(err, "unable to fetch injectables associated with certificate")
 			return nil
 		}
@@ -98,7 +99,7 @@ func certToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config se
 		certName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 		log := log.WithValues("type", config.resourceName, "certificate", certName)
 		objs := config.listType.DeepCopyObject().(client.ObjectList)
-		if err := cl.List(context.Background(), objs, client.MatchingFields{injectFromPath: certName.String()}); err != nil {
+		if err := cl.List(ctx, objs, client.MatchingFields{injectFromPath: certName.String()}); err != nil {
 			log.Error(err, "unable to fetch injectables associated with certificate")
 			return nil
 		}
@@ -136,7 +137,7 @@ func secretForInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config
 		log := log.WithValues("type", config.resourceName, "secret", secretName)
 		objs := config.listType.DeepCopyObject().(client.ObjectList)
 		// TODO: ensure that this is cache lister, not a direct client
-		if err := cl.List(context.Background(), objs, client.MatchingFields{injectFromSecretPath: secretName.String()}); err != nil {
+		if err := cl.List(ctx, objs, client.MatchingFields{injectFromSecretPath: secretName.String()}); err != nil {
 			log.Error(err, "unable to fetch injectables associated with secret")
 			return nil
 		}


### PR DESCRIPTION
This was discovered as part of the investigation into #6104

Manual backport.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
