### PR TITLE
Rename DontAllowInsecureCSRUsageDefinition feature flag and make it a Beta flag

### DIFF
--- a/internal/apis/certmanager/validation/certificaterequest.go
+++ b/internal/apis/certmanager/validation/certificaterequest.go
@@ -109,12 +109,12 @@ func validateCertificateRequestSpecRequest(crSpec *cmapi.CertificateRequestSpec,
 		return el
 	}
 
-	// If DontAllowInsecureCSRUsageDefinition is disabled and usages is empty,
+	// If DisallowInsecureCSRUsageDefinition is disabled and usages is empty,
 	// then we should allow the request to be created without requiring that the
 	// CSR usages match the default usages, instead we only validate that the
 	// BasicConstraints are valid.
 	// TODO: simplify this logic when we remove the feature gate
-	if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DontAllowInsecureCSRUsageDefinition) && len(crSpec.Usages) == 0 {
+	if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DisallowInsecureCSRUsageDefinition) && len(crSpec.Usages) == 0 {
 		_, err = pki.CertificateTemplateFromCSRPEM(
 			crSpec.Request,
 			pki.CertificateTemplateValidateAndOverrideBasicConstraints(crSpec.IsCA, nil),

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -110,12 +110,12 @@ const (
 	SecretsFilteredCaching featuregate.Feature = "SecretsFilteredCaching"
 
 	// Owner: @inteon
-	// GA: v1.13
+	// Beta: v1.13
 	//
-	// DontAllowInsecureCSRUsageDefinition will prevent the webhook from allowing
+	// DisallowInsecureCSRUsageDefinition will prevent the webhook from allowing
 	// CertificateRequest's usages to be only defined in the CSR, while leaving
 	// the usages field empty.
-	DontAllowInsecureCSRUsageDefinition featuregate.Feature = "DontAllowInsecureCSRUsageDefinition"
+	DisallowInsecureCSRUsageDefinition featuregate.Feature = "DisallowInsecureCSRUsageDefinition"
 )
 
 func init() {
@@ -126,7 +126,7 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available on the cert-manager controller binary.
 var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DontAllowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
+	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.Beta},
 
 	ValidateCAA: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -55,12 +55,12 @@ const (
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
 
 	// Owner: @inteon
-	// GA: v1.13
+	// Beta: v1.13
 	//
-	// DontAllowInsecureCSRUsageDefinition will prevent the webhook from allowing
+	// DisallowInsecureCSRUsageDefinition will prevent the webhook from allowing
 	// CertificateRequest's usages to be only defined in the CSR, while leaving
 	// the usages field empty.
-	DontAllowInsecureCSRUsageDefinition featuregate.Feature = "DontAllowInsecureCSRUsageDefinition"
+	DisallowInsecureCSRUsageDefinition featuregate.Feature = "DisallowInsecureCSRUsageDefinition"
 )
 
 func init() {
@@ -75,7 +75,7 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DontAllowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
+	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.Beta},
 
 	AdditionalCertificateOutputFormats: {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:          {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -72,7 +72,7 @@ func NewCA(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:      crutil.NewReporter(ctx.Clock, ctx.Recorder),
 		templateGenerator: func(cr *cmapi.CertificateRequest) (*x509.Certificate, error) {
-			if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DontAllowInsecureCSRUsageDefinition) {
+			if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DisallowInsecureCSRUsageDefinition) {
 				return pki.DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition(cr)
 			}
 

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -150,7 +150,7 @@ func (s *SelfSigned) Sign(ctx context.Context, cr *cmapi.CertificateRequest, iss
 	}
 
 	var template *x509.Certificate
-	if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DontAllowInsecureCSRUsageDefinition) {
+	if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DisallowInsecureCSRUsageDefinition) {
 		template, err = pki.DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition(cr)
 	} else {
 		template, err = pki.CertificateTemplateFromCertificateRequest(cr)

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -177,7 +177,7 @@ func TestValidationCertificateRequests(t *testing.T) {
 			defer cancel()
 
 			// The default is true, but we set it here to make sure it was not changed by other tests
-			utilfeature.DefaultMutableFeatureGate.Set("DontAllowInsecureCSRUsageDefinition=true")
+			utilfeature.DefaultMutableFeatureGate.Set("DisallowInsecureCSRUsageDefinition=true")
 
 			config, stop := framework.RunControlPlane(t, ctx)
 			defer stop()
@@ -203,10 +203,10 @@ func TestValidationCertificateRequests(t *testing.T) {
 	}
 }
 
-// TestValidationCertificateRequests_DontAllowInsecureCSRUsageDefinition_false makes sure that the
-// validation webhook keeps working as before when the DontAllowInsecureCSRUsageDefinition feature
+// TestValidationCertificateRequests_DisallowInsecureCSRUsageDefinition_false makes sure that the
+// validation webhook keeps working as before when the DisallowInsecureCSRUsageDefinition feature
 // gate is disabled.
-func TestValidationCertificateRequests_DontAllowInsecureCSRUsageDefinition_false(t *testing.T) {
+func TestValidationCertificateRequests_DisallowInsecureCSRUsageDefinition_false(t *testing.T) {
 	tests := map[string]struct {
 		input       runtime.Object
 		errorSuffix string // is a suffix as the API server sends the whole value back in the error
@@ -338,7 +338,7 @@ func TestValidationCertificateRequests_DontAllowInsecureCSRUsageDefinition_false
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 			defer cancel()
 
-			utilfeature.DefaultMutableFeatureGate.Set("DontAllowInsecureCSRUsageDefinition=false")
+			utilfeature.DefaultMutableFeatureGate.Set("DisallowInsecureCSRUsageDefinition=false")
 
 			config, stop := framework.RunControlPlane(t, ctx)
 			defer stop()


### PR DESCRIPTION
This flag was introduced in https://github.com/cert-manager/cert-manager/pull/6182 and https://github.com/cert-manager/cert-manager/pull/6199 (not yet released).
I incorrectly made the flag a GA flag, while it should be Beta flag (see https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).

This PR renames the `DontAllowInsecureCSRUsageDefinition` feature flag to `DisallowInsecureCSRUsageDefinition` and makes it a Beta flag.

fixes https://github.com/cert-manager/cert-manager/issues/6203

### Pull Request Motivation

/kind cleanup

### Release Note

```release-note
NONE
```
