### PR TITLE
Annual review of the OWNERS file (2023): remove Joakim

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - maelvls
 - irbekrm
 - sgtcodfish
-- jahrlin
 - inteon
 reviewers:
 - munnerz
@@ -18,5 +17,4 @@ reviewers:
 - maelvls
 - irbekrm
 - sgtcodfish
-- jahrlin
 - inteon


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```

Ref: https://github.com/cert-manager/cert-manager/issues/6231

