### PR TITLE
BUGFIX: Fix consistency bugs in filtered secrets logic

### DIFF
--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -32,8 +32,6 @@ import (
 
 var secretsGVR = corev1.SchemeGroupVersion.WithResource("secrets")
 
-const pleaseOpenIssue = "Please report this by opening an issue with this error and cert-manager controller logs and stack trace https://github.com/cert-manager/cert-manager/issues/new/choose"
-
 // KubeSharedInformerFactory represents a subset of methods in
 // informers.sharedInformerFactory. It allows us to use a wrapper around
 // informers.sharedInformerFactory to enforce particular custom informers for

--- a/internal/informers/transfomers.go
+++ b/internal/informers/transfomers.go
@@ -33,8 +33,8 @@ func partialMetadataRemoveAll(obj interface{}) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("internal error: cannot cast object %#+v to PartialObjectMetadata", obj)
 	}
+	partialMeta.Labels = nil
 	partialMeta.Annotations = nil
 	partialMeta.ManagedFields = nil
-	partialMeta.Labels = nil
 	return partialMeta, nil
 }


### PR DESCRIPTION
The SecretsFilteredCaching feature that was promoted to Beta in 1.13 has an issue with consistency across the typed and metadata cache. This results in cert-manager thinking that secrets do not exist when the label is being removed/ added from the resource. This can result in incorrect reconciliations of the linked Certificates https://github.com/cert-manager/cert-manager/issues/6494.

How to reproduce:
1. create a Certificate resource
2. remove the fao annotation from the Secret
3. notice that cert-manager re-issues the Certificate

### Kind

/kind bug

### Release Note

```release-note
NONE
```
