### PR TITLE
[release-1.12] Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances

### DIFF
--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -49,6 +49,17 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
 
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
+)
+
 // InjectorControllerOptions is a struct having injector controller options values
 type InjectorControllerOptions struct {
 	Logging *logs.Options
@@ -222,7 +233,8 @@ func (o InjectorControllerOptions) RunInjectorController(ctx context.Context) er
 		profiling.Install(profilerMux)
 		o.log.V(logf.InfoLevel).Info("running go profiler on", "address", o.PprofAddr)
 		server := &http.Server{
-			Handler: profilerMux,
+			Handler:           profilerMux,
+			ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 		}
 		g.Go(func() error {
 			<-gctx.Done()

--- a/pkg/issuer/acme/http/solver/solver.go
+++ b/pkg/issuer/acme/http/solver/solver.go
@@ -21,8 +21,20 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+)
+
+const (
+	// This is intended to mitigate "slowloris" attacks by limiting the time a
+	// deliberately slow client can spend sending HTTP headers.
+	// This default value is copied from:
+	// * kubernetes api-server:
+	//   https://github.com/kubernetes/kubernetes/blob/9e028b40b9e970142191259effe796b3dab39828/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L165-L173
+	// * controller-runtime:
+	//   https://github.com/kubernetes-sigs/controller-runtime/blob/1ea2be573f7887a9fbd766e9a921c5af344da6eb/pkg/internal/httpserver/server.go#L14
+	defaultReadHeaderTimeout = 32 * time.Second
 )
 
 type HTTP01Solver struct {
@@ -91,8 +103,9 @@ func (h *HTTP01Solver) Listen(log logr.Logger) error {
 	})
 
 	h.Server = http.Server{
-		Addr:    fmt.Sprintf(":%d", h.ListenPort),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", h.ListenPort),
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout, // Mitigation for G112: Potential slowloris attack
 	}
 
 	return h.Server.ListenAndServe()


### PR DESCRIPTION
This is a **manual** cherry-pick of #6538 because the automated cherry-pick failed:
 * https://github.com/cert-manager/cert-manager/pull/6538#issuecomment-1845843247

You can see that the patch is the same but the context is different using `git range-diff`:

> git range-diff d080ceca9426e1df9471b4a062f186a4b57553a2^- cad118954291c041c1f601ef198cfcce0d7c3784^-

<img width="559" alt="image" src="https://github.com/cert-manager/cert-manager/assets/978965/f8fb3701-78a6-4395-a2ec-6f9989cee68e">

```release-note
Mitigate potential Slowloris attacks by setting ReadHeaderTimeout in all http.Server instances
```

/kind bug