### PR TITLE
Refactor GenerateCSR and deprecate the helper functions

### DIFF
--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -104,6 +104,21 @@ func UnmarshalRawDerBytesToRDNSequence(der []byte) (rdnSequence pkix.RDNSequence
 	}
 }
 
+func ExtractCommonNameFromRDNSequence(rdns pkix.RDNSequence) string {
+	for _, rdn := range rdns {
+		for _, atv := range rdn {
+			if atv.Type.Equal(OIDConstants.CommonName) {
+				if str, ok := atv.Value.(string); ok {
+					return str
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// DEPRECATED: this function will be removed in a future release.
 func ParseSubjectStringToRawDERBytes(subject string) ([]byte, error) {
 	rdnSequence, err := UnmarshalSubjectStringToRDNSequence(subject)
 	if err != nil {


### PR DESCRIPTION
Move most of the helper function login into GenerateCSR, and deprecate them.
In the long term this will help reduce the surface area of the pki library.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
