### PR TITLE
docs: declare updated kube version in artifact hub doc

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -8,7 +8,7 @@ to renew certificates at an appropriate time before expiry.
 
 ## Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.22+
 
 ## Installing the Chart
 


### PR DESCRIPTION
### Pull Request Motivation

Noticed this today while trying to install cert manager on an old cluster

flux message:

<img width="694" alt="image" src="https://github.com/cert-manager/cert-manager/assets/27816957/ded45d40-e981-4eee-aed9-697b56ec31a2">

cheers

### Kind

documentation

### Release Note

```release-note
NONE
```
