### PR TITLE
Openshift E2E test compatibility

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -55,7 +55,7 @@ IMAGE_kind_arm64 := $(IMAGE_kind_amd64)
 # Once that is done, we can consume this variable from ./make/config/lib.sh
 SERVICE_IP_PREFIX = 10.0.0
 
-# This variable is exported so that the the Vault addon in the E2E tests can set
+# This variable is exported so that the Vault add-on in the E2E tests can set
 # the image reference of the locally loaded Docker image when it installs the
 # Vault Helm chart.
 # The Vault Docker image is loaded into kind by `make e2e-setup`.

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -55,6 +55,12 @@ IMAGE_kind_arm64 := $(IMAGE_kind_amd64)
 # Once that is done, we can consume this variable from ./make/config/lib.sh
 SERVICE_IP_PREFIX = 10.0.0
 
+# This variable is exported so that the the Vault addon in the E2E tests can set
+# the image reference of the locally loaded Docker image when it installs the
+# Vault Helm chart.
+# The Vault Docker image is loaded into kind by `make e2e-setup`.
+export E2E_VAULT_IMAGE := $(LOCALIMAGE_vaultretagged)
+
 .PHONY: e2e-setup-kind
 ## Create a Kubernetes cluster using Kind, which is required for `make e2e`.
 ## The Kind image is pre-pulled to avoid 'kind create' from blocking other make

--- a/make/test.mk
+++ b/make/test.mk
@@ -106,6 +106,13 @@ setup-integration-tests: test/integration/versionchecker/testdata/test_manifests
 integration-test: setup-integration-tests | $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBECTL) $(NEEDS_KUBE-APISERVER) $(NEEDS_GO)
 	cd test/integration && $(GOTESTSUM) ./...
 
+## (optional) Set this to true to run the E2E tests against an OpenShift cluster.
+## When set to true, the Hashicorp Vault Helm chart will be installed with
+## settings appropriate for OpenShift.
+##
+## @category Development
+E2E_OPENSHIFT ?= false
+
 .PHONY: e2e
 ## Run the end-to-end tests. Before running this, you need to run:
 ##

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -225,6 +225,22 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 		)
 	}
 
+	// Set E2E_OPENSHIFT=true if you're running the E2E tests against an OpenShift
+	// cluster.
+	// OpenShift requires some different settings. See
+	// https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-openshift
+	if os.Getenv("E2E_OPENSHIFT") == "true" {
+		v.chart.Vars = append(
+			v.chart.Vars,
+			[]chart.StringTuple{
+				{
+					Key:   "global.openshift",
+					Value: "true",
+				},
+			}...,
+		)
+	}
+
 	_, err := v.chart.Setup(cfg)
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -30,6 +30,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -47,12 +48,6 @@ import (
 const (
 	vaultHelmChartRepo    = "https://helm.releases.hashicorp.com"
 	vaultHelmChartVersion = "0.24.1"
-	// This local Vault image is only used when the tests are run using make,
-	// because it downloads the Vault image, saves it in the scratch folder on
-	// the filesystem, and copies it to the cluster-under-test before the E2E
-	// tests get executed.
-	vaultImageRepository = "local/vault"
-	vaultImageTag        = "local"
 )
 
 // Vault describes the configuration details for an instance of Vault
@@ -205,11 +200,11 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 	// the tests on their chosen cluster, in which case we do not override the
 	// Vault image and the default chart image will be downloaded and run
 	// instead.
-	// MAKELEVEL is always set by make so that it can know whether it is being
-	// called recursively, so we use that variable as a marker to know whether
-	// the tests are being executed from our Makefile. See
-	// https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html
-	if os.Getenv("MAKELEVEL") != "" {
+	// E2E_VAULT_IMAGE is exported by `make/e2e-setup.mk`.
+	if vaultImage := os.Getenv("E2E_VAULT_IMAGE"); vaultImage != "" {
+		parts := strings.Split(vaultImage, ":")
+		vaultImageRepository := parts[0]
+		vaultImageTag := parts[1]
 		v.chart.Vars = append(
 			v.chart.Vars,
 			[]chart.StringTuple{

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	vaultHelmChartRepo    = "https://helm.releases.hashicorp.com"
-	vaultHelmChartVersion = "0.24.1"
+	vaultHelmChartVersion = "0.25.0"
 )
 
 // Vault describes the configuration details for an instance of Vault


### PR DESCRIPTION
Following up on https://github.com/cert-manager/cert-manager/pull/6387 I've made some further changes to allow me to run the compiled e2e.test binary against an OpenShift cluster.

* The Vault helm chart is now installed with `--set global.openshift=true` if you supply the environment variable `E2E_OPENSHIFT=true, which is the [recommended way to install the Vault Helm chart on OpenShift](https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-openshift) and alters various deployment settings to work on OpenShift.
* I upgraded the [Vault helm chart to the latest version 0.25](https://github.com/hashicorp/vault-helm/releases/tag/v0.25.0)
  (The [docker images  used by that chart](https://github.com/hashicorp/vault-helm/blob/v0.25.0/values.yaml#L375-L379) are the same) 
* Use the E2E_VAULT_IMAGE environment variable which we set in the Makefile as a more targeted way of choosing whether to configure the Vault Helm chart to use those local images. MAKELEVEL was a bad choice because it prevents me executing the e2e.test binary from the cert-manager-olm Makefile.

## Testing

Checked that `make e2e` configures vault to use the local image

```bash
richard@LAPTOP-HJEQ9V9G:~/projects/cert-manager/cert-manager$ make e2e GINKGO_FOCUS="CA\ Issuer"
cd _bin/tools/ && ln -f -s ../downloaded/tools/ginkgo@v2.12.0_linux_amd64 ginkgo
make/e2e.sh
ginkgo --tags=e2e_test --procs=1 --output-dir=/home/richard/projects/cert-manager/cert-manager/_bin/artifacts --junit-report=junit__01.xml --flake-attempts=1 --timeout=1h -v --randomize-all --trace --poll-progress-after=60s ./test/e2e/ -- --repo-root=/home/richard/projects/cert-manager/cert-manager --report-dir=/home/richard/projects/cert-manager/cert-manager/_bin/artifacts --acme-dns-server=10.0.0.16 --acme-ingress-ip=10.0.0.15 --acme-gateway-ip=10.0.0.14 --ingress-controller-domain=ingress-nginx.http01.example.com --gateway-domain=gateway.http01.example.com --feature-gates=AdditionalCertificateOutputFormats=true,ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,LiteralCertificateSubject=true "--ginkgo.focus=CA\ Issuer" --ginkgo.v --test.v
=== RUN   TestE2E
Running Suite: cert-manager e2e suite - /home/richard/projects/cert-manager/cert-manager/test/e2e
=================================================================================================
Random Seed: 1696510643 - will randomize all specs

Will run 45 of 777 specs
------------------------------
[SynchronizedBeforeSuite]
/home/richard/projects/cert-manager/cert-manager/test/e2e/e2e.go:40
"hashicorp" already exists with the same configuration, skipping
Release "chart-vault-vault" does not exist. Installing it now.
NAME: chart-vault-vault
LAST DEPLOYED: Thu Oct  5 13:57:30 2023
NAMESPACE: e2e-vault
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named chart-vault-vault. To learn more about the release, try:

  $ helm status chart-vault-vault
  $ helm get manifest chart-vault-vault
[SynchronizedBeforeSuite] PASSED [11.957 seconds]

...

------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[SynchronizedAfterSuite]
/home/richard/projects/cert-manager/cert-manager/test/e2e/e2e.go:85
  STEP: Retrieving logs for global addons @ 10/05/23 13:58:42.395
  STEP: Cleaning up the provisioned globals @ 10/05/23 13:58:42.45
proxy logs:
[SynchronizedAfterSuite] PASSED [0.455 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.029 seconds]
------------------------------

Ran 43 of 777 Specs in 73.513 seconds
SUCCESS! -- 43 Passed | 0 Failed | 0 Pending | 734 Skipped
--- PASS: TestE2E (73.55s)
PASS

Ginkgo ran 1 suite in 1m19.043566056s
Test Suite Passed
```

```bash
richard@LAPTOP-HJEQ9V9G:~$ kubectl -n e2e-vault describe pod chart-vault-vault-0
...
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  13s   default-scheduler  Successfully assigned e2e-vault/chart-vault-vault-0 to kind-control-plane
  Normal  Pulled     13s   kubelet            Container image "local/vault:local" already present on machine
  Normal  Created    13s   kubelet            Created container vault
  Normal  Started    13s   kubelet            Started container vault
```

Tested against an OpenShift 4.13 cluster with cert-manager installed via OperatorHub
```bash
[crc@crc-4-13 ~]$ OPENSHIFT=true ./e2e --repo-root=/dev/null --ginkgo.focus="Vault\ Issuer" --ginkgo.skip="Gateway"
Running Suite: cert-manager e2e suite - /home/crc
=================================================
Random Seed: 1696508729

Will run 25 of 777 specs
"hashicorp" already exists with the same configuration, skipping
Release "chart-vault-vault" does not exist. Installing it now.
NAME: chart-vault-vault
LAST DEPLOYED: Thu Oct  5 12:25:31 2023
NAMESPACE: e2e-vault
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named chart-vault-vault. To learn more about the release, try:

  $ helm status chart-vault-vault
  $ helm get manifest chart-vault-vault
••••[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 152 [running]:
        >  runtime/debug.Stack()
        >       runtime/debug/stack.go:24 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc000149e40, {0x1da69f3, 0x14})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/deleg.go:147 +0x45
        >  github.com/go-logr/logr.Logger.WithName({{0x2070db0, 0xc000149e40}, 0x0}, {0x1da69f3?, 0xc000a79d98?})
        >       github.com/go-logr/logr@v1.2.4/logr.go:336 +0x3d
        >  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0xc000345110, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:122 +0xec
        >  sigs.k8s.io/controller-runtime/pkg/client.New(0x1dc1053?, {0x0, 0xc000345110, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:103 +0x7d
        >  github.com/cert-manager/cert-manager/e2e-tests/framework.(*Framework).BeforeEach(0xc00064de00)
        >       github.com/cert-manager/cert-manager/e2e-tests/framework/framework.go:145 +0x33c
        >  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0x0, 0x0})
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/node.go:463 +0x13
        >  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/suite.go:865 +0x8d
        >  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 11
        >       github.com/onsi/ginkgo/v2@v2.12.0/internal/suite.go:852 +0xd7b
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••••
------------------------------
• [FAILED] [61.016 seconds]
[cert-manager] Vault Issuer [It] should be ready with a valid serviceAccountRef
github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:346

  Timeline >>
  STEP: Creating a kubernetes client @ 10/05/23 12:27:00.888
  STEP: Creating an API extensions client @ 10/05/23 12:27:00.89
  STEP: Creating a cert manager client @ 10/05/23 12:27:00.89
  STEP: Creating a controller-runtime client @ 10/05/23 12:27:00.89
  STEP: Creating a gateway-api client @ 10/05/23 12:27:00.891
  STEP: Building a namespace api object @ 10/05/23 12:27:00.891
  STEP: Using the namespace e2e-tests-create-vault-issuer-z524j @ 10/05/23 12:27:00.909
  STEP: Building a ResourceQuota api object @ 10/05/23 12:27:00.909
  STEP: Configuring the Vault server @ 10/05/23 12:27:00.952
  STEP: creating a service account for Vault authentication @ 10/05/23 12:27:01.489
  STEP: Creating the Role and RoleBinding to let cert-manager use TokenRequest for the ServiceAccount @ 10/05/23 12:27:01.566
  STEP: Creating an Issuer @ 10/05/23 12:27:01.662
  STEP: Waiting for Issuer to become Ready @ 10/05/23 12:27:01.721
  Oct  5 12:27:01.721: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:06.870: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:13.368: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:20.868: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:29.868: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:40.368: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:27:52.868: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0}
  Oct  5 12:28:01.731: INFO: Waiting for issuer test-vault-issuer condition v1.IssuerCondition{Type:"Ready", Status:"True", LastTransitionTime:<nil>, Reason:"", Message:"", ObservedGeneration:0} (took 1m0s)
  [FAILED] in [It] - github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370 @ 10/05/23 12:28:01.786
  STEP: Cleaning up AppRole @ 10/05/23 12:28:01.786
  STEP: Cleaning up Kubernetes @ 10/05/23 12:28:01.856
  STEP: Cleaning up Vault @ 10/05/23 12:28:01.862
  STEP: Deleting test namespace @ 10/05/23 12:28:01.88
  << Timeline

  [FAILED] Unexpected error:
      <*errors.errorString | 0xc000db9550>:
      context deadline exceeded: Last Status: 'False' Reason: 'VaultError', Message: 'Failed to initialize Vault client: while requesting a Vault token using the Kubernetes auth: while requesting a token for the service account e2e-tests-create-vault-issuer-z524j/vault-serviceaccount: serviceaccounts "vault-serviceaccount" is forbidden: User "system:serviceaccount:openshift-operators:cert-manager" cannot create resource "serviceaccounts/token" in API group "" in the namespace "e2e-tests-create-vault-issuer-z524j"'
      {
          s: "context deadline exceeded: Last Status: 'False' Reason: 'VaultError', Message: 'Failed to initialize Vault client: while requesting a Vault token using the Kubernetes auth: while requesting a token for the service account e2e-tests-create-vault-issuer-z524j/vault-serviceaccount: serviceaccounts \"vault-serviceaccount\" is forbidden: User \"system:serviceaccount:openshift-operators:cert-manager\" cannot create resource \"serviceaccounts/token\" in API group \"\" in the namespace \"e2e-tests-create-vault-issuer-z524j\"'",
      }
  occurred
  In [It] at: github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370 @ 10/05/23 12:28:01.786
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••proxy logs:


Summarizing 1 Failure:
  [FAIL] [cert-manager] Vault Issuer [It] should be ready with a valid serviceAccountRef
  github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/vault/issuer.go:370

Ran 25 of 777 Specs in 169.298 seconds
FAIL! -- 24 Passed | 1 Failed | 0 Pending | 752 Skipped
--- FAIL: TestE2E (169.32s)
FAIL
```

```release-note
The end-to-end tests can now test the cert-manager Vault Issuer on an OpenShift cluster.
```

/kind cleanup
