### PR TITLE
Deprecate URLsFromStrings which is only used in other deprecated functions

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -69,6 +69,7 @@ func DNSNamesForCertificate(crt *v1.Certificate) ([]string, error) {
 	return crt.Spec.DNSNames, nil
 }
 
+// DEPRECATED: this function will be removed in a future release.
 func URLsFromStrings(urlStrs []string) ([]*url.URL, error) {
 	var urls []*url.URL
 	var errs []string


### PR DESCRIPTION
Adds a deprecation warning because the function is currently only used by other deprecated functions.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
