### PR TITLE
Fix kindest image digests

### DIFF
--- a/hack/latest-kind-images.sh
+++ b/hack/latest-kind-images.sh
@@ -64,7 +64,7 @@ LATEST_127_DIGEST=$(crane digest $KIND_IMAGE_REPO:$LATEST_127_TAG)
 
 # k8s 1.28 is manually added to ensure that we use the exact documented tag as per kind recommendation
 LATEST_128_TAG=v1.28.0
-LATEST_128_DIGEST=sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
+LATEST_128_DIGEST=sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
 
 cat << EOF > ./make/kind_images.sh
 # Copyright 2022 The cert-manager Authors.

--- a/make/kind_images.sh
+++ b/make/kind_images.sh
@@ -22,7 +22,7 @@ KIND_IMAGE_K8S_126=docker.io/kindest/node@sha256:6e2d8b28a5b601defe327b98bd1c2d1
 KIND_IMAGE_K8S_127=docker.io/kindest/node@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 
 # Manually set- see hack/latest-kind-images.sh for details
-KIND_IMAGE_K8S_128=docker.io/kindest/node@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
+KIND_IMAGE_K8S_128=docker.io/kindest/node@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
 
 # docker.io/kindest/node:v1.22.17
 KIND_IMAGE_SHA_K8S_122=sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2
@@ -44,7 +44,7 @@ KIND_IMAGE_SHA_K8S_127=sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e9
 
 # Manually set - see hack/latest-kind-images.sh for details
 # docker.io/kindest/node:v1.28.0
-KIND_IMAGE_SHA_K8S_128=sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
+KIND_IMAGE_SHA_K8S_128=sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
 
 # note that these 'full' digests should be avoided since not all tools support them
 # prefer KIND_IMAGE_K8S_*** instead
@@ -56,5 +56,5 @@ KIND_IMAGE_FULL_K8S_126=docker.io/kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe
 KIND_IMAGE_FULL_K8S_127=docker.io/kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 
 # Manually set - see hack/latest-kind-images.sh for details
-KIND_IMAGE_FULL_K8S_128=docker.io/kindest/node:v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c
+KIND_IMAGE_FULL_K8S_128=docker.io/kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
 


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6440 I fixed a problem with the remote image tag to digest check
when downloading single-arch images for the components that we install in our e2e cluster.
But I made the mistake of assuming that the kind node images were also pinned using the digest of the single-arch image,
and removed the special case Make rule which we had previously used for those.

Here I've fixed the multi-arch digest for the 1.28 kind node image, to match the digest in the Kind 0.20.0 release notes:
 * https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
 
And i've resurrected the special case Make rule for downloading that image, albeit without the digest check.
(I've tried to explain why the digest check is not appropriate in the comments above the rule)

Fixes:
 * https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-23
 * https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-24
 * https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-25
 * https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-26
 * https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-27

```release-note
NONE
```
