### PR TITLE
[release-1.13] Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -49,6 +49,17 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
 
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
+)
+
 func Run(opts *config.ControllerConfiguration, stopCh <-chan struct{}) error {
 	rootCtx, cancelContext := context.WithCancel(cmdutil.ContextWithStopCh(context.Background(), stopCh))
 	defer cancelContext()
@@ -107,7 +118,8 @@ func Run(opts *config.ControllerConfiguration, stopCh <-chan struct{}) error {
 		// Add pprof endpoints to this mux
 		profiling.Install(profilerMux)
 		profilerServer := &http.Server{
-			Handler: profilerMux,
+			Handler:           profilerMux,
+			ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 		}
 
 		g.Go(func() error {

--- a/pkg/issuer/acme/http/solver/solver.go
+++ b/pkg/issuer/acme/http/solver/solver.go
@@ -21,8 +21,20 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+)
+
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
 )
 
 type HTTP01Solver struct {
@@ -91,8 +103,9 @@ func (h *HTTP01Solver) Listen(log logr.Logger) error {
 	})
 
 	h.Server = http.Server{
-		Addr:    fmt.Sprintf(":%d", h.ListenPort),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", h.ListenPort),
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 	}
 
 	return h.Server.ListenAndServe()


### PR DESCRIPTION
This is a **manual** cherry-pick of https://github.com/cert-manager/cert-manager/pull/6534

The automated cherry-pick failed:
 * https://github.com/cert-manager/cert-manager/pull/6534#issuecomment-1845259559

You can kind of see the manual changes I had to make by using `git range-diff`:


> git range-diff 8bed16685845428af3989753bf16780f43e5829c^- d080ceca9426e1df9471b4a062f186a4b57553a2^-

<img width="566" alt="image" src="https://github.com/cert-manager/cert-manager/assets/978965/ab182ba0-de3e-4390-b852-593edddc5b3a">


## Testing

To verify that this version of the patch fixes all the same problems you can run  the following commands:
```
make go-workspace
golangci-lint run --exclude 'G(101|107|204|306|402|404|501|505|601)' --tests=false --disable-all --enable gosec -- $(find . -type f -name 'go.mod' -printf '%h/... ')
```

```release-note
Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances
```
