### PR TITLE
Add cluster-autoscaler.kubernetes.io/safe-to-evict

### DIFF
--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -175,7 +175,8 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			Namespace:    ch.Namespace,
 			Labels:       podLabels,
 			Annotations: map[string]string{
-				"sidecar.istio.io/inject": "false",
+				"sidecar.istio.io/inject":                        "false",
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
 		},

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -71,7 +71,8 @@ func TestEnsurePod(t *testing.T) {
 				Namespace:    testNamespace,
 				Labels:       podLabels(chal),
 				Annotations: map[string]string{
-					"sidecar.istio.io/inject": "false",
+					"sidecar.istio.io/inject":                        "false",
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
 				},
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
 			},
@@ -286,8 +287,9 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 											cmacme.DomainLabelKey: "44655555555",
 										},
 										Annotations: map[string]string{
-											"sidecar.istio.io/inject": "true",
-											"foo":                     "bar",
+											"sidecar.istio.io/inject":                        "true",
+											"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+											"foo": "bar",
 										},
 									},
 									Spec: cmacme.ACMEChallengeSolverHTTP01IngressPodSpec{
@@ -320,8 +322,9 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 					cmacme.SolverIdentificationLabelKey: "true",
 				}
 				resultingPod.Annotations = map[string]string{
-					"sidecar.istio.io/inject": "true",
-					"foo":                     "bar",
+					"sidecar.istio.io/inject":                        "true",
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+					"foo": "bar",
 				}
 				resultingPod.Spec.NodeSelector = map[string]string{
 					"kubernetes.io/os": "linux",


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This should make cert-manager installs on GKE friendlier to node autoscaling.
fixes #5267

### Kind

bug

### Release Note

```release-note
acme-challenge-solver-http01 will get a default annotation of `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"`. You can provide an annotation of `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` in your `podTemplate` if you don't like this.
```
