### PR TITLE
Add Core Infrastructure Initiative Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>
 <a href="https://api.securityscorecards.dev/projects/github.com/cert-manager/cert-manager"><img src="https://api.securityscorecards.dev/projects/github.com/cert-manager/cert-manager/badge" alt="Scorecard score"/></a>
 <a href="https://clomonitor.io/projects/cncf/cert-manager"><img src="https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/cert-manager/badge" alt="CLOMonitor"/></a>
+<br />
+<a href="https://www.bestpractices.dev/projects/8079"><img src="https://www.bestpractices.dev/projects/8079/badge"></a>
 </p>
 
 # cert-manager


### PR DESCRIPTION
I filled out the form on the CII site and they gave us a badge!

This is part of the work towards graduation - this is a required step listed in:

https://github.com/cncf/toc/blob/main/process/graduation_criteria.md


### Kind

/kind feature

### Release Note


```release-note
Adds cert-manager's new core infrastructure initiative badge! See more details on https://www.bestpractices.dev/projects/8079
```
