### PR TITLE
Add startupapicheck image to the server bundle of `make release`

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -91,12 +91,14 @@ $(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/cainjector.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/controller.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/webhook.docker_tag
+	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/startupapicheck.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/ctl.docker_tag
 	cp $(BINDIR)/scratch/cert-manager.license $(CTR_SCRATCHDIR)/LICENSES
 	gunzip -c $(BINDIR)/containers/cert-manager-acmesolver-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/acmesolver.tar
 	gunzip -c $(BINDIR)/containers/cert-manager-cainjector-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/cainjector.tar
 	gunzip -c $(BINDIR)/containers/cert-manager-controller-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/controller.tar
 	gunzip -c $(BINDIR)/containers/cert-manager-webhook-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/webhook.tar
+	gunzip -c $(BINDIR)/containers/cert-manager-startupapicheck-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/startupapicheck.tar
 	gunzip -c $(BINDIR)/containers/cert-manager-ctl-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/ctl.tar
 	chmod -R 755 $(CTR_SCRATCHDIR)/server/images/*
 	tar czf $@ -C $(BINDIR)/scratch/release-container-bundle $(CTR_BASENAME)


### PR DESCRIPTION
If you open the "staged" cert-manager-server archive (bundle), it doesn't contain the startupapicheck.
That's at least part of the reason why that image didn't get published to quay.io.
 * https://console.cloud.google.com/storage/browser/_details/cert-manager-release/stage/gcb/release/v1.14.0-alpha.0/cert-manager-server-linux-amd64.tar.gz;tab=live_object?project=cert-manager-release

I've added the image to the server bundle in this PR, so that when we do the next release, it will be automatically extracted and pushed by cmrel:

https://github.com/cert-manager/release/blob/e778ffcf93a9660a0679b269f6a240f002e5a2bd/cmd/cmrel/cmd/gcb_publish.go#L487-L497

https://github.com/cert-manager/release/blob/e778ffcf93a9660a0679b269f6a240f002e5a2bd/pkg/release/unpacker.go#L115-L122

https://github.com/cert-manager/release/blob/e778ffcf93a9660a0679b269f6a240f002e5a2bd/pkg/release/unpacker.go#L201-L223

Fixes: https://github.com/cert-manager/cert-manager/issues/6597
 * https://github.com/cert-manager/cert-manager/issues/6597

## Testing

I ran `make release-artifacts` on my laptop to verify that the cert-manager server bundle contains the startupapi check image:

```sh
$ make release-artifacts
...
gunzip -c _bin/containers/cert-manager-startupapicheck-linux-arm.tar.gz >_bin/scratch/release-container-bundle/cert-manager-server-linux-arm/server/images/startupapicheck.tar
...

$ tar --list -f _bin/release/cert-manager-server-linux-amd64.tar.gz  | gr
ep startupapicheck
cert-manager-server-linux-amd64/server/images/startupapicheck.tar
cert-manager-server-linux-amd64/server/images/startupapicheck.docker_tag
```

```release-note
NONE
```
