### PR TITLE
Only set logging settings once

### DIFF
--- a/cmd/controller/app/start_test.go
+++ b/cmd/controller/app/start_test.go
@@ -86,6 +86,15 @@ func TestFlagsAndConfigFile(t *testing.T) {
 
 	tests := []testCase{
 		{
+			yaml: ``,
+			args: func(tempFilePath string) []string {
+				return []string{"--kubeconfig=valid"}
+			},
+			expConfig: configFromDefaults(func(tempDir string, cc *config.ControllerConfiguration) {
+				cc.KubeConfig = "valid"
+			}),
+		},
+		{
 			yaml: `
 apiVersion: controller.config.cert-manager.io/v1alpha1
 kind: ControllerConfiguration

--- a/cmd/webhook/app/webhook_test.go
+++ b/cmd/webhook/app/webhook_test.go
@@ -86,6 +86,15 @@ func TestFlagsAndConfigFile(t *testing.T) {
 
 	tests := []testCase{
 		{
+			yaml: ``,
+			args: func(tempFilePath string) []string {
+				return []string{"--kubeconfig=valid"}
+			},
+			expConfig: configFromDefaults(func(tempDir string, cc *config.WebhookConfiguration) {
+				cc.KubeConfig = "valid"
+			}),
+		},
+		{
 			yaml: `
 apiVersion: webhook.config.cert-manager.io/v1alpha1
 kind: WebhookConfiguration

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -11,6 +11,8 @@ replace github.com/cert-manager/cert-manager => ../../
 require (
 	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.7.0
+	k8s.io/apimachinery v0.27.4
+	k8s.io/component-base v0.27.4
 )
 
 require (
@@ -82,10 +84,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.27.4 // indirect
 	k8s.io/apiextensions-apiserver v0.27.4 // indirect
-	k8s.io/apimachinery v0.27.4 // indirect
 	k8s.io/apiserver v0.27.4 // indirect
 	k8s.io/client-go v0.27.4 // indirect
-	k8s.io/component-base v0.27.4 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-aggregator v0.27.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	_ "k8s.io/component-base/logs/json/register"
@@ -97,6 +98,10 @@ func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 
 func ValidateAndApply(opts *logsapi.LoggingConfiguration) error {
 	return logsapi.ValidateAndApply(opts, nil)
+}
+
+func ValidateAndApplyAsField(opts *logsapi.LoggingConfiguration, fldPath *field.Path) error {
+	return logsapi.ValidateAndApplyAsField(opts, nil, fldPath)
 }
 
 // FlushLogs flushes logs immediately.


### PR DESCRIPTION
In preparation for the 1.28 upgrade (https://github.com/cert-manager/cert-manager/pull/6287), we have to fix an issue with loading the logging options from flags & configfile.

Currently, we set the logging options based on the config in the flags & re-set the options after we parsed the configfile. This is done so we can use the logging settings from the flags while parsing the config file.
In 1.28 however, the logging library has become a bit more strict & does no longer allow re-setting the logging options.

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
