### PR TITLE
Enable gosec 404: Use of weak random number generator

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -27,4 +27,4 @@ issues:
   exclude-rules:
     - linters:
         - gosec
-      text: "G(101|107|204|306|402|404)"
+      text: "G(101|107|204|306|402)"

--- a/pkg/controller/test/util.go
+++ b/pkg/controller/test/util.go
@@ -33,7 +33,7 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
 func RandStringBytes(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		b[i] = letterBytes[rand.Intn(len(letterBytes))] // #nosec G404 -- used only in tests
 	}
 	return string(b)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -168,7 +168,7 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 func RandStringRunes(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[rand.Intn(len(letterRunes))] // #nosec G404 -- used only in tests
 	}
 	return string(b)
 }


### PR DESCRIPTION
- [x] Enable gosec G404
```sh
$ make verify-golangci-lint
...
pkg/util/util.go:171:22: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
                b[i] = letterRunes[rand.Intn(len(letterRunes))]
                                   ^
pkg/controller/test/util.go:36:22: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
                b[i] = letterBytes[rand.Intn(len(letterBytes))]
```
-- https://github.com/cert-manager/cert-manager/actions/runs/7385479927?pr=6582

  * [`pkg/util.RandStringRunes`](https://github.com/cert-manager/cert-manager/blob/47d720be3960ecd50a77c9d50af5b39406d0c56d/pkg/util/util.go#L168C11-L174) was introduced in 7d8683bd169bdf2bc8a521fc9bdf6fb556213007 to generate a suffix for the HTTP01 solver Pod. But the solver Pod now uses GenerateName instead. 

https://github.com/cert-manager/cert-manager/blob/47d720be3960ecd50a77c9d50af5b39406d0c56d/pkg/issuer/acme/http/pod.go#L163-L182

* [`pkg/controller/test.RandStringBytes`](https://github.com/cert-manager/cert-manager/blob/47d720be3960ecd50a77c9d50af5b39406d0c56d/pkg/controller/test/util.go#L24-L39) is almost identical and was introduced in 0a0747dac7f8f892e264bb5bd0255c10b275abda.

* [x] Ignore the warnings: Both functions are now only used in tests and the output does not need to be cryptographically random, so I'm ignoring the warnings by adding a nosec annotation and creating a followup issue to consolidate the two functions.

```sh
$ git grep RandStringRunes | grep -v -i test
pkg/util/util.go:func RandStringRunes(n int) string {

$ git grep RandStringBytes | grep -v -i test

```

* I considered using `crypt/rand` instead, but it doesn't provide the convenient `rand.Intn` function. You'd either have to [use `crypto/rand.Int`](https://github.com/securego/gosec/issues/294#issuecomment-487452731) or [seed `math/rand` with a `crypto/rand` source](https://stackoverflow.com/a/35208651).

/kind cleanup

```release-note
Check code for unintended use of weak random number generator (`math/rand` instead of `crypto/rand`); using `golangci-lint` / `gosec` (G404).
```
