### PR TITLE
Replace calls to deprecated sets.String functions

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -11,6 +11,7 @@ linters:
   disable-all: true
   enable:
     - gosec
+    - staticcheck
 issues:
   # When we enable a new linter or a new issue check, we want to show **all**
   # instances of each issue in the GitHub UI or in the CLI report. This allows
@@ -28,3 +29,6 @@ issues:
     - linters:
         - gosec
       text: "G(101|107|204|306|402)"
+    - linters:
+        - staticcheck
+      text: "SA(1002|1006|4000|4006)"

--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -32,3 +32,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA(1002|1006|4000|4006)"
+    - linters:
+        - staticcheck
+      text: "(ioutil|KubeCtl|NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|eab.KeyAlgorithm|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL|v.client.RawRequest)"

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -80,7 +81,7 @@ func Run(opts *config.ControllerConfiguration, stopCh <-chan struct{}) error {
 	}
 
 	enabledControllers := options.EnabledControllers(opts)
-	log.Info(fmt.Sprintf("enabled controllers: %s", enabledControllers.List()))
+	log.Info(fmt.Sprintf("enabled controllers: %s", sets.List(enabledControllers)))
 
 	// Start metrics server
 	metricsLn, err := net.Listen("tcp", opts.MetricsListenAddress)

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -210,9 +210,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	logf.AddFlags(&c.Logging, fs)
 }
 
-func EnabledControllers(o *config.ControllerConfiguration) sets.String {
+func EnabledControllers(o *config.ControllerConfiguration) sets.Set[string] {
 	var disabled []string
-	enabled := sets.NewString()
+	enabled := sets.New[string]()
 
 	for _, controller := range o.Controllers {
 		switch {

--- a/cmd/controller/app/options/options_test.go
+++ b/cmd/controller/app/options/options_test.go
@@ -31,27 +31,27 @@ import (
 func TestEnabledControllers(t *testing.T) {
 	tests := map[string]struct {
 		controllers []string
-		expEnabled  sets.String
+		expEnabled  sets.Set[string]
 	}{
 		"if no controllers enabled, return empty": {
 			controllers: []string{},
-			expEnabled:  sets.NewString(),
+			expEnabled:  sets.New[string](),
 		},
 		"if some controllers enabled, return list": {
 			controllers: []string{"foo", "bar"},
-			expEnabled:  sets.NewString("foo", "bar"),
+			expEnabled:  sets.New[string]("foo", "bar"),
 		},
 		"if some controllers enabled, one then disabled, return list without disabled": {
 			controllers: []string{"foo", "bar", "-foo"},
-			expEnabled:  sets.NewString("bar"),
+			expEnabled:  sets.New[string]("bar"),
 		},
 		"if all default controllers enabled, return all default controllers": {
 			controllers: []string{"*"},
-			expEnabled:  sets.NewString(defaults.DefaultEnabledControllers...),
+			expEnabled:  sets.New[string](defaults.DefaultEnabledControllers...),
 		},
 		"if all controllers enabled, some diabled, return all controllers with disabled": {
 			controllers: []string{"*", "-clusterissuers", "-issuers"},
-			expEnabled:  sets.NewString(defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
+			expEnabled:  sets.New[string](defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
 		},
 	}
 

--- a/cmd/ctl/pkg/upgrade/migrateapiversion/migrator.go
+++ b/cmd/ctl/pkg/upgrade/migrateapiversion/migrator.go
@@ -216,7 +216,7 @@ func (m *Migrator) patchCRDStoredVersions(ctx context.Context, crds []*apiext.Cu
 			return newUnexpectedChangeError(crd)
 		}
 		newlyAddedVersions := storedVersionsAdded(crd, freshCRD)
-		if newlyAddedVersions.Len() != 0 && !newlyAddedVersions.Equal(sets.NewString(expectedStorageVersion)) {
+		if newlyAddedVersions.Len() != 0 && !newlyAddedVersions.Equal(sets.New[string](expectedStorageVersion)) {
 			return newUnexpectedChangeError(crd)
 		}
 
@@ -245,9 +245,9 @@ func storageVersionForCRD(crd *apiext.CustomResourceDefinition) string {
 
 // storedVersionsAdded returns a list of any versions added to the `status.storedVersions` field on
 // a CRD resource.
-func storedVersionsAdded(old, new *apiext.CustomResourceDefinition) sets.String {
-	oldStoredVersions := sets.NewString(old.Status.StoredVersions...)
-	newStoredVersions := sets.NewString(new.Status.StoredVersions...)
+func storedVersionsAdded(old, new *apiext.CustomResourceDefinition) sets.Set[string] {
+	oldStoredVersions := sets.New[string](old.Status.StoredVersions...)
+	newStoredVersions := sets.New[string](new.Status.StoredVersions...)
 	return newStoredVersions.Difference(oldStoredVersions)
 }
 

--- a/internal/plugin/plugins.go
+++ b/internal/plugin/plugins.go
@@ -39,8 +39,8 @@ func RegisterAllPlugins(plugins *admission.Plugins) {
 	resourcevalidation.Register(plugins)
 }
 
-func DefaultOnAdmissionPlugins() sets.String {
-	return sets.NewString(
+func DefaultOnAdmissionPlugins() sets.Set[string] {
+	return sets.New[string](
 		apideprecation.PluginName,
 		resourcevalidation.PluginName,
 		certificaterequestidentity.PluginName,
@@ -49,6 +49,6 @@ func DefaultOnAdmissionPlugins() sets.String {
 }
 
 // DefaultOffAdmissionPlugins gets admission plugins off by default for the webhook.
-func DefaultOffAdmissionPlugins() sets.String {
-	return sets.NewString(AllOrderedPlugins...).Difference(DefaultOnAdmissionPlugins())
+func DefaultOffAdmissionPlugins() sets.Set[string] {
+	return sets.New[string](AllOrderedPlugins...).Difference(DefaultOnAdmissionPlugins())
 }

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	"k8s.io/client-go/kubernetes"
@@ -109,7 +110,7 @@ func buildAdmissionChain(client kubernetes.Interface) (*admission.RequestHandler
 		return nil, fmt.Errorf("error creating authorization handler: %v", err)
 	}
 	pluginInitializer := initializer.New(client, nil, authorizer, nil)
-	pluginChain, err := pluginHandler.NewFromPlugins(plugin.DefaultOnAdmissionPlugins().List(), pluginInitializer)
+	pluginChain, err := pluginHandler.NewFromPlugins(sets.List(plugin.DefaultOnAdmissionPlugins()), pluginInitializer)
 	if err != nil {
 		return nil, fmt.Errorf("error building admission chain: %v", err)
 	}

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -267,17 +267,17 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, o *cm
 	}
 	log.V(logf.DebugLevel).Info("order URL not set, submitting Order to ACME server")
 
-	dnsIdentifierSet := sets.NewString(o.Spec.DNSNames...)
+	dnsIdentifierSet := sets.New[string](o.Spec.DNSNames...)
 	if o.Spec.CommonName != "" {
 		dnsIdentifierSet.Insert(o.Spec.CommonName)
 	}
-	log.V(logf.DebugLevel).Info("build set of domains for Order", "domains", dnsIdentifierSet.List())
+	log.V(logf.DebugLevel).Info("build set of domains for Order", "domains", sets.List(dnsIdentifierSet))
 
-	ipIdentifierSet := sets.NewString(o.Spec.IPAddresses...)
-	log.V(logf.DebugLevel).Info("build set of IPs for Order", "domains", dnsIdentifierSet.List())
+	ipIdentifierSet := sets.New[string](o.Spec.IPAddresses...)
+	log.V(logf.DebugLevel).Info("build set of IPs for Order", "domains", sets.List(dnsIdentifierSet))
 
-	authzIDs := acmeapi.DomainIDs(dnsIdentifierSet.List()...)
-	authzIDs = append(authzIDs, acmeapi.IPIDs(ipIdentifierSet.List()...)...)
+	authzIDs := acmeapi.DomainIDs(sets.List(dnsIdentifierSet)...)
+	authzIDs = append(authzIDs, acmeapi.IPIDs(sets.List(ipIdentifierSet)...)...)
 	// create a new order with the acme server
 
 	var options []acmeapi.OrderOption

--- a/pkg/util/pki/match.go
+++ b/pkg/util/pki/match.go
@@ -234,11 +234,11 @@ func SecretDataAltNamesMatchSpec(secret *corev1.Secret, spec cmapi.CertificateSp
 	// This check allows names to move between the DNSNames and CommonName
 	// field freely in order to account for CAs behaviour of promoting DNSNames
 	// to be CommonNames or vice-versa.
-	expectedDNSNames := sets.NewString(spec.DNSNames...)
+	expectedDNSNames := sets.New[string](spec.DNSNames...)
 	if spec.CommonName != "" {
 		expectedDNSNames.Insert(spec.CommonName)
 	}
-	allDNSNames := sets.NewString(x509cert.DNSNames...)
+	allDNSNames := sets.New[string](x509cert.DNSNames...)
 	if x509cert.Subject.CommonName != "" {
 		allDNSNames.Insert(x509cert.Subject.CommonName)
 	}

--- a/pkg/webhook/admission/handler.go
+++ b/pkg/webhook/admission/handler.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Handler struct {
-	operations sets.String
+	operations sets.Set[string]
 }
 
 func (h Handler) Handles(operation admissionv1.Operation) bool {
@@ -32,7 +32,7 @@ func (h Handler) Handles(operation admissionv1.Operation) bool {
 var _ Interface = &Handler{}
 
 func NewHandler(ops ...admissionv1.Operation) *Handler {
-	operations := sets.NewString()
+	operations := sets.New[string]()
 	for _, op := range ops {
 		operations.Insert(string(op))
 	}


### PR DESCRIPTION
* [x] Enable the staticcheck linter and show only the deprecation warnings for sets.String
> SA1019: sets.String is deprecated: use generic Set instead. new ways: 
> s1 := Set[string]{} 
> s2 := New[string]() 

-- https://github.com/cert-manager/cert-manager/actions/runs/7388630928?pr=6586

* [x] Replace all use of sets.String or sets.NewString with the new generic alternative.

I considered using https://github.com/kubernetes/utils/blob/master/set/set.go instead, but decided not, because I wanted to keep the changeset small and  I didn't want to introduce a new dependency. 
There is some discussion about whether it will eventually replace the apimachinery sets package:
 * https://github.com/kubernetes/kubernetes/issues/117673#issuecomment-1533488546
 * https://github.com/kubernetes/utils/pull/294

/kind cleanup

```release-note
Use the new generic `sets.Set` type in place of the deprecated `sets.String`.
```
