### PR TITLE
Use slices go library

### DIFF
--- a/cmd/cainjector/LICENSES
+++ b/cmd/cainjector/LICENSES
@@ -37,7 +37,7 @@ github.com/spf13/cobra,https://github.com/spf13/cobra/blob/v1.8.0/LICENSE.txt,Ap
 github.com/spf13/pflag,https://github.com/spf13/pflag/blob/v1.0.5/LICENSE,BSD-3-Clause
 go.uber.org/multierr,https://github.com/uber-go/multierr/blob/v1.11.0/LICENSE.txt,MIT
 go.uber.org/zap,https://github.com/uber-go/zap/blob/v1.26.0/LICENSE.txt,MIT
-golang.org/x/exp,https://cs.opensource.google/go/x/exp/+/02704c96:LICENSE,BSD-3-Clause
+golang.org/x/exp/maps,https://cs.opensource.google/go/x/exp/+/02704c96:LICENSE,BSD-3-Clause
 golang.org/x/net,https://cs.opensource.google/go/x/net/+/v0.19.0:LICENSE,BSD-3-Clause
 golang.org/x/oauth2,https://cs.opensource.google/go/x/oauth2/+/v0.15.0:LICENSE,BSD-3-Clause
 golang.org/x/sys/unix,https://cs.opensource.google/go/x/sys/+/v0.15.0:LICENSE,BSD-3-Clause

--- a/cmd/controller/LICENSES
+++ b/cmd/controller/LICENSES
@@ -114,7 +114,6 @@ go.opentelemetry.io/proto/otlp,https://github.com/open-telemetry/opentelemetry-p
 go.uber.org/multierr,https://github.com/uber-go/multierr/blob/v1.11.0/LICENSE.txt,MIT
 go.uber.org/zap,https://github.com/uber-go/zap/blob/v1.26.0/LICENSE.txt,MIT
 golang.org/x/crypto,https://cs.opensource.google/go/x/crypto/+/v0.17.0:LICENSE,BSD-3-Clause
-golang.org/x/exp,https://cs.opensource.google/go/x/exp/+/02704c96:LICENSE,BSD-3-Clause
 golang.org/x/net,https://cs.opensource.google/go/x/net/+/v0.19.0:LICENSE,BSD-3-Clause
 golang.org/x/oauth2,https://cs.opensource.google/go/x/oauth2/+/v0.15.0:LICENSE,BSD-3-Clause
 golang.org/x/sync/errgroup,https://cs.opensource.google/go/x/sync/+/v0.5.0:LICENSE,BSD-3-Clause

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -126,7 +126,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect

--- a/cmd/controller/go.sum
+++ b/cmd/controller/go.sum
@@ -379,8 +379,6 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/cmd/ctl/LICENSES
+++ b/cmd/ctl/LICENSES
@@ -117,7 +117,6 @@ go.starlark.net,https://github.com/google/starlark-go/blob/a134d8f9ddca/LICENSE,
 go.uber.org/multierr,https://github.com/uber-go/multierr/blob/v1.11.0/LICENSE.txt,MIT
 go.uber.org/zap,https://github.com/uber-go/zap/blob/v1.26.0/LICENSE.txt,MIT
 golang.org/x/crypto,https://cs.opensource.google/go/x/crypto/+/v0.17.0:LICENSE,BSD-3-Clause
-golang.org/x/exp,https://cs.opensource.google/go/x/exp/+/02704c96:LICENSE,BSD-3-Clause
 golang.org/x/net,https://cs.opensource.google/go/x/net/+/v0.19.0:LICENSE,BSD-3-Clause
 golang.org/x/oauth2,https://cs.opensource.google/go/x/oauth2/+/v0.15.0:LICENSE,BSD-3-Clause
 golang.org/x/sync,https://cs.opensource.google/go/x/sync/+/v0.5.0:LICENSE,BSD-3-Clause

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
@@ -158,6 +157,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"slices"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,6 @@ import (
 	crutil "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/util"
 	issuerpkg "github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/go-logr/logr"
 )
@@ -127,7 +127,7 @@ func (a *ACME) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuer cm
 	}
 
 	// If the CommonName is also not present in the DNS names or IP Addresses of the Request then hard fail.
-	if len(csr.Subject.CommonName) > 0 && !util.Contains(csr.DNSNames, csr.Subject.CommonName) && !util.Contains(pki.IPAddressesToString(csr.IPAddresses), csr.Subject.CommonName) {
+	if len(csr.Subject.CommonName) > 0 && !slices.Contains(csr.DNSNames, csr.Subject.CommonName) && !slices.Contains(pki.IPAddressesToString(csr.IPAddresses), csr.Subject.CommonName) {
 		err = fmt.Errorf("%q does not exist in %s or %s", csr.Subject.CommonName, csr.DNSNames, pki.IPAddressesToString(csr.IPAddresses))
 		message := "The CSR PEM requests a commonName that is not present in the list of dnsNames or ipAddresses. If a commonName is set, ACME requires that the value is also present in the list of dnsNames or ipAddresses"
 

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
@@ -270,7 +270,7 @@ func (tt *reporterT) runTest(t *testing.T) {
 			expConditions, gotConditions)
 	}
 
-	if !util.EqualSorted(tt.expectedEvents, recorder.Events) {
+	if !slices.Equal(tt.expectedEvents, recorder.Events) {
 		t.Errorf("got unexpected events, exp=%+v got=%+v",
 			tt.expectedEvents, recorder.Events)
 	}

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -44,7 +45,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	ctrlutil "github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -133,7 +133,7 @@ func (a *ACME) Sign(ctx context.Context, csr *certificatesv1.CertificateSigningR
 
 	// If the CommonName is also not present in the DNS names or IP Addresses of
 	// the Request then hard fail.
-	if len(req.Subject.CommonName) > 0 && !util.Contains(req.DNSNames, req.Subject.CommonName) && !util.Contains(pki.IPAddressesToString(req.IPAddresses), req.Subject.CommonName) {
+	if len(req.Subject.CommonName) > 0 && !slices.Contains(req.DNSNames, req.Subject.CommonName) && !slices.Contains(pki.IPAddressesToString(req.IPAddresses), req.Subject.CommonName) {
 		err = fmt.Errorf("%q does not exist in %s or %s", req.Subject.CommonName, req.DNSNames, pki.IPAddressesToString(req.IPAddresses))
 		message := fmt.Sprintf("The CSR PEM requests a commonName that is not present in the list of dnsNames or ipAddresses. If a commonName is set, ACME requires that the value is also present in the list of dnsNames or ipAddresses: %s", err)
 

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -41,7 +42,6 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/errors"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/coreclients"
@@ -611,7 +611,7 @@ func TestAcme_Setup(t *testing.T) {
 			}
 
 			// Verify that the expected events were recorded.
-			if !util.EqualSorted(test.expectedEvents, recorder.Events) {
+			if !slices.Equal(test.expectedEvents, recorder.Events) {
 				t.Errorf("Expected events:\n%+#v\ngot:%+#v",
 					test.expectedEvents,
 					recorder.Events)

--- a/pkg/issuer/venafi/setup_test.go
+++ b/pkg/issuer/venafi/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -33,7 +34,6 @@ import (
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client"
 	internalvenafifake "github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/fake"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
@@ -184,7 +184,7 @@ func (s *testSetupT) runTest(t *testing.T) {
 		t.Errorf("expected to get an error but did not get one")
 	}
 
-	if !util.EqualSorted(s.expectedEvents, rec.Events) {
+	if !slices.Equal(s.expectedEvents, rec.Events) {
 		t.Errorf("got unexpected events, exp='%s' got='%s'",
 			s.expectedEvents, rec.Events)
 	}

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -22,13 +22,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	experimentalapi "github.com/cert-manager/cert-manager/pkg/apis/experimental/v1alpha1"
-	"golang.org/x/exp/slices"
 	certificatesv1 "k8s.io/api/certificates/v1"
 )
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -49,7 +49,13 @@ func EqualSorted(s1, s2 []string) bool {
 	return slices.Equal(s1, s2)
 }
 
-func genericEqualSorted[S ~[]E, E any](
+// genericEqualUnsorted reports whether two slices are identical up to reordering
+// using a comparison function.
+// If the lengths are different, genericEqualUnsorted returns false. Otherwise, the
+// elements are sorted using the comparison function, and the sorted slices are
+// compared element by element using the same comparison function. If all elements
+// are equal, genericEqualUnsorted returns true. Otherwise it returns false.
+func genericEqualUnsorted[S ~[]E, E any](
 	s1 S, s2 S,
 	cmp func(a, b E) int,
 ) bool {
@@ -68,12 +74,12 @@ func genericEqualSorted[S ~[]E, E any](
 }
 
 func EqualUnsorted(s1 []string, s2 []string) bool {
-	return genericEqualSorted(s1, s2, strings.Compare)
+	return genericEqualUnsorted(s1, s2, strings.Compare)
 }
 
 // Test for equal URL slices even if unsorted. Panics if any element is nil
 func EqualURLsUnsorted(s1, s2 []*url.URL) bool {
-	return genericEqualSorted(s1, s2, func(a, b *url.URL) int {
+	return genericEqualUnsorted(s1, s2, func(a, b *url.URL) int {
 		return strings.Compare(a.String(), b.String())
 	})
 }
@@ -86,14 +92,14 @@ func EqualIPsUnsorted(s1, s2 []net.IP) bool {
 	// the other is stored as a 16-byte representation
 
 	// To avoid ambiguity, we ensure that only the 16-byte form is used for all addresses we work with.
-	return genericEqualSorted(s1, s2, func(a, b net.IP) int {
+	return genericEqualUnsorted(s1, s2, func(a, b net.IP) int {
 		return bytes.Compare(a.To16(), b.To16())
 	})
 }
 
 // Test for equal KeyUsage slices even if unsorted
 func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
-	return genericEqualSorted(s1, s2, func(a, b cmapi.KeyUsage) int {
+	return genericEqualUnsorted(s1, s2, func(a, b cmapi.KeyUsage) int {
 		return strings.Compare(string(a), string(b))
 	})
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
+// Deprecated: this function is no longer supported and will be removed in the future
 func OnlyOneNotNil(items ...interface{}) (any bool, one bool) {
 	oneNotNil := false
 	for _, i := range items {
@@ -44,119 +44,58 @@ func OnlyOneNotNil(items ...interface{}) (any bool, one bool) {
 	return oneNotNil, oneNotNil
 }
 
+// Deprecated: use slices#Equal instead
 func EqualSorted(s1, s2 []string) bool {
+	return slices.Equal(s1, s2)
+}
+
+func genericEqualSorted[S ~[]E, E any](
+	s1 S, s2 S,
+	cmp func(a, b E) int,
+) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
 
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
+	s1, s2 = slices.Clone(s1), slices.Clone(s2)
 
-	return true
+	slices.SortStableFunc(s1, cmp)
+	slices.SortStableFunc(s2, cmp)
+
+	return slices.EqualFunc(s1, s2, func(a, b E) bool {
+		return cmp(a, b) == 0
+	})
 }
 
 func EqualUnsorted(s1 []string, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	s1_2, s2_2 := make([]string, len(s1)), make([]string, len(s2))
-	copy(s1_2, s1)
-	copy(s2_2, s2)
-	sort.Strings(s1_2)
-	sort.Strings(s2_2)
-	for i, s := range s1_2 {
-		if s != s2_2[i] {
-			return false
-		}
-	}
-	return true
+	return genericEqualSorted(s1, s2, strings.Compare)
 }
 
 // Test for equal URL slices even if unsorted. Panics if any element is nil
 func EqualURLsUnsorted(s1, s2 []*url.URL) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	s1_2, s2_2 := make([]*url.URL, len(s1)), make([]*url.URL, len(s2))
-	copy(s1_2, s1)
-	copy(s2_2, s2)
-
-	sort.SliceStable(s1_2, func(i, j int) bool {
-		return s1_2[i].String() < s1_2[j].String()
+	return genericEqualSorted(s1, s2, func(a, b *url.URL) int {
+		return strings.Compare(a.String(), b.String())
 	})
-	sort.SliceStable(s2_2, func(i, j int) bool {
-		return s2_2[i].String() < s2_2[j].String()
-	})
-
-	for i, s := range s1_2 {
-		if s.String() != s2_2[i].String() {
-			return false
-		}
-	}
-	return true
 }
 
 // EqualIPsUnsorted checks if the given slices of IP addresses contain the same elements, even if in a different order
 func EqualIPsUnsorted(s1, s2 []net.IP) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-
 	// Two IPv4 addresses can compare unequal with bytes.Equal which is why net.IP.Equal exists.
 	// We still want to sort the lists, though, and we don't want different representations of IPv4 addresses
 	// to be sorted differently. That can happen if one is stored as a 4-byte address while
 	// the other is stored as a 16-byte representation
 
 	// To avoid ambiguity, we ensure that only the 16-byte form is used for all addresses we work with.
-
-	s1_2, s2_2 := make([]net.IP, len(s1)), make([]net.IP, len(s2))
-
-	for i := 0; i < len(s1); i++ {
-		s1_2[i] = s1[i].To16()
-		s2_2[i] = s2[i].To16()
-	}
-
-	slices.SortFunc(s1_2, func(a net.IP, b net.IP) int {
-		return bytes.Compare([]byte(a), []byte(b))
-	})
-
-	slices.SortFunc(s2_2, func(a net.IP, b net.IP) int {
-		return bytes.Compare([]byte(a), []byte(b))
-	})
-
-	return slices.EqualFunc(s1_2, s2_2, func(a net.IP, b net.IP) bool {
-		return a.Equal(b)
+	return genericEqualSorted(s1, s2, func(a, b net.IP) int {
+		return bytes.Compare(a.To16(), b.To16())
 	})
 }
 
 // Test for equal KeyUsage slices even if unsorted
 func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	s1_2, s2_2 := make([]string, len(s1)), make([]string, len(s2))
-	// we may want to implement a sort interface here instead of []byte conversion
-	for i := range s1 {
-		s1_2[i] = string(s1[i])
-		s2_2[i] = string(s2[i])
-	}
-
-	sort.SliceStable(s1_2, func(i, j int) bool {
-		return s1_2[i] < s1_2[j]
+	return genericEqualSorted(s1, s2, func(a, b cmapi.KeyUsage) int {
+		return strings.Compare(string(a), string(b))
 	})
-	sort.SliceStable(s2_2, func(i, j int) bool {
-		return s2_2[i] < s2_2[j]
-	})
-
-	for i, s := range s1_2 {
-		if s != s2_2[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // RandStringRunes generates a pseudo-random string of length `n`.
@@ -167,19 +106,16 @@ func RandStringRunes(n int) string {
 }
 
 // Contains returns true if a string is contained in a string slice
+//
+// Deprecated: Use slices#Contains instead
 func Contains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ss, s)
 }
 
 // Subset returns true if one slice is an unsorted subset of the first.
 func Subset(set, subset []string) bool {
 	for _, s := range subset {
-		if !Contains(set, s) {
+		if !slices.Contains(set, s) {
 			return false
 		}
 	}

--- a/test/e2e/LICENSES
+++ b/test/e2e/LICENSES
@@ -63,7 +63,6 @@ github.com/spf13/pflag,https://github.com/spf13/pflag/blob/v1.0.5/LICENSE,BSD-3-
 go.uber.org/multierr,https://github.com/uber-go/multierr/blob/v1.11.0/LICENSE.txt,MIT
 go.uber.org/zap,https://github.com/uber-go/zap/blob/v1.26.0/LICENSE.txt,MIT
 golang.org/x/crypto,https://cs.opensource.google/go/x/crypto/+/v0.17.0:LICENSE,BSD-3-Clause
-golang.org/x/exp,https://cs.opensource.google/go/x/exp/+/02704c96:LICENSE,BSD-3-Clause
 golang.org/x/net,https://cs.opensource.google/go/x/net/+/v0.19.0:LICENSE,BSD-3-Clause
 golang.org/x/oauth2,https://cs.opensource.google/go/x/oauth2/+/v0.15.0:LICENSE,BSD-3-Clause
 golang.org/x/sys/unix,https://cs.opensource.google/go/x/sys/+/v0.15.0:LICENSE,BSD-3-Clause

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ func (h *Helper) ValidateIssuedCertificateRequest(cr *cmapi.CertificateRequest, 
 	commonNameCorrect := true
 	expectedCN := csr.Subject.CommonName
 	if len(expectedCN) == 0 && len(cert.Subject.CommonName) > 0 {
-		if !util.Contains(cert.DNSNames, cert.Subject.CommonName) {
+		if !slices.Contains(cert.DNSNames, cert.Subject.CommonName) {
 			commonNameCorrect = false
 		}
 	} else if expectedCN != cert.Subject.CommonName {

--- a/test/e2e/framework/helper/validation/certificates/certificates.go
+++ b/test/e2e/framework/helper/validation/certificates/certificates.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/kr/pretty"
@@ -186,7 +187,7 @@ func ExpectValidCommonName(certificate *cmapi.Certificate, secret *corev1.Secret
 
 	if len(expectedCN) == 0 && len(cert.Subject.CommonName) > 0 {
 		// no CN is specified but our CA set one, checking if it is one of our DNS names or IP Addresses
-		if !util.Contains(cert.DNSNames, cert.Subject.CommonName) && !util.Contains(pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName) {
+		if !slices.Contains(cert.DNSNames, cert.Subject.CommonName) && !slices.Contains(pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName) {
 			return fmt.Errorf("Expected a common name for one of our DNSNames %v or IP Addresses %v, but got a CN of %v", cert.DNSNames, pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName)
 		}
 	} else if expectedCN != cert.Subject.CommonName {

--- a/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
+++ b/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -174,7 +175,7 @@ func ExpectValidCommonName(csr *certificatesv1.CertificateSigningRequest, _ cryp
 
 	if len(expectedCN) == 0 && len(cert.Subject.CommonName) > 0 {
 		// no CN is specified but our CA set one, checking if it is one of our DNS names or IP Addresses
-		if !util.Contains(cert.DNSNames, cert.Subject.CommonName) && !util.Contains(pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName) {
+		if !slices.Contains(cert.DNSNames, cert.Subject.CommonName) && !slices.Contains(pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName) {
 			return fmt.Errorf("Expected a common name for one of our DNSNames %v or IP Addresses %v, but got a CN of %v", cert.DNSNames, pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName)
 		}
 	} else if expectedCN != cert.Subject.CommonName {

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -90,7 +90,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect


### PR DESCRIPTION
This PR replaces a lot of our util functions with functions provided by the new upstream slices go library.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
