### PR TITLE
Enable readOnlyRootFilesystem by default

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -181,7 +181,7 @@ containerSecurityContext:
   capabilities:
     drop:
     - ALL
-  # readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: true
   # runAsNonRoot: true
 
 
@@ -345,7 +345,7 @@ webhook:
     capabilities:
       drop:
       - ALL
-    # readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
   # Optional additional annotations to add to the webhook Deployment
@@ -548,7 +548,7 @@ cainjector:
     capabilities:
       drop:
       - ALL
-    # readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
 
@@ -658,7 +658,7 @@ startupapicheck:
     capabilities:
       drop:
       - ALL
-    # readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
   # Timeout for 'kubectl check api' command

--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -8,6 +8,7 @@
 resources:
   - https://github.com/kyverno/policies/pod-security/enforce
   - https://raw.githubusercontent.com/kyverno/policies/main/other/res/restrict-automount-sa-token/restrict-automount-sa-token.yaml
+  - https://github.com/kyverno/policies/raw/main//best-practices/require-ro-rootfs/require-ro-rootfs.yaml
 patches:
   - patch: |-
       - op: replace

--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -5,9 +5,9 @@
 #
 # Use as follows:
 #  kustomize build . > policy.yaml
-bases:
+resources:
   - https://github.com/kyverno/policies/pod-security/enforce
-  - https://raw.githubusercontent.com/kyverno/policies/main/other/restrict_automount_sa_token/restrict_automount_sa_token.yaml
+  - https://raw.githubusercontent.com/kyverno/policies/main/other/res/restrict-automount-sa-token/restrict-automount-sa-token.yaml
 patches:
   - patch: |-
       - op: replace
@@ -18,6 +18,6 @@ patches:
         value: cert-manager
       - op: replace
         path: /spec/validationFailureAction
-        value: enforce
+        value: Enforce
     target:
       kind: ClusterPolicy

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -487,6 +487,40 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   annotations:
+    policies.kyverno.io/category: Best Practices, EKS Best Practices, PSP Migration
+    policies.kyverno.io/description: 'A read-only root file system helps to enforce
+      an immutable infrastructure strategy; the container only needs to write on the
+      mounted volume that persists the state. An immutable root filesystem can also
+      prevent malicious binaries from writing to the host system. This policy validates
+      that containers define a securityContext with `readOnlyRootFilesystem: true`.'
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Require Read-Only Root Filesystem
+  name: require-ro-rootfs
+  namespace: cert-manager
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    name: validate-readOnlyRootFilesystem
+    validate:
+      message: Root filesystem must be read-only.
+      pattern:
+        spec:
+          containers:
+          - securityContext:
+              readOnlyRootFilesystem: true
+  validationFailureAction: Enforce
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  annotations:
     kyverno.io/kubernetes-version: 1.22-1.23
     kyverno.io/kyverno-version: 1.6.0
     policies.kyverno.io/category: Pod Security Standards (Restricted)

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -22,6 +22,11 @@ spec:
           kinds:
           - Pod
     name: adding-capabilities
+    preconditions:
+      all:
+      - key: '{{ request.operation || ''BACKGROUND'' }}'
+        operator: NotEquals
+        value: DELETE
     validate:
       deny:
         conditions:
@@ -46,7 +51,7 @@ spec:
       message: Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN,
         DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID,
         SETPCAP, SETUID, SYS_CHROOT) are disallowed.
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -110,7 +115,7 @@ spec:
               - ""
         list: request.object.spec.[ephemeralContainers, initContainers, containers][]
       message: Any capabilities added other than NET_BIND_SERVICE are disallowed.
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -146,7 +151,7 @@ spec:
           =(hostIPC): "false"
           =(hostNetwork): "false"
           =(hostPID): "false"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -180,7 +185,7 @@ spec:
         spec:
           =(volumes):
           - X(hostPath): "null"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -221,7 +226,7 @@ spec:
           containers:
           - =(ports):
             - =(hostPort): 0
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -268,7 +273,7 @@ spec:
           - =(securityContext):
               =(windowsOptions):
                 =(hostProcess): "false"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -309,7 +314,7 @@ spec:
           containers:
           - securityContext:
               allowPrivilegeEscalation: "false"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -350,7 +355,7 @@ spec:
           containers:
           - =(securityContext):
               =(privileged): "false"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -393,7 +398,7 @@ spec:
           containers:
           - =(securityContext):
               =(procMount): Default
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -476,7 +481,7 @@ spec:
               =(seLinuxOptions):
                 X(role): "null"
                 X(user): "null"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -520,7 +525,7 @@ spec:
           containers:
           - =(securityContext):
               =(runAsUser): '>0'
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -575,7 +580,7 @@ spec:
         must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot,
         spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
         must be set to `true`.
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -612,7 +617,7 @@ spec:
           =(annotations):
             =(container.apparmor.security.beta.kubernetes.io/*): runtime/default |
               localhost/*
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -651,7 +656,7 @@ spec:
       pattern:
         spec:
           automountServiceAccountToken: "false"
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -699,7 +704,7 @@ spec:
           - =(securityContext):
               =(seccompProfile):
                 =(type): RuntimeDefault | Localhost
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -763,7 +768,7 @@ spec:
         spec.containers[*].securityContext.seccompProfile.type, spec.initContainers[*].securityContext.seccompProfile.type,
         and spec.ephemeralContainers[*].securityContext.seccompProfile.type must be
         set to `RuntimeDefault` or `Localhost`.
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -802,7 +807,7 @@ spec:
             =(sysctls):
             - =(name): kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.ip_unprivileged_port_start
                 | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
 ---
 apiVersion: kyverno.io/v1
 kind: Policy
@@ -830,6 +835,11 @@ spec:
           kinds:
           - Pod
     name: restricted-volumes
+    preconditions:
+      all:
+      - key: '{{ request.operation || ''BACKGROUND'' }}'
+        operator: NotEquals
+        value: DELETE
     validate:
       deny:
         conditions:
@@ -849,4 +859,4 @@ spec:
             - ""
       message: 'Only the following types of volumes may be used: configMap, csi, downwardAPI,
         emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.'
-  validationFailureAction: enforce
+  validationFailureAction: Enforce


### PR DESCRIPTION
I wanted to verify whether any of the components log to the /tmp filesystem, as reported in:

* https://github.com/cert-manager/cert-manager/issues/5580

...all the E2E tests pass when readOnlyRootFilesystem is enabled, so I assume that the problem reported in that issue was due to a bug or legacy behaviour of an older version of the logging libraries, which is now fixed.

xref: https://github.com/cert-manager/cert-manager/issues/5580

1. 9dfb7c3ecf578aac02373d1ec24616b2c58211de: Added the [Kyverno Require Read-Only Root Filesystem policy](https://kyverno.io/policies/best-practices/require-ro-rootfs/require-ro-rootfs/)
2. best practice E2E tests fail: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6453/pull-cert-manager-master-e2e-v1-28-bestpractice-install/1717949189654056960
3. 6d206795c70efc70395147493b296582807c4a21 Enable readOnlyRootFilesystem by default
4. best practice E2E tests pass: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6453/pull-cert-manager-master-e2e-v1-28-bestpractice-install/1719292325638705152

```release-note
All Pods are now configured with `readOnlyRootFilesystem` by default.
```
