### PR TITLE
[release-1.12] Bump to Go 1.20.7

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -53,7 +53,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.6
+VENDORED_GO_VERSION := 1.20.7
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
Go 1.20.6, which we used to build the cert-manager 1.20.3 binaries, are affected by a security bug in `crypto/tls`.

You can learn more at https://github.com/golang/go/issues/61460.


```release-note
Use Go 1.20.7 to fix a security issue in Go's `crypto/tls` library.
```

xref: https://github.com/cert-manager/cert-manager/pull/6317
