### PR TITLE
Add optional hostAliases to cert-manager pod

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -504,6 +504,13 @@ For more information, see [Pod's DNS Policy](https://kubernetes.io/docs/concepts
 
 Pod DNS configuration. The podDnsConfig field is optional and can work with any podDnsPolicy settings. However, when a Pod's dnsPolicy is set to "None", the dnsConfig field has to be specified. For more information, see [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).
 
+#### **hostAliases** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Optional hostAliases for cert-manager-controller pods. May be useful when performing ACME DNS-01 self checks.
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -223,3 +223,6 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -337,6 +337,17 @@ podLabels: {}
 #     - "1.1.1.1"
 #     - "8.8.8.8"
 
+# Optional hostAliases for cert-manager-controller pods. May be useful when performing ACME DNS-01 self checks.
+hostAliases: []
+# - ip: 127.0.0.1
+#   hostnames:
+#   - foo.local
+#   - bar.local
+# - ip: 10.1.2.3
+#   hostnames:
+#   - foo.remote
+#   - bar.remote
+
 # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
 # matching labels.
 # For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).


### PR DESCRIPTION
### Pull Request Motivation

As a mitigation for https://github.com/cert-manager/cert-manager/issues/1292 it may be desired to hardcode DNS entries on pod level to allow the self-check to pass, e.g. in the scenario where the network does not allow traffic to an internal IP by calling its external IP (which happens in the case of a public DNS). 

### Kind

feature

### Release Note

```release-note
[Helm] Add optional hostAliases to cert-manager pod to allow the DNS self-check to pass in custom scenarios.
```
