### PR TITLE
Remove redundant / misleading runAsNonRoot examples from values.yaml

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -182,7 +182,6 @@ containerSecurityContext:
     drop:
     - ALL
   readOnlyRootFilesystem: true
-  # runAsNonRoot: true
 
 
 volumes: []
@@ -346,7 +345,6 @@ webhook:
       drop:
       - ALL
     readOnlyRootFilesystem: true
-    # runAsNonRoot: true
 
   # Optional additional annotations to add to the webhook Deployment
   # deploymentAnnotations: {}
@@ -549,7 +547,6 @@ cainjector:
       drop:
       - ALL
     readOnlyRootFilesystem: true
-    # runAsNonRoot: true
 
 
   # Optional additional annotations to add to the cainjector Deployment
@@ -663,7 +660,6 @@ startupapicheck:
       drop:
       - ALL
     readOnlyRootFilesystem: true
-    # runAsNonRoot: true
 
   # Timeout for 'kubectl check api' command
   timeout: 1m


### PR DESCRIPTION

In https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1698746453367439 @hawksight and I both mis-interpreted the presence of a commented out `runAsNonRoot: true` in the values.yaml, to mean that this was not already the default.


But `runAsNonRoot` is already set to true in the *Pod*SecurityContext, so there isn't really any reason to set it at the Container SecurityContext too.

Having it in the example values.yaml file gives the misleading impression that runAsNonRoot is not the default.

 * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core


We already verify this using Kyverno, in 

https://github.com/cert-manager/cert-manager/blob/32418051c3595de90e36ac1ed0413158d275f62a/make/config/kyverno/policy.yaml#L564-L617


/kind cleanup

```release-note
NONE
```
