### PR TITLE
Update nameserver lookup test to use upstream targets

### DIFF
--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -22,11 +22,17 @@ var lookupNameserversTestsOK = []struct {
 	fqdn string
 	nss  []string
 }{
-	{"books.google.com.ng.",
-		[]string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
+	{
+		fqdn: "en.wikipedia.org.",
+		nss:  []string{"ns0.wikimedia.org.", "ns1.wikimedia.org.", "ns2.wikimedia.org."},
 	},
-	{"www.google.com.",
-		[]string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
+	{
+		fqdn: "www.google.com.",
+		nss:  []string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
+	},
+	{
+		fqdn: "physics.georgetown.edu.",
+		nss:  []string{"ns4.georgetown.edu.", "ns5.georgetown.edu.", "ns6.georgetown.edu."},
 	},
 }
 


### PR DESCRIPTION
In the long term I don't think this test should be run as a unit test because it can randomly break due to changes in DNS config we don't control, which is a pretty poor user experience for someone trying to change unrelated code.

If we're going to run this kind of check, we should probably run it as a periodic rather than a presubmit, perhaps with the test being run on presubmit when the DNS util code is changed.

But that's all more work than I can really do now. Instead, I'll copy what the upstream go-lego is doing, which should unblock us for now:

https://github.com/go-acme/lego/blob/07c4daeff3c5d5e228b2490e002295716083a5fa/challenge/dns01/nameserver_test.go

For more context / info, see [this slack thread](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1691139262485849).

For an example of the test failure that this PR fixes, see [here](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6015/pull-cert-manager-master-make-test/1689013073379069952).

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
