### PR TITLE
Deprecate RandStringBytes and RandStringRunes

### DIFF
--- a/pkg/api/util/names_test.go
+++ b/pkg/api/util/names_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -194,7 +194,7 @@ func TestComputeSecureUniqueDeterministicNameFromData(t *testing.T) {
 	}
 
 	aString64 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	randomString64 := cmutil.RandStringRunes(64)
+	randomString64 := rand.String(64)
 
 	tests := []testcase{
 		{
@@ -282,7 +282,7 @@ func TestComputeSecureUniqueDeterministicNameFromData(t *testing.T) {
 	}
 
 	aString70 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	randomString70 := cmutil.RandStringRunes(70)
+	randomString70 := rand.String(70)
 
 	// Test that the output is unique for different inputs
 	inputs := []string{

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -26,22 +26,22 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	"github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
 	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 const maxConcurrentChallenges = 60
 
-func randomChallenge(rand int) *cmacme.Challenge {
-	if rand == 0 {
-		rand = 10
+func randomChallenge(dnsNamelength int) *cmacme.Challenge {
+	if dnsNamelength == 0 {
+		dnsNamelength = 10
 	}
-	return gen.Challenge("test-"+util.RandStringRunes(10),
-		gen.SetChallengeDNSName(util.RandStringRunes(rand)),
+	return gen.Challenge("test-"+rand.String(10),
+		gen.SetChallengeDNSName(rand.String(dnsNamelength)),
 		gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01))
 }
 

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/metadata/metadatainformer"
@@ -112,7 +113,7 @@ func (b *Builder) Init() {
 		}
 	}
 	if b.StringGenerator == nil {
-		b.StringGenerator = RandStringBytes
+		b.StringGenerator = rand.String
 	}
 	scheme := metadatafake.NewTestScheme()
 	metav1.AddMetaToScheme(scheme)

--- a/pkg/controller/test/util.go
+++ b/pkg/controller/test/util.go
@@ -16,24 +16,13 @@ limitations under the License.
 
 package test
 
-import (
-	"math/rand"
-	"time"
-)
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+import "k8s.io/apimachinery/pkg/util/rand"
 
 type StringGenerator func(n int) string
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
-
 // RandStringBytes generates a pseudo-random string of length `n`.
+//
+// Deprecated: Use k8s.io/apimachinery/pkg/util/rand#String instead
 func RandStringBytes(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))] // #nosec G404 -- used only in tests
-	}
-	return string(b)
+	return rand.String(n)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,15 +20,15 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/url"
 	"sort"
 	"strings"
-	"time"
+
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"golang.org/x/exp/slices"
 )
 
 func OnlyOneNotNil(items ...interface{}) (any bool, one bool) {
@@ -159,18 +159,11 @@ func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
 	return true
 }
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
-
+// RandStringRunes generates a pseudo-random string of length `n`.
+//
+// Deprecated: Use k8s.io/apimachinery/pkg/util/rand#String instead
 func RandStringRunes(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))] // #nosec G404 -- used only in tests
-	}
-	return string(b)
+	return rand.String(n)
 }
 
 // Contains returns true if a string is contained in a string slice

--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -26,11 +26,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/cert-manager/cert-manager/pkg/util"
 	vault "github.com/hashicorp/vault/api"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
@@ -62,7 +62,7 @@ func NewVaultInitializerAppRole(
 	details Details,
 	configureWithRoot bool,
 ) *VaultInitializer {
-	testId := util.RandStringRunes(10)
+	testId := rand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -87,7 +87,7 @@ func NewVaultInitializerKubernetes(
 	configureWithRoot bool,
 	apiServerURL string,
 ) *VaultInitializer {
-	testId := util.RandStringRunes(10)
+	testId := rand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -113,7 +113,7 @@ func NewVaultInitializerAllAuth(
 	configureWithRoot bool,
 	apiServerURL string,
 ) *VaultInitializer {
-	testId := util.RandStringRunes(10)
+	testId := rand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -34,6 +34,7 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 
@@ -45,7 +46,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
@@ -194,7 +194,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			cn := "test-common-name-" + util.RandStringRunes(10)
+			cn := "test-common-name-" + rand.String(10)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testcert",
@@ -224,7 +224,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			host := fmt.Sprintf("*.%s.foo-long.bar.com", util.RandStringRunes(10))
+			host := fmt.Sprintf("*.%s.foo-long.bar.com", rand.String(10))
 			literalSubject := fmt.Sprintf("CN=%s,OU=FooLong,OU=Bar,OU=Baz,OU=Dept.,O=Corp.", host)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +289,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			cn := "test-common-name-" + util.RandStringRunes(10)
+			cn := "test-common-name-" + rand.String(10)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testcert",
@@ -321,7 +321,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			cn := "test-common-name-" + util.RandStringRunes(10)
+			cn := "test-common-name-" + rand.String(10)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testcert",
@@ -404,7 +404,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			cn := "test-common-name-" + util.RandStringRunes(10)
+			cn := "test-common-name-" + rand.String(10)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testcert",
@@ -459,7 +459,7 @@ func (s *Suite) Define() {
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
-			cn := "test-common-name-" + util.RandStringRunes(10)
+			cn := "test-common-name-" + rand.String(10)
 			testCertificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testcert",

--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -28,6 +28,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
@@ -36,7 +37,6 @@ import (
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificatesigningrequests"
 	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
 	experimentalapi "github.com/cert-manager/cert-manager/pkg/apis/experimental/v1alpha1"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
@@ -131,7 +131,7 @@ func (s *Suite) Define() {
 				name:    "should issue an RSA certificate for a single Common Name",
 				keyAlgo: x509.RSA,
 				csrModifiers: func() []gen.CSRModifier {
-					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + util.RandStringRunes(10))}
+					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + rand.String(10))}
 				},
 				kubeCSRUsages: []certificatesv1.KeyUsage{
 					certificatesv1.UsageDigitalSignature,
@@ -143,7 +143,7 @@ func (s *Suite) Define() {
 				name:    "should issue an ECDSA certificate for a single Common Name",
 				keyAlgo: x509.ECDSA,
 				csrModifiers: func() []gen.CSRModifier {
-					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + util.RandStringRunes(10))}
+					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + rand.String(10))}
 				},
 				kubeCSRUsages: []certificatesv1.KeyUsage{
 					certificatesv1.UsageDigitalSignature,
@@ -155,7 +155,7 @@ func (s *Suite) Define() {
 				name:    "should issue an Ed25519 certificate for a single Common Name",
 				keyAlgo: x509.Ed25519,
 				csrModifiers: func() []gen.CSRModifier {
-					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + util.RandStringRunes(10))}
+					return []gen.CSRModifier{gen.SetCSRCommonName("test-common-name-" + rand.String(10))}
 				},
 				kubeCSRUsages: []certificatesv1.KeyUsage{
 					certificatesv1.UsageDigitalSignature,
@@ -168,7 +168,7 @@ func (s *Suite) Define() {
 				keyAlgo: x509.RSA,
 				csrModifiers: func() []gen.CSRModifier {
 					return []gen.CSRModifier{
-						gen.SetCSRCommonName("test-common-name-" + util.RandStringRunes(10)),
+						gen.SetCSRCommonName("test-common-name-" + rand.String(10)),
 						gen.SetCSRIPAddresses(net.IPv4(127, 0, 0, 1), net.IPv4(8, 8, 8, 8)),
 					}
 				},
@@ -197,7 +197,7 @@ func (s *Suite) Define() {
 				keyAlgo: x509.RSA,
 				csrModifiers: func() []gen.CSRModifier {
 					return []gen.CSRModifier{
-						gen.SetCSRCommonName("test-common-name-" + util.RandStringRunes(10)),
+						gen.SetCSRCommonName("test-common-name-" + rand.String(10)),
 						gen.SetCSRURIs(sharedURI),
 					}
 				},

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon"
@@ -33,7 +34,6 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	csrutil "github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
-	"github.com/cert-manager/cert-manager/pkg/util"
 )
 
 var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
@@ -140,11 +140,11 @@ func (k *kubernetes) initVault(f *framework.Framework, boundNS string) {
 	By("Creating a ServiceAccount for Vault authentication")
 
 	// boundNS is name of the service account for which a Secret containing the service account token will be created
-	boundSA := "vault-issuer-" + util.RandStringRunes(5)
+	boundSA := "vault-issuer-" + rand.String(5)
 	err := k.setup.CreateKubernetesRole(f.KubeClientSet, boundNS, boundSA)
 	Expect(err).NotTo(HaveOccurred())
 
-	k.saTokenSecretName = "vault-sa-secret-" + util.RandStringRunes(5)
+	k.saTokenSecretName = "vault-sa-secret-" + rand.String(5)
 	_, err = f.KubeClientSet.CoreV1().Secrets(boundNS).Create(context.TODO(), vault.NewVaultKubernetesSecret(k.saTokenSecretName, boundSA), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/test/e2e/suite/conformance/certificatesigningrequests/venafi/tpp.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/venafi/tpp.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon/venafi"
@@ -30,7 +31,6 @@ import (
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/util/errors"
 	"github.com/cert-manager/cert-manager/e2e-tests/suite/conformance/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 )
 
 var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
@@ -61,7 +61,7 @@ var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
 		CreateIssuerFunc:    venafiIssuer.createIssuer,
 		DeleteIssuerFunc:    venafiIssuer.delete,
 		UnsupportedFeatures: unsupportedFeatures,
-		DomainSuffix:        fmt.Sprintf("%s-venafi-e2e", cmutil.RandStringRunes(5)),
+		DomainSuffix:        fmt.Sprintf("%s-venafi-e2e", rand.String(5)),
 	}).Define()
 
 	venafiClusterIssuer := new(tpp)
@@ -70,7 +70,7 @@ var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
 		CreateIssuerFunc:    venafiClusterIssuer.createClusterIssuer,
 		DeleteIssuerFunc:    venafiClusterIssuer.delete,
 		UnsupportedFeatures: unsupportedFeatures,
-		DomainSuffix:        fmt.Sprintf("%s-venafi-e2e", cmutil.RandStringRunes(5)),
+		DomainSuffix:        fmt.Sprintf("%s-venafi-e2e", rand.String(5)),
 	}).Define()
 })
 

--- a/test/e2e/suite/issuers/ca/clusterissuer.go
+++ b/test/e2e/suite/issuers/ca/clusterissuer.go
@@ -22,20 +22,20 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
 	f := framework.NewDefaultFramework("create-ca-clusterissuer")
 
-	issuerName := "test-ca-clusterissuer" + cmutil.RandStringRunes(5)
-	secretName := "ca-clusterissuer-signing-keypair-" + cmutil.RandStringRunes(5)
+	issuerName := "test-ca-clusterissuer" + rand.String(5)
+	secretName := "ca-clusterissuer-signing-keypair-" + rand.String(5)
 
 	BeforeEach(func() {
 		By("Creating a signing keypair fixture")

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon"
@@ -30,7 +31,6 @@ import (
 	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
@@ -146,7 +146,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	})
 
 	It("should be ready with a valid Kubernetes Role and ServiceAccount Secret", func() {
-		saTokenSecretName := "vault-sa-secret-" + util.RandStringRunes(5)
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -170,7 +170,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	})
 
 	It("should fail to init with missing Kubernetes Role", func() {
-		saTokenSecretName := "vault-sa-secret-" + util.RandStringRunes(5)
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
 		// we test without creating the secret
 
 		By("Creating an Issuer")
@@ -209,7 +209,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	})
 
 	It("should be ready with a caBundle from a Kubernetes Secret", func() {
-		saTokenSecretName := "vault-sa-secret-" + util.RandStringRunes(5)
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -244,7 +244,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	})
 
 	It("should be eventually ready when the CA bundle secret gets created after the Issuer", func() {
-		saTokenSecretName := "vault-sa-secret-" + util.RandStringRunes(5)
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -288,7 +288,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	})
 
 	It("it should become not ready when the CA certificate in the secret changes and doesn't match Vault's CA anymore", func() {
-		saTokenSecretName := "vault-sa-secret-" + util.RandStringRunes(5)
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -23,13 +23,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	vaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/venafi"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 )
 
 var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
@@ -78,7 +78,7 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
 		cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuer.Name, cmapi.IssuerKind, nil, nil)
-		cert.Spec.CommonName = cmutil.RandStringRunes(10) + ".venafi-e2e.example"
+		cert.Spec.CommonName = rand.String(10) + ".venafi-e2e.example"
 
 		By("Creating a Certificate")
 		cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})

--- a/test/e2e/suite/issuers/venafi/tpp/certificaterequest.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificaterequest.go
@@ -24,13 +24,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	vaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/venafi"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 )
 
 var _ = TPPDescribe("CertificateRequest with a properly configured Issuer", func() {
@@ -79,7 +79,7 @@ var _ = TPPDescribe("CertificateRequest with a properly configured Issuer", func
 	It("should obtain a signed certificate for a single domain", func() {
 		crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
-		dnsNames := []string{cmutil.RandStringRunes(10) + ".venafi-e2e.example"}
+		dnsNames := []string{rand.String(10) + ".venafi-e2e.example"}
 
 		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, issuer.Name, cmapi.IssuerKind, nil, dnsNames, nil, nil, x509.RSA)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/util/domains.go
+++ b/test/e2e/util/domains.go
@@ -19,7 +19,7 @@ package util
 import (
 	"fmt"
 
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // RandomSubdomain returns a new subdomain domain of the domain suffix.
@@ -32,5 +32,5 @@ func RandomSubdomain(domain string) string {
 // subdomain has `length` number of characters.
 // e.g. abcdefghij.example.com.
 func RandomSubdomainLength(domain string, length int) string {
-	return fmt.Sprintf("%s.%s", cmutil.RandStringRunes(length), domain)
+	return fmt.Sprintf("%s.%s", rand.String(length), domain)
 }

--- a/test/integration/versionchecker/getpodfromtemplate_test.go
+++ b/test/integration/versionchecker/getpodfromtemplate_test.go
@@ -25,8 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	cmutil "github.com/cert-manager/cert-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // Based on https://github.com/kubernetes/kubernetes/blob/ca643a4d1f7bfe34773c74f79527be4afd95bf39/pkg/controller/controller_utils.go#L542
@@ -48,7 +47,7 @@ func getPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 			Labels:       desiredLabels,
 			Annotations:  desiredAnnotations,
 			GenerateName: prefix,
-			Name:         prefix + cmutil.RandStringRunes(5),
+			Name:         prefix + rand.String(5),
 			Finalizers:   desiredFinalizers,
 		},
 		Status: v1.PodStatus{


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6582 @inteon  and I discussed consolidating the two near identical functions: `RandStringBytes` and `RandStringRunes`.

I found a function with the same intent and signature in https://pkg.go.dev/k8s.io/apimachinery@v0.29.0/pkg/util/rand#String so I have decided to deprecate those two functions and replace all their uses with https://pkg.go.dev/k8s.io/apimachinery@v0.29.0/pkg/util/rand#String instead.

The https://pkg.go.dev/k8s.io/apimachinery@v0.29.0/pkg/util/rand#String version is better tested and benchmarked and also avoids any embarrassing strings by omitting vowels.
It also avoids using the deprecated `math/rand.Seed` function.

In a followup PR #6586 I will enable checks to ensure that we do not call deprecated functions in our repo.


Fixes: #6584 

/kind cleanup

```release-note
Deprecated `pkg/util.RandStringRunes` and `pkg/controller/test.RandStringBytes`. Use `k8s.io/apimachinery/pkg/util/rand.String` instead.
```
