### PR TITLE
refactor: remove redundant nil check

### DIFF
--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -90,10 +90,8 @@ func (s *Solver) getGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge) 
 
 func (s *Solver) createGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge, svcName string) (*gwapi.HTTPRoute, error) {
 	labels := podLabels(ch)
-	if ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels != nil {
-		for k, v := range ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels {
-			labels[k] = v
-		}
+	for k, v := range ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels {
+		labels[k] = v
 	}
 	httpRoute := &gwapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -116,10 +114,8 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 	expectedSpec := generateHTTPRouteSpec(ch, svcName)
 	actualSpec := httpRoute.Spec
 	expectedLabels := podLabels(ch)
-	if ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels != nil {
-		for k, v := range ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels {
-			expectedLabels[k] = v
-		}
+	for k, v := range ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels {
+		expectedLabels[k] = v
 	}
 	actualLabels := ch.Labels
 	if reflect.DeepEqual(expectedSpec, actualSpec) && reflect.DeepEqual(expectedLabels, actualLabels) {


### PR DESCRIPTION
### Pull Request Motivation

From the Go specification:

> "3. If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.

### Kind

/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
