### PR TITLE
Enable verbose logging in startupapicheck by default

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -225,7 +225,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `startupapicheck.backoffLimit` | Job backoffLimit | `4` |
 | `startupapicheck.jobAnnotations` | Optional additional annotations to add to the startupapicheck Job | `{}` |
 | `startupapicheck.podAnnotations` | Optional additional annotations to add to the startupapicheck Pods | `{}` |
-| `startupapicheck.extraArgs` | Optional additional arguments for startupapicheck | `[]` |
+| `startupapicheck.extraArgs` | Optional additional arguments for startupapicheck | `["-v"]` |
 | `startupapicheck.resources` | CPU/memory resource requests/limits for the startupapicheck pod | `{}` |
 | `startupapicheck.nodeSelector` | Node labels for startupapicheck pod assignment | `{}` |
 | `startupapicheck.affinity` | Node affinity for startupapicheck pod assignment | `{}` |

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -703,7 +703,12 @@ startupapicheck:
 
   # Additional command line flags to pass to startupapicheck binary.
   # To see all available flags run docker run quay.io/jetstack/cert-manager-ctl:<version> --help
-  extraArgs: []
+  #
+  # We enable verbose logging by default so that if startupapicheck fails, users
+  # can know what exactly caused the failure. Verbose logs include details of
+  # the webhook URL, IP address and TCP connect errors for example.
+  extraArgs:
+  - -v
 
   resources: {}
     # requests:


### PR DESCRIPTION
So that if it fails, users can know exactly what caused the failure.

Fixes: https://github.com/cert-manager/cert-manager/issues/6482
 * https://github.com/cert-manager/cert-manager/issues/6482

/kind cleanup

```release-note
Enabled verbose logging in startupapicheck by default, so that if it fails, users can know exactly what caused the failure.
```


## Testing

The difference is clear if you run `cmctl check api` from the command line after scaling the cert-manager webhook to 0.

```sh
$ cmctl check api --wait=5m
Not ready: the cert-manager webhook deployment is not ready yet
Not ready: the cert-manager webhook deployment is not ready yet
Not ready: the cert-manager webhook deployment is not ready yet
Not ready: the cert-manager webhook deployment is not ready yet
```

vs

```sh
$ cmctl check api --wait=5m -v
2023/11/17 09:01:16 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
2023/11/17 09:01:21 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
2023/11/17 09:01:26 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
2023/11/17 09:01:31 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
2023/11/17 09:01:36 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
2023/11/17 09:01:41 Not ready: the cert-manager webhook deployment is not ready yet (Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.48.155:443: connect: connection refused)
```

☝️ That's the sort of info the user will now see when they run `kubectl logs -n cert-manager` on the failing startupapicheck Pod.