### PR TITLE
Enable gosec G505

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -27,4 +27,4 @@ issues:
   exclude-rules:
     - linters:
         - gosec
-      text: "G(101|107|204|306|402|404|501|505)"
+      text: "G(101|107|204|306|402|404|501)"

--- a/pkg/issuer/acme/dns/rfc2136/tsig.go
+++ b/pkg/issuer/acme/dns/rfc2136/tsig.go
@@ -22,7 +22,7 @@ package rfc2136
 import (
 	"crypto/hmac"
 	"crypto/md5"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- SHA1 is a supported TSIG Algorithm
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"

--- a/pkg/issuer/acme/dns/rfc2136/tsig_test.go
+++ b/pkg/issuer/acme/dns/rfc2136/tsig_test.go
@@ -22,7 +22,7 @@ package rfc2136
 import (
 	"crypto/hmac"
 	"crypto/md5"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- SHA1 is a supported TSIG Algorithm
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"


### PR DESCRIPTION
* Enabled the G505 check

```sh
$ golangci-lint run --config .golangci.ci.yaml -- $(find . -type f -name 'go.mod' -not -path './_bin/*' -printf '%h/... ')
pkg/issuer/acme/dns/rfc2136/tsig.go:25:2: G505: Blocklisted import crypto/sha1: weak cryptographic primitive (gosec)
        "crypto/sha1"
        ^
pkg/issuer/acme/dns/rfc2136/tsig_test.go:25:2: G505: Blocklisted import crypto/sha1: weak cryptographic primitive (gosec)
        "crypto/sha1"
        ^
```
-- https://github.com/cert-manager/cert-manager/actions/runs/7384493583?pr=6579

* Those two imports are in TSIG code which we [copied from github.com/miekg/dns](https://github.com/cert-manager/cert-manager/pull/4958) and which is used as part of the  [DNS01 DNS UPDATE mechanism in the ACME issuer](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/). 
* SHA1 is allowed by our API so I've added ignore annotations to the two imports...
* [x] but perhaps we should return a [deprecation warning](https://github.com/cert-manager/cert-manager/pull/3936) if it is used. (https://github.com/cert-manager/cert-manager/issues/6580)

https://github.com/cert-manager/cert-manager/blob/833311d278af13e222e55f2507297f37d4e902b2/internal/apis/certmanager/validation/issuer.go#L386-L392

## Links
* https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/
* https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderRFC2136
* https://github.com/cert-manager/cert-manager/pull/4958
* [RFC 2136: Dynamic Updates in the Domain Name System (DNS UPDATE)](https://www.rfc-editor.org/rfc/rfc2136)
* https://github.com/securego/gosec/issues/226
* https://github.com/securego/gosec/pull/227

/kind cleanup

```release-note
Check code for unintended use of weak cryptographic primitive using golangci-lint / gosec (G505).
```
