### PR TITLE
Upgrade Go from 1.20.7 to 1.20.8

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -73,7 +73,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.7
+VENDORED_GO_VERSION := 1.20.8
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

Upgrading the go patch version to fix some CVE alerts.

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade Go from 1.20.7 to 1.20.8.
```
