### PR TITLE
BUGFIX: CertificateRequest short names must be unique.

### DIFF
--- a/pkg/api/util/names.go
+++ b/pkg/api/util/names.go
@@ -72,6 +72,11 @@ func ComputeSecureUniqueDeterministicNameFromData(fullName string, maxNameLength
 		return "", err
 	}
 
+	// Although fullName is already a DNS subdomain, we can't just cut it
+	// at N characters and expect another DNS subdomain. That's because
+	// we might cut it right after a ".", which would give an invalid DNS
+	// subdomain (eg. test.-<hash>). So we make sure the last character
+	// is an alpha-numeric character.
 	prefix := DNSSafeShortenToNCharacters(fullName, maxNameLength-hashLength-1)
 	hashResult := hash.Sum(nil)
 

--- a/pkg/api/util/names.go
+++ b/pkg/api/util/names.go
@@ -82,7 +82,7 @@ func ComputeSecureUniqueDeterministicNameFromData(fullName string, maxNameLength
 	return fmt.Sprintf("%s-%08x", prefix, hashResult), nil
 }
 
-// DNSSafeShortenToNCharacters shortens the input string to 52 chars and ensures the last char is an alpha-numeric character.
+// DNSSafeShortenToNCharacters shortens the input string to N chars and ensures the last char is an alpha-numeric character.
 func DNSSafeShortenToNCharacters(in string, maxLength int) string {
 	var alphaNumeric = regexp.MustCompile(`[a-zA-Z\d]`)
 

--- a/pkg/api/util/names.go
+++ b/pkg/api/util/names.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -43,39 +44,65 @@ func ComputeName(prefix string, obj interface{}) (string, error) {
 	// and pods down the road for ACME resources.
 	prefix = DNSSafeShortenTo52Characters(prefix)
 
+	// the prefix is <= 52 characters, the decimal representation of
+	// the hash is <= 10 characters, and the hyphen is 1 character.
+	// 52 + 10 + 1 = 63, so we're good.
 	return fmt.Sprintf("%s-%d", prefix, hashF.Sum32()), nil
 }
 
-// ComputeUniqueDeterministicNameFromData returns a short unique name for the given object.
-func ComputeUniqueDeterministicNameFromData(fullName string) (string, error) {
-	const maxNameLength = 61 // 52 + 1 + 8
+// ComputeSecureUniqueDeterministicNameFromData computes a deterministic name from the given data.
+// The algorithm in use is SHA256 and is cryptographically secure.
+// The output is a string that is safe to use as a DNS label.
+// The output is guaranteed to be unique for the given input.
+// The output will be at least 64 characters long.
+func ComputeSecureUniqueDeterministicNameFromData(fullName string, maxNameLength int) (string, error) {
+	const hashLength = 64
+	if maxNameLength < hashLength {
+		return "", fmt.Errorf("maxNameLength must be at least %d", hashLength)
+	}
 
 	if len(fullName) <= maxNameLength {
 		return fullName, nil
 	}
 
-	hashF := fnv.New32()
+	hash := sha256.New()
 
-	_, err := hashF.Write([]byte(fullName))
+	_, err := hash.Write([]byte(fullName))
 	if err != nil {
 		return "", err
 	}
 
-	prefix := DNSSafeShortenTo52Characters(fullName)
+	prefix := DNSSafeShortenToNCharacters(fullName, maxNameLength-hashLength-1)
+	hashResult := hash.Sum(nil)
 
 	if len(prefix) == 0 {
-		return fmt.Sprintf("%08x", hashF.Sum32()), nil
+		return fmt.Sprintf("%08x", hashResult), nil
 	}
 
-	return fmt.Sprintf("%s-%08x", prefix, hashF.Sum32()), nil
+	return fmt.Sprintf("%s-%08x", prefix, hashResult), nil
+}
+
+// DNSSafeShortenToNCharacters shortens the input string to 52 chars and ensures the last char is an alpha-numeric character.
+func DNSSafeShortenToNCharacters(in string, maxLength int) string {
+	var alphaNumeric = regexp.MustCompile(`[a-zA-Z\d]`)
+
+	if len(in) < maxLength {
+		return in
+	}
+
+	if maxLength <= 0 {
+		return ""
+	}
+
+	validCharIndexes := alphaNumeric.FindAllStringIndex(in[:maxLength], -1)
+	if len(validCharIndexes) == 0 {
+		return ""
+	}
+
+	return in[:validCharIndexes[len(validCharIndexes)-1][1]]
 }
 
 // DNSSafeShortenTo52Characters shortens the input string to 52 chars and ensures the last char is an alpha-numeric character.
 func DNSSafeShortenTo52Characters(in string) string {
-	if len(in) >= 52 {
-		validCharIndexes := regexp.MustCompile(`[a-zA-Z\d]`).FindAllStringIndex(fmt.Sprintf("%.52s", in), -1)
-		in = in[:validCharIndexes[len(validCharIndexes)-1][1]]
-	}
-
-	return in
+	return DNSSafeShortenToNCharacters(in, 52)
 }

--- a/pkg/api/util/names.go
+++ b/pkg/api/util/names.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-
 	"regexp"
 )
 
@@ -45,6 +44,30 @@ func ComputeName(prefix string, obj interface{}) (string, error) {
 	prefix = DNSSafeShortenTo52Characters(prefix)
 
 	return fmt.Sprintf("%s-%d", prefix, hashF.Sum32()), nil
+}
+
+// ComputeUniqueDeterministicNameFromData returns a short unique name for the given object.
+func ComputeUniqueDeterministicNameFromData(fullName string) (string, error) {
+	const maxNameLength = 61 // 52 + 1 + 8
+
+	if len(fullName) <= maxNameLength {
+		return fullName, nil
+	}
+
+	hashF := fnv.New32()
+
+	_, err := hashF.Write([]byte(fullName))
+	if err != nil {
+		return "", err
+	}
+
+	prefix := DNSSafeShortenTo52Characters(fullName)
+
+	if len(prefix) == 0 {
+		return fmt.Sprintf("%08x", hashF.Sum32()), nil
+	}
+
+	return fmt.Sprintf("%s-%08x", prefix, hashF.Sum32()), nil
 }
 
 // DNSSafeShortenTo52Characters shortens the input string to 52 chars and ensures the last char is an alpha-numeric character.

--- a/pkg/api/util/names_test.go
+++ b/pkg/api/util/names_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -107,6 +108,49 @@ func TestComputeName(t *testing.T) {
 			}
 			if len(validation.IsQualifiedName(got)) != 0 {
 				t.Errorf("ComputeName() = %v is not DNS-1123 valid", got)
+			}
+		})
+	}
+}
+
+func TestComputeUniqueDeterministicNameFromData(t *testing.T) {
+	type testcase struct {
+		in     string
+		expOut string
+	}
+
+	tests := []testcase{
+		{
+			in:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expOut: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-014e7a7f",
+		},
+		{
+			in:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expOut: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			in:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.",
+			expOut: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.",
+		},
+		{
+			in:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaa",
+			expOut: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaa",
+		},
+		{
+			in:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaa",
+			expOut: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-72314ca8",
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			out, err := ComputeUniqueDeterministicNameFromData(test.in)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if out != test.expOut {
+				t.Errorf("expected %q, got %q", test.expOut, out)
 			}
 		})
 	}

--- a/pkg/api/util/names_test.go
+++ b/pkg/api/util/names_test.go
@@ -124,6 +124,26 @@ func TestDNSSafeShortenToNCharacters(t *testing.T) {
 	tests := []testcase{
 		{
 			in:        "aaaaaaaaaaaaaaa",
+			maxLength: 0,
+			expOut:    "",
+		},
+		{
+			in:        "aa-----aaaa",
+			maxLength: 5,
+			expOut:    "aa",
+		},
+		{
+			in:        "aa11111aaaa",
+			maxLength: 5,
+			expOut:    "aa111",
+		},
+		{
+			in:        "aaAAAAAaaaa",
+			maxLength: 5,
+			expOut:    "aaAAA",
+		},
+		{
+			in:        "aaaaaaaaaaaaaaa",
 			maxLength: 3,
 			expOut:    "aaa",
 		},

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -394,7 +394,16 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.StableCertificateRequestName) {
 		cr.ObjectMeta.GenerateName = ""
-		cr.ObjectMeta.Name = apiutil.DNSSafeShortenTo52Characters(crt.Name) + "-" + fmt.Sprintf("%d", nextRevision)
+
+		// limit the name to 54 chars to leave room for 8 characters that represent the revision
+		// number and a hyphen. This way, we stay within the 63 character limit for pod names (which is not
+		// a hard limit since we are working with CertificateRequest resources).
+		crName, err := apiutil.ComputeUniqueDeterministicNameFromData(crt.Name)
+		if err != nil {
+			return err
+		}
+
+		cr.ObjectMeta.Name = fmt.Sprintf("%s-%d", crName, nextRevision)
 	}
 
 	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -377,7 +377,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 
 	cr := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       crt.Namespace,
+			Namespace: crt.Namespace,
+			// We limit the GenerateName to 52 + 1 characters to stay within the 63 - 5 character limit that
+			// is used in Kubernetes when generating names.
+			// see https://github.com/kubernetes/apiserver/blob/696768606f546f71a1e90546613be37d1aa37f64/pkg/storage/names/generate.go
 			GenerateName:    apiutil.DNSSafeShortenTo52Characters(crt.Name) + "-",
 			Annotations:     annotations,
 			Labels:          crt.Labels,
@@ -395,10 +398,14 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	if utilfeature.DefaultFeatureGate.Enabled(feature.StableCertificateRequestName) {
 		cr.ObjectMeta.GenerateName = ""
 
-		// limit the name to 54 chars to leave room for 8 characters that represent the revision
-		// number and a hyphen. This way, we stay within the 63 character limit for pod names (which is not
-		// a hard limit since we are working with CertificateRequest resources).
-		crName, err := apiutil.ComputeUniqueDeterministicNameFromData(crt.Name)
+		// The CertificateRequest name is limited to 253 characters, assuming the nextRevision and hyphen
+		// can be represented using 20 characters, we can directly accept certificate names up to 233
+		// characters. Certificate names that are longer than this will be hashed to a shorter name. We want
+		// to make crafting two Certificates with the same truncated name as difficult as possible, so we
+		// use a cryptographic hash function to hash the full certificate name to 64 characters.
+		// Finally, for Certificates with a name longer than 233 characters, we build the CertificateRequest
+		// name as follows: <first-168-chars-of-certificate-name>-<64-char-hash>-<19-char-nextRevision>
+		crName, err := apiutil.ComputeSecureUniqueDeterministicNameFromData(crt.Name, 233)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -90,6 +90,14 @@ func TestProcessItem(t *testing.T) {
 		},
 		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-3"}},
 	)
+	bundle4 := mustCreateCryptoBundle(t, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabcccccccccccc",
+			UID:       "test",
+		},
+		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-4"}},
+	)
 	fixedNow := metav1.NewTime(time.Now())
 	fixedClock := fakeclock.NewFakeClock(fixedNow.Time)
 	failedCRConditionPreviousIssuance := cmapi.CertificateRequestCondition{
@@ -224,6 +232,54 @@ func TestProcessItem(t *testing.T) {
 						gen.SetCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
 							cmapi.CertificateRequestRevisionAnnotationKey:   "1",
+						}),
+					)), relaxedCertificateRequestMatcher),
+			},
+		},
+		"create a CertificateRequest if none exists (with long name)": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle4.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevision(19),
+			),
+			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-20"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+					gen.CertificateRequestFrom(bundle4.certificateRequest,
+						gen.SetCertificateRequestName("long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-20"),
+						gen.SetCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+							cmapi.CertificateRequestRevisionAnnotationKey:   "20",
+						}),
+					)), relaxedCertificateRequestMatcher),
+			},
+		},
+		"create a CertificateRequest if none exists (with long name and very large revision)": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle4.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevision(999999999),
+			),
+			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-1000000000"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+					gen.CertificateRequestFrom(bundle4.certificateRequest,
+						gen.SetCertificateRequestName("long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-1000000000"),
+						gen.SetCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+							cmapi.CertificateRequestRevisionAnnotationKey:   "1000000000",
 						}),
 					)), relaxedCertificateRequestMatcher),
 			},

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,7 +94,7 @@ func TestProcessItem(t *testing.T) {
 	bundle4 := mustCreateCryptoBundle(t, &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testns",
-			Name:      "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabcccccccccccc",
+			Name:      strings.Repeat("a", 167) + "b" + strings.Repeat("c", 85),
 			UID:       "test",
 		},
 		Spec: cmapi.CertificateSpec{CommonName: "test-bundle-4"}},
@@ -248,11 +249,13 @@ func TestProcessItem(t *testing.T) {
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
 				gen.SetCertificateRevision(19),
 			),
-			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-20"`},
+			expectedEvents: []string{
+				fmt.Sprintf(`Normal Requested Created new CertificateRequest resource "%s"`, strings.Repeat("a", 167)+"b-d3f4fc40a686edfd404adf1d3fb1530653988c878e6c9c07b2e2fa4001a21269-20"),
+			},
 			expectedActions: []testpkg.Action{
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
 					gen.CertificateRequestFrom(bundle4.certificateRequest,
-						gen.SetCertificateRequestName("long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-20"),
+						gen.SetCertificateRequestName(strings.Repeat("a", 167)+"b-d3f4fc40a686edfd404adf1d3fb1530653988c878e6c9c07b2e2fa4001a21269-20"),
 						gen.SetCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
 							cmapi.CertificateRequestRevisionAnnotationKey:   "20",
@@ -272,11 +275,13 @@ func TestProcessItem(t *testing.T) {
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
 				gen.SetCertificateRevision(999999999),
 			),
-			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-1000000000"`},
+			expectedEvents: []string{
+				fmt.Sprintf(`Normal Requested Created new CertificateRequest resource "%s"`, strings.Repeat("a", 167)+"b-d3f4fc40a686edfd404adf1d3fb1530653988c878e6c9c07b2e2fa4001a21269-1000000000"),
+			},
 			expectedActions: []testpkg.Action{
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
 					gen.CertificateRequestFrom(bundle4.certificateRequest,
-						gen.SetCertificateRequestName("long-name-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-6c93132b-1000000000"),
+						gen.SetCertificateRequestName(strings.Repeat("a", 167)+"b-d3f4fc40a686edfd404adf1d3fb1530653988c878e6c9c07b2e2fa4001a21269-1000000000"),
 						gen.SetCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
 							cmapi.CertificateRequestRevisionAnnotationKey:   "1000000000",


### PR DESCRIPTION
Fixes https://github.com/cert-manager/cert-manager/issues/6342

The new mechanism is explained here: https://github.com/cert-manager/cert-manager/blob/860df2294b53ee512bfde186ed8478e6a43dd204/pkg/controller/certificates/requestmanager/requestmanager_controller.go#L401-L411

### Kind

/kind cleanup

### Release Note

```release-note
BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature.
```
