### PR TITLE
fix(helm): templating of required value in controller and webhook configmaps

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-config.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-config.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.cainjector.config -}}
-{{- required ".Values.cainjector.config.apiVersion must be set !" .Values.cainjector.config.apiVersion -}}
-{{- required ".Values.cainjector.config.kind must be set !" .Values.cainjector.config.kind -}}
+{{- $_ := .Values.cainjector.config.apiVersion | required ".Values.cainjector.config.apiVersion must be set !" -}}
+{{- $_ := .Values.cainjector.config.kind | required ".Values.cainjector.config.kind must be set !" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/charts/cert-manager/templates/controller-config.yaml
+++ b/deploy/charts/cert-manager/templates/controller-config.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.config -}}
-{{- required ".Values.config.apiVersion must be set !" .Values.config.apiVersion -}}
-{{- required ".Values.config.kind must be set !" .Values.config.kind -}}
+{{- $_ := .Values.config.apiVersion | required ".Values.config.apiVersion must be set !" -}}
+{{- $_ := .Values.config.kind | required ".Values.config.kind must be set !" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/charts/cert-manager/templates/webhook-config.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-config.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.webhook.config -}}
-{{- required ".Values.webhook.config.apiVersion must be set !" .Values.webhook.config.apiVersion -}}
-{{- required ".Values.webhook.config.kind must be set !" .Values.webhook.config.kind -}}
+{{- $_ := .Values.webhook.config.apiVersion | required ".Values.webhook.config.apiVersion must be set !" -}}
+{{- $_ := .Values.webhook.config.kind | required ".Values.webhook.config.kind must be set !" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
### Pull Request Motivation

A couple of weeks ago I made two PRs (https://github.com/cert-manager/cert-manager/pull/6360 and https://github.com/cert-manager/cert-manager/pull/6357) that improved the behavior of the Helm Chart. The goal was to disable the creation of the Controller and Webhook ConfigMaps resp. if the ```.Values.config``` and the ```.Values.webhook.config``` sections were not defined.

In this PRs, I also changed the way we check that some required values in these sections are defined, but I actually introduced a bug. The current code is :

```{{- required ".Values.xyz must be set !" .Values.xyz -}}```

With this code, the values that are checked are actually templated at the top of the ConfigMap which can result in some issues.

The goal of this PR is to fix this bug by doing this :

```{{- $_ := .Values.xyz | required ".Values.xyz must be set !" -}}```

The variable $_ is used by convention to indicate that the value is not used. This is somewhat similar to the use of the [blank identifier](https://go.dev/ref/spec#Blank_identifier) in Go.

Sorry for the inconvenience.

### Kind

bug

### Release Note

```release-note
fix(helm): templating of required value in controller and webhook configmaps
```
