### PR TITLE
Increase the default webhook timeout to its maximum value of 30 seconds

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -145,7 +145,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `config` | ControllerConfiguration YAML used to configure flags for the controller. Generates a ConfigMap containing contents of the field. See `values.yaml` for example. | `{}` |
 | `enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. | `false` |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
-| `webhook.timeoutSeconds` | Seconds the API server should wait the webhook to respond before treating the call as a failure. | `10` |
+| `webhook.timeoutSeconds` | Seconds the API server should wait for the webhook to respond before treating the call as a failure. Value must be between 1 and 30 seconds. | `30` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.podLabels` | Labels to add to the cert-manager webhook pod | `{}` |
 | `webhook.serviceLabels` | Labels to add to the cert-manager webhook service | `{}` |

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -296,7 +296,22 @@ enableServiceLinks: false
 
 webhook:
   replicaCount: 1
-  timeoutSeconds: 10
+
+  # Seconds the API server should wait for the webhook to respond before treating the call as a failure.
+  # Value must be between 1 and 30 seconds. See:
+  # https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1/
+  #
+  # We set the default to the maximum value of 30 seconds. Here's why:
+  # Users sometimes report that the connection between the K8S API server and
+  # the cert-manager webhook server times out.
+  # If *this* timeout is reached, the error message will be "context deadline exceeded",
+  # which doesn't help the user diagnose what phase of the HTTPS connection timed out.
+  # For example, it could be during DNS resolution, TCP connection, TLS
+  # negotiation, HTTP negotiation, or slow HTTP response from the webhook
+  # server.
+  # So by setting this timeout to its maximum value the underlying timeout error
+  # message has more chance of being returned to the end user.
+  timeoutSeconds: 30
 
   # Used to configure options for the webhook pod.
   # This allows setting options that'd usually be provided via flags.


### PR DESCRIPTION
@maelvls I'm sure that I saw you suggest this change on Slack or in a GitHub issue, but I can't find the reference now.
Was it you and is this what you meant?

> Users sometimes report that the connection between the K8S API server and the cert-manager webhook server times out.
> 
> But the error message is often only "context deadline exceeded", which doesn't help the user know what phase of the HTTPS connection timed out.
> 
> It could be during DNS resolution, TCP connection, TLS negotiation, HTTP channel negotiation, or slow HTTP response from the webhook server.
> 
> So this change increases the context timeout to its maximum value so that the underlying timeout error message has more chance of being returned to the end user.

```release-note
Increase the default webhook timeout to its maximum value of 30 seconds, so that the underlying timeout error message has more chance of being returned to the end user.
```


## Testing

```
$ make helm-chart
$ helm template _bin/cert-manager-v1.13.0-beta.0-118-ga0e5afc0f45cab.tgz | grep -B 40 'timeoutSeconds: 30'
            readOnlyRootFilesystem: true
          env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
      nodeSelector:
        kubernetes.io/os: linux
---
# Source: cert-manager/templates/webhook-mutating-webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  name: release-name-cert-manager-webhook
  labels:
    app: webhook
    app.kubernetes.io/name: webhook
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: "webhook"
    app.kubernetes.io/version: "v1.13.0-beta.0-118-ga0e5afc0f45cab"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: cert-manager-v1.13.0-beta.0-118-ga0e5afc0f45cab
  annotations:
    cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
webhooks:
  - name: webhook.cert-manager.io
    rules:
      - apiGroups:
          - "cert-manager.io"
        apiVersions:
          - "v1"
        operations:
          - CREATE
        resources:
          - "certificaterequests"
    admissionReviewVersions: ["v1"]
    # This webhook only accepts v1 cert-manager resources.
    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
    # this webhook (after the resources have been converted to v1).
    matchPolicy: Equivalent
    timeoutSeconds: 30
--
---
# Source: cert-manager/templates/webhook-validating-webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  name: release-name-cert-manager-webhook
  labels:
    app: webhook
    app.kubernetes.io/name: webhook
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: "webhook"
    app.kubernetes.io/version: "v1.13.0-beta.0-118-ga0e5afc0f45cab"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: cert-manager-v1.13.0-beta.0-118-ga0e5afc0f45cab
  annotations:
    cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
webhooks:
  - name: webhook.cert-manager.io
    namespaceSelector:
      matchExpressions:
      - key: "cert-manager.io/disable-validation"
        operator: "NotIn"
        values:
        - "true"
    rules:
      - apiGroups:
          - "cert-manager.io"
          - "acme.cert-manager.io"
        apiVersions:
          - "v1"
        operations:
          - CREATE
          - UPDATE
        resources:
          - "*/*"
    admissionReviewVersions: ["v1"]
    # This webhook only accepts v1 cert-manager resources.
    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
    # this webhook (after the resources have been converted to v1).
    matchPolicy: Equivalent
    timeoutSeconds: 30
```