### PR TITLE
cleanup: Scope mutating webhook to only certificaterequest resources

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -22,7 +22,6 @@ webhooks:
           - "v1"
         operations:
           - CREATE
-          - UPDATE
         resources:
           - "certificaterequests"
     admissionReviewVersions: ["v1"]

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -18,7 +18,6 @@ webhooks:
     rules:
       - apiGroups:
           - "cert-manager.io"
-          - "acme.cert-manager.io"
         apiVersions:
           - "v1"
         operations:

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -25,7 +25,7 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - "*/*"
+          - "certificaterequests"
     admissionReviewVersions: ["v1"]
     # This webhook only accepts v1 cert-manager resources.
     # Equivalent matchPolicy ensures that non-v1 resource requests are sent to


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Relating to the [certificate-preset](https://hackmd.io/@hawksight/r1CVOU9i3) investigations we have been exploring ideas on how provide users of the `Certificate` resource without baking a new feature into cert-manager code. (See #2239 for back story).

As suggested by @wallrj in [a slack thread](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1692950767141859?thread_ts=1692898220.457779&cid=CDEQJ0Q8M), it seems that cert-manager only uses this mutating webhook for `CertificateRequest` resources, and not for actual certificates. (**NOTE** this may not be true and we should absolutely validate this). 

The impact of this webhook was that it applied to `Certificate` resources when cert-manager does nothing useful with them at admission time. In fact as @erikgb has pointed out [in slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1692898220457779), the required fields `issuerRef` and `secretName` do not set `omitempty` on the resources [here](https://github.com/cert-manager/cert-manager/blob/master/pkg/apis/certmanager/v1/types_certificate.go#L166) and [here](https://github.com/cert-manager/cert-manager/blob/master/pkg/apis/certmanager/v1/types_certificate.go#L145). 

- So an empty value is applied to these fields when they are not present in the Certificate resource supplied.
- This means that other mutation policies may well skip injecting a default because the value, although blank, has already been provided. 
- The empty value is then rejected by the cert-manager validating webhook as it needs a value.

This change basically makes enables other mutating webhooks to apply a default value to the field before validation. Because now the mutating webhook does not pickup `Certificate` resources and cause the small change of setting blanks.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

claeanup?

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
cleanup: Restrict mutatingwebhookconfiguration to only CertificateRequest resources
```
