### PR TITLE
Fix gosec G601: Implicit memory aliasing of items from a range statement

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -12,12 +12,23 @@ linters:
   enable:
     - gosec
 issues:
+  # When we enable a new linter or a new issue check, we want to show **all**
+  # instances of each issue in the GitHub UI or in the CLI report. This allows
+  # the all the issues to be addressed in a single commit or addressed in a
+  # series of followup commits grouped per-package or per-module.
+  # By default golangci-lint only shows 50 issues per linter and only shows the
+  # first three instances of any particular issue. Why? We do not know, but
+  # perhaps it's to avoid overwhelming the user when there are a large number of
+  # issues.
+  # The value 0 below means show all.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # Ignore some of the gosec warnings until we have time to address them.
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
         - gosec
-    # Ignore some of the gosec warnings until we have time to address them.
     - linters:
         - gosec
       text: "G(101|107|204|306|402|404|501|505)"

--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -25,10 +25,6 @@ issues:
   max-same-issues: 0
   # Ignore some of the gosec warnings until we have time to address them.
   exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gosec
     - linters:
         - gosec
       text: "G(101|107|204|306|402|404|501|505)"

--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -20,4 +20,4 @@ issues:
     # Ignore some of the gosec warnings until we have time to address them.
     - linters:
         - gosec
-      text: "G(101|107|204|306|402|404|501|505|601)"
+      text: "G(101|107|204|306|402|404|501|505)"

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -195,6 +195,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	}
 
 	for _, crt := range crts {
+		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if err := o.renewCertificate(ctx, &crt); err != nil {
 			return err
 		}

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -307,6 +307,7 @@ func findMatchingCR(cmClient cmclient.Interface, ctx context.Context, crt *cmapi
 		nextRevision = *crt.Status.Revision + 1
 	}
 	for _, req := range reqs.Items {
+		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if predicate.CertificateRequestRevision(nextRevision)(&req) &&
 			predicate.ResourceOwnedBy(crt)(&req) {
 			possibleMatches = append(possibleMatches, req.DeepCopy())
@@ -334,6 +335,7 @@ func findMatchingOrder(cmClient cmclient.Interface, ctx context.Context, req *cm
 
 	possibleMatches := []*cmacme.Order{}
 	for _, order := range orders.Items {
+		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if predicate.ResourceOwnedBy(req)(&order) {
 			possibleMatches = append(possibleMatches, order.DeepCopy())
 		}
@@ -384,6 +386,7 @@ func findMatchingChallenges(cmClient cmclient.Interface, ctx context.Context, or
 
 	possibleMatches := []*cmacme.Challenge{}
 	for _, challenge := range challenges.Items {
+		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if predicate.ResourceOwnedBy(order)(&challenge) {
 			possibleMatches = append(possibleMatches, challenge.DeepCopy())
 		}

--- a/cmd/ctl/pkg/upgrade/migrateapiversion/migrator.go
+++ b/cmd/ctl/pkg/upgrade/migrateapiversion/migrator.go
@@ -183,7 +183,9 @@ func (m *Migrator) migrateResourcesForCRD(ctx context.Context, crd *apiext.Custo
 		}, func(err error) bool {
 			// Retry on any errors that are not otherwise skipped/ignored
 			return handleUpdateErr(err) != nil
-		}, func() error { return m.Client.Update(ctx, &obj) }); handleUpdateErr(err) != nil {
+		}, func() error {
+			return m.Client.Update(ctx, &obj) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
+		}); handleUpdateErr(err) != nil {
 			return err
 		}
 	}

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -856,6 +856,7 @@ func TestValidateDuration(t *testing.T) {
 		},
 	}
 	for n, s := range scenarios {
+		s := s // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		t.Run(n, func(t *testing.T) {
 			errs := ValidateDuration(&s.cfg.Spec, fldPath)
 			assert.ElementsMatch(t, errs, s.errs)

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -142,7 +142,7 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) (fiel
 	}
 
 	for i, sol := range iss.Solvers {
-		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...)
+		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 	}
 
 	return el, warnings

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -123,7 +123,7 @@ func partialChallengeSpecForAuthorization(ctx context.Context, issuer cmapi.Gene
 
 	// 2. filter solvers to only those that matchLabels
 	for _, cfg := range solvers {
-		acmech := challengeForSolver(&cfg)
+		acmech := challengeForSolver(&cfg) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if acmech == nil {
 			dbg.Info("cannot use solver as the ACME authorization does not allow solvers of this type")
 			continue

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -275,6 +275,7 @@ func Test_translateAnnotations(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
+		tc := tc // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		t.Run(name, func(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(&tc)

--- a/pkg/issuer/vault/setup_test.go
+++ b/pkg/issuer/vault/setup_test.go
@@ -406,6 +406,7 @@ func TestVault_Setup(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		t.Run(tt.name, func(t *testing.T) {
 			givenIssuer := &v1.Issuer{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -52,6 +52,7 @@ func Test_RestConfigWithUserAgent(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		test := test // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		t.Run(name, func(t *testing.T) {
 			gotRestConfig := RestConfigWithUserAgent(new(rest.Config), test.component...)
 			assert.Equal(t, &test.expRestConfig, gotRestConfig)

--- a/pkg/webhook/handlers/conversion_test.go
+++ b/pkg/webhook/handlers/conversion_test.go
@@ -216,6 +216,7 @@ func TestConvertTestType(t *testing.T) {
 	}
 
 	for n, test := range tests {
+		test := test // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		t.Run(n, func(t *testing.T) {
 			resp := c.Convert(&test.inputRequest)
 			if !reflect.DeepEqual(&test.expectedResponse, resp) {

--- a/test/e2e/suite/certificates/duplicatesecretname.go
+++ b/test/e2e/suite/certificates/duplicatesecretname.go
@@ -129,6 +129,7 @@ var _ = framework.CertManagerDescribe("Certificate Duplicate Secret Name", func(
 				Expect(err).NotTo(HaveOccurred())
 				var ownedReqs int
 				for _, req := range reqs.Items {
+					// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 					if predicate.ResourceOwnedBy(crt)(&req) {
 						ownedReqs++
 					}

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -181,6 +181,7 @@ func listOwnedChallenges(cl versioned.Interface, owner *cmacme.Order) ([]*cmacme
 
 	var owned []*cmacme.Challenge
 	for _, ch := range l.Items {
+		ch := ch // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		if !metav1.IsControlledBy(&ch, owner) {
 			continue
 		}
@@ -198,6 +199,7 @@ func listOwnedOrders(cl versioned.Interface, owner *v1.Certificate) ([]*cmacme.O
 
 	var owned []*cmacme.Order
 	for _, o := range l.Items {
+		o := o // G601: Remove after Go 1.22. https://go.dev/wiki/LoopvarExperiment
 		v, ok := o.Annotations[v1.CertificateNameKey]
 		if !ok || v != owner.Name {
 			continue

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -151,7 +151,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 				continue
 			}
 
-			secondReq = &req
+			secondReq = &req // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 			return true, nil
 		}
 
@@ -288,7 +288,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 				continue
 			}
 
-			secondReq = &req
+			secondReq = &req // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 			return true, nil
 		}
 

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -640,7 +640,7 @@ func createEventsOwnedByRef(kubernetesCl kubernetes.Interface, ctx context.Conte
 	eventList *corev1.EventList, objRef *corev1.ObjectReference, ns string) error {
 	for _, event := range eventList.Items {
 		event.InvolvedObject = *objRef
-		_, err := kubernetesCl.CoreV1().Events(ns).Create(ctx, &event, metav1.CreateOptions{})
+		_, err := kubernetesCl.CoreV1().Events(ns).Create(ctx, &event, metav1.CreateOptions{}) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 		if err != nil {
 			return fmt.Errorf(err.Error())
 		}


### PR DESCRIPTION
* Enables the Gosec G601 check in golangci-lint
* Reconfigures golangci-lint to show all issues in all files (rather than limiting the results)
* Reconfigures golangci-lint to also check `_test.go` files
* Makes a local copy of the loop var where necessary.
* Annotates the failed code where the failure is a false positive.

G601 is described in https://github.com/securego/gosec#available-rules as follows:
> G601: Implicit memory aliasing of items from a range statement

This gosec check was proposed in https://github.com/securego/gosec/issues/438 and implemented in https://github.com/securego/gosec/pull/443.
* https://github.com/securego/gosec/issues/438
* https://github.com/securego/gosec/pull/443

It is intended to identify instances of the problem described in [The Go Common Mistakes section: Using reference to loop iterator variable](https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable), but the check suffers from the problems described by RSC in https://github.com/golang/go/discussions/56010:
> Static analysis is not a viable alternative
> Whether a particular loop is “buggy” due to the current behavior depends on whether the address of an iteration value  is taken and then that pointer is used after the next iteration begins. It is impossible in general for analyzers to see where the pointer lands and what will happen to it.

Most of these are false positives and I've annotated these using the gosec `# nosec ` annotation,
because it allows me to specify exactly which issue I want to ignore.
 * https://github.com/securego/gosec?tab=readme-ov-file#annotating-code

The alternative is `// nolint:gosec` which is less specific:
 * https://golangci-lint.run/usage/false-positives/#nolint-directive

I wasn't aware when I started this PR, that the check (G601), these changes and annotations will become obsolete upon the release of Go 1.22 which changes the scope of the loop var. Once cert-manager upgrades to Go 1.22 we can probably revert all these changes:
 * https://tip.golang.org/doc/go1.22#language
 * https://go.dev/blog/loopvar-preview

## Testing

Example failures:
 * https://github.com/cert-manager/cert-manager/actions/runs/7194804266
 * https://github.com/cert-manager/cert-manager/actions/runs/7195748663?pr=6551

You can also run the checks locally as follows:
```sh
make verify-golangci-lint
```

```release-note
Fix gosec G601: Implicit memory aliasing of items from a range statement
```

/kind cleanup