### PR TITLE
Fix image checksum validation and upgrade ingress NGINX to demonstrate the problem

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -173,21 +173,12 @@ $(LOAD_TARGETS): load-%: % $(BINDIR)/scratch/kind-exists | $(NEEDS_KIND)
 # We don't pull using both the digest and tag because crane replaces the
 # tag with "i-was-a-digest". We still check that the downloaded image
 # matches the digest.
-$(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,sampleexternalissuer) $(call image-tar,ingressnginx): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
+$(call image-tar,kind) $(call image-tar,vault) $(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,sampleexternalissuer) $(call image-tar,ingressnginx): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
 	@$(eval IMAGE=$(subst +,:,$*))
 	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
 	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))
 	@mkdir -p $(dir $@)
 	diff <(echo "$(DIGEST)  -" | cut -d: -f2) <($(CRANE) manifest --platform=linux/$(CRI_ARCH) $(IMAGE_WITHOUT_DIGEST) | sha256sum)
-	$(CRANE) pull $(IMAGE_WITHOUT_DIGEST) $@ --platform=linux/$(CRI_ARCH)
-
-# Same as above, except it supports multiarch images.
-$(call image-tar,kind) $(call image-tar,vault): $(BINDIR)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
-	@$(eval IMAGE=$(subst +,:,$*))
-	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
-	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))
-	@mkdir -p $(dir $@)
-	diff <(echo "$(DIGEST)  -" | cut -d: -f2) <($(CRANE) manifest $(IMAGE) | sha256sum)
 	$(CRANE) pull $(IMAGE_WITHOUT_DIGEST) $@ --platform=linux/$(CRI_ARCH)
 
 # Since we dynamically install Vault via Helm during the end-to-end tests,

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -178,7 +178,7 @@ $(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(
 	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
 	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))
 	@mkdir -p $(dir $@)
-	diff <(echo "$(DIGEST)  -" | cut -d: -f2) <($(CRANE) manifest --platform=linux/$(CRI_ARCH) $(IMAGE) | sha256sum)
+	diff <(echo "$(DIGEST)  -" | cut -d: -f2) <($(CRANE) manifest --platform=linux/$(CRI_ARCH) $(IMAGE_WITHOUT_DIGEST) | sha256sum)
 	$(CRANE) pull $(IMAGE_WITHOUT_DIGEST) $@ --platform=linux/$(CRI_ARCH)
 
 # Same as above, except it supports multiarch images.

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -26,7 +26,7 @@ CRI_ARCH := $(HOST_ARCH)
 # is set in one place only.
 K8S_VERSION := 1.28
 
-IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:8f754c28c4a98dc818f0fb01a083a3c42694af37fb3874f468d5a2db4d4283e6
+IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:0115d7e01987c13e1be90b09c223c3e0d8e9a92e97c0421e712ad3577e2d78e5
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.10.3@sha256:031d2da484f3d89c78007cbb1cf1d7ae992e069683a2cdca0a0efb63a63fc735
 IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.10.3@sha256:5371ead07ebd09ff858f568a07b6807e8568772af61e626c9a0a5137bd7e62db
 IMAGE_vault_amd64 := docker.io/hashicorp/vault:1.14.1@sha256:436d056e8e2a96c7356720069c29229970466f4f686886289dcc94dfa21d3155
@@ -34,7 +34,7 @@ IMAGE_bind_amd64 := docker.io/eafxx/bind:latest-ccf145d3@sha256:b6ea4da6cb689985
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:964b378fe0dda7fc38ce3f211c3b24c780e44cef13c39d3206de985bad67f294
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.25.2@sha256:1570f04e96fb5e0ad71c2de61fee71c8d55b2fe5b7c827ce65e81bf7cc99bcbd
 
-IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:e88220610f88c5e4aa76a07a49da516b0b6701be11b62481105a8a16478d7966
+IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:3cdc716f0395886008c5e49972297adf1af87eeef472f71ff8de11bf53f25766
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.10.3@sha256:acf77f4fd08056941b5640d9489d46f2a1777e29d574e51926eac5250144dbd2
 IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.10.3@sha256:3ec997a6a26f600e4c2e439c3671e9f21c83a73bf486134eb6732481d0e371ca
 IMAGE_vault_arm64 := docker.io/hashicorp/vault:1.14.1@sha256:27dd264f3813c71a66792191db5382f0cf9eeaf1ae91770634911facfcfe4837

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -26,7 +26,7 @@ CRI_ARCH := $(HOST_ARCH)
 # is set in one place only.
 K8S_VERSION := 1.28
 
-IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.8.1@sha256:8f754c28c4a98dc818f0fb01a083a3c42694af37fb3874f468d5a2db4d4283e6
+IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:8f754c28c4a98dc818f0fb01a083a3c42694af37fb3874f468d5a2db4d4283e6
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.10.3@sha256:031d2da484f3d89c78007cbb1cf1d7ae992e069683a2cdca0a0efb63a63fc735
 IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.10.3@sha256:5371ead07ebd09ff858f568a07b6807e8568772af61e626c9a0a5137bd7e62db
 IMAGE_vault_amd64 := docker.io/hashicorp/vault:1.14.1@sha256:436d056e8e2a96c7356720069c29229970466f4f686886289dcc94dfa21d3155
@@ -34,7 +34,7 @@ IMAGE_bind_amd64 := docker.io/eafxx/bind:latest-ccf145d3@sha256:b6ea4da6cb689985
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:964b378fe0dda7fc38ce3f211c3b24c780e44cef13c39d3206de985bad67f294
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.25.2@sha256:1570f04e96fb5e0ad71c2de61fee71c8d55b2fe5b7c827ce65e81bf7cc99bcbd
 
-IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.1.0@sha256:e88220610f88c5e4aa76a07a49da516b0b6701be11b62481105a8a16478d7966
+IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.9.4@sha256:e88220610f88c5e4aa76a07a49da516b0b6701be11b62481105a8a16478d7966
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.10.3@sha256:acf77f4fd08056941b5640d9489d46f2a1777e29d574e51926eac5250144dbd2
 IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.10.3@sha256:3ec997a6a26f600e4c2e439c3671e9f21c83a73bf486134eb6732481d0e371ca
 IMAGE_vault_arm64 := docker.io/hashicorp/vault:1.14.1@sha256:27dd264f3813c71a66792191db5382f0cf9eeaf1ae91770634911facfcfe4837
@@ -308,7 +308,7 @@ e2e-setup-ingressnginx: $(call image-tar,ingressnginx) load-$(call image-tar,ing
 	$(HELM) upgrade \
 		--install \
 		--wait \
-		--version 4.7.1 \
+		--version 4.7.3 \
 		--namespace ingress-nginx \
 		--create-namespace \
 		--set controller.image.tag=$(TAG) \


### PR DESCRIPTION
The checksum validation for Docker images is broken because we use `crane manifest repo:tag@sha256:digest` which gets the file by checksum (the checksum from the makefile) rather than by tag....so the checksum always matches.
But the image is then pulled by reference to its tag, so although the local image on the filesystem will be the right version,
we won't detect if someone has pushed a different image to the registry using the same tag.

The problem is demonstrated in this PR follows:
1. [Updated only the semver **tag** of the ingress-nginx image and Helm chart](https://github.com/cert-manager/cert-manager/pull/6440/commits/ecada9c30f8612614793fa81e3f27b1546bb3bbb). **Did not** update the sha256 sum of the images.
2. Expected the build to fail because of a checksum validation. [But it passed](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6440/pull-cert-manager-master-e2e-v1-28/1716826334606397440).
3. [Updated the checksum validation](https://github.com/cert-manager/cert-manager/pull/6440/commits/5db745b1038a0778bc41d7590b673e8a577d82dc). The checksum test still passes, because the [script this time loads the cached image ](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6440/pull-cert-manager-master-e2e-v1-28/1716834748057260032#1:build-log.txt%3A159) which the [previous CI run downloaded and cached with the wrong checksum in the filename](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6440/pull-cert-manager-master-e2e-v1-28/1716826334606397440#1:build-log.txt%3A121). 
4. [Updated the checksums](https://github.com/cert-manager/cert-manager/pull/6440/commits/c34bddace771c327a6170d88ea7d5be098d653c6). Expect the  [checksum validation to pass and the image to be downloaded again](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6440/pull-cert-manager-master-e2e-v1-28/1716840942759055360#1:build-log.txt%3A74) but with new filename containing new checksum.

I also [removed the multi-arch variant of the image-download rule ](https://github.com/cert-manager/cert-manager/pull/6440/commits/4d2a2277941d45c9b9fc5af4b72f0ac943074d12)because it was also broken which had been obscuring the fact that we were supplying it with digests of single-arch vault and kind images.

## Testing

There were a couple of test flakes, which I assume was caused by Prow jobs getting killed (or something):
 * https://prow.build-infra.jetstack.net/pr-history/?org=cert-manager&repo=cert-manager&pr=6440



I deleted `_bin/` and tested locally and everything worked.

```bash
 rm -rf _bin/
make -j e2e-setup
make e2e GINKGO_FOCUS="Vault\ Issuer"
...
Ran 25 of 778 Specs in 51.981 seconds
SUCCESS! -- 25 Passed | 0 Failed | 0 Pending | 753 Skipped
--- PASS: TestE2E (52.02s)
PASS

Ginkgo ran 1 suite in 1m27.4800163s
Test Suite Passed
```

```release-note
NONE
```