### PR TITLE
Feature gates: promote StableCertificateRequestName and SecretsFilteredCaching to Beta

### DIFF
--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -81,7 +81,7 @@ const (
 	// See https://github.com/cert-manager/cert-manager/issues/3203 and https://github.com/cert-manager/cert-manager/issues/4424 for context.
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
 
-	// Owner: N/A
+	// Owner: @inteon
 	// Alpha: v1.10
 	// Beta: v1.13
 	//

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -83,6 +83,7 @@ const (
 
 	// Owner: N/A
 	// Alpha: v1.10
+	// Beta: v1.13
 	//
 	// StableCertificateRequestName will enable generation of CertificateRequest resources with a fixed name. The name of the CertificateRequest will be a function of Certificate resource name and its revision
 	// This feature gate will disable auto-generated CertificateRequest name
@@ -99,6 +100,7 @@ const (
 
 	// Owner: @irbekrm
 	// Alpha v1.12
+	// Beta: v1.13
 	//
 	// SecretsFilteredCaching reduces controller's memory consumption by
 	// filtering which Secrets are cached in full using
@@ -127,6 +129,8 @@ func init() {
 // available on the cert-manager controller binary.
 var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.Beta},
+	StableCertificateRequestName:       {Default: true, PreRelease: featuregate.Beta},
+	SecretsFilteredCaching:             {Default: true, PreRelease: featuregate.Beta},
 
 	ValidateCAA: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
@@ -134,7 +138,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
 	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},
-	StableCertificateRequestName:                     {Default: false, PreRelease: featuregate.Alpha},
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
-	SecretsFilteredCaching:                           {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/controller/certificates/requestmanager/util_test.go
+++ b/pkg/controller/certificates/requestmanager/util_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,12 +101,8 @@ func createCryptoBundle(originalCert *cmapi.Certificate) (*cryptoBundle, error) 
 	for k, v := range crt.Annotations {
 		annotations[k] = v
 	}
-	if crt.Status.Revision != nil {
-		annotations[cmapi.CertificateRequestRevisionAnnotationKey] = fmt.Sprintf("%d", crt.Status.Revision)
-	} else {
-		annotations[cmapi.CertificateRequestRevisionAnnotationKey] = "1"
-	}
 
+	annotations[cmapi.CertificateRequestRevisionAnnotationKey] = "NOT SET"
 	annotations[cmapi.CertificateRequestPrivateKeyAnnotationKey] = crt.Spec.SecretName
 	annotations[cmapi.CertificateNameKey] = crt.Name
 	if crt.Status.NextPrivateKeySecretName != nil {
@@ -115,7 +110,7 @@ func createCryptoBundle(originalCert *cmapi.Certificate) (*cryptoBundle, error) 
 	}
 	certificateRequest := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    crt.Name + "-",
+			Name:            "NOT SET",
 			Namespace:       crt.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},
 			Annotations:     annotations,

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -144,7 +144,10 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 		}
 
 		for _, req := range reqs.Items {
-			if req.Name == firstReq.Name {
+			// We expect a new request to be created (with the same name as the first request)
+			// and the old request to be deleted. We can check this by comparing the UID of the
+			// first request with the UID of the second request.
+			if req.UID == firstReq.UID {
 				continue
 			}
 
@@ -278,7 +281,10 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 		}
 
 		for _, req := range reqs.Items {
-			if req.Name == firstReq.Name {
+			// We expect a new request to be created (with the same name as the first request)
+			// and the old request to be deleted. We can check this by comparing the UID of the
+			// first request with the UID of the second request.
+			if req.UID == firstReq.UID {
 				continue
 			}
 


### PR DESCRIPTION
Based on our CI testing, we can be reasonably comfortable with enabling StableCertificateRequestName and SecretsFilteredCaching by default & promoting them to Beta (see "A Beta feature means:" https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).

I had to update some of our tests so they work with the new defaults.

### Kind

/kind feature

### Release Note

```release-note
Promoted the StableCertificateRequestName and SecretsFilteredCaching featureflags to Beta (enabled by default).
```
