### PR TITLE
Do not process Gateway listeners that do not support TLS

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -322,6 +322,11 @@ func buildCertificates(
 		}
 	case *gwapi.Gateway:
 		for i, l := range ingLike.Spec.Listeners {
+			// TLS is only supported for a limited set of protocol types: https://gateway-api.sigs.k8s.io/guides/tls/#listeners-and-tls
+			if l.Protocol != gwapi.HTTPSProtocolType && l.Protocol != gwapi.TLSProtocolType {
+				continue
+			}
+
 			err := validateGatewayListenerBlock(field.NewPath("spec", "listeners").Index(i), l, ingLike).ToAggregate()
 			if err != nil {
 				rec.Eventf(ingLike, corev1.EventTypeWarning, reasonBadConfig, "Skipped a listener block: "+err.Error())

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -1680,7 +1680,7 @@ func TestSync(t *testing.T) {
 
 	testGatewayShim := []testT{
 		{
-			Name:   "return a single Certificate for a Gateway with a single valid TLS entry and common-name annotation",
+			Name:   "return a single Certificate for a Gateway with a single valid TLS entry and common-name annotation (HTTPS)",
 			Issuer: acmeClusterIssuer,
 			IngressLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1702,6 +1702,68 @@ func TestSync(t *testing.T) {
 							Hostname: ptrHostname("example.com"),
 							Port:     443,
 							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.GatewayTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-com-tls",
+						Namespace: gen.DefaultTestNamespace,
+						Labels: map[string]string{
+							"my-test-label": "should be copied",
+						},
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						CommonName: "my-cn",
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:   "return a single Certificate for a Gateway with a single valid TLS entry and common-name annotation (TLS)",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels: map[string]string{
+						"my-test-label": "should be copied",
+					},
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.CommonNameAnnotationKey:               "my-cn",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.TLSProtocolType,
 							TLS: &gwapi.GatewayTLSConfig{
 								Mode: ptrMode(gwapi.TLSModeTerminate),
 								CertificateRefs: []gwapi.SecretObjectReference{

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -1701,7 +1701,7 @@ func TestSync(t *testing.T) {
 						{
 							Hostname: ptrHostname("example.com"),
 							Port:     443,
-							Protocol: "HTTPS",
+							Protocol: gwapi.HTTPSProtocolType,
 							TLS: &gwapi.GatewayTLSConfig{
 								Mode: ptrMode(gwapi.TLSModeTerminate),
 								CertificateRefs: []gwapi.SecretObjectReference{
@@ -1762,7 +1762,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -1825,7 +1825,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -1884,7 +1884,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -1937,7 +1937,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -1991,7 +1991,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2048,7 +2048,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2100,7 +2100,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2156,7 +2156,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2193,7 +2193,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2207,7 +2207,7 @@ func TestSync(t *testing.T) {
 					}, {
 						Hostname: nil, // 🔥
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2262,7 +2262,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode:            ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{},
@@ -2270,7 +2270,7 @@ func TestSync(t *testing.T) {
 					}, {
 						Hostname: ptrHostname("www.example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2334,7 +2334,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2388,7 +2388,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2450,7 +2450,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2528,7 +2528,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2580,7 +2580,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2684,7 +2684,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2759,7 +2759,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2773,7 +2773,7 @@ func TestSync(t *testing.T) {
 					}, {
 						Hostname: ptrHostname("www.example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2787,7 +2787,7 @@ func TestSync(t *testing.T) {
 					}, {
 						Hostname: ptrHostname("foo.example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2844,7 +2844,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("foo.example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2858,7 +2858,7 @@ func TestSync(t *testing.T) {
 					}, {
 						Hostname: ptrHostname("bar.example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2933,7 +2933,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{
@@ -2971,7 +2971,7 @@ func TestSync(t *testing.T) {
 					Listeners: []gwapi.Listener{{
 						Hostname: ptrHostname("example.com"),
 						Port:     443,
-						Protocol: "HTTPS",
+						Protocol: gwapi.HTTPSProtocolType,
 						TLS: &gwapi.GatewayTLSConfig{
 							Mode: ptrMode(gwapi.TLSModeTerminate),
 							CertificateRefs: []gwapi.SecretObjectReference{


### PR DESCRIPTION
### Pull Request Motivation

If listeners that do not support TLS are processed, they will raise warnings in the next steps (e.g. about empty TLS blocks, which are not supported for HTTP listeners).

See #6197

### Kind

/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Listeners that do not support TLS on Gateway resources will now not raise `BadConfig` warnings anymore
```
