### PR TITLE
New option to specify encryption and MAC algorithms for PKCS#12 keystores.

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -154,7 +154,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         algorithms:
-                          description: "Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility. \n If provided, allowed values are: `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `LegacyDES`: Less secure, used for maximal compatibility. `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret."
+                          description: "Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility. \n If provided, allowed values are: `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility. `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (eg. because of company policy). Please note that the security of the algorithm is not that important in reality, because the unencrypted certificate and private key are also stored in the Secret."
                           type: string
                           enum:
                             - LegacyRC2

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -154,11 +154,12 @@ spec:
                         - passwordSecretRef
                       properties:
                         algorithm:
-                          description: "Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore. \n If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`. Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility. Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`."
+                          description: "Algorithm is the encryption algorithm used to create the PKCS12 keystore. Default value is `RC2` for backward compatibility. \n If provided, allowed values are: `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `DES3`: Less secure, used for maximal compatibility. `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)"
                           type: string
                           enum:
-                            - RC2-40-CBC:HMAC-SHA-1
-                            - AES-256-CBC:HMAC-SHA-2
+                            - RC2
+                            - DES3
+                            - AES256
                         create:
                           description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -153,13 +153,13 @@ spec:
                         - create
                         - passwordSecretRef
                       properties:
-                        algorithm:
-                          description: "Algorithm is the encryption algorithm used to create the PKCS12 keystore. Default value is `RC2` for backward compatibility. \n If provided, allowed values are: `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `DES3`: Less secure, used for maximal compatibility. `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)"
+                        algorithms:
+                          description: "Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility. \n If provided, allowed values are: `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `LegacyDES`: Less secure, used for maximal compatibility. `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret."
                           type: string
                           enum:
-                            - RC2
-                            - DES3
-                            - AES256
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
                         create:
                           description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -168,6 +168,12 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                        algorithm:
+                          description: "Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore. \n If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`. Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility. Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`."
+                          type: string
+                          enum:
+                            - RC2-40-CBC:HMAC-SHA-1
+                            - AES-256-CBC:HMAC-SHA-2
                 literalSubject:
                   description: "Requested X.509 certificate subject, represented using the LDAP \"String Representation of a Distinguished Name\" [1]. Important: the LDAP string format also specifies the order of the attributes in the subject, this is important when issuing certs for LDAP authentication. Example: `CN=foo,DC=corp,DC=example,DC=com` More info [1]: https://datatracker.ietf.org/doc/html/rfc4514 More info: https://github.com/cert-manager/cert-manager/issues/3203 More info: https://github.com/cert-manager/cert-manager/issues/4424 \n Cannot be set if the `subject` or `commonName` field is set. This is an Alpha Feature and is only enabled with the `--feature-gates=LiteralCertificateSubject=true` option set on both the controller and webhook components."
                   type: string

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -153,6 +153,12 @@ spec:
                         - create
                         - passwordSecretRef
                       properties:
+                        algorithm:
+                          description: "Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore. \n If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`. Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility. Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`."
+                          type: string
+                          enum:
+                            - RC2-40-CBC:HMAC-SHA-1
+                            - AES-256-CBC:HMAC-SHA-2
                         create:
                           description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
@@ -168,12 +174,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                        algorithm:
-                          description: "Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore. \n If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`. Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility. Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`."
-                          type: string
-                          enum:
-                            - RC2-40-CBC:HMAC-SHA-1
-                            - AES-256-CBC:HMAC-SHA-2
                 literalSubject:
                   description: "Requested X.509 certificate subject, represented using the LDAP \"String Representation of a Distinguished Name\" [1]. Important: the LDAP string format also specifies the order of the attributes in the subject, this is important when issuing certs for LDAP authentication. Example: `CN=foo,DC=corp,DC=example,DC=com` More info [1]: https://datatracker.ietf.org/doc/html/rfc4514 More info: https://github.com/cert-manager/cert-manager/issues/3203 More info: https://github.com/cert-manager/cert-manager/issues/4424 \n Cannot be set if the `subject` or `commonName` field is set. This is an Alpha Feature and is only enabled with the `--feature-gates=LiteralCertificateSubject=true` option set on both the controller and webhook components."
                   type: string

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -153,13 +153,6 @@ spec:
                         - create
                         - passwordSecretRef
                       properties:
-                        algorithms:
-                          description: "Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility. \n If provided, allowed values are: `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility. `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (eg. because of company policy). Please note that the security of the algorithm is not that important in reality, because the unencrypted certificate and private key are also stored in the Secret."
-                          type: string
-                          enum:
-                            - LegacyRC2
-                            - LegacyDES
-                            - Modern2023
                         create:
                           description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
@@ -175,6 +168,13 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                        profile:
+                          description: "Profile specifies the key and certificate encryption algorithms and the HMAC algorithm used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility. \n If provided, allowed values are: `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20. `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility. `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (eg. because of company policy). Please note that the security of the algorithm is not that important in reality, because the unencrypted certificate and private key are also stored in the Secret."
+                          type: string
+                          enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
                 literalSubject:
                   description: "Requested X.509 certificate subject, represented using the LDAP \"String Representation of a Distinguished Name\" [1]. Important: the LDAP string format also specifies the order of the attributes in the subject, this is important when issuing certs for LDAP authentication. Example: `CN=foo,DC=corp,DC=example,DC=com` More info [1]: https://datatracker.ietf.org/doc/html/rfc4514 More info: https://github.com/cert-manager/cert-manager/issues/3203 More info: https://github.com/cert-manager/cert-manager/issues/4424 \n Cannot be set if the `subject` or `commonName` field is set. This is an Alpha Feature and is only enabled with the `--feature-gates=LiteralCertificateSubject=true` option set on both the controller and webhook components."
                   type: string

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -423,10 +423,13 @@ type PKCS12Algorithm string
 
 const (
 	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+
+	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
+	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
 
 	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -411,11 +411,13 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector
 
-	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
+	// Default value is `RC2` for backward compatibility.
 	//
-	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
-	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
-	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// If provided, allowed values are:
+	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `DES3`: Less secure, used for maximal compatibility.
+	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
 	Algorithm PKCS12Algorithm
 }
 

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -411,7 +411,7 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector
 
-	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
@@ -420,20 +420,20 @@ type PKCS12Keystore struct {
 	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
-	Algorithms PKCS12Algorithms
+	Profile PKCS12Profile
 }
 
-type PKCS12Algorithms string
+type PKCS12Profile string
 
 const (
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
-	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
-	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
-	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -410,7 +410,24 @@ type PKCS12Keystore struct {
 	// PasswordSecretRef is a reference to a key in a Secret resource
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector
+
+	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	//
+	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
+	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
+	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	Algorithm PKCS12Algorithm
 }
+
+type PKCS12Algorithm string
+
+const (
+	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+
+	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
+	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+)
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -416,8 +416,10 @@ type PKCS12Keystore struct {
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `LegacyDES`: Less secure, used for maximal compatibility.
-	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	Algorithms PKCS12Algorithms
 }
 

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -411,27 +411,27 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector
 
-	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
-	// Default value is `RC2` for backward compatibility.
+	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
-	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `DES3`: Less secure, used for maximal compatibility.
-	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
-	Algorithm PKCS12Algorithm
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure, used for maximal compatibility.
+	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	Algorithms PKCS12Algorithms
 }
 
-type PKCS12Algorithm string
+type PKCS12Algorithms string
 
 const (
-	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
 
-	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
-	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
 
-	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1330,6 +1330,7 @@ func autoConvert_v1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *v1.PKCS12Ke
 	if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 
@@ -1343,6 +1344,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1_PKCS12Keystore(in *certmanager
 	if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = v1.PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1330,7 +1330,7 @@ func autoConvert_v1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *v1.PKCS12Ke
 	if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 
@@ -1344,7 +1344,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1_PKCS12Keystore(in *certmanager
 	if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = v1.PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = v1.PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1330,7 +1330,7 @@ func autoConvert_v1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *v1.PKCS12Ke
 	if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
+	out.Profile = certmanager.PKCS12Profile(in.Profile)
 	return nil
 }
 
@@ -1344,7 +1344,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1_PKCS12Keystore(in *certmanager
 	if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = v1.PKCS12Algorithms(in.Algorithms)
+	out.Profile = v1.PKCS12Profile(in.Profile)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -333,29 +333,29 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
-	// Default value is `RC2` for backward compatibility.
+	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
-	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `DES3`: Less secure, used for maximal compatibility.
-	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure, used for maximal compatibility.
+	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
 	// +optional
-	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
+	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=RC2;DES3;AES256
-type PKCS12Algorithm string
+// +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
+type PKCS12Algorithms string
 
 const (
-	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
 
-	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
-	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
 
-	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -338,8 +338,10 @@ type PKCS12Keystore struct {
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `LegacyDES`: Less secure, used for maximal compatibility.
-	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
 	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -333,11 +333,13 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
+	// Default value is `RC2` for backward compatibility.
 	//
-	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
-	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
-	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// If provided, allowed values are:
+	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `DES3`: Less secure, used for maximal compatibility.
+	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
 	// +optional
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -344,7 +344,7 @@ type PKCS12Keystore struct {
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
 
-// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+// +kubebuilder:validation:Enum=RC2;DES3;AES256
 type PKCS12Algorithm string
 
 const (

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -332,7 +332,26 @@ type PKCS12Keystore struct {
 	// PasswordSecretRef is a reference to a key in a Secret resource
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
+
+	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	//
+	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
+	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
+	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// +optional
+	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
+
+// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+type PKCS12Algorithm string
+
+const (
+	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+
+	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
+	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+)
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -347,10 +347,13 @@ type PKCS12Algorithm string
 
 const (
 	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+
+	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
+	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
 
 	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -333,7 +333,7 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
@@ -343,21 +343,21 @@ type PKCS12Keystore struct {
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
-	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
+	Profile PKCS12Profile `json:"profile,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
-type PKCS12Algorithms string
+type PKCS12Profile string
 
 const (
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
-	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
-	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
-	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1336,7 +1336,7 @@ func autoConvert_v1alpha2_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
+	out.Profile = certmanager.PKCS12Profile(in.Profile)
 	return nil
 }
 
@@ -1350,7 +1350,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha2_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = PKCS12Algorithms(in.Algorithms)
+	out.Profile = PKCS12Profile(in.Profile)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1336,6 +1336,7 @@ func autoConvert_v1alpha2_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 
@@ -1349,6 +1350,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha2_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1336,7 +1336,7 @@ func autoConvert_v1alpha2_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 
@@ -1350,7 +1350,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha2_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -346,8 +346,10 @@ type PKCS12Keystore struct {
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `LegacyDES`: Less secure, used for maximal compatibility.
-	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
 	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -340,11 +340,14 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
-	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+
+	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
+	// Default value is `RC2` for backward compatibility.
 	//
-	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
-	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
-	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// If provided, allowed values are:
+	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `DES3`: Less secure, used for maximal compatibility.
+	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
 	// +optional
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -354,10 +354,13 @@ type PKCS12Algorithm string
 
 const (
 	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+
+	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
+	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
 
 	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -338,8 +338,27 @@ type PKCS12Keystore struct {
 
 	// PasswordSecretRef is a reference to a key in a Secret resource
 	// containing the password used to encrypt the PKCS12 keystore.
+
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
+	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	//
+	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
+	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
+	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// +optional
+	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
+
+// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+type PKCS12Algorithm string
+
+const (
+	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+
+	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
+	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+)
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -341,29 +341,29 @@ type PKCS12Keystore struct {
 
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
-	// Default value is `RC2` for backward compatibility.
+	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
-	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `DES3`: Less secure, used for maximal compatibility.
-	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure, used for maximal compatibility.
+	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
 	// +optional
-	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
+	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=RC2;DES3;AES256
-type PKCS12Algorithm string
+// +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
+type PKCS12Algorithms string
 
 const (
-	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
 
-	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
-	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
 
-	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -341,7 +341,7 @@ type PKCS12Keystore struct {
 
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
@@ -351,21 +351,21 @@ type PKCS12Keystore struct {
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
-	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
+	Profile PKCS12Profile `json:"profile,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
-type PKCS12Algorithms string
+type PKCS12Profile string
 
 const (
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
-	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
-	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
-	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -352,7 +352,7 @@ type PKCS12Keystore struct {
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
 
-// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+// +kubebuilder:validation:Enum=RC2;DES3;AES256
 type PKCS12Algorithm string
 
 const (

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1335,7 +1335,7 @@ func autoConvert_v1alpha3_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 
@@ -1349,7 +1349,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha3_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1335,6 +1335,7 @@ func autoConvert_v1alpha3_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 
@@ -1348,6 +1349,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha3_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1335,7 +1335,7 @@ func autoConvert_v1alpha3_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS1
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
+	out.Profile = certmanager.PKCS12Profile(in.Profile)
 	return nil
 }
 
@@ -1349,7 +1349,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1alpha3_PKCS12Keystore(in *certm
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = PKCS12Algorithms(in.Algorithms)
+	out.Profile = PKCS12Profile(in.Profile)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -338,11 +338,13 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
+	// Default value is `RC2` for backward compatibility.
 	//
-	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
-	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
-	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// If provided, allowed values are:
+	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `DES3`: Less secure, used for maximal compatibility.
+	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
 	// +optional
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -338,7 +338,7 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
@@ -348,21 +348,21 @@ type PKCS12Keystore struct {
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
-	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
+	Profile PKCS12Profile `json:"profile,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
-type PKCS12Algorithms string
+type PKCS12Profile string
 
 const (
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
-	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
-	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
-	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -352,10 +352,13 @@ type PKCS12Algorithm string
 
 const (
 	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+
+	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
+	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
 
 	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -349,7 +349,7 @@ type PKCS12Keystore struct {
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
 
-// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+// +kubebuilder:validation:Enum=RC2;DES3;AES256
 type PKCS12Algorithm string
 
 const (

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -338,29 +338,29 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
-	// Default value is `RC2` for backward compatibility.
+	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
-	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `DES3`: Less secure, used for maximal compatibility.
-	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure, used for maximal compatibility.
+	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
 	// +optional
-	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
+	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=RC2;DES3;AES256
-type PKCS12Algorithm string
+// +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
+type PKCS12Algorithms string
 
 const (
-	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
 
-	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
-	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
 
-	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -343,8 +343,10 @@ type PKCS12Keystore struct {
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `LegacyDES`: Less secure, used for maximal compatibility.
-	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
 	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -337,7 +337,26 @@ type PKCS12Keystore struct {
 	// PasswordSecretRef is a reference to a key in a Secret resource
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
+
+	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	//
+	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
+	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
+	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// +optional
+	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
+
+// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+type PKCS12Algorithm string
+
+const (
+	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+
+	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
+	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+)
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1318,7 +1318,7 @@ func autoConvert_v1beta1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS12
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 
@@ -1332,7 +1332,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1beta1_PKCS12Keystore(in *certma
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithm = PKCS12Algorithm(in.Algorithm)
+	out.Algorithms = PKCS12Algorithms(in.Algorithms)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1318,6 +1318,7 @@ func autoConvert_v1beta1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS12
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = certmanager.PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 
@@ -1331,6 +1332,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1beta1_PKCS12Keystore(in *certma
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
+	out.Algorithm = PKCS12Algorithm(in.Algorithm)
 	return nil
 }
 

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1318,7 +1318,7 @@ func autoConvert_v1beta1_PKCS12Keystore_To_certmanager_PKCS12Keystore(in *PKCS12
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = certmanager.PKCS12Algorithms(in.Algorithms)
+	out.Profile = certmanager.PKCS12Profile(in.Profile)
 	return nil
 }
 
@@ -1332,7 +1332,7 @@ func autoConvert_certmanager_PKCS12Keystore_To_v1beta1_PKCS12Keystore(in *certma
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.PasswordSecretRef, &out.PasswordSecretRef, s); err != nil {
 		return err
 	}
-	out.Algorithms = PKCS12Algorithms(in.Algorithms)
+	out.Profile = PKCS12Profile(in.Profile)
 	return nil
 }
 

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -471,7 +471,7 @@ type PKCS12Keystore struct {
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=RC2-40-CBC:HMAC-SHA-1;AES-256-CBC:HMAC-SHA-2
+// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
 type PKCS12Algorithm string
 
 const (

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -467,8 +467,10 @@ type PKCS12Keystore struct {
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `LegacyDES`: Less secure, used for maximal compatibility.
-	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
 	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -462,7 +462,7 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
@@ -472,21 +472,21 @@ type PKCS12Keystore struct {
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
 	// +optional
-	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
+	Profile PKCS12Profile `json:"profile,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
-type PKCS12Algorithms string
+type PKCS12Profile string
 
 const (
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
-	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
-	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
-	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -461,7 +461,26 @@ type PKCS12Keystore struct {
 	// PasswordSecretRef is a reference to a key in a Secret resource
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
+
+	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	//
+	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
+	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
+	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// +optional
+	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=RC2-40-CBC:HMAC-SHA-1;AES-256-CBC:HMAC-SHA-2
+type PKCS12Algorithm string
+
+const (
+	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+
+	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
+	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+)
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -462,29 +462,29 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
-	// Default value is `RC2` for backward compatibility.
+	// Algorithms are specifying the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
 	//
 	// If provided, allowed values are:
-	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-	// `DES3`: Less secure, used for maximal compatibility.
-	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure, used for maximal compatibility.
+	// `Modern2023`: Preferred for security, used when indicated by policy. PEM format also stored in Secret.
 	// +optional
-	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
+	Algorithms PKCS12Algorithms `json:"algorithms,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=RC2;DES3;AES256
-type PKCS12Algorithm string
+// +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
+type PKCS12Algorithms string
 
 const (
-	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Algorithms PKCS12Algorithms = "LegacyRC2"
 
-	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
-	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Algorithms PKCS12Algorithms = "LegacyDES"
 
-	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Algorithms PKCS12Algorithms = "Modern2023"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -462,24 +462,29 @@ type PKCS12Keystore struct {
 	// containing the password used to encrypt the PKCS12 keystore.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 
-	// Algorithm is the encryption and MAC algorithms used to create the PKCS12 keystore.
+	// Algorithm is the encryption algorithm used to create the PKCS12 keystore.
+	// Default value is `RC2` for backward compatibility.
 	//
-	// If provided, allowed values are either `RC2-40-CBC:HMAC-SHA-1` or `AES-256-CBC:HMAC-SHA-2`.
-	// Default value is `RC2-40-CBC:HMAC-SHA-1` for backward compatibility.
-	// Note: By default, OpenSSL 3 can't decode PKCS#12 files created using `RC2-40-CBC:HMAC-SHA-1`.
+	// If provided, allowed values are:
+	// `RC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `DES3`: Less secure, used for maximal compatibility.
+	// `SHA256`: Preferred for security, used when indicated by policy. (PEM format also stored in Secret.)
 	// +optional
 	Algorithm PKCS12Algorithm `json:"algorithm,omitempty"`
 }
 
-// +kubebuilder:validation:Enum="RC2-40-CBC:HMAC-SHA-1";"AES-256-CBC:HMAC-SHA-2"
+// +kubebuilder:validation:Enum=RC2;DES3;AES256
 type PKCS12Algorithm string
 
 const (
 	// PBE with RC2 certificate algorithm, PBE with 3DES key algorithm and HMAC-SHA-1 MAC algorithm.
-	RC2PKCS12Algorithm PKCS12Algorithm = "RC2-40-CBC:HMAC-SHA-1"
+	RC2PKCS12Algorithm PKCS12Algorithm = "RC2"
+
+	// PBE with 3DES certificate and key algorithm and HMAC-SHA-1 MAC algorithm.
+	DES3PKCS12Algorithm PKCS12Algorithm = "DES3"
 
 	// PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC certificate and key algorithm and HMAC-SHA-2 MAC algorithm.
-	AESPKCS12Algorithm PKCS12Algorithm = "AES-256-CBC:HMAC-SHA-2"
+	AESPKCS12Algorithm PKCS12Algorithm = "AES256"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -39,7 +39,7 @@ import (
 // If the certificate data contains multiple certificates, the first will be used
 // as the keystores 'certificate' and the remaining certificates will be prepended
 // to the list of CAs in the resulting keystore.
-func encodePKCS12Keystore(algorithm cmapi.PKCS12Algorithm, password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
+func encodePKCS12Keystore(algorithms cmapi.PKCS12Algorithms, password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
 	key, err := pki.DecodePrivateKeyBytes(rawKey)
 	if err != nil {
 		return nil, err
@@ -61,19 +61,19 @@ func encodePKCS12Keystore(algorithm cmapi.PKCS12Algorithm, password string, rawK
 		cas = append(certs[1:], cas...)
 	}
 
-	switch algorithm {
-	case cmapi.AESPKCS12Algorithm:
+	switch algorithms {
+	case cmapi.Modern2023PKCS12Algorithms:
 		return pkcs12.Modern2023.Encode(key, certs[0], cas, password)
-	case cmapi.DES3PKCS12Algorithm:
+	case cmapi.LegacyDESPKCS12Algorithms:
 		return pkcs12.LegacyDES.Encode(key, certs[0], cas, password)
-	case cmapi.RC2PKCS12Algorithm:
+	case cmapi.LegacyRC2PKCS12Algorithms:
 		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
 	default:
 		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
 	}
 }
 
-func encodePKCS12Truststore(algorithm cmapi.PKCS12Algorithm, password string, caPem []byte) ([]byte, error) {
+func encodePKCS12Truststore(algorithms cmapi.PKCS12Algorithms, password string, caPem []byte) ([]byte, error) {
 	ca, err := pki.DecodeX509CertificateBytes(caPem)
 	if err != nil {
 		return nil, err
@@ -81,12 +81,12 @@ func encodePKCS12Truststore(algorithm cmapi.PKCS12Algorithm, password string, ca
 
 	var cas = []*x509.Certificate{ca}
 
-	switch algorithm {
-	case cmapi.AESPKCS12Algorithm:
+	switch algorithms {
+	case cmapi.Modern2023PKCS12Algorithms:
 		return pkcs12.Modern2023.EncodeTrustStore(cas, password)
-	case cmapi.DES3PKCS12Algorithm:
+	case cmapi.LegacyDESPKCS12Algorithms:
 		return pkcs12.LegacyDES.EncodeTrustStore(cas, password)
-	case cmapi.RC2PKCS12Algorithm:
+	case cmapi.LegacyRC2PKCS12Algorithms:
 		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
 	default:
 		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -39,7 +39,7 @@ import (
 // If the certificate data contains multiple certificates, the first will be used
 // as the keystores 'certificate' and the remaining certificates will be prepended
 // to the list of CAs in the resulting keystore.
-func encodePKCS12Keystore(algorithms cmapi.PKCS12Algorithms, password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
+func encodePKCS12Keystore(profile cmapi.PKCS12Profile, password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
 	key, err := pki.DecodePrivateKeyBytes(rawKey)
 	if err != nil {
 		return nil, err
@@ -61,19 +61,19 @@ func encodePKCS12Keystore(algorithms cmapi.PKCS12Algorithms, password string, ra
 		cas = append(certs[1:], cas...)
 	}
 
-	switch algorithms {
-	case cmapi.Modern2023PKCS12Algorithms:
+	switch profile {
+	case cmapi.Modern2023PKCS12Profile:
 		return pkcs12.Modern2023.Encode(key, certs[0], cas, password)
-	case cmapi.LegacyDESPKCS12Algorithms:
+	case cmapi.LegacyDESPKCS12Profile:
 		return pkcs12.LegacyDES.Encode(key, certs[0], cas, password)
-	case cmapi.LegacyRC2PKCS12Algorithms:
+	case cmapi.LegacyRC2PKCS12Profile:
 		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
 	default:
 		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
 	}
 }
 
-func encodePKCS12Truststore(algorithms cmapi.PKCS12Algorithms, password string, caPem []byte) ([]byte, error) {
+func encodePKCS12Truststore(profile cmapi.PKCS12Profile, password string, caPem []byte) ([]byte, error) {
 	ca, err := pki.DecodeX509CertificateBytes(caPem)
 	if err != nil {
 		return nil, err
@@ -81,12 +81,12 @@ func encodePKCS12Truststore(algorithms cmapi.PKCS12Algorithms, password string, 
 
 	var cas = []*x509.Certificate{ca}
 
-	switch algorithms {
-	case cmapi.Modern2023PKCS12Algorithms:
+	switch profile {
+	case cmapi.Modern2023PKCS12Profile:
 		return pkcs12.Modern2023.EncodeTrustStore(cas, password)
-	case cmapi.LegacyDESPKCS12Algorithms:
+	case cmapi.LegacyDESPKCS12Profile:
 		return pkcs12.LegacyDES.EncodeTrustStore(cas, password)
-	case cmapi.LegacyRC2PKCS12Algorithms:
+	case cmapi.LegacyRC2PKCS12Profile:
 		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
 	default:
 		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -30,6 +30,7 @@ import (
 	jks "github.com/pavlo-v-chernykh/keystore-go/v4"
 	"software.sslmate.com/src/go-pkcs12"
 
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -38,7 +39,7 @@ import (
 // If the certificate data contains multiple certificates, the first will be used
 // as the keystores 'certificate' and the remaining certificates will be prepended
 // to the list of CAs in the resulting keystore.
-func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
+func encodePKCS12Keystore(algorithm cmapi.PKCS12Algorithm, password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
 	key, err := pki.DecodePrivateKeyBytes(rawKey)
 	if err != nil {
 		return nil, err
@@ -59,17 +60,27 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 	if len(certs) > 1 {
 		cas = append(certs[1:], cas...)
 	}
-	return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
+
+	if algorithm == cmapi.AESPKCS12Algorithm {
+		return pkcs12.Modern2023.Encode(key, certs[0], cas, password)
+	} else {
+		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
+	}
 }
 
-func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
+func encodePKCS12Truststore(algorithm cmapi.PKCS12Algorithm, password string, caPem []byte) ([]byte, error) {
 	ca, err := pki.DecodeX509CertificateBytes(caPem)
 	if err != nil {
 		return nil, err
 	}
 
 	var cas = []*x509.Certificate{ca}
-	return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
+
+	if algorithm == cmapi.AESPKCS12Algorithm {
+		return pkcs12.Modern2023.EncodeTrustStore(cas, password)
+	} else {
+		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
+	}
 }
 
 func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -61,9 +61,14 @@ func encodePKCS12Keystore(algorithm cmapi.PKCS12Algorithm, password string, rawK
 		cas = append(certs[1:], cas...)
 	}
 
-	if algorithm == cmapi.AESPKCS12Algorithm {
+	switch algorithm {
+	case cmapi.AESPKCS12Algorithm:
 		return pkcs12.Modern2023.Encode(key, certs[0], cas, password)
-	} else {
+	case cmapi.DES3PKCS12Algorithm:
+		return pkcs12.LegacyDES.Encode(key, certs[0], cas, password)
+	case cmapi.RC2PKCS12Algorithm:
+		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
+	default:
 		return pkcs12.LegacyRC2.Encode(key, certs[0], cas, password)
 	}
 }
@@ -76,9 +81,14 @@ func encodePKCS12Truststore(algorithm cmapi.PKCS12Algorithm, password string, ca
 
 	var cas = []*x509.Certificate{ca}
 
-	if algorithm == cmapi.AESPKCS12Algorithm {
+	switch algorithm {
+	case cmapi.AESPKCS12Algorithm:
 		return pkcs12.Modern2023.EncodeTrustStore(cas, password)
-	} else {
+	case cmapi.DES3PKCS12Algorithm:
+		return pkcs12.LegacyDES.EncodeTrustStore(cas, password)
+	case cmapi.RC2PKCS12Algorithm:
+		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
+	default:
 		return pkcs12.LegacyRC2.EncodeTrustStore(cas, password)
 	}
 }

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -312,8 +312,8 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
-				out, err := encodePKCS12Keystore(algorithm, test.password, test.rawKey, test.certPEM, test.caPEM)
+			for _, profile := range []cmapi.PKCS12Profile{"", cmapi.LegacyRC2PKCS12Profile, cmapi.LegacyDESPKCS12Profile, cmapi.Modern2023PKCS12Profile} {
+				out, err := encodePKCS12Keystore(profile, test.password, test.rawKey, test.certPEM, test.caPEM)
 				test.verify(t, out, err)
 			}
 		})
@@ -323,8 +323,8 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		var emptyCAChain []byte = nil
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
-			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
+		for _, profile := range []cmapi.PKCS12Profile{"", cmapi.LegacyRC2PKCS12Profile, cmapi.LegacyDESPKCS12Profile, cmapi.Modern2023PKCS12Profile} {
+			out, err := encodePKCS12Keystore(profile, password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
 			require.NoError(t, err)
 
 			pkOut, certOut, caChain, err := pkcs12.DecodeChain(out, password)
@@ -344,8 +344,8 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		require.NoError(t, err)
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
-			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
+		for _, profile := range []cmapi.PKCS12Profile{"", cmapi.LegacyRC2PKCS12Profile, cmapi.LegacyDESPKCS12Profile, cmapi.Modern2023PKCS12Profile} {
+			out, err := encodePKCS12Keystore(profile, password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
 			require.NoError(t, err)
 
 			pkOut, certOut, caChainOut, err := pkcs12.DecodeChain(out, password)
@@ -393,8 +393,8 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
-				out, err := encodePKCS12Truststore(algorithm, test.password, test.caPEM)
+			for _, profile := range []cmapi.PKCS12Profile{"", cmapi.LegacyRC2PKCS12Profile, cmapi.LegacyDESPKCS12Profile, cmapi.Modern2023PKCS12Profile} {
+				out, err := encodePKCS12Truststore(profile, test.password, test.caPEM)
 				test.verify(t, test.caPEM, out, err)
 			}
 		})

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -312,7 +312,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
 				out, err := encodePKCS12Keystore(algorithm, test.password, test.rawKey, test.certPEM, test.caPEM)
 				test.verify(t, out, err)
 			}
@@ -323,7 +323,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		var emptyCAChain []byte = nil
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+		for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
 			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
 			require.NoError(t, err)
 
@@ -344,7 +344,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		require.NoError(t, err)
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+		for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
 			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
 			require.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			for _, algorithm := range []cmapi.PKCS12Algorithms{"", cmapi.LegacyRC2PKCS12Algorithms, cmapi.LegacyDESPKCS12Algorithms, cmapi.Modern2023PKCS12Algorithms} {
 				out, err := encodePKCS12Truststore(algorithm, test.password, test.caPEM)
 				test.verify(t, test.caPEM, out, err)
 			}

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -312,7 +312,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
 				out, err := encodePKCS12Keystore(algorithm, test.password, test.rawKey, test.certPEM, test.caPEM)
 				test.verify(t, out, err)
 			}
@@ -323,7 +323,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		var emptyCAChain []byte = nil
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
 			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
 			require.NoError(t, err)
 
@@ -344,7 +344,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		require.NoError(t, err)
 
 		chain := mustLeafWithChain(t)
-		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
 			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
 			require.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.DES3PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
 				out, err := encodePKCS12Truststore(algorithm, test.password, test.caPEM)
 				test.verify(t, test.caPEM, out, err)
 			}

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -312,8 +312,10 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			out, err := encodePKCS12Keystore("", test.password, test.rawKey, test.certPEM, test.caPEM)
-			test.verify(t, out, err)
+			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+				out, err := encodePKCS12Keystore(algorithm, test.password, test.rawKey, test.certPEM, test.caPEM)
+				test.verify(t, out, err)
+			}
 		})
 	}
 	t.Run("encodePKCS12Keystore encodes non-leaf certificates to the CA certificate chain, even when the supplied CA chain is empty", func(t *testing.T) {
@@ -321,16 +323,18 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		var emptyCAChain []byte = nil
 
 		chain := mustLeafWithChain(t)
-		out, err := encodePKCS12Keystore("", password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
-		require.NoError(t, err)
+		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
+			require.NoError(t, err)
 
-		pkOut, certOut, caChain, err := pkcs12.DecodeChain(out, password)
-		require.NoError(t, err)
-		assert.NotNil(t, pkOut)
-		assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
-		if assert.Len(t, caChain, 2, "caChain should contain 2 items: intermediate certificate and top-level certificate") {
-			assert.Equal(t, chain.cas[0].cert.Signature, caChain[0].Signature, "intermediate certificate signature does not match")
-			assert.Equal(t, chain.cas[1].cert.Signature, caChain[1].Signature, "top-level certificate signature does not match")
+			pkOut, certOut, caChain, err := pkcs12.DecodeChain(out, password)
+			require.NoError(t, err)
+			assert.NotNil(t, pkOut)
+			assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
+			if assert.Len(t, caChain, 2, "caChain should contain 2 items: intermediate certificate and top-level certificate") {
+				assert.Equal(t, chain.cas[0].cert.Signature, caChain[0].Signature, "intermediate certificate signature does not match")
+				assert.Equal(t, chain.cas[1].cert.Signature, caChain[1].Signature, "top-level certificate signature does not match")
+			}
 		}
 	})
 	t.Run("encodePKCS12Keystore *prepends* non-leaf certificates to the supplied CA certificate chain", func(t *testing.T) {
@@ -340,17 +344,19 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		require.NoError(t, err)
 
 		chain := mustLeafWithChain(t)
-		out, err := encodePKCS12Keystore("", password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
-		require.NoError(t, err)
+		for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+			out, err := encodePKCS12Keystore(algorithm, password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
+			require.NoError(t, err)
 
-		pkOut, certOut, caChainOut, err := pkcs12.DecodeChain(out, password)
-		require.NoError(t, err)
-		assert.NotNil(t, pkOut)
-		assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
-		if assert.Len(t, caChainOut, 3, "caChain should contain 3 items: intermediate certificate and top-level certificate and supplied CA") {
-			assert.Equal(t, chain.cas[0].cert.Signature, caChainOut[0].Signature, "intermediate certificate signature does not match")
-			assert.Equal(t, chain.cas[1].cert.Signature, caChainOut[1].Signature, "top-level certificate signature does not match")
-			assert.Equal(t, caChainIn, caChainOut[2:], "supplied certificate chain is not at the end of the chain")
+			pkOut, certOut, caChainOut, err := pkcs12.DecodeChain(out, password)
+			require.NoError(t, err)
+			assert.NotNil(t, pkOut)
+			assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
+			if assert.Len(t, caChainOut, 3, "caChain should contain 3 items: intermediate certificate and top-level certificate and supplied CA") {
+				assert.Equal(t, chain.cas[0].cert.Signature, caChainOut[0].Signature, "intermediate certificate signature does not match")
+				assert.Equal(t, chain.cas[1].cert.Signature, caChainOut[1].Signature, "top-level certificate signature does not match")
+				assert.Equal(t, caChainIn, caChainOut[2:], "supplied certificate chain is not at the end of the chain")
+			}
 		}
 	})
 }
@@ -387,8 +393,10 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			out, err := encodePKCS12Truststore("", test.password, test.caPEM)
-			test.verify(t, test.caPEM, out, err)
+			for _, algorithm := range []cmapi.PKCS12Algorithm{"", cmapi.RC2PKCS12Algorithm, cmapi.AESPKCS12Algorithm} {
+				out, err := encodePKCS12Truststore(algorithm, test.password, test.caPEM)
+				test.verify(t, test.caPEM, out, err)
+			}
 		})
 	}
 }

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -312,7 +312,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			out, err := encodePKCS12Keystore(test.password, test.rawKey, test.certPEM, test.caPEM)
+			out, err := encodePKCS12Keystore("", test.password, test.rawKey, test.certPEM, test.caPEM)
 			test.verify(t, out, err)
 		})
 	}
@@ -321,7 +321,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		var emptyCAChain []byte = nil
 
 		chain := mustLeafWithChain(t)
-		out, err := encodePKCS12Keystore(password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
+		out, err := encodePKCS12Keystore("", password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
 		require.NoError(t, err)
 
 		pkOut, certOut, caChain, err := pkcs12.DecodeChain(out, password)
@@ -340,7 +340,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		require.NoError(t, err)
 
 		chain := mustLeafWithChain(t)
-		out, err := encodePKCS12Keystore(password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
+		out, err := encodePKCS12Keystore("", password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
 		require.NoError(t, err)
 
 		pkOut, certOut, caChainOut, err := pkcs12.DecodeChain(out, password)
@@ -387,7 +387,7 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			out, err := encodePKCS12Truststore(test.password, test.caPEM)
+			out, err := encodePKCS12Truststore("", test.password, test.caPEM)
 			test.verify(t, test.caPEM, out, err)
 		})
 	}

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -258,7 +258,8 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 			return fmt.Errorf("PKCS12 keystore password Secret contains no data for key %q", ref.Key)
 		}
 		pw := pwSecret.Data[ref.Key]
-		keystoreData, err := encodePKCS12Keystore(string(pw), data.PrivateKey, data.Certificate, data.CA)
+		algorithm := crt.Spec.Keystores.PKCS12.Algorithm
+		keystoreData, err := encodePKCS12Keystore(algorithm, string(pw), data.PrivateKey, data.Certificate, data.CA)
 		if err != nil {
 			return fmt.Errorf("error encoding PKCS12 bundle: %w", err)
 		}
@@ -266,7 +267,7 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 		secret.Data[cmapi.PKCS12SecretKey] = keystoreData
 
 		if len(data.CA) > 0 {
-			truststoreData, err := encodePKCS12Truststore(string(pw), data.CA)
+			truststoreData, err := encodePKCS12Truststore(algorithm, string(pw), data.CA)
 			if err != nil {
 				return fmt.Errorf("error encoding PKCS12 trust store bundle: %w", err)
 			}

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -258,8 +258,8 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 			return fmt.Errorf("PKCS12 keystore password Secret contains no data for key %q", ref.Key)
 		}
 		pw := pwSecret.Data[ref.Key]
-		algorithms := crt.Spec.Keystores.PKCS12.Algorithms
-		keystoreData, err := encodePKCS12Keystore(algorithms, string(pw), data.PrivateKey, data.Certificate, data.CA)
+		profile := crt.Spec.Keystores.PKCS12.Profile
+		keystoreData, err := encodePKCS12Keystore(profile, string(pw), data.PrivateKey, data.Certificate, data.CA)
 		if err != nil {
 			return fmt.Errorf("error encoding PKCS12 bundle: %w", err)
 		}
@@ -267,7 +267,7 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 		secret.Data[cmapi.PKCS12SecretKey] = keystoreData
 
 		if len(data.CA) > 0 {
-			truststoreData, err := encodePKCS12Truststore(algorithms, string(pw), data.CA)
+			truststoreData, err := encodePKCS12Truststore(profile, string(pw), data.CA)
 			if err != nil {
 				return fmt.Errorf("error encoding PKCS12 trust store bundle: %w", err)
 			}

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -258,8 +258,8 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 			return fmt.Errorf("PKCS12 keystore password Secret contains no data for key %q", ref.Key)
 		}
 		pw := pwSecret.Data[ref.Key]
-		algorithm := crt.Spec.Keystores.PKCS12.Algorithm
-		keystoreData, err := encodePKCS12Keystore(algorithm, string(pw), data.PrivateKey, data.Certificate, data.CA)
+		algorithms := crt.Spec.Keystores.PKCS12.Algorithms
+		keystoreData, err := encodePKCS12Keystore(algorithms, string(pw), data.PrivateKey, data.Certificate, data.CA)
 		if err != nil {
 			return fmt.Errorf("error encoding PKCS12 bundle: %w", err)
 		}
@@ -267,7 +267,7 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 		secret.Data[cmapi.PKCS12SecretKey] = keystoreData
 
 		if len(data.CA) > 0 {
-			truststoreData, err := encodePKCS12Truststore(algorithm, string(pw), data.CA)
+			truststoreData, err := encodePKCS12Truststore(algorithms, string(pw), data.CA)
 			if err != nil {
 				return fmt.Errorf("error encoding PKCS12 trust store bundle: %w", err)
 			}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
(resolves #5957, #6523)

This PR adds a new field .spec.keystores.pkcs12.algorithm to allow specifying encryption and MAC algorithms for PKCS#12 keystores, enhancing compatibility with OpenSSL 3 and keep maintaining support for legacy systems.

### Kind
/kind feature 
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
New option .spec.keystores.pkcs12.algorithms to specify encryption and MAC algorithms for PKCS#12 keystores. Fixes issues #5957 and #6523.
```
