### PR TITLE
Add health probe that detects skew between system clock and monotonic go process clock

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -277,9 +277,8 @@ topologySpreadConstraints: []
 
 # LivenessProbe settings for the controller container of the controller Pod.
 #
-# Disabled by default, because the controller has a leader election mechanism
-# which should cause it to exit if it is unable to renew its leader election
-# record.
+# Enabled by default, because we want to enable the clock-skew liveness probe that
+# restarts the controller in case of a skew between the system clock and the monotonic clock.
 # LivenessProbe durations and thresholds are based on those used for the Kubernetes
 # controller-manager. See:
 # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -284,7 +284,7 @@ topologySpreadConstraints: []
 # controller-manager. See:
 # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
 livenessProbe:
-  enabled: false
+  enabled: true
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 15

--- a/pkg/healthz/clock_health.go
+++ b/pkg/healthz/clock_health.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+type clockHealthAdaptor struct {
+	clock              clock.Clock
+	startTimeReal      time.Time
+	startTimeMonotonic time.Time
+}
+
+func NewClockHealthAdaptor(c clock.Clock) *clockHealthAdaptor {
+	return &clockHealthAdaptor{
+		clock:              c,
+		startTimeReal:      c.Now().Round(0), // .Round(0) removes the monotonic part from the time
+		startTimeMonotonic: c.Now(),
+	}
+}
+
+func (c *clockHealthAdaptor) skew() time.Duration {
+	realDuration := c.clock.Since(c.startTimeReal)
+	monotonicDuration := c.clock.Since(c.startTimeMonotonic)
+
+	if monotonicDuration > realDuration {
+		return monotonicDuration - realDuration
+	}
+
+	return realDuration - monotonicDuration
+}
+
+// Name returns the name of the health check we are implementing.
+func (l *clockHealthAdaptor) Name() string {
+	return "clockHealth"
+}
+
+// Check is called by the healthz endpoint handler.
+// It fails (returns an error) if we own the lease but had not been able to renew it.
+func (l *clockHealthAdaptor) Check(req *http.Request) error {
+	if skew := l.skew(); skew > 1*time.Minute {
+		return fmt.Errorf("the system clock is out of sync with the internal monotonic clock by %v, which is more than the allowed 1m", skew)
+	}
+	return nil
+}

--- a/pkg/healthz/clock_health.go
+++ b/pkg/healthz/clock_health.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/clock"
 )
 
-const maxClockSkew = 1 * time.Minute
+const maxClockSkew = 5 * time.Minute
 
 // The clockHealthAdaptor implements the HealthChecker interface.
 // It checks the system clock is in sync with the internal monotonic clock.
@@ -41,7 +41,7 @@ const maxClockSkew = 1 * time.Minute
 //     -> the monotonic clock will stop, but the system clock will continue
 //     -> this eg. happens when you pause a VM/ hibernate a laptop
 //
-// Small clock skews of < 1m are allowed, because they can happen when the system clock is
+// Small clock skews of < 5m are allowed, because they can happen when the system clock is
 // adjusted. However, we do compound the clock skew over time, so that if the clock skew
 // is small but constant, it will eventually fail the health check.
 type clockHealthAdaptor struct {

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/utils/clock"
 )
 
 const (
@@ -51,8 +52,9 @@ type Server struct {
 // leader lease time, the leader election will be considered to have failed.
 func NewServer(leaderElectionHealthzAdaptorTimeout time.Duration) *Server {
 	leaderHealthzAdaptor := leaderelection.NewLeaderHealthzAdaptor(leaderElectionHealthzAdaptorTimeout)
+	clockHealthAdaptor := NewClockHealthAdaptor(clock.RealClock{})
 	mux := http.NewServeMux()
-	healthz.InstallLivezHandler(mux, leaderHealthzAdaptor)
+	healthz.InstallLivezHandler(mux, leaderHealthzAdaptor, clockHealthAdaptor)
 	return &Server{
 		server: &http.Server{
 			ReadTimeout:    healthzServerReadTimeout,


### PR DESCRIPTION
### Pull Request Motivation

This PR adds a new LivenessProbe that makes sure the clock skew is not more than 5 minutes.
If we detect that the monotonic duration since the start of the controller differs more than 5 minutes from the system clock duration since the start of the project, we return HTTP error code 500 and force a restart.

This check will fix the following issues:
- if the controller was started at time A & a timer for time B is created, hibernating for duration h will cause the timer to trigger at time B + h
- if the controller was started at time A & a timer for time B is created, changing the system clock (eg. fixing a wrong delta using ntp) will still result in the timer triggering at the original time

See https://github.com/golang/go/issues/35012 for the background on this issue in upstream Go.

fixes https://github.com/cert-manager/cert-manager/issues/6341

### Kind

/kind feature

### Release Note

```release-note
Added a clock skew detector liveness probe that will force a restart in case we detect a skew between the internal monotonic clock and the system clock of more than 5 minutes.
Also, the controller's liveness probe is now enabled by default.
```
