### PR TITLE
Upgrade go-licenses to the latest master version

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -20,7 +20,6 @@ github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/v4/LICENS
 github.com/cenkalti/backoff/v3,https://github.com/cenkalti/backoff/blob/v3.2.2/LICENSE,MIT
 github.com/cenkalti/backoff/v4,https://github.com/cenkalti/backoff/blob/v4.2.1/LICENSE,MIT
 github.com/cert-manager/cert-manager,https://github.com/cert-manager/cert-manager/blob/HEAD/LICENSE,Apache-2.0
-github.com/cert-manager/cert-manager/make/config/samplewebhook/sample,https://github.com/cert-manager/cert-manager/blob/HEAD/make/licenses.mk,Apache-2.0
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/azuredns/LICENSE,MIT
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/clouddns,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/clouddns/LICENSE,MIT
 github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/cloudflare,https://github.com/cert-manager/cert-manager/blob/HEAD/pkg/issuer/acme/dns/cloudflare/LICENSE,MIT
@@ -32,6 +31,7 @@ github.com/coreos/go-systemd/v22,https://github.com/coreos/go-systemd/blob/v22.5
 github.com/cpu/goacmedns,https://github.com/cpu/goacmedns/blob/v0.1.1/LICENSE,MIT
 github.com/davecgh/go-spew/spew,https://github.com/davecgh/go-spew/blob/d8f796af33cc/LICENSE,ISC
 github.com/digitalocean/godo,https://github.com/digitalocean/godo/blob/v1.102.1/LICENSE.txt,MIT
+github.com/digitalocean/godo,https://github.com/digitalocean/godo/blob/v1.102.1/LICENSE.txt,BSD-3-Clause
 github.com/emicklei/go-restful/v3,https://github.com/emicklei/go-restful/blob/v3.10.1/LICENSE,MIT
 github.com/evanphx/json-patch,https://github.com/evanphx/json-patch/blob/v5.6.0/LICENSE,BSD-3-Clause
 github.com/evanphx/json-patch/v5,https://github.com/evanphx/json-patch/blob/v5.6.0/v5/LICENSE,BSD-3-Clause
@@ -53,6 +53,7 @@ github.com/golang/groupcache/lru,https://github.com/golang/groupcache/blob/41bb1
 github.com/golang/protobuf,https://github.com/golang/protobuf/blob/v1.5.3/LICENSE,BSD-3-Clause
 github.com/golang/snappy,https://github.com/golang/snappy/blob/v0.0.4/LICENSE,BSD-3-Clause
 github.com/google/cel-go,https://github.com/google/cel-go/blob/v0.16.0/LICENSE,Apache-2.0
+github.com/google/cel-go,https://github.com/google/cel-go/blob/v0.16.0/LICENSE,BSD-3-Clause
 github.com/google/gnostic-models,https://github.com/google/gnostic-models/blob/v0.6.8/LICENSE,Apache-2.0
 github.com/google/go-cmp/cmp,https://github.com/google/go-cmp/blob/v0.5.9/LICENSE,BSD-3-Clause
 github.com/google/go-querystring/query,https://github.com/google/go-querystring/blob/v1.1.0/LICENSE,BSD-3-Clause
@@ -75,7 +76,7 @@ github.com/hashicorp/hcl,https://github.com/hashicorp/hcl/blob/v1.0.1-vault-5/LI
 github.com/hashicorp/vault/api,https://github.com/hashicorp/vault/blob/api/v1.9.2/api/LICENSE,MPL-2.0
 github.com/hashicorp/vault/sdk/helper,https://github.com/hashicorp/vault/blob/sdk/v0.9.2/sdk/LICENSE,MPL-2.0
 github.com/imdario/mergo,https://github.com/imdario/mergo/blob/v0.3.13/LICENSE,BSD-3-Clause
-github.com/jmespath/go-jmespath,https://github.com/jmespath/go-jmespath/blob/v0.4.0/LICENSE,Apache-2.0
+github.com/jmespath/go-jmespath,Unknown,Unknown
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
 github.com/kr/pretty,https://github.com/kr/pretty/blob/v0.3.1/License,MIT
@@ -164,6 +165,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client,https://github.com/kuber
 sigs.k8s.io/controller-runtime,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.0/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause
 software.sslmate.com/src/go-pkcs12,https://github.com/SSLMate/go-pkcs12/blob/v0.2.1/LICENSE,BSD-3-Clause

--- a/cmd/acmesolver/LICENSES
+++ b/cmd/acmesolver/LICENSES
@@ -40,5 +40,7 @@ k8s.io/utils,https://github.com/kubernetes/utils/blob/3b25d923346b/LICENSE,Apach
 k8s.io/utils/internal/third_party/forked/golang/net,https://github.com/kubernetes/utils/blob/3b25d923346b/internal/third_party/forked/golang/LICENSE,BSD-3-Clause
 sigs.k8s.io/gateway-api/apis/v1beta1,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4/value,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause

--- a/cmd/cainjector/LICENSES
+++ b/cmd/cainjector/LICENSES
@@ -66,5 +66,7 @@ k8s.io/utils/internal/third_party/forked/golang/net,https://github.com/kubernete
 sigs.k8s.io/controller-runtime,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.0/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api/apis/v1beta1,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause

--- a/cmd/controller/LICENSES
+++ b/cmd/controller/LICENSES
@@ -29,6 +29,7 @@ github.com/coreos/go-systemd/v22/journal,https://github.com/coreos/go-systemd/bl
 github.com/cpu/goacmedns,https://github.com/cpu/goacmedns/blob/v0.1.1/LICENSE,MIT
 github.com/davecgh/go-spew/spew,https://github.com/davecgh/go-spew/blob/d8f796af33cc/LICENSE,ISC
 github.com/digitalocean/godo,https://github.com/digitalocean/godo/blob/v1.102.1/LICENSE.txt,MIT
+github.com/digitalocean/godo,https://github.com/digitalocean/godo/blob/v1.102.1/LICENSE.txt,BSD-3-Clause
 github.com/emicklei/go-restful/v3,https://github.com/emicklei/go-restful/blob/v3.10.1/LICENSE,MIT
 github.com/felixge/httpsnoop,https://github.com/felixge/httpsnoop/blob/v1.0.3/LICENSE.txt,MIT
 github.com/go-asn1-ber/asn1-ber,https://github.com/go-asn1-ber/asn1-ber/blob/v1.5.4/LICENSE,MIT
@@ -68,7 +69,7 @@ github.com/hashicorp/hcl,https://github.com/hashicorp/hcl/blob/v1.0.1-vault-5/LI
 github.com/hashicorp/vault/api,https://github.com/hashicorp/vault/blob/api/v1.9.2/api/LICENSE,MPL-2.0
 github.com/hashicorp/vault/sdk/helper,https://github.com/hashicorp/vault/blob/sdk/v0.9.2/sdk/LICENSE,MPL-2.0
 github.com/imdario/mergo,https://github.com/imdario/mergo/blob/v0.3.13/LICENSE,BSD-3-Clause
-github.com/jmespath/go-jmespath,https://github.com/jmespath/go-jmespath/blob/v0.4.0/LICENSE,Apache-2.0
+github.com/jmespath/go-jmespath,Unknown,Unknown
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
 github.com/kr/pretty,https://github.com/kr/pretty/blob/v0.3.1/License,MIT
@@ -150,6 +151,8 @@ k8s.io/utils/internal/third_party/forked/golang/net,https://github.com/kubernete
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client,https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/konnectivity-client/v0.1.2/konnectivity-client/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause
 software.sslmate.com/src/go-pkcs12,https://github.com/SSLMate/go-pkcs12/blob/v0.2.1/LICENSE,BSD-3-Clause

--- a/cmd/ctl/LICENSES
+++ b/cmd/ctl/LICENSES
@@ -58,7 +58,9 @@ github.com/imdario/mergo,https://github.com/imdario/mergo/blob/v0.3.13/LICENSE,B
 github.com/jmoiron/sqlx,https://github.com/jmoiron/sqlx/blob/v1.3.5/LICENSE,MIT
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
+github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,MIT
 github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,Apache-2.0
+github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,BSD-3-Clause
 github.com/klauspost/compress/internal/snapref,https://github.com/klauspost/compress/blob/v1.16.5/internal/snapref/LICENSE,BSD-3-Clause
 github.com/klauspost/compress/zstd/internal/xxhash,https://github.com/klauspost/compress/blob/v1.16.5/zstd/internal/xxhash/LICENSE.txt,MIT
 github.com/lann/builder,https://github.com/lann/builder/blob/47ae307949d0/LICENSE,MIT
@@ -145,9 +147,11 @@ oras.land/oras-go/pkg,https://github.com/oras-project/oras-go/blob/v1.2.3/LICENS
 sigs.k8s.io/controller-runtime/pkg,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.0/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api/apis/v1beta1,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/kustomize/api,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/api/LICENSE,Apache-2.0
 sigs.k8s.io/kustomize/kyaml,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/LICENSE,Apache-2.0
 sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/go-yaml/yaml,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/internal/forked/github.com/go-yaml/yaml/LICENSE,MIT
 sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/qri-io/starlib/util,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/internal/forked/github.com/qri-io/starlib/util/LICENSE,MIT
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause

--- a/cmd/webhook/LICENSES
+++ b/cmd/webhook/LICENSES
@@ -84,5 +84,7 @@ k8s.io/utils/internal/third_party/forked/golang,https://github.com/kubernetes/ut
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client,https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/konnectivity-client/v0.1.2/konnectivity-client/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api/apis/v1beta1,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -54,7 +54,7 @@ TOOLS += release-notes=v0.15.1
 # https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=versions
 TOOLS += goimports=v0.12.0
 # https://pkg.go.dev/github.com/google/go-licenses?tab=versions
-TOOLS += go-licenses=v1.6.0
+TOOLS += go-licenses=9a41918e8c1e254f6472bdd8454b6030d445b255
 # https://pkg.go.dev/gotest.tools/gotestsum?tab=versions
 TOOLS += gotestsum=v1.10.1
 # https://pkg.go.dev/github.com/google/go-containerregistry/cmd/crane?tab=versions

--- a/test/e2e/LICENSES
+++ b/test/e2e/LICENSES
@@ -89,5 +89,7 @@ k8s.io/utils/internal/third_party/forked/golang/net,https://github.com/kubernete
 sigs.k8s.io/controller-runtime/pkg,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.0/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause

--- a/test/integration/LICENSES
+++ b/test/integration/LICENSES
@@ -66,7 +66,9 @@ github.com/imdario/mergo,https://github.com/imdario/mergo/blob/v0.3.13/LICENSE,B
 github.com/jmoiron/sqlx,https://github.com/jmoiron/sqlx/blob/v1.3.5/LICENSE,MIT
 github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/license.md,MIT
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
+github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,MIT
 github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,Apache-2.0
+github.com/klauspost/compress,https://github.com/klauspost/compress/blob/v1.16.5/LICENSE,BSD-3-Clause
 github.com/klauspost/compress/internal/snapref,https://github.com/klauspost/compress/blob/v1.16.5/internal/snapref/LICENSE,BSD-3-Clause
 github.com/klauspost/compress/zstd/internal/xxhash,https://github.com/klauspost/compress/blob/v1.16.5/zstd/internal/xxhash/LICENSE.txt,MIT
 github.com/lann/builder,https://github.com/lann/builder/blob/47ae307949d0/LICENSE,MIT
@@ -169,9 +171,11 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client,https://github.com/kuber
 sigs.k8s.io/controller-runtime/pkg,https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.0/LICENSE,Apache-2.0
 sigs.k8s.io/gateway-api,https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/LICENSE,Apache-2.0
 sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,Apache-2.0
+sigs.k8s.io/json,https://github.com/kubernetes-sigs/json/blob/bc3834ca7abd/LICENSE,BSD-3-Clause
 sigs.k8s.io/kustomize/api,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/api/LICENSE,Apache-2.0
 sigs.k8s.io/kustomize/kyaml,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/LICENSE,Apache-2.0
 sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/go-yaml/yaml,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/internal/forked/github.com/go-yaml/yaml/LICENSE,MIT
 sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/qri-io/starlib/util,https://github.com/kubernetes-sigs/kustomize/blob/6ce0bf390ce3/kyaml/internal/forked/github.com/qri-io/starlib/util/LICENSE,MIT
 sigs.k8s.io/structured-merge-diff/v4,https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.3.0/LICENSE,Apache-2.0
 sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,MIT
+sigs.k8s.io/yaml,https://github.com/kubernetes-sigs/yaml/blob/v1.3.0/LICENSE,BSD-3-Clause


### PR DESCRIPTION
This allows us to use the performance improvements made upstream: https://github.com/google/go-licenses/pull/204

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
