### PR TITLE
Enable gosec G501: Blocklisted import crypto/md5

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -27,4 +27,4 @@ issues:
   exclude-rules:
     - linters:
         - gosec
-      text: "G(101|107|204|306|402|404|501)"
+      text: "G(101|107|204|306|402|404)"

--- a/pkg/issuer/acme/dns/rfc2136/tsig.go
+++ b/pkg/issuer/acme/dns/rfc2136/tsig.go
@@ -21,7 +21,7 @@ package rfc2136
 
 import (
 	"crypto/hmac"
-	"crypto/md5"
+	"crypto/md5"  // #nosec G501 -- MD5 is a supported TSIG Algorithm
 	"crypto/sha1" // #nosec G505 -- SHA1 is a supported TSIG Algorithm
 	"crypto/sha256"
 	"crypto/sha512"

--- a/pkg/issuer/acme/dns/rfc2136/tsig_test.go
+++ b/pkg/issuer/acme/dns/rfc2136/tsig_test.go
@@ -21,7 +21,7 @@ package rfc2136
 
 import (
 	"crypto/hmac"
-	"crypto/md5"
+	"crypto/md5"  // #nosec G501 -- MD5 is a supported TSIG Algorithm
 	"crypto/sha1" // #nosec G505 -- SHA1 is a supported TSIG Algorithm
 	"crypto/sha256"
 	"crypto/sha512"


### PR DESCRIPTION
* [x] Enable the G505 check
```sh
$ make verify-golangci-lint
...
pkg/issuer/acme/dns/rfc2136/tsig.go:24:2: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)
        "crypto/md5"
        ^
pkg/issuer/acme/dns/rfc2136/tsig_test.go:24:2: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)
        "crypto/md5"
        ^
```
-- https://github.com/cert-manager/cert-manager/actions/runs/7385074055?pr=6581
  * Those two imports are in TSIG code which we [copied from github.com/miekg/dns](https://github.com/cert-manager/cert-manager/pull/4958) and which is used as part of the  [DNS01 DNS UPDATE mechanism in the ACME issuer](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/). 
* [x] MD5 is allowed by our API so add ignore annotations to the two imports.
* [x] Created follow issue: https://github.com/cert-manager/cert-manager/issues/6580

https://github.com/cert-manager/cert-manager/blob/833311d278af13e222e55f2507297f37d4e902b2/internal/apis/certmanager/validation/issuer.go#L386-L392

## Links
* https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/
* https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderRFC2136
* https://github.com/cert-manager/cert-manager/pull/4958
* [RFC 2136: Dynamic Updates in the Domain Name System (DNS UPDATE)](https://www.rfc-editor.org/rfc/rfc2136)

/kind cleanup

```release-note
Check code for unintended use of `crypto/md5`, a weak cryptographic primitive; using `golangci-lint` / `gosec` (G501).
```
