### PR TITLE
Move logging options to webhook config file

### DIFF
--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -95,7 +95,7 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 				os.Exit(1)
 			}
 
-			if err := logf.ValidateAndApply(webhookFlags.Logging); err != nil {
+			if err := logf.ValidateAndApply(&webhookConfig.Logging); err != nil {
 				log.Error(err, "Failed to validate webhook flags")
 				os.Exit(1)
 			}
@@ -115,6 +115,11 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 				// update feature gates based on new config
 				if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(webhookConfig.FeatureGates); err != nil {
 					log.Error(err, "Failed to set feature gates from config file")
+					os.Exit(1)
+				}
+
+				if err := logf.ValidateAndApply(&webhookConfig.Logging); err != nil {
+					log.Error(err, "Failed to validate webhook flags")
 					os.Exit(1)
 				}
 			}

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -19,9 +19,8 @@ package controller
 import (
 	"time"
 
-	"k8s.io/component-base/logs"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logsapi "k8s.io/component-base/logs/api/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -110,7 +109,7 @@ type ControllerConfiguration struct {
 	PprofAddress string
 
 	// https://pkg.go.dev/k8s.io/component-base@v0.27.3/logs/api/v1#LoggingConfiguration
-	Logging logs.Options
+	Logging logsapi.LoggingConfiguration
 
 	// featureGates is a map of feature names to bools that enable or disable experimental
 	// features.

--- a/internal/apis/config/webhook/fuzzer/fuzzer.go
+++ b/internal/apis/config/webhook/fuzzer/fuzzer.go
@@ -19,6 +19,7 @@ package fuzzer
 import (
 	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	logsapi "k8s.io/component-base/logs/api/v1"
 
 	"github.com/cert-manager/cert-manager/internal/apis/config/webhook"
 )
@@ -32,6 +33,8 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			if s.PprofAddress == "" {
 				s.PprofAddress = "something:1234"
 			}
+
+			logsapi.SetRecommendedLoggingConfiguration(&s.Logging)
 		},
 	}
 }

--- a/internal/apis/config/webhook/types.go
+++ b/internal/apis/config/webhook/types.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/logs"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -52,6 +53,9 @@ type WebhookConfiguration struct {
 	// pprofAddress configures the address on which /debug/pprof endpoint will be served if enabled.
 	// Defaults to 'localhost:6060'.
 	PprofAddress string
+
+	// https://pkg.go.dev/k8s.io/component-base@v0.27.3/logs/api/v1#LoggingConfiguration
+	Logging logs.Options
 
 	// featureGates is a map of feature names to bools that enable or disable experimental
 	// features.

--- a/internal/apis/config/webhook/types.go
+++ b/internal/apis/config/webhook/types.go
@@ -18,7 +18,7 @@ package webhook
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/component-base/logs"
+	logsapi "k8s.io/component-base/logs/api/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -55,7 +55,7 @@ type WebhookConfiguration struct {
 	PprofAddress string
 
 	// https://pkg.go.dev/k8s.io/component-base@v0.27.3/logs/api/v1#LoggingConfiguration
-	Logging logs.Options
+	Logging logsapi.LoggingConfiguration
 
 	// featureGates is a map of feature names to bools that enable or disable experimental
 	// features.

--- a/internal/apis/config/webhook/v1alpha1/defaults.go
+++ b/internal/apis/config/webhook/v1alpha1/defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/utils/pointer"
 
 	"github.com/cert-manager/cert-manager/pkg/apis/config/webhook/v1alpha1"
@@ -37,4 +38,6 @@ func SetDefaults_WebhookConfiguration(obj *v1alpha1.WebhookConfiguration) {
 	if obj.PprofAddress == "" {
 		obj.PprofAddress = "localhost:6060"
 	}
+
+	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)
 }

--- a/internal/apis/config/webhook/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/webhook/v1alpha1/zz_generated.conversion.go
@@ -175,6 +175,7 @@ func autoConvert_v1alpha1_WebhookConfiguration_To_webhook_WebhookConfiguration(i
 	out.APIServerHost = in.APIServerHost
 	out.EnablePprof = in.EnablePprof
 	out.PprofAddress = in.PprofAddress
+	out.Logging = in.Logging
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
@@ -198,6 +199,7 @@ func autoConvert_webhook_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(i
 	out.APIServerHost = in.APIServerHost
 	out.EnablePprof = in.EnablePprof
 	out.PprofAddress = in.PprofAddress
+	out.Logging = in.Logging
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }

--- a/internal/apis/config/webhook/zz_generated.deepcopy.go
+++ b/internal/apis/config/webhook/zz_generated.deepcopy.go
@@ -90,6 +90,7 @@ func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.TLSConfig.DeepCopyInto(&out.TLSConfig)
+	in.Logging.DeepCopyInto(&out.Logging)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/apis/config/webhook/v1alpha1/types.go
+++ b/pkg/apis/config/webhook/v1alpha1/types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logsapi "k8s.io/component-base/logs/api/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -52,6 +53,10 @@ type WebhookConfiguration struct {
 	// pprofAddress configures the address on which /debug/pprof endpoint will be served if enabled.
 	// Defaults to 'localhost:6060'.
 	PprofAddress string `json:"pprofAddress,omitempty"`
+
+	// logging configures the logging behaviour of the webhook.
+	// https://pkg.go.dev/k8s.io/component-base@v0.27.3/logs/api/v1#LoggingConfiguration
+	Logging logsapi.LoggingConfiguration `json:"logging"`
 
 	// featureGates is a map of feature names to bools that enable or disable experimental
 	// features.

--- a/pkg/apis/config/webhook/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/webhook/v1alpha1/zz_generated.deepcopy.go
@@ -100,6 +100,7 @@ func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 		**out = **in
 	}
 	in.TLSConfig.DeepCopyInto(&out.TLSConfig)
+	in.Logging.DeepCopyInto(&out.Logging)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -68,7 +68,7 @@ func InitLogs() {
 	log.SetFlags(0)
 }
 
-func AddFlagsNonDeprecated(opts *logs.Options, fs *pflag.FlagSet) {
+func AddFlagsNonDeprecated(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 	var allFlags pflag.FlagSet
 	logsapi.AddFlags(opts, &allFlags)
 
@@ -80,7 +80,7 @@ func AddFlagsNonDeprecated(opts *logs.Options, fs *pflag.FlagSet) {
 	})
 }
 
-func AddFlags(opts *logs.Options, fs *pflag.FlagSet) {
+func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 	var allFlags flag.FlagSet
 	klog.InitFlags(&allFlags)
 
@@ -95,7 +95,7 @@ func AddFlags(opts *logs.Options, fs *pflag.FlagSet) {
 	AddFlagsNonDeprecated(opts, fs)
 }
 
-func ValidateAndApply(opts *logs.Options) error {
+func ValidateAndApply(opts *logsapi.LoggingConfiguration) error {
 	return logsapi.ValidateAndApply(opts, nil)
 }
 

--- a/pkg/webhook/options/options.go
+++ b/pkg/webhook/options/options.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
 
 	config "github.com/cert-manager/cert-manager/internal/apis/config/webhook"
 	configscheme "github.com/cert-manager/cert-manager/internal/apis/config/webhook/scheme"
@@ -32,21 +31,16 @@ import (
 
 // WebhookFlags defines options that can only be configured via flags.
 type WebhookFlags struct {
-	Logging *logs.Options
-
 	// Path to a file containing a WebhookConfiguration resource
 	Config string
 }
 
 func NewWebhookFlags() *WebhookFlags {
-	return &WebhookFlags{
-		Logging: logs.NewOptions(),
-	}
+	return &WebhookFlags{}
 }
 
 func (f *WebhookFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.Config, "config", "", "Path to a file containing a WebhookConfiguration object used to configure the webhook")
-	logf.AddFlags(f.Logging, fs)
 }
 
 func NewWebhookConfiguration() (*config.WebhookConfiguration, error) {
@@ -93,4 +87,6 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.WebhookConfiguration) {
 			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
 	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
+
+	logf.AddFlags(&c.Logging, fs)
 }


### PR DESCRIPTION
### Pull Request Motivation

The webhook config file is missing the logging options.
In https://github.com/cert-manager/cert-manager/pull/5337, I learned that we can include the logging options in our config file.
While writing this PR, I noticed the current controller config file still has a defaulting bug wrt. the logging options.
This PR fixes that bug and adds the logging options in the webhook config file.

### Kind

/kind feature

### Release Note

```release-note
Add support for logging options to webhook config file.
```
