### PR TITLE
feat(helm) Add support for PodMonitor

### DIFF
--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -1,12 +1,12 @@
 {{- if and .Values.prometheus.enabled (and .Values.prometheus.podmonitor.enabled .Values.prometheus.servicemonitor.enabled) }}
 {{- fail "Either .Values.prometheus.podmonitor.enabled or .Values.prometheus.servicemonitor.enabled can be enabled at a time, but not both." }}
-{{- else if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- else if and .Values.prometheus.enabled .Values.prometheus.podmonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ template "cert-manager.fullname" . }}
-{{- if .Values.prometheus.servicemonitor.namespace }}
-  namespace: {{ .Values.prometheus.servicemonitor.namespace }}
+{{- if .Values.prometheus.podmonitor.namespace }}
+  namespace: {{ .Values.prometheus.podmonitor.namespace }}
 {{- else }}
   namespace: {{ include "cert-manager.namespace" . }}
 {{- end }}
@@ -16,13 +16,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
-    prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
-    {{- with .Values.prometheus.servicemonitor.labels }}
+    prometheus: {{ .Values.prometheus.podmonitor.prometheusInstance }}
+    {{- with .Values.prometheus.podmonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if .Values.prometheus.servicemonitor.annotations }}
+{{- if .Values.prometheus.podmonitor.annotations }}
   annotations:
-    {{- with .Values.prometheus.servicemonitor.annotations }}
+    {{- with .Values.prometheus.podmonitor.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}
@@ -33,18 +33,18 @@ spec:
       app.kubernetes.io/name: {{ template "cert-manager.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "controller"
-{{- if .Values.prometheus.servicemonitor.namespace }}
+{{- if .Values.prometheus.podmonitor.namespace }}
   namespaceSelector:
     matchNames:
       - {{ include "cert-manager.namespace" . }}
 {{- end }}
-  endpoints:
-  - targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
-    path: {{ .Values.prometheus.servicemonitor.path }}
-    interval: {{ .Values.prometheus.servicemonitor.interval }}
-    scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
-    honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
-    {{- with .Values.prometheus.servicemonitor.endpointAdditionalProperties }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  podMetricsEndpoints:
+    - port: http-metrics
+      path: {{ .Values.prometheus.podmonitor.path }}
+      interval: {{ .Values.prometheus.podmonitor.interval }}
+      scrapeTimeout: {{ .Values.prometheus.podmonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.prometheus.podmonitor.honorLabels }}
+      {{- with .Values.prometheus.servicemonitor.endpointAdditionalProperties }}
+      {{- toYaml . | nindent 4 }}
+      {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -235,7 +235,17 @@ prometheus:
     annotations: {}
     honorLabels: false
     endpointAdditionalProperties: {}
-
+  # Note: Enabling both PodMonitor and ServiceMonitor is mutually exclusive, enabling both will result in a error.
+  podmonitor:
+    enabled: false
+    prometheusInstance: default
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+    labels: {}
+    annotations: {}
+    honorLabels: false
+    endpointAdditionalProperties: {}
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"
 # https_proxy: "https://proxy:8080"


### PR DESCRIPTION
**Pull Request Motivation**
In the current chart, users are limited to using ServiceMonitor for metric scraping,
This PR aims to add support for PodMonitor, providing an alternative to ServiceMonitor and conserving ClusterIP services.

Kind
feature

**Changes**
Added support for configuring PodMonitor in the Helm Chart.
Implemented conditional logic to ensure PodMonitor and ServiceMonitor are mutually exclusive to avoid configuration errors.
**Testing**
Deployed the Helm chart with PodMonitor enabled and verified metrics scraping.
Deployed the Helm chart with ServiceMonitor enabled to ensure no regressions.
Deployed the Helm chart with both enabled to confirm that a configuration error is correctly thrown.

**Release Note**
feat(helm): Added support for PodMonitor to conserve ClusterIP services used solely for metrics.