### PR TITLE
Don't return in validation, use else block instead

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -184,7 +184,7 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 			el = append(el, field.Forbidden(fldPath.Child("nameConstraints"), "feature gate NameConstraints must be enabled"))
 		} else {
 			if !crt.IsCA {
-				el = append(el, field.Invalid(fldPath.Child("nameConstraints"), crt.NameConstraints, "isCa should be true when nameConstraints is set"))
+				el = append(el, field.Invalid(fldPath.Child("nameConstraints"), crt.NameConstraints, "isCA should be true when nameConstraints is set"))
 			}
 
 			if crt.NameConstraints.Permitted == nil && crt.NameConstraints.Excluded == nil {


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6542, I missed a small error in the validation logic.
A return statement was introduced, which skips the following validation steps.
The validation function should normally not return and append all validation errors instead.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
