### PR TITLE
Add target + installation for golangci-lint

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -19,6 +19,10 @@
 ## @category CI
 ci-presubmit: verify-imports verify-errexit verify-boilerplate verify-codegen verify-crds verify-modules
 
+.PHONY: verify-golangci-lint
+verify-golangci-lint: test/integration/versionchecker/testdata/test_manifests.tar | $(NEEDS_GOLANGCI-LINT)
+	find . -name go.mod -not \( -path "./$(BINDIR)/*" -prune \)  -execdir $(GOLANGCI-LINT) run --timeout=30m --config=$(CURDIR)/.golangci.ci.yaml \;
+
 .PHONY: verify-modules
 verify-modules: | $(NEEDS_CMREL)
 	$(CMREL) validate-gomod --path $(shell pwd) --direct-import-modules github.com/cert-manager/cert-manager/cmd/ctl --no-dummy-modules github.com/cert-manager/cert-manager/integration-tests

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -63,6 +63,8 @@ TOOLS += crane=v0.16.1
 TOOLS += boilersuite=v0.1.0
 # https://pkg.go.dev/github.com/onsi/ginkgo/v2/ginkgo?tab=versions
 TOOLS += ginkgo=$(shell awk '/ginkgo\/v2/ {print $$2}' go.mod)
+# https://github.com/golangci/golangci-lint/releases
+TOOLS += golangci-lint=v1.55.2
 
 # Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
 GATEWAY_API_VERSION=v0.8.0
@@ -239,6 +241,7 @@ GO_DEPENDENCIES += go-licenses=github.com/google/go-licenses
 GO_DEPENDENCIES += gotestsum=gotest.tools/gotestsum
 GO_DEPENDENCIES += crane=github.com/google/go-containerregistry/cmd/crane
 GO_DEPENDENCIES += boilersuite=github.com/cert-manager/boilersuite
+GO_DEPENDENCIES += golangci-lint=github.com/golangci/golangci-lint/cmd/golangci-lint
 
 define go_dependency
 $$(BINDIR)/downloaded/tools/$1@$($(call UC,$1)_VERSION)_%: | $$(NEEDS_GO) $$(BINDIR)/downloaded/tools


### PR DESCRIPTION
This lets users locally run the same commands that are run in CI without needing to open a browser to find out how to install golangci-lint.

It also removes the need (when running locally) to install `gh` or copy+paste the actual command from the github actions definition.

My personal preference would be to replace the github action entirely with a prow job for many reasons, but this PR doesn't do that. It also intentionally doesn't add this to `ci-presubmit` since golangci-lint really needs a cache configured.

I've not made any efforts towards changing how we run this job in CI in this PR because that's a bigger change. In this PR, I just want to be able to run the tool locally to debug what went wrong, without having to install other tools globally.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
