### PR TITLE
GRADUATION: Write up the Governance and Steering documents

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,93 @@
+# cert-manager Governance (proposal)
+
+This document defines project governance for the cert-manager project.
+
+## Contributors
+
+cert-manager is for everyone. Anyone can become a cert-manager contributor
+simply by contributing to the project, whether through code, documentation, blog
+posts, community management, or other means. As with all cert-manager community
+members, contributors are expected to follow the [cert-manager Code of
+Conduct][coc].
+
+All contributions to cert-manager code, documentation, or other components in
+the cert-manager GitHub org must follow the guidelines in [the contributing
+page][contrib]. Whether these contributions are merged into the project is the
+prerogative of the maintainers.
+
+## Maintainers
+
+Maintainers have the ability to merge code into the project. Anyone can become a
+cert-manager maintainer (see "Becoming a maintainer" below.)
+
+> **Note:** In some CNCF projects, a difference is made between a "committer"
+> and a "maintainer" (cf. [committer-vs-maintainer][]). In the context of the
+> cert-manager project, committer and maintainer are the same. We will be using
+> the term "maintainer" throughout this document.
+
+[committer-vs-maintainer]: https://github.com/cncf/toc/pull/876#issuecomment-1189399941
+
+The cert-manager maintainers are:
+
+- James Munnelly (@munnerz)
+- Josh van Leeuwen (@joshvanl)
+- Richard Wall (@wallrj)
+- Jake Sanders (@jakexks)
+- Maël Valais (@maelvls)
+- Irbe Krumina (@irbekrm)
+- Ashley Davis (@sgtcodfish)
+- Tim Ramlot (@inteon)
+
+This list is reflected in `OWNERS.md` files present at the root of the projects
+within the cert-manager organization.
+
+### Maintainers Responsibilities
+
+cert-manager maintainers are expected to:
+
+- Review pull requests, triage issues, and fix bugs in their areas of expertise,
+  ensuring that all changes go through the project's code review and integration
+  processes.
+- Monitor cncf-cert-manager-\* emails and the cert-manager-dev and
+  cert-manager-dev channels on Slack, and help out when possible.
+- Rapidly respond to any time-sensitive security release processes.
+- Attend meetings with the cert-manager Steering Committee.
+
+### Maintainer Decision-Making
+
+Ideally, all project decisions are resolved by maintainer consensus. If this is
+not possible, maintainers may call a vote. The voting process is a simple
+majority in which each maintainer receives one vote.
+
+### Becoming a Maintainer
+
+Anyone can become a cert-manager maintainer. Maintainers should be proficient in
+Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
+the time and ability to meet the maintainer expectations above; and demonstrate
+the ability to work with the existing maintainers and project processes.
+
+To become a maintainer, start by expressing interest to existing maintainers.
+Existing maintainers will then ask you to demonstrate the qualifications above
+by contributing PRs, doing code reviews, and other such tasks under their
+guidance. After several months of working together, maintainers will decide
+whether to grant maintainer status.
+
+### Stepping Down as a Maintainer
+
+If a maintainer is no longer interested in or cannot perform the duties listed
+above, they should move themselves to emeritus status. If necessary, this can
+also occur through the decision-making process outlined above.
+
+A review of the OWNERS file is performed every year by the current maintainers.
+During this review, the maintainers that have not been active in the last year
+are asked whether they would like to become an emeritus maintainer.
+
+[coc]: https://github.com/cert-manager/cert-manager/blob/master/CODE_OF_CONDUCT.md
+[contrib]: https://cert-manager.io/docs/contributing/
+
+### Emeriti Maintainers
+
+Former maintainers include:
+
+- Maartje Eyskens (@meyskens)
+- Joakim Ahrlin (@jahrlin)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,7 +44,7 @@ the related projects in the cert-manager GitHub organisation.
 
 A contributor is considered to be active when they have had at least one
 interaction (comment on an issue or PR or message in the `#cert-manager` or
-`#cert- manager-dev` channels) within the last 18 months.
+`#cert-manager-dev` channels in the Kubernetes Slack) within the last 18 months.
 
 Members that have been inactive over the past 18 months may be removed from the
 GitHub organization.
@@ -56,7 +56,7 @@ GitHub organization.
 To be added as a GitHub member of the cert-manager organization, you will need
 to look for two sponsors with at least the `reviewer` role. These two sponsors
 must have had some meaningful interaction with you on an issue on GitHub or on
-the cert-manager or cert-manager-dev channels on Slack.
+the `#cert-manager` or `#cert-manager-dev` channels on the Kubernetes Slack.
 
 Then, open an issue on the [community][] repository and mention your sponsors as
 well as links to the meaningful interactions (Slack threads, GitHub issues). Ask
@@ -67,7 +67,7 @@ SLO.
 To be added as a GitHub member, you will also need to enable [two-factor
 authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on your GitHub account.
 
-GitHub members are encouraged to engage with the [cert-manager-dev](https://groups.google.com/g/cert-manager-dev) mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
+GitHub members are encouraged to engage with the mailing list [cert-manager-dev@googlegroups.com](https://groups.google.com/g/cert-manager-dev) as well as the [`#cert-manager`](https://kubernetes.slack.com/messages/cert-manager) and [`#cert-manager-dev`](https://kubernetes.slack.com/messages/cert-manager-dev) channels on the Kubernetes Slack.
 
 ## Reviewer
 
@@ -127,9 +127,9 @@ description. The PR description should also list the PRs you have reviewed.
 ### Approver Responsibilities
 
 - Expected to be responsive to review requests.
-- Stay up to date with the project's direction and goals,
-  e.g., by attending some of the bi-weekly meetings, standups,
-  or being around in the cert-manager-dev Slack channel.
+- Stay up to date with the project's direction and goals, e.g., by attending
+  some of the bi-weekly meetings, standups, or being around in the
+  `#cert-manager` and the `#cert-manager-dev` channels on the Kubernetes Slack.
 
 ### Approver Privileges
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,4 +1,3 @@
-
 # cert-manager Governance
 
 This document defines project governance for the cert-manager project. Its
@@ -37,6 +36,8 @@ manager-dev channels) within the last 18 months.
 Members that have been inactive over the past 18 months may be removed from the
 GitHub organization.
 
+**Defined by:** Member of the cert-manager GitHub organization.
+
 ### Becoming a GitHub Member
 
 To be added as a GitHub member of the cert-manager organization, you will need
@@ -44,13 +45,14 @@ to look for two sponsors with at least the `reviewer` role. These two sponsors
 must have had some meaningful interaction with you on an issue on GitHub or on
 the cert-manager or cert-manager-dev channels on Slack.
 
-Then, open an issue on the `cert-manager/cert-manager` repository and mention
-the sponsors as well as links to the meaningful interations (Slack threads,
-GitHub issues). Ask your sponsors to confirm their sponsorship by commenting on
-your PR. After that, your request will be reviewed by a cert-manager admin, in
-accordance with their SLO.
+Then, open an issue on the cert-manager repository and mention your sponsors as
+well as links to the meaningful interations (Slack threads, GitHub issues). Ask
+your sponsors to confirm their sponsorship by commenting on your PR. After that,
+your request will be reviewed by a cert-manager admin, in accordance with their
+SLO.
 
-To be added as a GitHub member, you will also need to enable [two-factor authentication][] on your GitHub account.
+To be added as a GitHub member, you will also need to enable [two-factor
+authentication][] on your GitHub account.
 
 GitHub members are encouraged to engage with the [cert-manager-dev][] mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
 
@@ -61,21 +63,20 @@ GitHub members are encouraged to engage with the [cert-manager-dev][] mailing li
 
 The mission of the reviewer is to read through PRs for quality and correctness
 on all or some part of cert-manager. Reviewers are knowledgeable about the
-codebase as well as software engineering principles. Reviewers are defined in
-the file [`OWNERS`](./OWNERS).
+codebase as well as software engineering principles.
+
+**Defined by:** the `reviewers` section in the file [`OWNERS`](./OWNERS).
 
 ### Becoming a Reviewer
 
 To become a reviewer, you will need to look for a sponsor with at least the
-`approver` role. Then, create a PR to add your name to the list of `reviewers`
-in the `OWNERS` file. The PR description should list your significant
-contributions.
+approver role. Your sponsor must have had close interactions with you: he must
+have been closely reviewed one of your PRs or worked with you on a thorny issue.
 
-Your sponsor must have the approver role. Your sponsor must have had close
-interactions with you: he must have been closely reviewed one of your PRs or
-worked with you on a thorny issue. The sponsor is expected to give his approval
-as a comment on the `OWNERS` PR. Additionally, your `OWNERS` PR should list your
-substantial contributions to the project.
+Then, create a PR to add your name to the list of `reviewers` in the `OWNERS`
+file. The PR description should list your significant contributions and should
+mention your sponsor. Your sponsor is expected to give his approval as a comment
+on your PR.
 
 ### Responsibilities
 
@@ -98,8 +99,7 @@ on an existing review with the command `/approve`. Note that it is always
 possible to review a PR as an approver with `/lgtm`, in which case the PR will
 be automatically approved.
 
-Approvers are defined under the `approver` section in the
-[`OWNERS`](./OWNERS) file.
+**Defined by:** the `approver` section in the [`OWNERS`](./OWNERS) file.
 
 ### Becoming an Approver
 
@@ -126,8 +126,9 @@ description. The PR description should also list the PRs you have reviewed.
 ## Maintainer
 
 A maintainer is someone who can communicate with the CNCF on behalf of the
-project and who can participate in a maintainers vote. The list of maintainers
-is available in the file [`MAINTAINERS.md`](./MAINTAINERS.md).
+project and who can participate in lazy consensus and votes. 
+
+**Defined by:** [`MAINTAINERS.md`](./MAINTAINERS.md).
 
 ### Becoming a Maintainer
 
@@ -145,22 +146,32 @@ whether to grant maintainer status.
 ### Privileges
 
 - Can communicate with the CNCF on behalf of the project.
-- Can participate in a "maintainers vote".
+- Can participate in lazy consensus and votes.
 
 ### Responsibilities
 
 - Monitor cncf-cert-manager-\* emails and help out when possible.
 - Respond to time-sensitive security release processes.
-- Attend meetings with the cert-manager Steering Committee.
+- Create and attend meetings with the cert-manager Steering Committee (not less than once a quarter).
 - Attend "maintainers vote" meetings when one is scheduled.
 
-### Maintainer Decision-Making (maintainers vote)
+### Maintainer Decision-Making
 
-Substantial changes to the project, require a "maintainers vote". This includes,
+Substantial changes to the project require a "maintainers decision". This includes,
 but is not limited to, changes to the project's roadmap, changes to the project's
-scope, fundamental design decisions, and changes to the project's governance. 
+scope, fundamental design decisions, and changes to the project's governance.
 
-A maintainer vote is a simple majority in which each maintainer receives one vote.
+A "maintainers decision" is made using lazy consensus. Email or Slack
+can be used to reach lazy consensus as long as the deliberation date
+and time are specified and the maintainers are CC'ed. You may use the
+following message template:
+
+> Dear maintainers, I'd like us to reach an agreement on the following matter using lazy consensus: [...]
+> - 🧑‍💻 Participants: @cert-manager-maintainers
+> - 📢 Deadline: April 3rd, 2023 23:59 UTC  
+> - 🚨 Note: to speed up the process, you may answer with a :+1: or a comment stating that your are lazy to help reach consensus before the deadline.
+
+Any non-agreements with regards to the decision can be posted as comments on the Slack message or to the email thread.
 
 ### Stepping Down as a Maintainer
 
@@ -196,10 +207,15 @@ approval.
 
 ### Privileges
 
-- Can remove protected branches and change settings in the GitHub organization.
+- Can change settings in the GitHub organization (e.g., remove protected branches, add GitHub members, etc.)
 - Can run the Google Cloud Build playbooks to release new versions of cert-manager.
 
 ### Responsibilities
 
-- Must be responsible with the privileges granted to them
-- Must manage cert-manager membership requests in a timely manner when requested using the process outlined in the Member Role section above.
+- Must have availability to allocate time to perform
+  cert-manager releases.
+- Must be available to perform admin-related tasks (add
+  a GitHub member, promote a GitHub user to "Owner",
+  add someone to the GCP projects, etc.)
+- Must be responsible with the privileges granted to
+  them.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 This document defines project governance for the cert-manager project. Its
 purpose is to describe how decisions are made on the project and how anyone can
-influence these decisions. We have six levels of responsability, each one
+influence these decisions. We have six levels of responsibility, each one
 building on the previous:
 
 - Contributor,
@@ -169,9 +169,9 @@ following message template:
 > Dear maintainers, I'd like us to reach an agreement on the following matter using lazy consensus: [...]
 > - 🧑‍💻 Participants: @cert-manager-maintainers
 > - 📢 Deadline: April 3rd, 2023 23:59 UTC  
-> - 🚨 Note: to speed up the process, you may answer with a :+1: or a comment stating that your are lazy to help reach consensus before the deadline.
+> - 🚨 Note: to speed up the process, you may answer with a :+1: or a comment stating that you are lazy to help reach consensus before the deadline.
 
-Any non-agreements with regards to the decision can be posted as comments on the Slack message or to the email thread.
+Any disagreements with regards to the decision must be posted as a comment on the Slack message or to the email thread along with an explanation of why. Disagreements posted without justification will not be considered.
 
 ### Stepping Down as a Maintainer
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,14 +5,14 @@ purpose is to describe how decisions are made on the project and how anyone can
 influence these decisions. We have six levels of responsibility, each one
 building on the previous:
 
-- Contributor,
-- GitHub Member,
-- Reviewer,
-- Approver,
-- Maintainer,
-- Admin.
+- [Contributor](#contributor),
+- [GitHub Member](#github-member),
+- [Reviewer](#reviewer),
+- [Approver](#approver),
+- [Maintainer](#maintainer),
+- [Admin](#admin).
 
-## Contributors
+## Contributor
 
 cert-manager is for everyone. Whether you're an experienced developer, a
 dedicated documenter, a passionate community builder, or simply someone eager to
@@ -29,9 +29,10 @@ or other means.
 - Follow the [cert-manager Code of Conduct][coc].
 - Follow the guidelines in [the Contributing page][contrib].
 
-## GitHub Members
+## GitHub Member
 
-GitHub Members are active contributors to the cert-manager project, or one of the related projects in the cert-manager GitHub organisation.
+GitHub Members are active contributors to the cert-manager project, or one of
+the related projects in the cert-manager GitHub organisation.
 
 A contributor is considered to be active when they have had at least one
 interaction (comment on an issue or PR or message in the #cert-manager or #cert-
@@ -63,7 +64,7 @@ GitHub members are encouraged to engage with the [cert-manager-dev](https://grou
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
 [cert-manager-dev]: https://groups.google.com/forum/#!forum/cert-manager-dev
 
-## Reviewers
+## Reviewer
 
 The mission of the reviewer is to read through PRs for quality and correctness
 on all or some part of cert-manager. Reviewers are knowledgeable about the
@@ -84,14 +85,14 @@ file. The PR description should list your significant contributions and should
 mention your sponsor. Your sponsor is expected to give their approval as a comment
 on your PR.
 
-### Responsibilities
+### Reviewer Responsibilities
 
 - When possible, review pull requests, triage issues, and fix bugs in their
   areas of expertise.
 - Ensure that all changes go through the project's code review and integration
   processes.
 
-### Privileges
+### Reviewer Privileges
 
 - Able to `/lgtm` on pull requests.
 
@@ -118,14 +119,14 @@ knowledgeable of some of your work.
 To apply, open a PR to update the `OWNERS` file and mention your sponsor in the
 description. The PR description should also list the PRs you have reviewed.
 
-### Responsibilities
+### Approver Responsibilities
 
 - Expected to be responsive to review requests.
 - Stay up to date with the project's direction and goals,
   e.g., by attending some of the bi-weekly meetings, standups,
   or being around in the cert-manager-dev Slack channel.
 
-### Privileges
+### Approver Privileges
 
 - Can `/approve` on pull requests.
 
@@ -149,12 +150,12 @@ by contributing PRs, doing code reviews, and other such tasks under their
 guidance. After several months of working together, maintainers will decide
 whether to grant maintainer status.
 
-### Privileges
+### Maintainer Privileges
 
 - Can communicate with the CNCF on behalf of the project.
 - Can participate in lazy consensus and votes.
 
-### Responsibilities
+### Maintainer Responsibilities
 
 - Monitor cncf-cert-manager-\* emails and help out when possible.
 - Respond to time-sensitive security release processes.
@@ -212,17 +213,16 @@ Prow). Then, create an issue on the cert-manager project and mention each
 maintainer. Each maintainer will need to comment on the issue to express their
 approval.
 
-### Privileges
+### Admin Privileges
 
-- Can change settings in the GitHub organization (e.g., remove protected branches, add GitHub members, etc.)
-- Can run the Google Cloud Build playbooks to release new versions of cert-manager.
+- Can change settings in the GitHub organization (e.g., remove protected
+  branches, add GitHub members, etc.)
+- Can run the Google Cloud Build playbooks to release new versions of
+  cert-manager.
 
-### Responsibilities
+### Admin Responsibilities
 
-- Must have availability to allocate time to perform
-  cert-manager releases.
-- Must be available to perform admin-related tasks (add
-  a GitHub member, promote a GitHub user to "Owner",
-  add someone to the GCP projects, etc.)
-- Must be responsible with the privileges granted to
-  them.
+- Must have availability to allocate time to perform cert-manager releases.
+- Must be available to perform admin-related tasks (add a GitHub member, promote
+  a GitHub user to "Owner", add someone to the GCP projects, etc.)
+- Must be responsible with the privileges granted to them.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,11 +1,19 @@
+
 # cert-manager Governance
 
-This document defines project governance for the cert-manager project.  
-It contains a list of roles that can be held by humans, and any additional
-requirements, privileges, and responsibilities that come with each role.  
-A role is held by a person, and a person can hold multiple roles.
+This document defines project governance for the cert-manager project. Its
+purpose is to describe how decisions are made on the project and how anyone can
+influence these decisions. We have six levels of responsability, each one
+building on the previous:
 
-## Contributor Role
+- Contributor,
+- GitHub Member,
+- Reviewer,
+- Approver,
+- Maintainer,
+- Admin.
+
+## Contributors
 
 cert-manager is for everyone. Anyone can become a cert-manager contributor
 simply by contributing to the project, whether through code, documentation, blog
@@ -18,129 +26,133 @@ the cert-manager GitHub org must follow the guidelines in [the contributing
 page][contrib]. Whether these contributions are merged into the project is the
 prerogative of the reviewers, approvers and/or maintainers.
 
-### Requirements
-- Contribute to the project in some way.
+## GitHub Members
 
-### Privileges
-- Create issues and pull requests in the cert-manager GitHub org.
+GitHub Members are active contributors to the cert-manager project.
 
-### Responsibilities
-- Follow the [cert-manager Code of Conduct][coc].
-- Follow the [contributing guidelines][contrib].
+A contributor is considered to be active when they have had at least one
+interaction (comment on an issue or PR or message in the #cert-manager or #cert-
+manager-dev channels) within the last 18 months.
 
-## Member Role
+Members that have been inactive over the past 18 months may be removed from the
+GitHub organization.
 
-Members are continuously active contributors.  
-Members are expected to remain active contributors.
+### Becoming a GitHub Member
 
-**Defined by:** Member of the cert-manager GitHub organization
+To be added as a GitHub member of the cert-manager organization, you will need
+to look for two sponsors with at least the `reviewer` role. These two sponsors
+must have had some meaningful interaction with you on an issue on GitHub or on
+the cert-manager or cert-manager-dev channels on Slack.
 
-### Requirements
-- You must be a contributor.
-- Enabled [two-factor authentication] on their GitHub account
-- Must be part of the [cert-manager-dev] Google group
-- Must be part of the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) Slack channel
-- Must be part of the [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channel
-- Sponsored by 2 reviewers. Note the following requirements for sponsors:
-    - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
-    - Sponsors must be reviewers or approvers.
-- Open an issue against the cert-manager/org repo
-    - Ensure your sponsors are @mentioned on the issue.
-    - Include a list of your contributions to the project.
-- Have your sponsors reply confirmation of sponsorship: +1
-- Once your sponsors have responded, your request will be reviewed by a cert-manager admin, in accordance with their SLO. Any missing information will be requested.
+Then, open an issue on the `cert-manager/cert-manager` repository and mention
+the sponsors as well as links to the meaningful interations (Slack threads,
+GitHub issues). Ask your sponsors to confirm their sponsorship by commenting on
+your PR. After that, your request will be reviewed by a cert-manager admin, in
+accordance with their SLO.
+
+To be added as a GitHub member, you will also need to enable [two-factor authentication][] on your GitHub account.
+
+GitHub members are encouraged to engage with the [cert-manager-dev][] mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
 
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
 [cert-manager-dev]: https://groups.google.com/forum/#!forum/cert-manager-dev
 
-### Privileges
-- Is a member of the cert-manager GitHub organization
+## Reviewers
+
+The mission of the reviewer is to read through PRs for quality and correctness
+on all or some part of cert-manager. Reviewers are knowledgeable about the
+codebase as well as software engineering principles. Reviewers are defined in
+the file [`OWNERS`](./OWNERS).
+
+### Becoming a Reviewer
+
+To become a reviewer, you will need to look for a sponsor with at least the
+`approver` role. Then, create a PR to add your name to the list of `reviewers`
+in the `OWNERS` file. The PR description should list your significant
+contributions.
+
+Your sponsor must have the approver role. Your sponsor must have had close
+interactions with you: he must have been closely reviewed one of your PRs or
+worked with you on a thorny issue. The sponsor is expected to give his approval
+as a comment on the `OWNERS` PR. Additionally, your `OWNERS` PR should list your
+substantial contributions to the project.
 
 ### Responsibilities
-- Remain an active contributor to the project. If you have not been able to contribute to the project in longer than 18 months, you will be removed from the organization. You must respond to any raised member inactivity issues on the cert-manager/org repo in which you are @mentioned as the inactive member within 30 days to prove your activity.
-- Monitor the cert-manager-dev and cert-manager-dev channels on Slack, and help out when possible.
 
-## Reviewer Role
-
-Reviewers are able to review code for quality and correctness on some part of cert-manager.  
-They are knowledgeable about both the codebase and software engineering principles.
-
-**Defined by:** `reviewers` entry in the cert-manager [OWNERS](./OWNERS) file
-
-### Requirements
-- You must be a contributor.
-- You can be trusted to review PRs thoroughly.
-- Knowledgeable about the relevant part of the codebase, and can be referenced for questions about it.
-- Must have made a substantial contribution to the project that indicates their knowledge of (part of) the codebase.
-- Sponsored by 1 approver. Note the following requirements for sponsors:
-    - Sponsors must have close interactions with the prospective reviewer - e.g. code/design/proposal review, coordinating on issues, etc.
-    - Sponsors must be approvers.
-- Open a PR to update the OWNERS file
-    - Ensure your sponsor is @mentioned on the PR.
-    - Include a list of your substantial contributions to the project.
+- When possible, review pull requests, triage issues, and fix bugs in their
+  areas of expertise.
+- Ensure that all changes go through the project's code review and integration
+  processes.
 
 ### Privileges
-- Can /lgtm on pull requests
+
+- Able to `/lgtm` on pull requests.
+
+## Approver
+
+> **Note:** some projects call this role "committer".
+
+As an approver, your role is to make sure the right people reviewed the PRs. The
+approver's focus isn't to review the code; instead, they put a stamp of approval
+on an existing review with the command `/approve`. Note that it is always
+possible to review a PR as an approver with `/lgtm`, in which case the PR will
+be automatically approved.
+
+Approvers are defined under the `approver` section in the
+[`OWNERS`](./OWNERS) file.
+
+### Becoming an Approver
+
+To become an approver and start merging PRs, you must have reviewed 5 PRs.
+
+You will then need to get sponsorship from one of the maintainers. The
+maintainer sponsoring you must have had close work interactions with you and be
+knowledgeable of some of your work. 
+
+To apply, open a PR to update the `OWNERS` file and mention your sponsor in the
+description. The PR description should also list the PRs you have reviewed.
 
 ### Responsibilities
-- When possible, review pull requests, triage issues, and fix bugs in their areas
-  of expertise
-- Ensure that all changes go through the project's code review and integration processes.
 
-## Approver Role
-
-= (in CNCF terms) comitter
-
-Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
-
-**Defined by:** `approvers` entry in the cert-manager [OWNERS](./OWNERS) file
-
-### Requirements
-- You must be a reviewer.
-- Your interests mostly align with the project's direction as determined by the maintainers and steering committee.
-- You have successfully reviewed & /lgtm'ed 5 PRs.
-- Sponsored by 1 maintainer. Note the following requirements for sponsors:
-    - Sponsors must have close interactions with the prospective reviewer - e.g. code/design/proposal review, coordinating on issues, etc.
-    - Sponsors must be maintainer.
-- Open a PR to update the OWNERS file
-    - Ensure your sponsor is @mentioned on the PR.
-    - Include a list of the 5 PRs you reviewed & /lgtm'ed.
-
-### Privileges
-- Can /approve on pull requests
-
-### Responsibilities
 - Expected to be responsive to review requests.
-- Stay up to date with the project's direction and goals. eg. by attending the weekly and/or bi-weekly meetings.
-
-## Maintainer Role
-
-= (in CNCF terms) maintainer
-
-Someone who can communicate with the CNCF on behalf of the project and who can
-participate in a "maintainers vote".
-
-**Defined by:** the list in the [MAINTAINERS.md](./MAINTAINERS.md) file
-
-### Requirements
-- You must be an approver.
-- You have successfully reviewed & /approved'ed 10 PRs.
-- Must be able to dedicate time to participate in maintainer meetings.
-- Must be able to dedicate time to participate in maintainer votes.
-- Must be able to dedicate time to monitor the cert-manager-\* mailing lists and help out when possible.
-- Must be able to dedicate time to rapidly respond to any time-sensitive security release processes.
-- Must be able to dedicate time to attend meetings with the cert-manager Steering Committee.
-- Must be able to dedicate time to communicate with the CNCF on behalf of the project.
+- Stay up to date with the project's direction and goals,
+  e.g., by attending some of the bi-weekly meetings, standups,
+  or being around in the cert-manager-dev Slack channel.
 
 ### Privileges
+
+- Can `/approve` on pull requests.
+
+## Maintainer
+
+A maintainer is someone who can communicate with the CNCF on behalf of the
+project and who can participate in a maintainers vote. The list of maintainers
+is available in the file [`MAINTAINERS.md`](./MAINTAINERS.md).
+
+### Becoming a Maintainer
+
+Anyone can become a cert-manager maintainer. Maintainers should be proficient in
+Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
+the time and ability to meet the maintainer expectations above; and demonstrate
+the ability to work with the existing maintainers and project processes.
+
+To become a maintainer, start by expressing interest to existing maintainers.
+Existing maintainers will then ask you to demonstrate the qualifications above
+by contributing PRs, doing code reviews, and other such tasks under their
+guidance. After several months of working together, maintainers will decide
+whether to grant maintainer status.
+
+### Privileges
+
 - Can communicate with the CNCF on behalf of the project.
 - Can participate in a "maintainers vote".
 
 ### Responsibilities
+
 - Monitor cncf-cert-manager-\* emails and help out when possible.
-- Rapidly respond to any time-sensitive security release processes.
+- Respond to time-sensitive security release processes.
 - Attend meetings with the cert-manager Steering Committee.
-- Participate in "maintainer votes".
+- Attend "maintainers vote" meetings when one is scheduled.
 
 ### Maintainer Decision-Making (maintainers vote)
 
@@ -156,30 +168,38 @@ If a maintainer is no longer interested in or cannot perform the duties listed
 above, they should move themselves to emeritus status. If necessary, this can
 also occur through the decision-making process outlined above.
 
-A review of the [MAINTAINERS.md](./MAINTAINERS.md) file is performed every year by the current maintainers.
-During this review, the maintainers that have not been active in the last 18 months
-are asked whether they would like to become an emeritus maintainer, they are expected
-to respond within 30 days. If they do not respond, they will automatically be moved to
-emeritus status.
+A review of the [`MAINTAINERS.md`](./MAINTAINERS.md) file is performed every
+year by the current maintainers. During this review, the maintainers that have
+not been active in the last 18 months are asked whether they would like to
+become an emeritus maintainer, they are expected to respond within 30 days. If
+they do not respond, they will automatically be moved to emeritus status.
 
 [coc]: https://github.com/cert-manager/cert-manager/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://cert-manager.io/docs/contributing/
 
-## Admin Role
+## Admin
 
-An admin is a maintainer who has admin privileges on the cert-manager infrastructure.
+An admin is a maintainer who has admin privileges on the cert-manager
+infrastructure. 
 
-**Defined by:** Admins of the cert-manager GitHub organization
+The admins aren't defined in any public file. The admins are the GitHub members
+on the cert-manager org that are set as "Owner". Additionally, admins have their
+email listed in GCP so that they can perform releases.
 
-### Requirements
-- You must be a maintainer.
-- You must have a good understanding of the technologies used in the cert-manager infrastructure.
+### Becoming an Admin
+
+To become an admin, you must already be a maintainer for a time and have some
+understanding of the technologies used in the cert-manager infrastructure (e.g.,
+Prow). Then, create an issue on the cert-manager project and mention each
+maintainer. Each maintainer will need to comment on the issue to express their
+approval.
 
 ### Privileges
-- Can perform administrative tasks on the cert-manager infrastructure
-- Can release new versions of cert-manager
+
+- Can remove protected branches and change settings in the GitHub organization.
+- Can run the Google Cloud Build playbooks to release new versions of cert-manager.
 
 ### Responsibilities
+
 - Must be responsible with the privileges granted to them
 - Must manage cert-manager membership requests in a timely manner when requested using the process outlined in the Member Role section above.
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,4 +1,4 @@
-# cert-manager Governance (proposal)
+# cert-manager Governance
 
 This document defines project governance for the cert-manager project.
 
@@ -38,7 +38,7 @@ The cert-manager maintainers are:
 - Ashley Davis (@sgtcodfish)
 - Tim Ramlot (@inteon)
 
-This list is reflected in `OWNERS.md` files present at the root of the projects
+This list is reflected in `OWNERS` files present at the root of the projects
 within the cert-manager organization.
 
 ### Maintainers Responsibilities

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,8 +2,16 @@
 
 This document defines project governance for the cert-manager project. Its
 purpose is to describe how decisions are made on the project and how anyone can
-influence these decisions. We have six levels of responsibility, each one
-building on the previous:
+influence these decisions.
+
+This governance charter applies to every project under the cert-manager GitHub
+organisation. The term "cert-manager project" refers to any work done under the
+cert-manager GitHub organisation and includes the cert-manager/cert-manager
+repository itself as well as cert-manager/trust-manager,
+cert-manager/approver-policy and all the other repositories under the
+cert-manager GitHub organisation.
+
+We have six levels of responsibility, each one building on the previous:
 
 - [Contributor](#contributor),
 - [GitHub Member](#github-member),

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -176,7 +176,17 @@ following message template:
 > - 📢 Deadline: April 3rd, 2023 23:59 UTC
 > - 🚨 Note: to speed up the process, you may answer with a :+1: or a comment stating that you are lazy to help reach consensus before the deadline.
 
-Any disagreements with regards to the decision must be posted as a comment on the Slack message or to the email thread along with an explanation of why. Disagreements posted without justification will not be considered.
+Any disagreements with regards to the decision must be posted as a comment on
+the Slack message or to the email thread along with an explanation of why.
+Disagreements posted without justification will not be considered.
+
+While most decisions are typically reached through the principle of lazy
+consensus, there exists the option for a maintainer to propose a formal vote.
+Unless otherwise specified, such a vote would require a simple majority approval
+from all maintainers to be considered successful. Situations that might warrant
+a formal vote include, but are not limited to, cases where a decision
+necessitates explicit input from every participant or when disagreements arise
+during a lazy consensus discussion.
 
 ### Stepping Down as a Maintainer
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,7 +67,9 @@ GitHub members are encouraged to engage with the [cert-manager-dev](https://grou
 
 The mission of the reviewer is to read through PRs for quality and correctness
 on all or some part of cert-manager. Reviewers are knowledgeable about the
-codebase as well as software engineering principles.
+codebase as well as software engineering principles. Individuals with expertise
+in documentation, website content, and other facets of the project are also
+encouraged to join as reviewers.
 
 **Defined by:** the `reviewers` section in the file [`OWNERS`](./OWNERS).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -26,8 +26,8 @@ or other means.
 
 ### Contributor Responsibilities
 
-- Follow the [cert-manager Code of Conduct][coc].
-- Follow the guidelines in [the Contributing page][contrib].
+- Follow the [cert-manager Code of Conduct](https://github.com/cert-manager/cert-manager/blob/master/CODE_OF_CONDUCT.md).
+- Follow the guidelines in [the Contributing page](https://cert-manager.io/docs/contributing/).
 
 ## GitHub Member
 
@@ -60,9 +60,6 @@ To be added as a GitHub member, you will also need to enable [two-factor
 authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on your GitHub account.
 
 GitHub members are encouraged to engage with the [cert-manager-dev](https://groups.google.com/g/cert-manager-dev) mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
-
-[two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-[cert-manager-dev]: https://groups.google.com/forum/#!forum/cert-manager-dev
 
 ## Reviewer
 
@@ -192,9 +189,6 @@ year by the current maintainers. During this review, the maintainers that have
 not been active in the last 18 months are asked whether they would like to
 become an emeritus maintainer, they are expected to respond within 30 days. If
 they do not respond, they will automatically be moved to emeritus status.
-
-[coc]: https://github.com/cert-manager/cert-manager/blob/master/CODE_OF_CONDUCT.md
-[contrib]: https://cert-manager.io/docs/contributing/
 
 ## Admin
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,8 +1,11 @@
 # cert-manager Governance
 
-This document defines project governance for the cert-manager project.
+This document defines project governance for the cert-manager project.  
+It contains a list of roles that can be held by humans, and any additional
+requirements, privileges, and responsibilities that come with each role.  
+A role is held by a person, and a person can hold multiple roles.
 
-## Contributors
+## Contributor Role
 
 cert-manager is for everyone. Anyone can become a cert-manager contributor
 simply by contributing to the project, whether through code, documentation, blog
@@ -13,64 +16,139 @@ Conduct][coc].
 All contributions to cert-manager code, documentation, or other components in
 the cert-manager GitHub org must follow the guidelines in [the contributing
 page][contrib]. Whether these contributions are merged into the project is the
-prerogative of the maintainers.
+prerogative of the reviewers, approvers and/or maintainers.
 
-## Maintainers
+### Requirements
+- Contribute to the project in some way.
 
-Maintainers have the ability to merge code into the project. Anyone can become a
-cert-manager maintainer (see "Becoming a maintainer" below.)
+### Privileges
+- Create issues and pull requests in the cert-manager GitHub org.
 
-> **Note:** In some CNCF projects, a difference is made between a "committer"
-> and a "maintainer" (cf. [committer-vs-maintainer][]). In the context of the
-> cert-manager project, committer and maintainer are the same. We will be using
-> the term "maintainer" throughout this document.
+### Responsibilities
+- Follow the [cert-manager Code of Conduct][coc].
+- Follow the [contributing guidelines][contrib].
 
-[committer-vs-maintainer]: https://github.com/cncf/toc/pull/876#issuecomment-1189399941
+## Member Role
 
-The cert-manager maintainers are:
+Members are continuously active contributors.  
+Members are expected to remain active contributors.
 
-- James Munnelly (@munnerz)
-- Josh van Leeuwen (@joshvanl)
-- Richard Wall (@wallrj)
-- Jake Sanders (@jakexks)
-- Maël Valais (@maelvls)
-- Irbe Krumina (@irbekrm)
-- Ashley Davis (@sgtcodfish)
-- Tim Ramlot (@inteon)
+**Defined by:** Member of the cert-manager GitHub organization
 
-This list is reflected in `OWNERS` files present at the root of the projects
-within the cert-manager organization.
+### Requirements
+- You must be a contributor.
+- Enabled [two-factor authentication] on their GitHub account
+- Must be part of the [cert-manager-dev] Google group
+- Must be part of the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) Slack channel
+- Must be part of the [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channel
+- Sponsored by 2 reviewers. Note the following requirements for sponsors:
+    - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
+    - Sponsors must be reviewers or approvers.
+- Open an issue against the cert-manager/org repo
+    - Ensure your sponsors are @mentioned on the issue.
+    - Include a list of your contributions to the project.
+- Have your sponsors reply confirmation of sponsorship: +1
+- Once your sponsors have responded, your request will be reviewed by a cert-manager admin, in accordance with their SLO. Any missing information will be requested.
 
-### Maintainers Responsibilities
+[two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
+[cert-manager-dev]: https://groups.google.com/forum/#!forum/cert-manager-dev
 
-cert-manager maintainers are expected to:
+### Privileges
+- Is a member of the cert-manager GitHub organization
 
-- Review pull requests, triage issues, and fix bugs in their areas of expertise,
-  ensuring that all changes go through the project's code review and integration
-  processes.
-- Monitor cncf-cert-manager-\* emails and the cert-manager-dev and
-  cert-manager-dev channels on Slack, and help out when possible.
+### Responsibilities
+- Remain an active contributor to the project. If you have not been able to contribute to the project in longer than 18 months, you will be removed from the organization. You must respond to any raised member inactivity issues on the cert-manager/org repo in which you are @mentioned as the inactive member within 30 days to prove your activity.
+- Monitor the cert-manager-dev and cert-manager-dev channels on Slack, and help out when possible.
+
+## Reviewer Role
+
+Reviewers are able to review code for quality and correctness on some part of cert-manager.  
+They are knowledgeable about both the codebase and software engineering principles.
+
+**Defined by:** `reviewers` entry in the cert-manager [OWNERS][] file
+
+### Requirements
+- You must be a contributor.
+- You can be trusted to review PRs thoroughly.
+- Knowledgeable about the relevant part of the codebase, and can be referenced for questions about it.
+- Must have made a substantial contribution to the project that indicates their knowledge of (part of) the codebase.
+- Sponsored by 1 approver. Note the following requirements for sponsors:
+    - Sponsors must have close interactions with the prospective reviewer - e.g. code/design/proposal review, coordinating on issues, etc.
+    - Sponsors must be approvers.
+- Open a PR to update the OWNERS file
+    - Ensure your sponsor is @mentioned on the PR.
+    - Include a list of your substantial contributions to the project.
+
+### Privileges
+- Can /lgtm on pull requests
+
+### Responsibilities
+- When possible, review pull requests, triage issues, and fix bugs in their areas
+  of expertise
+- Ensure that all changes go through the project's code review and integration processes.
+
+## Approver Role
+
+= (in CNCF terms) comitter
+
+Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
+
+**Defined by:** `approvers` entry in the cert-manager [OWNERS][] file
+
+### Requirements
+- You must be a reviewer.
+- Your interests mostly align with the project's direction as determined by the maintainers and steering committee.
+- You have successfully reviewed & /lgtm'ed 5 PRs.
+- Sponsored by 1 maintainer. Note the following requirements for sponsors:
+    - Sponsors must have close interactions with the prospective reviewer - e.g. code/design/proposal review, coordinating on issues, etc.
+    - Sponsors must be maintainer.
+- Open a PR to update the OWNERS file
+    - Ensure your sponsor is @mentioned on the PR.
+    - Include a list of the 5 PRs you reviewed & /lgtm'ed.
+
+### Privileges
+- Can /approve on pull requests
+
+### Responsibilities
+- Expected to be responsive to review requests.
+- Stay up to date with the project's direction and goals. eg. by attending the weekly and/or bi-weekly meetings.
+
+## Maintainer Role
+
+= (in CNCF terms) maintainer
+
+Someone who can communicate with the CNCF on behalf of the project and who can
+participate in a "maintainers vote".
+
+**Defined by:** the list in the [MAINTAINERS.md][] file
+
+### Requirements
+- You must be an approver.
+- You have successfully reviewed & /approved'ed 10 PRs.
+- Must be able to dedicate time to participate in maintainer meetings.
+- Must be able to dedicate time to participate in maintainer votes.
+- Must be able to dedicate time to monitor the cert-manager-\* mailing lists and help out when possible.
+- Must be able to dedicate time to rapidly respond to any time-sensitive security release processes.
+- Must be able to dedicate time to attend meetings with the cert-manager Steering Committee.
+- Must be able to dedicate time to communicate with the CNCF on behalf of the project.
+
+### Privileges
+- Can communicate with the CNCF on behalf of the project.
+- Can participate in a "maintainers vote".
+
+### Responsibilities
+- Monitor cncf-cert-manager-\* emails and help out when possible.
 - Rapidly respond to any time-sensitive security release processes.
 - Attend meetings with the cert-manager Steering Committee.
+- Participate in "maintainer votes".
 
-### Maintainer Decision-Making
+### Maintainer Decision-Making (maintainers vote)
 
-Ideally, all project decisions are resolved by maintainer consensus. If this is
-not possible, maintainers may call a vote. The voting process is a simple
-majority in which each maintainer receives one vote.
+Substantial changes to the project, require a "maintainers vote". This includes,
+but is not limited to, changes to the project's roadmap, changes to the project's
+scope, fundamental design decisions, and changes to the project's governance. 
 
-### Becoming a Maintainer
-
-Anyone can become a cert-manager maintainer. Maintainers should be proficient in
-Go; have expertise in at least one of the domains (Kubernetes, PKI, ACME); have
-the time and ability to meet the maintainer expectations above; and demonstrate
-the ability to work with the existing maintainers and project processes.
-
-To become a maintainer, start by expressing interest to existing maintainers.
-Existing maintainers will then ask you to demonstrate the qualifications above
-by contributing PRs, doing code reviews, and other such tasks under their
-guidance. After several months of working together, maintainers will decide
-whether to grant maintainer status.
+A maintainer vote is a simple majority in which each maintainer receives one vote.
 
 ### Stepping Down as a Maintainer
 
@@ -78,16 +156,30 @@ If a maintainer is no longer interested in or cannot perform the duties listed
 above, they should move themselves to emeritus status. If necessary, this can
 also occur through the decision-making process outlined above.
 
-A review of the OWNERS file is performed every year by the current maintainers.
-During this review, the maintainers that have not been active in the last year
-are asked whether they would like to become an emeritus maintainer.
+A review of the [MAINTAINERS.md][] file is performed every year by the current maintainers.
+During this review, the maintainers that have not been active in the last 18 months
+are asked whether they would like to become an emeritus maintainer, they are expected
+to respond within 30 days. If they do not respond, they will automatically be moved to
+emeritus status.
 
 [coc]: https://github.com/cert-manager/cert-manager/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://cert-manager.io/docs/contributing/
 
-### Emeriti Maintainers
+## Admin Role
 
-Former maintainers include:
+An admin is a maintainer who has admin privileges on the cert-manager infrastructure.
 
-- Maartje Eyskens (@meyskens)
-- Joakim Ahrlin (@jahrlin)
+**Defined by:** Admins of the cert-manager GitHub organization
+
+### Requirements
+- You must be a maintainer.
+- You must have a good understanding of the technologies used in the cert-manager infrastructure.
+
+### Privileges
+- Can perform administrative tasks on the cert-manager infrastructure
+- Can release new versions of cert-manager
+
+### Responsibilities
+- Must be responsible with the privileges granted to them
+- Must manage cert-manager membership requests in a timely manner when requested using the process outlined in the Member Role section above.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -89,10 +89,12 @@ To become a reviewer, you will need to look for a sponsor with at least the
 approver role. Your sponsor must have had close interactions with you: they must
 have closely reviewed one of your PRs or worked with you on a complex issue.
 
-Then, create a PR on the [community][] repository to add your name to the list
-of `reviewers` in the `OWNERS` file. The PR description should list your
-significant contributions and should mention your sponsor. Your sponsor is
-expected to give their approval as a comment on your PR.
+Then, create a PR to add your name to the list of `reviewers` in the `OWNERS`
+file on the repository in which you want to become a Reviewer. The PR
+description should list your significant contributions and should mention your
+sponsor. Your sponsor is expected to give their approval as a comment on your
+PR. If you would like to become a reviewer for multiple repositories, you will
+need to repeat the process for each repository.
 
 ### Reviewer Responsibilities
 
@@ -125,8 +127,11 @@ You will then need to get sponsorship from one of the maintainers. The
 maintainer sponsoring you must have had close work interactions with you and be
 knowledgeable of some of your work.
 
-To apply, open a PR to update the `OWNERS` file and mention your sponsor in the
-description. The PR description should also list the PRs you have reviewed.
+To apply, open a PR to update the `OWNERS` file on the repository you would like
+to become an Approver for and mention your sponsor in the description. The PR
+description should also list the PRs you have reviewed. If you would like to
+become an approver for multiple repositories, you will need to repeat the
+process for each repository.
 
 ### Approver Responsibilities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -65,7 +65,7 @@ Members are expected to remain active contributors.
 Reviewers are able to review code for quality and correctness on some part of cert-manager.  
 They are knowledgeable about both the codebase and software engineering principles.
 
-**Defined by:** `reviewers` entry in the cert-manager [OWNERS][] file
+**Defined by:** `reviewers` entry in the cert-manager [OWNERS](./OWNERS) file
 
 ### Requirements
 - You must be a contributor.
@@ -93,7 +93,7 @@ They are knowledgeable about both the codebase and software engineering principl
 
 Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
 
-**Defined by:** `approvers` entry in the cert-manager [OWNERS][] file
+**Defined by:** `approvers` entry in the cert-manager [OWNERS](./OWNERS) file
 
 ### Requirements
 - You must be a reviewer.
@@ -120,7 +120,7 @@ Code approvers are able to both review and approve code contributions. While cod
 Someone who can communicate with the CNCF on behalf of the project and who can
 participate in a "maintainers vote".
 
-**Defined by:** the list in the [MAINTAINERS.md][] file
+**Defined by:** the list in the [MAINTAINERS.md](./MAINTAINERS.md) file
 
 ### Requirements
 - You must be an approver.
@@ -156,7 +156,7 @@ If a maintainer is no longer interested in or cannot perform the duties listed
 above, they should move themselves to emeritus status. If necessary, this can
 also occur through the decision-making process outlined above.
 
-A review of the [MAINTAINERS.md][] file is performed every year by the current maintainers.
+A review of the [MAINTAINERS.md](./MAINTAINERS.md) file is performed every year by the current maintainers.
 During this review, the maintainers that have not been active in the last 18 months
 are asked whether they would like to become an emeritus maintainer, they are expected
 to respond within 30 days. If they do not respond, they will automatically be moved to

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,16 +14,20 @@ building on the previous:
 
 ## Contributors
 
-cert-manager is for everyone. Anyone can become a cert-manager contributor
-simply by contributing to the project, whether through code, documentation, blog
-posts, community management, or other means. As with all cert-manager community
-members, contributors are expected to follow the [cert-manager Code of
-Conduct][coc].
+cert-manager is for everyone. Whether you're an experienced developer, a
+dedicated documenter, a passionate community builder, or simply someone eager to
+make a positive impact, cert-manager welcomes you as a valued contributor.
 
-All contributions to cert-manager code, documentation, or other components in
-the cert-manager GitHub org must follow the guidelines in [the contributing
-page][contrib]. Whether these contributions are merged into the project is the
-prerogative of the reviewers, approvers and/or maintainers.
+### Becoming a Contributor
+
+Anyone can become a cert-manager contributor simply by contributing to the
+project, whether through code, documentation, blog posts, community management,
+or other means.
+
+### Contributor Responsibilities
+
+- Follow the [cert-manager Code of Conduct][coc].
+- Follow the guidelines in [the Contributing page][contrib].
 
 ## GitHub Members
 
@@ -107,7 +111,7 @@ To become an approver and start merging PRs, you must have reviewed 5 PRs.
 
 You will then need to get sponsorship from one of the maintainers. The
 maintainer sponsoring you must have had close work interactions with you and be
-knowledgeable of some of your work. 
+knowledgeable of some of your work.
 
 To apply, open a PR to update the `OWNERS` file and mention your sponsor in the
 description. The PR description should also list the PRs you have reviewed.
@@ -126,7 +130,7 @@ description. The PR description should also list the PRs you have reviewed.
 ## Maintainer
 
 A maintainer is someone who can communicate with the CNCF on behalf of the
-project and who can participate in lazy consensus and votes. 
+project and who can participate in lazy consensus and votes.
 
 **Defined by:** [`MAINTAINERS.md`](./MAINTAINERS.md).
 
@@ -167,8 +171,9 @@ and time are specified and the maintainers are CC'ed. You may use the
 following message template:
 
 > Dear maintainers, I'd like us to reach an agreement on the following matter using lazy consensus: [...]
+>
 > - 🧑‍💻 Participants: @cert-manager-maintainers
-> - 📢 Deadline: April 3rd, 2023 23:59 UTC  
+> - 📢 Deadline: April 3rd, 2023 23:59 UTC
 > - 🚨 Note: to speed up the process, you may answer with a :+1: or a comment stating that you are lazy to help reach consensus before the deadline.
 
 Any disagreements with regards to the decision must be posted as a comment on the Slack message or to the email thread along with an explanation of why. Disagreements posted without justification will not be considered.
@@ -191,7 +196,7 @@ they do not respond, they will automatically be moved to emeritus status.
 ## Admin
 
 An admin is a maintainer who has admin privileges on the cert-manager
-infrastructure. 
+infrastructure.
 
 The admins aren't defined in any public file. The admins are the GitHub members
 on the cert-manager org that are set as "Owner". Additionally, admins have their

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,8 +35,8 @@ GitHub Members are active contributors to the cert-manager project, or one of
 the related projects in the cert-manager GitHub organisation.
 
 A contributor is considered to be active when they have had at least one
-interaction (comment on an issue or PR or message in the #cert-manager or #cert-
-manager-dev channels) within the last 18 months.
+interaction (comment on an issue or PR or message in the `#cert-manager` or
+`#cert- manager-dev` channels) within the last 18 months.
 
 Members that have been inactive over the past 18 months may be removed from the
 GitHub organization.
@@ -50,7 +50,7 @@ to look for two sponsors with at least the `reviewer` role. These two sponsors
 must have had some meaningful interaction with you on an issue on GitHub or on
 the cert-manager or cert-manager-dev channels on Slack.
 
-Then, open an issue on the cert-manager repository and mention your sponsors as
+Then, open an issue on the [community][] repository and mention your sponsors as
 well as links to the meaningful interactions (Slack threads, GitHub issues). Ask
 your sponsors to confirm their sponsorship by commenting on your PR. After that,
 your request will be reviewed by a cert-manager admin, in accordance with their
@@ -77,10 +77,10 @@ To become a reviewer, you will need to look for a sponsor with at least the
 approver role. Your sponsor must have had close interactions with you: they must
 have closely reviewed one of your PRs or worked with you on a complex issue.
 
-Then, create a PR to add your name to the list of `reviewers` in the `OWNERS`
-file. The PR description should list your significant contributions and should
-mention your sponsor. Your sponsor is expected to give their approval as a comment
-on your PR.
+Then, create a PR on the [community][] repository to add your name to the list
+of `reviewers` in the `OWNERS` file. The PR description should list your
+significant contributions and should mention your sponsor. Your sponsor is
+expected to give their approval as a comment on your PR.
 
 ### Reviewer Responsibilities
 
@@ -213,9 +213,11 @@ email listed in GCP so that they can perform releases.
 
 To become an admin, you must already be a maintainer for a time and have some
 understanding of the technologies used in the cert-manager infrastructure (e.g.,
-Prow). Then, create an issue on the cert-manager project and mention each
+Prow). Then, create an issue on the [community][] repository and mention each
 maintainer. Each maintainer will need to comment on the issue to express their
 approval.
+
+[community]: https://github.com/cert-manager/community
 
 ### Admin Privileges
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -27,7 +27,7 @@ prerogative of the reviewers, approvers and/or maintainers.
 
 ## GitHub Members
 
-GitHub Members are active contributors to the cert-manager project.
+GitHub Members are active contributors to the cert-manager project, or one of the related projects in the cert-manager GitHub organisation.
 
 A contributor is considered to be active when they have had at least one
 interaction (comment on an issue or PR or message in the #cert-manager or #cert-
@@ -46,15 +46,15 @@ must have had some meaningful interaction with you on an issue on GitHub or on
 the cert-manager or cert-manager-dev channels on Slack.
 
 Then, open an issue on the cert-manager repository and mention your sponsors as
-well as links to the meaningful interations (Slack threads, GitHub issues). Ask
+well as links to the meaningful interactions (Slack threads, GitHub issues). Ask
 your sponsors to confirm their sponsorship by commenting on your PR. After that,
 your request will be reviewed by a cert-manager admin, in accordance with their
 SLO.
 
 To be added as a GitHub member, you will also need to enable [two-factor
-authentication][] on your GitHub account.
+authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on your GitHub account.
 
-GitHub members are encouraged to engage with the [cert-manager-dev][] mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
+GitHub members are encouraged to engage with the [cert-manager-dev](https://groups.google.com/g/cert-manager-dev) mailing list as well as the [cert-manager](https://kubernetes.slack.com/messages/cert-manager) and [cert-manager-dev](https://kubernetes.slack.com/messages/cert-manager-dev) Slack channels.
 
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
 [cert-manager-dev]: https://groups.google.com/forum/#!forum/cert-manager-dev
@@ -70,12 +70,12 @@ codebase as well as software engineering principles.
 ### Becoming a Reviewer
 
 To become a reviewer, you will need to look for a sponsor with at least the
-approver role. Your sponsor must have had close interactions with you: he must
-have been closely reviewed one of your PRs or worked with you on a thorny issue.
+approver role. Your sponsor must have had close interactions with you: they must
+have closely reviewed one of your PRs or worked with you on a complex issue.
 
 Then, create a PR to add your name to the list of `reviewers` in the `OWNERS`
 file. The PR description should list your significant contributions and should
-mention your sponsor. Your sponsor is expected to give his approval as a comment
+mention your sponsor. Your sponsor is expected to give their approval as a comment
 on your PR.
 
 ### Responsibilities

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -69,6 +69,10 @@ authentication](https://docs.github.com/en/authentication/securing-your-account-
 
 GitHub members are encouraged to engage with the mailing list [cert-manager-dev@googlegroups.com](https://groups.google.com/g/cert-manager-dev) as well as the [`#cert-manager`](https://kubernetes.slack.com/messages/cert-manager) and [`#cert-manager-dev`](https://kubernetes.slack.com/messages/cert-manager-dev) channels on the Kubernetes Slack.
 
+### GitHub Member Responsibilities
+
+No extra responsabilities.
+
 ## Reviewer
 
 The mission of the reviewer is to read through PRs for quality and correctness

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,15 +1,17 @@
 # Active Maintainers
 
-The cert-manager maintainers are:
+The current maintainers group for the cert-manager project consists of:
 
-- James Munnelly (@munnerz)
-- Josh van Leeuwen (@joshvanl)
-- Richard Wall (@wallrj)
-- Jake Sanders (@jakexks)
-- Maël Valais (@maelvls)
-- Irbe Krumina (@irbekrm)
-- Ashley Davis (@sgtcodfish)
-- Tim Ramlot (@inteon)
+| Name                         | Employer   |
+| ---------------------------- | ---------- |
+| James Munnelly (@munnerz)    | Apple      |
+| Josh van Leeuwen (@joshvanl) | Diagrid    |
+| Richard Wall (@wallrj)       | Venafi     |
+| Jake Sanders (@jakexks)      | G-Research |
+| Maël Valais (@maelvls)       | Venafi     |
+| Irbe Krumina (@irbekrm)      | Tailscale  |
+| Ashley Davis (@sgtcodfish)   | Venafi     |
+| Tim Ramlot (@inteon)         | Venafi     |
 
 # Emeriti Maintainers
 
@@ -17,3 +19,8 @@ Former maintainers are:
 
 - Maartje Eyskens (@meyskens)
 - Joakim Ahrlin (@jahrlin)
+
+This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv) as well as the [cert-manager Maintainers Group on Slack](https://github.com/kubernetes/community/blob/master/communication/slack-config/usergroups.yaml#L302) (`@cert-manager-maintainers`).
+
+See [the project Governance](GOVERNANCE.md) for how maintainers are selected and
+replaced.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,26 +1,17 @@
-# Active Maintainers
+# Maintainers
 
-The current maintainers group for the cert-manager project consists of:
+See [the project Governance](GOVERNANCE.md) for how maintainers are selected and
+replaced.
 
-| Name                         | Employer   |
-| ---------------------------- | ---------- |
-| James Munnelly (@munnerz)    | Apple      |
-| Josh van Leeuwen (@joshvanl) | Diagrid    |
-| Richard Wall (@wallrj)       | Venafi     |
-| Jake Sanders (@jakexks)      | G-Research |
-| Maël Valais (@maelvls)       | Venafi     |
-| Irbe Krumina (@irbekrm)      | Tailscale  |
-| Ashley Davis (@sgtcodfish)   | Venafi     |
-| Tim Ramlot (@inteon)         | Venafi     |
+## Active Maintainers
 
-# Emeriti Maintainers
+The current maintainers group for the cert-manager project is listed in [`maintainers.csv`](/maintainers.csv).
+
+This list is kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv) as well as the [cert-manager Maintainers Group on Slack](https://github.com/kubernetes/community/blob/master/communication/slack-config/usergroups.yaml#L302) (`@cert-manager-maintainers`).
+
+## Emeriti Maintainers
 
 Former maintainers are:
 
 - Maartje Eyskens (@meyskens)
 - Joakim Ahrlin (@jahrlin)
-
-This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv) as well as the [cert-manager Maintainers Group on Slack](https://github.com/kubernetes/community/blob/master/communication/slack-config/usergroups.yaml#L302) (`@cert-manager-maintainers`).
-
-See [the project Governance](GOVERNANCE.md) for how maintainers are selected and
-replaced.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Active Maintainers
+
+The cert-manager maintainers are:
+
+- James Munnelly (@munnerz)
+- Josh van Leeuwen (@joshvanl)
+- Richard Wall (@wallrj)
+- Jake Sanders (@jakexks)
+- Maël Valais (@maelvls)
+- Irbe Krumina (@irbekrm)
+- Ashley Davis (@sgtcodfish)
+- Tim Ramlot (@inteon)
+
+# Emeriti Maintainers
+
+Former maintainers are:
+
+- Maartje Eyskens (@meyskens)
+- Joakim Ahrlin (@jahrlin)

--- a/STEERING.md
+++ b/STEERING.md
@@ -1,0 +1,55 @@
+# Linkerd Steering Committee Charter
+
+The goal of the cert-manager Steering Committee is to ensure that cert-manager
+meets the needs of its current and future users. The Steering Committee
+represents the voice of the user, and works with the cert-manager maintainers to
+help guide development efforts towards solving concrete and immediate problems
+for cert-manager adopters.
+
+The members of the Steering Committee are:
+
+- TBD
+
+## Steering Committee Responsibilities
+
+The Steering Committee’s responsibilities are to:
+
+1. Provide feedback to project maintainers about cert-manager's featureset, UX,
+   and operational model.
+2. Assist cert-manager maintainers in prioritizing upcoming roadmap items and
+   planned work.
+3. Represent the "voice of the cert-manager user" both internally and to the
+   broader community.
+4. Provide neutral mediation for non-technical disputes.
+5. Develop and maintain a project continuity plan.
+
+## Steering Committee Membership
+
+The Steering Committee comprises at most 7 people. To be eligible for membership
+in the Steering Committee, you must:
+
+1. Be responsible for a production cert-manager deployment of non-trivial size
+2. Be willing and able to attend regularly-scheduled Steering Committee meetings
+3. Abide by cert-manager's Code of Conduct.
+
+Candidates for membership will be nominated by current Steering Committee
+members or by cert-manager maintainers. If there are more nominations than
+Steering Committee seats remaining, the same group shall vote on the candidates,
+and the candidates with the most votes will become Steering Committee members.
+Any ties will be broken by cert-manager maintainers.
+
+Membership expires if any of the eligibility conditions is unmet, or after one
+year. Members may seek reinstatement immediately in accordance with the rules
+above.
+
+## Steering Committee Meetings
+
+Meetings will happen periodically not less than once a quarter. Recordings and
+minutes will be posted publicly.
+
+## Changes to this charter
+
+Changes to this document must be approved by a majority of Steering Committee
+members and a majority of cert-manager maintainers, except for the list of
+steering committee members that may be changed under the conditions listed under
+"Steering Committee Membership".

--- a/STEERING.md
+++ b/STEERING.md
@@ -1,4 +1,4 @@
-# Linkerd Steering Committee Charter
+# Steering Committee Charter
 
 The goal of the cert-manager Steering Committee is to ensure that cert-manager
 meets the needs of its current and future users. The Steering Committee

--- a/STEERING.md
+++ b/STEERING.md
@@ -38,16 +38,19 @@ Steering Committee seats remaining, the same group shall vote on the candidates,
 and the candidates with the most votes will become Steering Committee members.
 Any ties will be broken by cert-manager maintainers.
 
-Membership expires if any of the eligibility conditions is unmet, or after one
+Membership expires if any of the eligibility conditions are unmet, or after one
 year. Members may seek reinstatement immediately in accordance with the rules
 above.
 
 ## Steering Committee Meetings
 
-Meetings will happen periodically not less than once a quarter. Recordings and
-minutes will be posted publicly.
+Steering Committee meetings will happen at least once per quarter but can be more frequent if needed.
 
-## Changes to this charter
+All recordings and minutes will be posted publicly.
+
+It is the responsibility of maintainers to ensure that meetings are scheduled and run, and maintainers are generally expected to attend these meetings to provide input and to listen.
+
+## Changes to This Charter
 
 Changes to this document must be approved by a majority of Steering Committee
 members and a majority of cert-manager maintainers, except for the list of

--- a/STEERING.md
+++ b/STEERING.md
@@ -33,10 +33,20 @@ in the Steering Committee, you must:
 3. Abide by cert-manager's Code of Conduct.
 
 Candidates for membership will be nominated by current Steering Committee
-members or by cert-manager maintainers. If there are more nominations than
-Steering Committee seats remaining, the same group shall vote on the candidates,
-and the candidates with the most votes will become Steering Committee members.
-Any ties will be broken by cert-manager maintainers.
+members or by cert-manager maintainers. To be accepted as a candidate, a
+person must have at least two nominators from this group.
+
+If there are fewer proposed candidates than there are open seats, then the proposed
+candidates may assume their seats immediately.
+
+If there are more nominations than there are open seats remaining, existing
+Steering Committee members may vote for candidates using the
+[single transferable vote](https://en.wikipedia.org/wiki/Single_transferable_vote)
+system wherein candidates are ranked in order.
+
+In the event of a tie, the tie shall be broken by a simple vote among cert-manager maintainers.
+If the vote among maintainers is tied, then the tie shall be broken by random chance using a method
+to be determined fair by all participants.
 
 Membership expires if any of the eligibility conditions are unmet, or after one
 year. Members may seek reinstatement immediately in accordance with the rules

--- a/maintainers.csv
+++ b/maintainers.csv
@@ -1,0 +1,9 @@
+Maintainer Name,Github Name,Company
+James Munnelly,munnerz,Apple
+Josh van Leeuwen,joshvanl,Diagrid
+Richard Wall,wallrj,Venafi
+Jake Sanders,jakexks,G-Research
+Maël Valais,maelvls,Venafi
+Irbe Krumina,irbekrm,Tailscale
+Ashley Davis,sgtcodfish,Venafi
+Tim Ramlot,inteon,Venafi


### PR DESCRIPTION
This PR is part of #6132.

To apply for graduation, cert-manager is required to perform the two following steps:

> - Explicitly define a project governance and committer process. The committer process should cover the full committer lifecycle including onboarding and offboarding or emeritus criteria. This preferably is laid out in a `GOVERNANCE.md` file and references an `OWNERS.md` file showing the current and emeritus committers.
> - Explicitly define the criteria, process and offboarding or emeritus conditions for project maintainers; or those who may interact with the CNCF on behalf of the project. The list of maintainers should be preferably be stored in a `MAINTAINERS.md` file and audited at a minimum of an annual cadence.

In the cert-manager project, we don't make a distinction between "committer" and "maintainer". In the `GOVERNANCE.md` document, I use the term "maintainer" for simplicity. Since committers and maintainers are the same in our project, we will not have a `MAINTAINERS.md` file.

Back in 15 June 2023, I had presented [the first proposal of `GOVERNANCE.md` [OLD, FOR REFERENCE ONLY]](https://hackmd.io/YkDBYQP1Qlekdx4NS11iIg?view) (hosted on HackMD); this PR is the "second iteration" of that proposal.

Regarding the list of steering committee members, I propose that we update the `STEERING.md` as we go. For context, we have 1 volunteer and the goal is to have at least 3 (out of the 7 seats available).

**For this PR to be merged, all maintainers need to approve by posting a message such as "As a maintainer, I approve with this change" or a comment with a thumbs up emoji or a comment saying `/approve`.** Since many things in these two documents had not been defined previously, I propose to have the documents adopted via a **lazy consensus that ends on 12 Sept 2023 23:59 UTC+2** involving the cert-manager maintainers.

/kind documentation

```release-note
NONE
```
