### PR TITLE
Use io instead of deprecated ioutil package

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(ioutil|KubeCtl|NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|eab.KeyAlgorithm|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL|v.client.RawRequest)"
+      text: "(KubeCtl|NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|eab.KeyAlgorithm|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL|v.client.RawRequest)"

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -281,7 +281,7 @@ func TestHealthzLivezLeaderElection(t *testing.T) {
 				defer func() {
 					require.NoError(t, resp.Body.Close())
 				}()
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
 				lastResponseCode = resp.StatusCode

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -255,7 +255,7 @@ func (c *httpDNSClient) Exchange(ctx context.Context, m *dns.Msg, a string) (r *
 		return nil, 0, fmt.Errorf("dns: unexpected Content-Type %q; expected %q", ct, dohMimeType)
 	}
 
-	p, err = ioutil.ReadAll(resp.Body)
+	p, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
> SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details.
-- https://go.dev/doc/go1.16#ioutil

- [x] Unhide the ioutil deprecation warnings
       - https://github.com/cert-manager/cert-manager/actions/runs/7411458268?pr=6598
- [x] Use io package instead.

/kind cleanup

```release-note
NONE
```
