### PR TITLE
Venafi issuer: ResetCertificate wasn't working

### DIFF
--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -66,9 +66,12 @@ func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, custo
 	//
 	// Note that resetting won't affect the existing certificate if one was
 	// already issued.
-	tppConnector, isTPP := v.vcertClient.(*tpp.Connector)
-	if isTPP {
-		err := tppConnector.ResetCertificate(vreq, false)
+	if v.tppClient != nil {
+		// We can't use the instrumented v.vcertClient because its concrete
+		// value is `instrumentedConnector`, which doesn't give access to the
+		// *tpp.Connector it wraps. Also, `instrumentedConnector` doesn't
+		// support `ResetCertificate`.
+		err := v.tppClient.ResetCertificate(vreq, false)
 		notFoundErr := &tpp.ErrCertNotFound{}
 		if err != nil && !errors.As(err, &notFoundErr) {
 			return "", err


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/issues/6397, I showed that cert-manager 1.11, 1.12, and 1.13 still get stuck when retrying renewing a certificate after the error "This certificate has encountered errors. Fix any errors, and then click Retry". I used `dlv` and pin-pointed where the issue originated from:

![Screenshot 2023-10-06 at 15 43 16](https://github.com/cert-manager/cert-manager/assets/2195781/36779a63-2cc3-4d0d-a257-b74fcb3bc1c4)

The line in question is the following:

```go
tppConnector, isTPP := v.vcertClient.(*tpp.Connector)
```

The variable `isTPP` is always false since the concrete value is actually an instrumentedConnector. This problem appeared because we aren’t testing this code path.

I have tested the fix locally with both a TPP Venafi issuer and with a Venafi Cloud issuer. All seems well.

**Release note:**

```release-note
The Venafi issuer now properly resets the certificate and should no longer get stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`.
```

Fixes #6397 

/area venafi