### PR TITLE
Allow customizing labels copied from ingresses to certificates

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -328,7 +328,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DefaultIssuerKind:                 opts.IngressShimConfig.DefaultIssuerKind,
 			DefaultIssuerGroup:                opts.IngressShimConfig.DefaultIssuerGroup,
 			DefaultAutoCertificateAnnotations: opts.IngressShimConfig.DefaultAutoCertificateAnnotations,
-			SkipIngressLabels:                 opts.IngressShimConfig.SkipIngressLabels,
+			CopiedLabelPrefixes:               opts.IngressShimConfig.CopiedLabelPrefixes,
 		},
 
 		CertificateOptions: controller.CertificateOptions{

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -328,6 +328,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DefaultIssuerKind:                 opts.IngressShimConfig.DefaultIssuerKind,
 			DefaultIssuerGroup:                opts.IngressShimConfig.DefaultIssuerGroup,
 			DefaultAutoCertificateAnnotations: opts.IngressShimConfig.DefaultAutoCertificateAnnotations,
+			SkipIngressLabels:                 opts.IngressShimConfig.SkipIngressLabels,
 		},
 
 		CertificateOptions: controller.CertificateOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -150,6 +150,8 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 		"Kind of the Issuer to use when the tls is requested but issuer kind is not specified on the ingress resource.")
 	fs.StringVar(&c.IngressShimConfig.DefaultIssuerGroup, "default-issuer-group", c.IngressShimConfig.DefaultIssuerGroup, ""+
 		"Group of the Issuer to use when the tls is requested but issuer group is not specified on the ingress resource.")
+	fs.StringSliceVar(&c.IngressShimConfig.SkipIngressLabels, "skip-ingress-labels", c.IngressShimConfig.SkipIngressLabels, ""+
+		"The labels on the ingress that shouldn't be copied to certificates.")
 
 	fs.StringSliceVar(&c.ACMEDNS01Config.RecursiveNameservers, "dns01-recursive-nameservers",
 		c.ACMEDNS01Config.RecursiveNameservers, "A list of comma separated dns server endpoints used for DNS01 and DNS-over-HTTPS (DoH) check requests. "+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -150,8 +150,10 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 		"Kind of the Issuer to use when the tls is requested but issuer kind is not specified on the ingress resource.")
 	fs.StringVar(&c.IngressShimConfig.DefaultIssuerGroup, "default-issuer-group", c.IngressShimConfig.DefaultIssuerGroup, ""+
 		"Group of the Issuer to use when the tls is requested but issuer group is not specified on the ingress resource.")
-	fs.StringSliceVar(&c.IngressShimConfig.SkipIngressLabels, "skip-ingress-labels", c.IngressShimConfig.SkipIngressLabels, ""+
-		"The labels on the ingress that shouldn't be copied to certificates.")
+	fs.StringSliceVar(&c.IngressShimConfig.CopiedLabelPrefixes, "copied-label-prefixes", c.IngressShimConfig.CopiedLabelPrefixes, ""+
+		"Specifies which should/shouldn't be copied from Ingresses to Certificates by passing a list of key prefixes. "+
+		"A prefix starting with a dash(-) specifies a label that shouldn't be copied. Example: '*,-kubectl.kuberenetes.io/' - all labels "+
+		"will be copied apart from the ones where the key is prefixed with 'kubectl.kubernetes.io/'.")
 
 	fs.StringSliceVar(&c.ACMEDNS01Config.RecursiveNameservers, "dns01-recursive-nameservers",
 		c.ACMEDNS01Config.RecursiveNameservers, "A list of comma separated dns server endpoints used for DNS01 and DNS-over-HTTPS (DoH) check requests. "+
@@ -172,9 +174,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.BoolVar(&c.EnableCertificateOwnerRef, "enable-certificate-owner-ref", c.EnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
-	fs.StringSliceVar(&c.CopiedAnnotationPrefixes, "copied-annotation-prefixes", c.CopiedAnnotationPrefixes, "Specify which annotations should/shouldn't be copied"+
-		"from Certificate to CertificateRequest and Order, as well as from CertificateSigningRequest to Order, by passing a list of annotation key prefixes."+
-		"A prefix starting with a dash(-) specifies an annotation that shouldn't be copied. Example: '*,-kubectl.kuberenetes.io/'- all annotations"+
+	fs.StringSliceVar(&c.CopiedAnnotationPrefixes, "copied-annotation-prefixes", c.CopiedAnnotationPrefixes, "Specify which annotations should/shouldn't be copied "+
+		"from Certificate to CertificateRequest and Order, as well as from CertificateSigningRequest to Order, by passing a list of annotation key prefixes. "+
+		"A prefix starting with a dash(-) specifies an annotation that shouldn't be copied. Example: '*,-kubectl.kuberenetes.io/' - all annotations "+
 		"will be copied apart from the ones where the key is prefixed with 'kubectl.kubernetes.io/'.")
 	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -171,6 +171,9 @@ type IngressShimConfig struct {
 	// The annotation consumed by the ingress-shim controller to indicate a ingress
 	// is requesting a certificate
 	DefaultAutoCertificateAnnotations []string
+
+	// These labels are not copied to any certificates created from the ingress
+	SkipIngressLabels []string
 }
 
 type ACMEHTTP01Config struct {

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -173,7 +173,7 @@ type IngressShimConfig struct {
 	DefaultAutoCertificateAnnotations []string
 
 	// These labels are not copied to any certificates created from the ingress
-	SkipIngressLabels []string
+	CopiedLabelPrefixes []string
 }
 
 type ACMEHTTP01Config struct {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -166,6 +166,11 @@ var (
 		"-fluxcd.io/",
 		"-argocd.argoproj.io/",
 	}
+
+	defaultCopiedIngressLabelPrefixes = []string{
+		"*",
+		"-applyset.kubernetes.io/",
+	}
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -286,6 +291,10 @@ func SetDefaults_IngressShimConfig(obj *v1alpha1.IngressShimConfig) {
 
 	if len(obj.DefaultAutoCertificateAnnotations) == 0 {
 		obj.DefaultAutoCertificateAnnotations = defaultAutoCertificateAnnotations
+	}
+
+	if len(obj.CopiedLabelPrefixes) == 0 {
+		obj.CopiedLabelPrefixes = defaultCopiedIngressLabelPrefixes
 	}
 }
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -191,6 +191,13 @@ type IngressShimConfig struct {
 	// The annotation consumed by the ingress-shim controller to indicate a ingress
 	// is requesting a certificate
 	DefaultAutoCertificateAnnotations []string `json:"defaultAutoCertificateAnnotations,omitempty"`
+
+	// Specify which labels should/shouldn't be copied from Ingress to
+	// Certificate, by passing a list of label key prefixes. A prefix starting
+	// with a dash(-) specifies a label that shouldn't be copied. Example:
+	// '*,-kubectl.kuberenetes.io/' - all labels will be copied apart from the
+	// ones where the key is prefixed with 'kubectl.kubernetes.io/'.
+	CopiedLabelPrefixes []string `json:"copiedLabelPrefixes,omitempty"`
 }
 
 type ACMEHTTP01Config struct {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -3134,7 +3134,7 @@ func TestSync(t *testing.T) {
 				DefaultIssuerKind:                 test.DefaultIssuerKind,
 				DefaultIssuerGroup:                test.DefaultIssuerGroup,
 				DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
-				SkipIngressLabels:                 []string{"my-other-label"},
+				CopiedLabelPrefixes:               []string{"*", "-my-other-label"},
 			}, "cert-manager-test")
 			b.Start()
 

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -103,7 +103,8 @@ func TestSync(t *testing.T) {
 					Name:      "ingress-name",
 					Namespace: gen.DefaultTestNamespace,
 					Labels: map[string]string{
-						"my-test-label": "should be copied",
+						"my-test-label":  "should be copied",
+						"my-other-label": "should not be copied",
 					},
 					Annotations: map[string]string{
 						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
@@ -3133,6 +3134,7 @@ func TestSync(t *testing.T) {
 				DefaultIssuerKind:                 test.DefaultIssuerKind,
 				DefaultIssuerGroup:                test.DefaultIssuerGroup,
 				DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
+				SkipIngressLabels:                 []string{"my-other-label"},
 			}, "cert-manager-test")
 			b.Start()
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -371,7 +371,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		return err
 	}
 
-	annotations := controllerpkg.BuildAnnotationsToCopy(crt.Annotations, c.copiedAnnotationPrefixes)
+	annotations := controllerpkg.CopyMatchingPrefixes(crt.Annotations, c.copiedAnnotationPrefixes)
 	annotations[cmapi.CertificateRequestRevisionAnnotationKey] = strconv.Itoa(nextRevision)
 	annotations[cmapi.CertificateRequestPrivateKeyAnnotationKey] = nextPrivateKeySecretName
 	annotations[cmapi.CertificateNameKey] = crt.Name

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -321,7 +321,7 @@ func (a *ACME) buildOrder(csr *certificatesv1.CertificateSigningRequest, req *x5
 	}
 
 	// Filter the annotations copied from CertificateSigningRequest to the Order.
-	annotations := controllerpkg.BuildAnnotationsToCopy(csr.Annotations, a.copiedAnnotationPrefixes)
+	annotations := controllerpkg.CopyMatchingPrefixes(csr.Annotations, a.copiedAnnotationPrefixes)
 
 	// Truncate certificate name so final name will be <= 63 characters. Hash
 	// (uint32) will be at most 10 digits long, and we account for the hyphen.

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -218,6 +218,7 @@ type IngressShimOptions struct {
 	DefaultIssuerKind                 string
 	DefaultIssuerGroup                string
 	DefaultAutoCertificateAnnotations []string
+	SkipIngressLabels                 []string
 }
 
 type CertificateOptions struct {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -218,7 +218,7 @@ type IngressShimOptions struct {
 	DefaultIssuerKind                 string
 	DefaultIssuerGroup                string
 	DefaultAutoCertificateAnnotations []string
-	SkipIngressLabels                 []string
+	CopiedLabelPrefixes               []string
 }
 
 type CertificateOptions struct {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestBuildAnnotationsToCopy(t *testing.T) {
+func TestCopyMatchingPrefixes(t *testing.T) {
 	tests := map[string]struct {
 		allAnnotations map[string]string
 		prefixes       []string
@@ -57,8 +57,8 @@ func TestBuildAnnotationsToCopy(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := BuildAnnotationsToCopy(test.allAnnotations, test.prefixes); !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildAnnotationsToCopy() = %+#v, want %+#v", got, test.want)
+			if got := CopyMatchingPrefixes(test.allAnnotations, test.prefixes); !reflect.DeepEqual(got, test.want) {
+				t.Errorf("CopyMatchingPrefixes() = %+#v, want %+#v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Pull Request Motivation

Fixes #6473, by allowing the user to specify which labels should be propagated from ingresses to created certificates. By default, ignore the `applyset.kubernetes.io/*` labels that prompted the original issue (as discussed in the standup).

I'm not sure if the testing I've added is sufficient - please let me know what tests you'd like to see.

### Kind

bug

### Release Note

```release-note
Allow configuring which labels are copied from ingresses to certificates created from them. By default, skip `applyset.kubernetes.io/*` labels.
```
