### PR TITLE
Add the golangci-lint GitHub action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,41 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          # setup-go v4 uses cache automatically, which conflicts with golangci-lint's cache.
+          # See https://github.com/golangci/golangci-lint-action/pull/704
+          cache: false
+      # A workspace file is needed for golangci-lint to check the sub-modules.
+      # https://github.com/golangci/golangci-lint-action/issues/544
+      - run: make go-workspace
+      # Work around missing go:embed file which causes a typecheck error.
+      # https://github.com/golangci/golangci-lint/issues/2912
+      - run: touch test/integration/versionchecker/testdata/test_manifests.tar
+      # To check sub-modules, you need to supply their paths as positional arguments.
+      # This step finds the paths and adds them to a variable which is used
+      # later in the args value.
+      # https://github.com/golangci/golangci-lint/issues/828
+      - name: find-go-modules
+        id: find-go-modules
+        run: |
+          find . -type f -name 'go.mod' -printf '%h/...\n' \
+          | jq -r -R -s 'split("\n")[:-1] | sort | join(" ") | "GO_MODULES=\(.)"' \
+          >> "$GITHUB_OUTPUT"
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
+          args: --timeout=30m --config=.golangci.ci.yaml ${{ steps.find-go-modules.outputs.GO_MODULES }}

--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -1,0 +1,23 @@
+# This golangci-lint configuration is for use in CI.
+# It has a non-standard filename so that maintainers can still easily run the
+# full `golangci-lint` suite locally on their laptops.
+# This configuration limits golangci-lint to check only for those issues that
+# have already been fixed. to allow us to incrementally fix the remaining
+# issues.
+# Please contribute small PRs where a new linter is added or a particular
+# exclude is removed in the first commit, wait for golangci-lint-action to
+# report the issues and then fix those issues in a subsequent commit.
+linters:
+  disable-all: true
+  enable:
+    - gosec
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gosec
+    # Ignore some of the gosec warnings until we have time to address them.
+    - linters:
+        - gosec
+      text: "G(101|107|204|306|402|404|501|505|601)"


### PR DESCRIPTION
Run golangci-lint as a GitHub action, to provide fast feedback to a PR author about various common mistakes that are found in their code.

Initially we enable only on linter and check only G112.
The idea is that other checks and linters can be enabled one-by-one in separate PRs.
Each PR will enable only one new check and fix any offending code.
This way, the PRs are easy to review 
and easy to cherry-pick into previous release branches if the fixes are deemed important enough.

Eventually, when all standard linters and checks have been enabled, the non-standard file `.golangci-lint.*ci*.yaml` can be renamed to `.golangci-lint.yaml` so that it developers can simply run `golangci-lint run .` locally (or via their editor / lsp-server) and get feedback before even creating a PR>

The advantages of running golangci-lint via a GitHub Action vs running it via prow + make target, are:
1. Performance: The GitHub action has been optimized to report as fast as possible, by careful caching and parallelization:  https://github.com/golangci/golangci-lint-action#performance. It is possible to achieve the same results via Prow but it would take time and effort to achieve and maintain.
2. Web UI: Any failures are reported as GitHub Actions annotations which show up alongside the code changes in each PR. This makes it very easy to see what code needs changing. It would not be possible to achieve this using Prow.

The disadvantages are:
1. The cert-manager maintainers will need to  have expertise in Prow **and** GitHub  Actions.


Instances of G112 have already been fixed in a another PR:
 * https://github.com/cert-manager/cert-manager/pull/6534

```release-note
NONE
```

/kind cleanup
