### PR TITLE
WebhookConfiguration: change the types of ports from *int to *int32

### DIFF
--- a/internal/apis/config/webhook/fuzzer/fuzzer.go
+++ b/internal/apis/config/webhook/fuzzer/fuzzer.go
@@ -19,7 +19,6 @@ package fuzzer
 import (
 	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/utils/pointer"
 
 	"github.com/cert-manager/cert-manager/internal/apis/config/webhook"
 )
@@ -30,12 +29,6 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 		func(s *webhook.WebhookConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again
 
-			if s.HealthzPort == nil {
-				s.HealthzPort = pointer.Int(12)
-			}
-			if s.SecurePort == nil {
-				s.SecurePort = pointer.Int(123)
-			}
 			if s.PprofAddress == "" {
 				s.PprofAddress = "something:1234"
 			}

--- a/internal/apis/config/webhook/types.go
+++ b/internal/apis/config/webhook/types.go
@@ -26,10 +26,12 @@ type WebhookConfiguration struct {
 	metav1.TypeMeta
 
 	// securePort is the port number to listen on for secure TLS connections from the kube-apiserver.
+	// If 0, a random available port will be chosen.
 	// Defaults to 6443.
 	SecurePort int32
 
 	// healthzPort is the port number to listen on (using plaintext HTTP) for healthz connections.
+	// If 0, a random available port will be chosen.
 	// Defaults to 6080.
 	HealthzPort int32
 

--- a/internal/apis/config/webhook/types.go
+++ b/internal/apis/config/webhook/types.go
@@ -27,11 +27,11 @@ type WebhookConfiguration struct {
 
 	// securePort is the port number to listen on for secure TLS connections from the kube-apiserver.
 	// Defaults to 6443.
-	SecurePort *int
+	SecurePort int32
 
 	// healthzPort is the port number to listen on (using plaintext HTTP) for healthz connections.
 	// Defaults to 6080.
-	HealthzPort *int
+	HealthzPort int32
 
 	// tlsConfig is used to configure the secure listener's TLS settings.
 	TLSConfig TLSConfig

--- a/internal/apis/config/webhook/v1alpha1/defaults.go
+++ b/internal/apis/config/webhook/v1alpha1/defaults.go
@@ -29,10 +29,10 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_WebhookConfiguration(obj *v1alpha1.WebhookConfiguration) {
 	if obj.SecurePort == nil {
-		obj.SecurePort = pointer.Int(6443)
+		obj.SecurePort = pointer.Int32(6443)
 	}
 	if obj.HealthzPort == nil {
-		obj.HealthzPort = pointer.Int(6080)
+		obj.HealthzPort = pointer.Int32(6080)
 	}
 	if obj.PprofAddress == "" {
 		obj.PprofAddress = "localhost:6060"

--- a/internal/apis/config/webhook/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/webhook/v1alpha1/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	webhook "github.com/cert-manager/cert-manager/internal/apis/config/webhook"
 	v1alpha1 "github.com/cert-manager/cert-manager/pkg/apis/config/webhook/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -161,8 +162,12 @@ func Convert_webhook_TLSConfig_To_v1alpha1_TLSConfig(in *webhook.TLSConfig, out 
 }
 
 func autoConvert_v1alpha1_WebhookConfiguration_To_webhook_WebhookConfiguration(in *v1alpha1.WebhookConfiguration, out *webhook.WebhookConfiguration, s conversion.Scope) error {
-	out.SecurePort = (*int)(unsafe.Pointer(in.SecurePort))
-	out.HealthzPort = (*int)(unsafe.Pointer(in.HealthzPort))
+	if err := v1.Convert_Pointer_int32_To_int32(&in.SecurePort, &out.SecurePort, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.HealthzPort, &out.HealthzPort, s); err != nil {
+		return err
+	}
 	if err := Convert_v1alpha1_TLSConfig_To_webhook_TLSConfig(&in.TLSConfig, &out.TLSConfig, s); err != nil {
 		return err
 	}
@@ -180,8 +185,12 @@ func Convert_v1alpha1_WebhookConfiguration_To_webhook_WebhookConfiguration(in *v
 }
 
 func autoConvert_webhook_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(in *webhook.WebhookConfiguration, out *v1alpha1.WebhookConfiguration, s conversion.Scope) error {
-	out.SecurePort = (*int)(unsafe.Pointer(in.SecurePort))
-	out.HealthzPort = (*int)(unsafe.Pointer(in.HealthzPort))
+	if err := v1.Convert_int32_To_Pointer_int32(&in.SecurePort, &out.SecurePort, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_int32_To_Pointer_int32(&in.HealthzPort, &out.HealthzPort, s); err != nil {
+		return err
+	}
 	if err := Convert_webhook_TLSConfig_To_v1alpha1_TLSConfig(&in.TLSConfig, &out.TLSConfig, s); err != nil {
 		return err
 	}

--- a/internal/apis/config/webhook/validation/validation.go
+++ b/internal/apis/config/webhook/validation/validation.go
@@ -48,11 +48,11 @@ func ValidateWebhookConfiguration(cfg *config.WebhookConfiguration) error {
 			}
 		}
 	}
-	if cfg.HealthzPort == nil {
-		allErrors = append(allErrors, fmt.Errorf("invalid configuration: healthzPort must be specified"))
+	if cfg.HealthzPort < 0 || cfg.HealthzPort > 65535 {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: healthzPort must be a valid port number"))
 	}
-	if cfg.SecurePort == nil {
-		allErrors = append(allErrors, fmt.Errorf("invalid configuration: securePort must be specified"))
+	if cfg.SecurePort < 0 || cfg.SecurePort > 65535 {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: securePort must be a valid port number"))
 	}
 	return utilerrors.NewAggregate(allErrors)
 }

--- a/internal/apis/config/webhook/zz_generated.deepcopy.go
+++ b/internal/apis/config/webhook/zz_generated.deepcopy.go
@@ -89,16 +89,6 @@ func (in *TLSConfig) DeepCopy() *TLSConfig {
 func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.SecurePort != nil {
-		in, out := &in.SecurePort, &out.SecurePort
-		*out = new(int)
-		**out = **in
-	}
-	if in.HealthzPort != nil {
-		in, out := &in.HealthzPort, &out.HealthzPort
-		*out = new(int)
-		**out = **in
-	}
 	in.TLSConfig.DeepCopyInto(&out.TLSConfig)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -71,8 +71,8 @@ func NewCertManagerWebhookServer(log logr.Logger, opts config.WebhookConfigurati
 	}
 
 	s := &server.Server{
-		ListenAddr:        fmt.Sprintf(":%d", *opts.SecurePort),
-		HealthzAddr:       fmt.Sprintf(":%d", *opts.HealthzPort),
+		ListenAddr:        fmt.Sprintf(":%d", opts.SecurePort),
+		HealthzAddr:       fmt.Sprintf(":%d", opts.HealthzPort),
 		EnablePprof:       opts.EnablePprof,
 		PprofAddr:         opts.PprofAddress,
 		CertificateSource: buildCertificateSource(log, opts.TLSConfig, restcfg),

--- a/pkg/apis/config/webhook/v1alpha1/types.go
+++ b/pkg/apis/config/webhook/v1alpha1/types.go
@@ -26,10 +26,12 @@ type WebhookConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// securePort is the port number to listen on for secure TLS connections from the kube-apiserver.
+	// If 0, a random available port will be chosen.
 	// Defaults to 6443.
 	SecurePort *int32 `json:"securePort,omitempty"`
 
 	// healthzPort is the port number to listen on (using plaintext HTTP) for healthz connections.
+	// If 0, a random available port will be chosen.
 	// Defaults to 6080.
 	HealthzPort *int32 `json:"healthzPort,omitempty"`
 

--- a/pkg/apis/config/webhook/v1alpha1/types.go
+++ b/pkg/apis/config/webhook/v1alpha1/types.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package v1alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -25,11 +27,11 @@ type WebhookConfiguration struct {
 
 	// securePort is the port number to listen on for secure TLS connections from the kube-apiserver.
 	// Defaults to 6443.
-	SecurePort *int `json:"securePort,omitempty"`
+	SecurePort *int32 `json:"securePort,omitempty"`
 
 	// healthzPort is the port number to listen on (using plaintext HTTP) for healthz connections.
 	// Defaults to 6080.
-	HealthzPort *int `json:"healthzPort,omitempty"`
+	HealthzPort *int32 `json:"healthzPort,omitempty"`
 
 	// tlsConfig is used to configure the secure listener's TLS settings.
 	TLSConfig TLSConfig `json:"tlsConfig"`

--- a/pkg/apis/config/webhook/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/webhook/v1alpha1/zz_generated.deepcopy.go
@@ -91,12 +91,12 @@ func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 	out.TypeMeta = in.TypeMeta
 	if in.SecurePort != nil {
 		in, out := &in.SecurePort, &out.SecurePort
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.HealthzPort != nil {
 		in, out := &in.HealthzPort, &out.HealthzPort
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	in.TLSConfig.DeepCopyInto(&out.TLSConfig)

--- a/pkg/webhook/options/options.go
+++ b/pkg/webhook/options/options.go
@@ -64,8 +64,8 @@ func NewWebhookConfiguration() (*config.WebhookConfiguration, error) {
 }
 
 func AddConfigFlags(fs *pflag.FlagSet, c *config.WebhookConfiguration) {
-	fs.IntVar(c.SecurePort, "secure-port", *c.SecurePort, "port number to listen on for secure TLS connections")
-	fs.IntVar(c.HealthzPort, "healthz-port", *c.HealthzPort, "port number to listen on for insecure healthz connections")
+	fs.Int32Var(&c.SecurePort, "secure-port", c.SecurePort, "port number to listen on for secure TLS connections")
+	fs.Int32Var(&c.HealthzPort, "healthz-port", c.HealthzPort, "port number to listen on for insecure healthz connections")
 
 	fs.StringVar(&c.TLSConfig.Filesystem.CertFile, "tls-cert-file", c.TLSConfig.Filesystem.CertFile, "path to the file containing the TLS certificate to serve with")
 	fs.StringVar(&c.TLSConfig.Filesystem.KeyFile, "tls-private-key-file", c.TLSConfig.Filesystem.KeyFile, "path to the file containing the TLS private key to serve with")

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -34,7 +34,6 @@ import (
 	logtesting "github.com/go-logr/logr/testing"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
 
 	"github.com/cert-manager/cert-manager/internal/webhook"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -95,8 +94,8 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string, argume
 	}
 
 	// Listen on a random port number
-	webhookConfig.SecurePort = pointer.Int(0)
-	webhookConfig.HealthzPort = pointer.Int(0)
+	webhookConfig.SecurePort = 0
+	webhookConfig.HealthzPort = 0
 
 	errCh := make(chan error)
 	srv, err := webhook.NewCertManagerWebhookServer(log, *webhookConfig, argumentsForNewServerWithOptions...)


### PR DESCRIPTION
## For the public API:

public: *int -> *int32

> All public integer fields MUST use the Go int32 or Go int64 types, not int (which is ambiguously sized, depending on target platform). Internal types may use int.

see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md

## For the internal API:

internal: *int -> int32

Since the value is always being defaulted, it makes no sense to have a pointer value here. Also, I changed the type to int32 to match the public API.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Kind

/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
