### PR TITLE
Switch go-pkcs12 to use LegacyDES encoder

### DIFF
--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -59,7 +59,7 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 	if len(certs) > 1 {
 		cas = append(certs[1:], cas...)
 	}
-	return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
+	return pkcs12.LegacyDES.Encode(key, certs[0], cas, password)
 }
 
 func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
@@ -69,7 +69,7 @@ func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
 	}
 
 	var cas = []*x509.Certificate{ca}
-	return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
+	return pkcs12.LegacyDES.EncodeTrustStore(cas, password)
 }
 
 func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Our dependency to build PKCS12 keystores, https://github.com/SSLMate/go-pkcs12, has released newer versions that deprecate our current use of the dependency. The recommendation is to switch to the more "modern" encoder, but I am pretty sure this would be a breaking change. For this reason, I suggest migrating to the less secure, but more compatible, `LegacyDES` encoder.

Related upstream PR: https://github.com/SSLMate/go-pkcs12/pull/48.

Relates to https://github.com/cert-manager/cert-manager/issues/6511. I am unsure if this PR (without switching to the less compatible `Modern` encoder) solves the issue reported in the security audit, but I think compatibility is more important. The JKS and PKCS12 encodings are not secure by just the password anyway.

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Upgrade go-pkcs12 to latest version and switch to LegacyDES encoder
```
