### PR TITLE
Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances

### DIFF
--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -45,6 +45,17 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
 
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
+)
+
 func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 	ctx = logf.NewContext(ctx, logf.Log, "cainjector")
 	log := logf.FromContext(ctx)
@@ -97,7 +108,8 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 		profiling.Install(profilerMux)
 		log.V(logf.InfoLevel).Info("running go profiler on", "address", opts.PprofAddress)
 		server := &http.Server{
-			Handler: profilerMux,
+			Handler:           profilerMux,
+			ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 		}
 
 		mgr.Add(runnableNoLeaderElectionFunc(func(ctx context.Context) error {

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -49,6 +49,17 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
 
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
+)
+
 func Run(opts *config.ControllerConfiguration, stopCh <-chan struct{}) error {
 	rootCtx, cancelContext := context.WithCancel(cmdutil.ContextWithStopCh(context.Background(), stopCh))
 	defer cancelContext()
@@ -107,7 +118,8 @@ func Run(opts *config.ControllerConfiguration, stopCh <-chan struct{}) error {
 		// Add pprof endpoints to this mux
 		profiling.Install(profilerMux)
 		profilerServer := &http.Server{
-			Handler: profilerMux,
+			Handler:           profilerMux,
+			ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 		}
 
 		g.Go(func() error {

--- a/pkg/issuer/acme/http/solver/solver.go
+++ b/pkg/issuer/acme/http/solver/solver.go
@@ -21,8 +21,20 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+)
+
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
 )
 
 type HTTP01Solver struct {
@@ -91,8 +103,9 @@ func (h *HTTP01Solver) Listen(log logr.Logger) error {
 	})
 
 	h.Server = http.Server{
-		Addr:    fmt.Sprintf(":%d", h.ListenPort),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", h.ListenPort),
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 	}
 
 	return h.Server.ListenAndServe()


### PR DESCRIPTION
A recent security audit has shown that there are some http servers in cert-manager where the ReadHeaderTimeout setting is not set. 
The risk is low but if we add sensible default ReadHeaderTimeout values it will mitigate the risk of "slowloris" style DDOS attacks.
I have used the same `32s` values as are used in the Kubernetes api-server and which were then adopted by controller-runtime. 
Kyverno uses slightly lower `30s` values but I can't find any documentation explaining how that value was chosen.

## Testing

```sh
# pprof server now times out stalled connections after 32s
$ time telnet 127.0.0.1 6060
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
Connection closed by foreign host.

real    0m32.013s
user    0m0.005s
sys     0m0.000s

# The metrics and healthz servers were already configured with ReadHeaderTimeout of 8s
$ time telnet 127.0.0.1 9402
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
Connection closed by foreign host.

real    0m8.005s
user    0m0.000s
sys     0m0.004s

$ time telnet 127.0.0.1 9403
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
Connection closed by foreign host.

real    0m8.006s
user    0m0.003s
sys     0m0.001s
```

## Example Failure
* https://github.com/cert-manager/cert-manager/actions/runs/7116007299/job/19373411374?pr=6534
<img width="687" alt="image" src="https://github.com/cert-manager/cert-manager/assets/978965/3bf1b4e0-0ad2-496c-b16c-e3374ecfdebb">

<img width="723" alt="image" src="https://github.com/cert-manager/cert-manager/assets/978965/f7b5f65c-e936-442f-9d03-be2e0ec49ef8">

## Example code from other projects

* https://github.com/knative/eventing/blob/2ee2699c9c04aa34bb8e5481f4df84785afb9d1f/pkg/adapter/apiserver/adapter.go#L127-L134

* https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173

 * https://github.com/kyverno/kyverno/blob/e1eb9f6cdb067c6cd657864d976ec4ca98e8e437/pkg/webhooks/server.go#L164-L196
 
## Links 

* https://en.wikipedia.org/wiki/Slowloris_(computer_security)
* https://www.cloudflare.com/en-gb/learning/ddos/ddos-attack-tools/slowloris/
* https://golangci-lint.run/usage/linters/#gosec
* https://github.com/securego/gosec#available-rules
* https://github.com/search?q=org%3Aknative+slowloris&type=code
* https://github.com/kubernetes/kubernetes/pull/103958
* https://github.com/karmada-io/karmada/pull/3951
* https://github.com/karmada-io/karmada/pull/2594
* https://github.com/kubernetes-sigs/controller-runtime/pull/1695
* https://github.com/search?q=repo%3Akyverno%2Fkyverno%20ReadHeaderTimeout&type=code
* https://github.com/kyverno/kyverno/pull/4388

```release-note
Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances
```
