### PR TITLE
Use latest version of the best-practice Helm values

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -238,7 +238,7 @@ E2E_SETUP_OPTION_BESTPRACTICE ?=
 ## Kyverno and the policies in make/config/kyverno have been applied.
 ##
 ## @category Development
-E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL ?= https://raw.githubusercontent.com/cert-manager/website/f0cc0f3b88846969dd7e9894cddd43391a3135d1/public/docs/installation/best-practice/values.best-practice.yaml
+E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL ?= https://raw.githubusercontent.com/cert-manager/website/ea5db62772e6b9d1430b9d63f581e74d5c18b627/public/docs/installation/best-practice/values.best-practice.yaml
 E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL_SUM := $(shell sha256sum <<<$(E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL) | cut -d ' ' -f 1)
 
 ## A local Helm values file containing best-practice configuration values.


### PR DESCRIPTION
Run the [periodic best-practice tests](https://github.com/cert-manager/testing/blob/01d89492c1525be852e59ad726010c8f96f6a579/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml#L606) using the latest content from: 
 * https://cert-manager.io/docs/installation/best-practice/#best-practice-helm-chart-values

The changes are are listed here:
 * https://github.com/cert-manager/website/commits/master/public/docs/installation/best-practice/values.best-practice.yaml

## Testing

I ran the best practice E2E tests and all seems ok:
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6452/pull-cert-manager-master-e2e-v1-28-bestpractice-install/1717898613478133760

/kind cleanup

```release-note
NONE
```
