### PR TITLE
improvement(helm): fixed empty controller configmap + refactored

### DIFF
--- a/deploy/charts/cert-manager/templates/controller-config.yaml
+++ b/deploy/charts/cert-manager/templates/controller-config.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.config -}}
-  {{- if not .Values.config.apiVersion -}}
-    {{- fail "config.apiVersion must be set" -}}
-  {{- end -}}
-
-  {{- if not .Values.config.kind -}}
-    {{- fail "config.kind must be set" -}}
-  {{- end -}}
-{{- end -}}
+{{- required ".Values.config.apiVersion must be set !" .Values.config.apiVersion -}}
+{{- required ".Values.config.kind must be set !" .Values.config.kind -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
 data:
-  {{- if .Values.config }}
   config.yaml: |
-    {{ .Values.config | toYaml | nindent 4 }}
-  {{- end }}
+    {{- .Values.config | toYaml | nindent 4 }}
+{{- end -}}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR resolves the issue https://github.com/cert-manager/cert-manager/issues/6343. The controller ConfigMap is created even if `.Values.config` isn't set. It doesn't create any issue with cert-manager, but after discussion it was decided to refactor the Helm Chart to create the ConfigMap only if `.Values.config` is set, along with other changes.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Controller ConfigMap if now created only if .Values.config is set.
```
