### PR TITLE
[release-1.12] Bump to go 1.20.12

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -56,7 +56,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.10
+VENDORED_GO_VERSION := 1.20.12
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
See https://go.dev/doc/devel/release#go1.20

- go1.20.11 (released 2023-11-07) includes security fixes to the path/filepath package, as well as bug fixes to the linker and the net/http package.
- go1.20.12 (released 2023-12-05) includes security fixes to the go command, and the net/http and path/filepath packages, as well as bug fixes to the compiler and the go command.

```release-note
cert-manager is now built with Go 1.20.12
```

/kind feature


## Testing

Before:

```sh
$ make vendor-go
curl --silent --show-error --fail --location --retry 10 --retry-connrefused https://go.dev/dl/go1.20.10.linux-amd64.tar.gz -o _bin/downloaded/tools/go-1.20.10-linux-amd64.tar.gz
rm -rf _bin/downloaded/tools/_go-1.20.10-linux-amd64/goroot
tar xzf _bin/downloaded/tools/go-1.20.10-linux-amd64.tar.gz -C _bin/downloaded/tools/_go-1.20.10-linux-amd64
mv _bin/downloaded/tools/_go-1.20.10-linux-amd64/go _bin/downloaded/tools/_go-1.20.10-linux-amd64/goroot
cd _bin/tools/ && ln -f -s ../downloaded/tools/_go-1.20.10-linux-amd64/goroot .
cd _bin/tools/ && ln -f -s ../downloaded/tools/_go-1.20.10-linux-amd64/goroot/bin/go .
rm _bin/downloaded/tools/go-1.20.10-linux-amd64.tar.gz

$ export PATH=/home/richard/projects/cert-manager/cert-manager/_bin/tools:$PATH

$ go version
go version go1.20.10 linux/amd64

$ make go-workspace
go work init
go work use . ./cmd/acmesolver ./cmd/cainjector ./cmd/controller ./cmd/ctl ./cmd/webhook ./test/integration ./test/e2e

$ govulncheck --version
Go: go1.20.10
Scanner: govulncheck@v1.0.1
DB: https://vuln.go.dev
DB updated: 2023-12-11 15:30:30 +0000 UTC
```

```sh
$ govulncheck ./...
Scanning your code and 1396 packages across 149 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2023-2382
    Denial of service via chunk extensions in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2382
  Standard library
    Found in: net/http/internal@go1.20.10
    Fixed in: net/http/internal@go1.21.5
    Example traces found:
      #1: pkg/issuer/acme/dns/util/wait.go:258:25: util.httpDNSClient.Exchange calls ioutil.ReadAll, which eventually calls internal.chunkedReader.Read

Vulnerability #2: GO-2023-2186
    Incorrect detection of reserved device names on Windows in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2186
  Standard library
    Found in: path/filepath@go1.20.10
    Fixed in: path/filepath@go1.21.4
    Example traces found:
      #1: pkg/issuer/venafi/client/instrumentedvenaficlient.go:67:51: client.instrumentedConnector.RetrieveCertificate calls cloud.Connector.RetrieveCertificate, which eventually calls filepath.IsLocal

Vulnerability #3: GO-2023-2185
    Insecure parsing of Windows paths with a \??\ prefix in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2185
  Standard library
    Found in: internal/safefilepath@go1.20.10
    Fixed in: internal/safefilepath@go1.21.4
    Platforms: windows
    Example traces found:
      #1: test/apiserver/apiserver.go:44:24: apiserver.RunBareControlPlane calls envtest.Environment.Start, which eventually calls safefilepath.FromFS
      #2: test/apiserver/apiserver.go:44:24: apiserver.RunBareControlPlane calls envtest.Environment.Start, which eventually calls safefilepath.FromFS
      #3: pkg/controller/context.go:254:51: controller.NewContextFactory calls clientcmd.BuildConfigFromFlags, which eventually calls filepath.Abs
      #4: pkg/logs/logs.go:34:2: logs.init calls klog.init, which calls filepath.Base
      #5: test/acme/suite.go:94:40: acme.fixture.TestExtendedDeletingOneRecordRetainsOthers calls wait.PollUntilContextTimeout, which eventually calls filepath.Clean
      #6: pkg/util/configfile/configfile.go:53:43: configfile.configurationFSLoader.Load calls filepath.Dir
      #7: pkg/issuer/venafi/client/instrumentedvenaficlient.go:67:51: client.instrumentedConnector.RetrieveCertificate calls cloud.Connector.RetrieveCertificate, which eventually calls filepath.IsLocal
      #8: test/webhook/testwebhook.go:85:39: webhook.StartWebhookServer calls filepath.Join
      #9: pkg/acme/client/http.go:73:37: client.Transport.RoundTrip calls exec.roundTripper.RoundTrip, which eventually calls filepath.VolumeName
      #10: test/acme/util.go:50:26: acme.fixture.setupNamespace calls filepath.Walk
      #11: pkg/controller/context.go:254:51: controller.NewContextFactory calls clientcmd.BuildConfigFromFlags, which eventually calls filepath.Abs
      #12: pkg/logs/logs.go:34:2: logs.init calls klog.init, which calls filepath.Base
      #13: test/acme/suite.go:94:40: acme.fixture.TestExtendedDeletingOneRecordRetainsOthers calls wait.PollUntilContextTimeout, which eventually calls filepath.Clean
      #14: pkg/util/configfile/configfile.go:53:43: configfile.configurationFSLoader.Load calls filepath.Dir
      #15: pkg/issuer/venafi/client/instrumentedvenaficlient.go:67:51: client.instrumentedConnector.RetrieveCertificate calls cloud.Connector.RetrieveCertificate, which eventually calls filepath.IsLocal
      #16: test/webhook/testwebhook.go:85:39: webhook.StartWebhookServer calls filepath.Join
      #17: pkg/acme/client/http.go:73:37: client.Transport.RoundTrip calls exec.roundTripper.RoundTrip, which eventually calls filepath.VolumeName
      #18: test/acme/util.go:50:26: acme.fixture.setupNamespace calls filepath.Walk

Your code is affected by 3 vulnerabilities from the Go standard library.

Share feedback at https://go.dev/s/govulncheck-feedback.
```

After:

```sh
$ make vendor-go
curl --silent --show-error --fail --location --retry 10 --retry-connrefused https://go.dev/dl/go1.20.12.linux-amd64.tar.gz -o _bin/downloaded/tools/go-1.20.12-linux-amd64.tar.gz
rm -rf _bin/downloaded/tools/_go-1.20.12-linux-amd64/goroot
tar xzf _bin/downloaded/tools/go-1.20.12-linux-amd64.tar.gz -C _bin/downloaded/tools/_go-1.20.12-linux-amd64
mv _bin/downloaded/tools/_go-1.20.12-linux-amd64/go _bin/downloaded/tools/_go-1.20.12-linux-amd64/goroot
cd _bin/tools/ && ln -f -s ../downloaded/tools/_go-1.20.12-linux-amd64/goroot .
cd _bin/tools/ && ln -f -s ../downloaded/tools/_go-1.20.12-linux-amd64/goroot/bin/go .
rm _bin/downloaded/tools/go-1.20.12-linux-amd64.tar.gz

$ go version
go version go1.20.12 linux/amd64
```

```sh
$ govulncheck ./...
Scanning your code and 1429 packages across 153 dependent modules for known vulnerabilities...

No vulnerabilities found.

Share feedback at https://go.dev/s/govulncheck-feedback.
```
