### PR TITLE
Hide deprecated CLI flags

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -91,6 +91,7 @@ func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 			"logtostderr", "one_output", "skip_headers", "skip_log_headers", "stderrthreshold":
 			pf := pflag.PFlagFromGoFlag(f)
 			pf.Deprecated = "this flag may be removed in the future"
+			pf.Hidden = true
 			fs.AddFlag(pf)
 		}
 	})


### PR DESCRIPTION
### Pull Request Motivation

These flags were deprecated as part of the 1.13 release.
Now, I would like to hide them so the `--help` output is a lot cleaner.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
