### PR TITLE
[release-1.11] Bump to Go 1.19.12

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -38,7 +38,7 @@ KUBEBUILDER_ASSETS_VERSION=1.25.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.19.11
+VENDORED_GO_VERSION := 1.19.12
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
Go 1.19.9, which we used to build the 1.11.4 binaries, are affected by a security bug in `crypto/tls`.

```release-note
Use Go 1.19.9 to fix a security issue in Go's `crypto/tls` library.
```
