### PR TITLE
feat: Add the ability to communicate with Vault via mTLS

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1250,6 +1250,30 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    clientCertSecretRef:
+                      description: Reference to a Secret containing a PEM-encoded Client Certificate to use when the Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    clientKeySecretRef:
+                      description: Reference to a Secret containing a PEM-encoded Client Private Key to use when the Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
                     namespace:
                       description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                       type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1250,6 +1250,30 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    clientCertSecretRef:
+                      description: Reference to a Secret containing a PEM-encoded Client Certificate to use when the Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    clientKeySecretRef:
+                      description: Reference to a Secret containing a PEM-encoded Client Private Key to use when the Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
                     namespace:
                       description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
                       type: string

--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -197,6 +197,16 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector
+
+	// Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientCertSecretRef *cmmeta.SecretKeySelector
+
+	// Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientKeySecretRef *cmmeta.SecretKeySelector
 }
 
 // VaultAuth is configuration used to authenticate with a Vault server. The

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1544,6 +1544,24 @@ func autoConvert_v1_VaultIssuer_To_certmanager_VaultIssuer(in *v1.VaultIssuer, o
 	} else {
 		out.CABundleSecretRef = nil
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
+	}
 	return nil
 }
 
@@ -1568,6 +1586,24 @@ func autoConvert_certmanager_VaultIssuer_To_v1_VaultIssuer(in *certmanager.Vault
 		}
 	} else {
 		out.CABundleSecretRef = nil
+	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(apismetav1.SecretKeySelector)
+		if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(apismetav1.SecretKeySelector)
+		if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
 	}
 	return nil
 }

--- a/internal/apis/certmanager/v1alpha2/types_issuer.go
+++ b/internal/apis/certmanager/v1alpha2/types_issuer.go
@@ -214,6 +214,16 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientCertSecretRef *cmmeta.SecretKeySelector `json:"clientCertSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientKeySecretRef *cmmeta.SecretKeySelector `json:"clientKeySecretRef,omitempty"`
 }
 
 // Configuration used to authenticate with a Vault server.

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1550,6 +1550,24 @@ func autoConvert_v1alpha2_VaultIssuer_To_certmanager_VaultIssuer(in *VaultIssuer
 	} else {
 		out.CABundleSecretRef = nil
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
+	}
 	return nil
 }
 
@@ -1574,6 +1592,24 @@ func autoConvert_certmanager_VaultIssuer_To_v1alpha2_VaultIssuer(in *certmanager
 		}
 	} else {
 		out.CABundleSecretRef = nil
+	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
 	}
 	return nil
 }

--- a/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -993,6 +993,16 @@ func (in *VaultIssuer) DeepCopyInto(out *VaultIssuer) {
 		*out = new(metav1.SecretKeySelector)
 		**out = **in
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/apis/certmanager/v1alpha3/types_issuer.go
+++ b/internal/apis/certmanager/v1alpha3/types_issuer.go
@@ -214,6 +214,16 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientCertSecretRef *cmmeta.SecretKeySelector `json:"clientCertSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientKeySecretRef *cmmeta.SecretKeySelector `json:"clientKeySecretRef,omitempty"`
 }
 
 // Configuration used to authenticate with a Vault server.

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1549,6 +1549,24 @@ func autoConvert_v1alpha3_VaultIssuer_To_certmanager_VaultIssuer(in *VaultIssuer
 	} else {
 		out.CABundleSecretRef = nil
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
+	}
 	return nil
 }
 
@@ -1573,6 +1591,24 @@ func autoConvert_certmanager_VaultIssuer_To_v1alpha3_VaultIssuer(in *certmanager
 		}
 	} else {
 		out.CABundleSecretRef = nil
+	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
 	}
 	return nil
 }

--- a/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -988,6 +988,16 @@ func (in *VaultIssuer) DeepCopyInto(out *VaultIssuer) {
 		*out = new(metav1.SecretKeySelector)
 		**out = **in
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/apis/certmanager/v1beta1/types_issuer.go
+++ b/internal/apis/certmanager/v1beta1/types_issuer.go
@@ -216,6 +216,16 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientCertSecretRef *cmmeta.SecretKeySelector `json:"clientCertSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientKeySecretRef *cmmeta.SecretKeySelector `json:"clientKeySecretRef,omitempty"`
 }
 
 // Configuration used to authenticate with a Vault server.

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1532,6 +1532,24 @@ func autoConvert_v1beta1_VaultIssuer_To_certmanager_VaultIssuer(in *VaultIssuer,
 	} else {
 		out.CABundleSecretRef = nil
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
+	}
 	return nil
 }
 
@@ -1556,6 +1574,24 @@ func autoConvert_certmanager_VaultIssuer_To_v1beta1_VaultIssuer(in *certmanager.
 		}
 	} else {
 		out.CABundleSecretRef = nil
+	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientCertSecretRef = nil
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ClientKeySecretRef = nil
 	}
 	return nil
 }

--- a/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
@@ -988,6 +988,16 @@ func (in *VaultIssuer) DeepCopyInto(out *VaultIssuer) {
 		*out = new(metav1.SecretKeySelector)
 		**out = **in
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -281,6 +281,12 @@ func ValidateVaultIssuerConfig(iss *certmanager.VaultIssuer, fldPath *field.Path
 		el = append(el, field.Invalid(fldPath.Child("caBundleSecretRef"), iss.CABundleSecretRef.Name, "specified caBundleSecretRef and caBundle cannot be used together"))
 	}
 
+	if iss.ClientCertSecretRef != nil && iss.ClientKeySecretRef == nil {
+		el = append(el, field.Invalid(fldPath.Child("clientKeySecretRef"), "<snip>", "clientKeySecretRef must be provided when defining the clientCertSecretRef"))
+	} else if iss.ClientCertSecretRef == nil && iss.ClientKeySecretRef != nil {
+		el = append(el, field.Invalid(fldPath.Child("clientCertSecretRef"), "<snip>", "clientCertSecretRef must be provided when defining the clientKeySecretRef"))
+	}
+
 	el = append(el, ValidateVaultIssuerAuth(&iss.Auth, fldPath.Child("auth"))...)
 
 	return el

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -119,6 +119,54 @@ func TestValidateVaultIssuerConfig(t *testing.T) {
 				field.Invalid(fldPath.Child("caBundle"), "<snip>", "cert bundle didn't contain any valid certificates"),
 			},
 		},
+		"vault issuer define clientCertSecretRef but not clientKeySecretRef": {
+			spec: &cmapi.VaultIssuer{
+				Server: "https://vault.example.com",
+				Path:   "secret/path",
+				CABundleSecretRef: &cmmeta.SecretKeySelector{
+					Key: "ca.crt",
+					LocalObjectReference: cmmeta.LocalObjectReference{
+						Name: "test-secret",
+					},
+				},
+				ClientCertSecretRef: &cmmeta.SecretKeySelector{
+					Key: "tls.crt",
+					LocalObjectReference: cmmeta.LocalObjectReference{
+						Name: "test-secret",
+					},
+				},
+				Auth: cmapi.VaultAuth{
+					TokenSecretRef: &validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("clientKeySecretRef"), "<snip>", "clientKeySecretRef must be provided when defining the clientCertSecretRef"),
+			},
+		},
+		"vault issuer define clientKeySecretRef but not clientCertSecretRef": {
+			spec: &cmapi.VaultIssuer{
+				Server: "https://vault.example.com",
+				Path:   "secret/path",
+				CABundleSecretRef: &cmmeta.SecretKeySelector{
+					Key: "ca.crt",
+					LocalObjectReference: cmmeta.LocalObjectReference{
+						Name: "test-secret",
+					},
+				},
+				ClientKeySecretRef: &cmmeta.SecretKeySelector{
+					Key: "tls.key",
+					LocalObjectReference: cmmeta.LocalObjectReference{
+						Name: "test-secret",
+					},
+				},
+				Auth: cmapi.VaultAuth{
+					TokenSecretRef: &validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("clientCertSecretRef"), "<snip>", "clientCertSecretRef must be provided when defining the clientKeySecretRef"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -988,6 +988,16 @@ func (in *VaultIssuer) DeepCopyInto(out *VaultIssuer) {
 		*out = new(meta.SecretKeySelector)
 		**out = **in
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(meta.SecretKeySelector)
+		**out = **in
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(meta.SecretKeySelector)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -148,6 +148,58 @@ oXeN5eS8iO5fx0EOvIcYQ4yRZLGafZxsLHlsZmt32N/ZZtcl4KDP5LRE7iZEOaE/
 UXY5wAUH2A==
 -----END CERTIFICATE-----
 `
+	testClientCertificate = `-----BEGIN CERTIFICATE-----
+MIIDuzCCAqOgAwIBAgIBATANBgkqhkiG9w0BAQsFADBZMQswCQYDVQQGEwJVUzEL
+MAkGA1UECAwCQ0ExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xFDASBgNVBAoMC0NF
+UlRNQU5BR0VSMQ8wDQYDVQQDDAZiYXIuY2EwHhcNMjQwMTA0MTAxMzQ3WhcNNDMx
+MjMwMTAxMzQ3WjBgMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExFjAUBgNVBAcM
+DVNhbiBGcmFuY2lzY28xFDASBgNVBAoMC0NFUlRNQU5BR0VSMRYwFAYDVQQDDA1j
+bGllbnQuYmFyLmNhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvFLC
+dXqU33bG8TrVQ2mwTZF6UxNgrQCjLYJZWgK7AUvOzdsMUiZfQ51GVRLw7inRYgYn
+QuIjPwgXQDYCHfQJEsBghSMNze+QjmGYwT2dy2QZm47Q0lGi57n2rtgRrM2Q+19E
+SlEOZhi45ZVaU2NAEMAD8jIj3XznukrZLUZQSt7lN0xS2w1IvhO7Xb1n+wFcjwMt
+f4ciRQyKprHQGTcaTzGn4Fjhua3kyFydg7elE1U23UJT42TbZ0WfgNG9KLGLWYpD
+pMDnAgkgwMggguQz4izgFyeD2NnvDIviGbwnTC9WAlogwBZx2SOrBGIjoyWNmfIj
+9uu5CytBgCdmhzMx1QIDAQABo4GGMIGDMAkGA1UdEwQCMAAwEQYJYIZIAYb4QgEB
+BAQDAgeAMB0GA1UdDgQWBBRQlAnVwsjjnb3lu44c2Rt/zz4l3zAfBgNVHSMEGDAW
+gBR/PgLMjVGMUxKzqRqcocLfB500ETAOBgNVHQ8BAf8EBAMCBeAwEwYDVR0lBAww
+CgYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBACXv/vfiuC8VXnvFo+Cvpn1H
+eG1qsjOHOnPFhvHaMY55wsFchnZd7t0aqRNwkqLEvqpMIMDiXh7nw5pQZZu5IGBi
++cNDtfadmFi6NMFZNqlgPsYmb6pCI6OOG2r8VkmG+OdIg8QOdH60FQamT3MYKelE
+JHxBQYgtiJr+vNTzBdrq9/qDgDJdx0OVo2U8+igFKkrWqgbPeJDLJb1NpVJBIhSG
+ntdrtA87wmrLkV09SLUpvTYuTm3NMMrlD3hSBBBm3evb+65tsJg9/M5QjtAb8pQT
+gtrc5PnSjjZzCeL94DkWQ+A7oLQStJMVePFvizMTozlnjCpVaJJN25nf+yVm22E=
+-----END CERTIFICATE-----
+`
+	testClientCertificatePrivateKey = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC8UsJ1epTfdsbx
+OtVDabBNkXpTE2CtAKMtgllaArsBS87N2wxSJl9DnUZVEvDuKdFiBidC4iM/CBdA
+NgId9AkSwGCFIw3N75COYZjBPZ3LZBmbjtDSUaLnufau2BGszZD7X0RKUQ5mGLjl
+lVpTY0AQwAPyMiPdfOe6StktRlBK3uU3TFLbDUi+E7tdvWf7AVyPAy1/hyJFDIqm
+sdAZNxpPMafgWOG5reTIXJ2Dt6UTVTbdQlPjZNtnRZ+A0b0osYtZikOkwOcCCSDA
+yCCC5DPiLOAXJ4PY2e8Mi+IZvCdML1YCWiDAFnHZI6sEYiOjJY2Z8iP267kLK0GA
+J2aHMzHVAgMBAAECggEACAEWfcrHgBX6z675+IMJ+MoJonVM4x2HUfxb0t0R2LTB
+pfM8+1LhMq0BG8WR0vWZDisHySp2aAvufQ6umVpRdmgR0ibSw+F+SebxCKmXRtlK
+01dHHeFVZLb9OqI5YhhcpKqAaw415/X+CdgGvkuWIgAfStCBwLy51quuvmNiL0Rm
+XEq0tUAhJ8Z0G4z1e7PCabjq1eGPfsA6K3V/Bguo9ePIXls7AKn8xtyvQHL67RPy
+wiupVB77RuViDYArx0ybMIvSKu8n2GAB0cBOICFe9MU8RiSGHl9MbgfDvW4BU/Fj
++YIrGjBV2MYdvjMCb2wlxyR11Yaaupd4u1e0eYxp4wKBgQDdaGHDgYQvTVOlgHrr
+pYJoML50OIi9rh5q5HVRb3iLziSCaDUSBg7HuwC1vGLvZjfX3GVHpvwGaV9ZTk1c
+C4jTtDAVibbCeL0/t9OzIE1EZbEwpMg0BXm0Jt97PhEKqxM2QHPGBAXKMxzJHYEO
+HUHQpMCeHm5fLxZgv9qcTWisGwKBgQDZvxpCJ2qkRVyEhFYDJKBZ7KTlgH1TDZq6
+XvbVL/Q6c+6/iM+7TvytfnN36yb/p22eaBRf19ZkPHjGUqnCQnudwsK/bdyf0smh
+6zZVirTL5/5qWIUPgIgWv5trqksMRm0NtRyo6ZwGWJnKTKPoxZJiW/d8v5bUw5IR
+boLBMiCYzwKBgH4FCZAzyb76rl+HD2/M1rri86RHAV2lG18QBc6COgSpIpKvKXXG
+yObaA39taIqGjcZphaQQ4WXs1/6G2PVJA2osJyo7JjDudBkuUmqkOhZyIzZitCkX
+7LujXJRTMXP3B4pbiQnuBDWgfgPirTARawKMo63b+EppDL2otY89aBR9AoGBAK8q
+VcRcEyTdC4UrNEpI/5n3jdt2FttmOU+uL2Dmt9ECDFEWjQ4Ah7JF5DvW9sN4++0P
+izxi1HxETWA1hYzZkLojwCjhBzenCT9xiX8dGz5hfcAtP7Vtz4yFTVE6aC8SxI3f
+YZPcggB07Bratoz9yznHA/vd4Ed+oJXXUeZ7Hc/vAoGBAKOpdDIzkKIkUIrbIKVI
+DjlJQMrnnVpHB+7q2z+EnmVHzfn5zduL77hEBA/tXnkIvOyLm8WXDo/9K4E1xa93
+nUclMMQnJneyw8RRXGvgiy7EsLnRY8EhR/AgjoHY37etpj+v6kcaA+B7Q2oSYr11
+beE8ft41eEFS8AnSJd5hE9Ym
+-----END PRIVATE KEY-----
+`
 )
 
 func generateRSAPrivateKey(t *testing.T) *rsa.PrivateKey {
@@ -976,6 +1028,25 @@ func TestNewConfig(t *testing.T) {
 			}
 		})
 	}
+	clientCertificateSecretRefFakeSecretLister := func(namespace, secret, caKey, caCert, clientKey, clientCert, privateKey, privateKeyCert string) *listers.FakeSecretLister {
+		return listers.FakeSecretListerFrom(listers.NewFakeSecretLister(), func(f *listers.FakeSecretLister) {
+			f.SecretsFn = func(namespace string) clientcorev1.SecretNamespaceLister {
+				return listers.FakeSecretNamespaceListerFrom(listers.NewFakeSecretNamespaceLister(), func(fn *listers.FakeSecretNamespaceLister) {
+					fn.GetFn = func(name string) (*corev1.Secret, error) {
+						if name == secret && namespace == namespace {
+							return &corev1.Secret{
+								Data: map[string][]byte{
+									caKey:      []byte(caCert),
+									clientKey:  []byte(clientCert),
+									privateKey: []byte(privateKeyCert),
+								}}, nil
+						}
+						return nil, errors.New("unexpected secret name or namespace passed to FakeSecretLister")
+					}
+				})
+			}
+		})
+	}
 	tests := map[string]testNewConfigT{
 		"no CA bundle set in issuer should return nil": {
 			issuer: gen.Issuer("vault-issuer",
@@ -1132,6 +1203,72 @@ func TestNewConfig(t *testing.T) {
 					}}, nil
 				}
 			},
+		},
+		"a good client certificate with default key should be added to the config": {
+			issuer: gen.Issuer("vault-issuer",
+				gen.SetIssuerVault(cmapi.VaultIssuer{
+					Server: "https://vault.example.com",
+					CABundleSecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+					ClientCertSecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+					ClientKeySecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+				},
+				)),
+			checkFunc: func(cfg *vault.Config, error error) error {
+				if error != nil {
+					return error
+				}
+
+				certificates := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.Certificates
+				if len(certificates) != 1 {
+					return fmt.Errorf("got unexpected number of client certificates in config, exp=1 got=%d", len(certificates))
+				}
+				certificate, err := x509.ParseCertificate(certificates[0].Certificate[0])
+				if err != nil {
+					return err
+				}
+				if certificate.Subject.CommonName != "client.bar.ca" {
+					return fmt.Errorf("got unexpected common name from the client certificate in config, exp=client.bar.ca got=%s", certificate.Subject.CommonName)
+				}
+
+				return nil
+			},
+			fakeLister: clientCertificateSecretRefFakeSecretLister("test-namespace", "bundle", "ca.crt", testLeafCertificate, "tls.crt", testClientCertificate, "tls.key", testClientCertificatePrivateKey),
+		},
+		"a bad client certificate should error": {
+			issuer: gen.Issuer("vault-issuer",
+				gen.SetIssuerVault(cmapi.VaultIssuer{
+					Server: "https://vault.example.com",
+					CABundleSecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+					ClientCertSecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+					ClientKeySecretRef: &cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: "bundle",
+						},
+					},
+				},
+				)),
+			expectedErr: errors.New("failed to load vault client certificate: could not parse the TLS certificate from Secrets 'test-namespace/bundle'(cert) and 'test-namespace/bundle'(key): tls: failed to find any PEM data in certificate input"),
+			fakeLister:  clientCertificateSecretRefFakeSecretLister("test-namespace", "bundle", "ca.crt", testLeafCertificate, "tls.crt", "not a valid certificate", "tls.key", "not a valid certificate"),
 		},
 	}
 

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -218,6 +218,16 @@ type VaultIssuer struct {
 	// If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
 	// +optional
 	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientCertSecretRef *cmmeta.SecretKeySelector `json:"clientCertSecretRef,omitempty"`
+
+	// Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+	// Vault server requires mTLS.
+	// +optional
+	ClientKeySecretRef *cmmeta.SecretKeySelector `json:"clientKeySecretRef,omitempty"`
 }
 
 // VaultAuth is configuration used to authenticate with a Vault server. The

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -988,6 +988,16 @@ func (in *VaultIssuer) DeepCopyInto(out *VaultIssuer) {
 		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
+	if in.ClientCertSecretRef != nil {
+		in, out := &in.ClientCertSecretRef, &out.ClientCertSecretRef
+		*out = new(apismetav1.SecretKeySelector)
+		**out = **in
+	}
+	if in.ClientKeySecretRef != nil {
+		in, out := &in.ClientKeySecretRef, &out.ClientKeySecretRef
+		*out = new(apismetav1.SecretKeySelector)
+		**out = **in
+	}
 	return
 }
 

--- a/test/e2e/framework/addon/globals.go
+++ b/test/e2e/framework/addon/globals.go
@@ -38,8 +38,9 @@ type AddonTransferableData = internal.AddonTransferableData
 
 var (
 	// Base is a base addon containing Kubernetes clients
-	Base  = &base.Base{}
-	Vault = &vault.Vault{}
+	Base             = &base.Base{}
+	Vault            = &vault.Vault{}
+	VaultEnforceMtls = &vault.Vault{}
 
 	// allAddons is populated by InitGlobals and defines the order in which
 	// addons will be provisioned
@@ -65,9 +66,16 @@ func InitGlobals(cfg *config.Config) {
 		Namespace: "e2e-vault",
 		Name:      "vault",
 	}
+	*VaultEnforceMtls = vault.Vault{
+		Base:        Base,
+		Namespace:   "e2e-vault-mtls",
+		Name:        "vault-mtls",
+		EnforceMtls: true,
+	}
 	allAddons = []Addon{
 		Base,
 		Vault,
+		VaultEnforceMtls,
 	}
 }
 

--- a/test/e2e/suite/issuers/vault/mtls.go
+++ b/test/e2e/suite/issuers/vault/mtls.go
@@ -1,0 +1,468 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon"
+	vaultaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/vault"
+	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
+	f := framework.NewDefaultFramework("create-vault-issuer")
+
+	issuerName := "test-vault-issuer"
+	vaultSecretServiceAccount := "vault-serviceaccount"
+	vaultClientCertificateSecretName := "vault-client-cert-secret-" + rand.String(5)
+	var roleId, secretId, vaultSecretName string
+
+	appRoleSecretGeneratorName := "vault-approle-secret-"
+	var setup *vaultaddon.VaultInitializer
+
+	details := addon.VaultEnforceMtls.Details()
+
+	BeforeEach(func() {
+		By("Configuring the Vault server")
+
+		setup = vaultaddon.NewVaultInitializerAllAuth(
+			addon.Base.Details().KubeClient,
+			*details,
+			false,
+			"https://kubernetes.default.svc.cluster.local",
+		)
+		Expect(setup.Init()).NotTo(HaveOccurred(), "failed to init vault")
+		Expect(setup.Setup()).NotTo(HaveOccurred(), "failed to setup vault")
+
+		var err error
+		roleId, secretId, err = setup.CreateAppRole()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a service account for Vault authentication")
+		err = setup.CreateKubernetesRole(f.KubeClientSet, f.Namespace.Name, vaultSecretServiceAccount)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a client certificate for Vault mTLS")
+		secret := vaultaddon.NewVaultClientCertificateSecret(vaultClientCertificateSecretName, details.VaultClientCertificate, details.VaultClientPrivateKey)
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustAfterEach(func() {
+		By("Cleaning up AppRole")
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), vaultSecretName, metav1.DeleteOptions{})
+		setup.CleanAppRole()
+
+		By("Cleaning up Kubernetes")
+		setup.CleanKubernetesRole(f.KubeClientSet, f.Namespace.Name, vaultSecretServiceAccount)
+
+		By("Cleaning up Vault")
+		Expect(setup.Clean()).NotTo(HaveOccurred())
+	})
+
+	It("should be ready with a valid AppRole", func() {
+		sec, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultAppRoleSecret(appRoleSecretGeneratorName, secretId), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultSecretName = sec.Name
+
+		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			iss.Name,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to init with missing client certificates", func() {
+		sec, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultAppRoleSecret(appRoleSecretGeneratorName, secretId), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultSecretName = sec.Name
+
+		By("Creating an Issuer")
+		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			iss.Name,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to init with missing Vault AppRole", func() {
+		By("Creating an Issuer")
+		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", roleId, setup.Role(), setup.AppRoleAuthPath()))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			iss.Name,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to init with missing Vault Token", func() {
+		By("Creating an Issuer")
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultTokenAuth("secretkey", "vault-token"))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be ready with a valid Kubernetes Role and ServiceAccount Secret", func() {
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to init with missing Kubernetes Role", func() {
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
+		// we test without creating the secret
+
+		By("Creating an Issuer")
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to init when both caBundle and caBundleSecretRef are set", func() {
+		By("Creating an Issuer")
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(
+			"spec.vault.caBundle: Invalid value: \"<snip>\": specified caBundle and caBundleSecretRef cannot be used together",
+		))
+		Expect(err.Error()).To(ContainSubstring("spec.vault.caBundleSecretRef: Invalid value: \"ca-bundle\": specified caBundleSecretRef and caBundle cannot be used together"))
+	})
+
+	It("should be ready with a caBundle from a Kubernetes Secret", func() {
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ca-bundle",
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"ca.crt": details.VaultCA,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be eventually ready when the CA bundle secret gets created after the Issuer", func() {
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validate that the Issuer is not ready yet")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ca-bundle",
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"ca.crt": details.VaultCA,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be eventually ready when the Vault client certificate secret gets created after the Issuer", func() {
+		sec, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultAppRoleSecret(appRoleSecretGeneratorName, secretId), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultSecretName = sec.Name
+		customVaultClientCertificateSecretName := "vault-client-cert-secret-custom-" + rand.String(5)
+
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(customVaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(customVaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validate that the Issuer is not ready yet")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a client certificate for Vault mTLS")
+		secret := vaultaddon.NewVaultClientCertificateSecret(customVaultClientCertificateSecretName, details.VaultClientCertificate, details.VaultClientPrivateKey)
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			iss.Name,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("it should become not ready when the CA certificate in the secret changes and doesn't match Vault's CA anymore", func() {
+		saTokenSecretName := "vault-sa-secret-" + rand.String(5)
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ca-bundle",
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"ca.crt": details.VaultCA,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Updating CA bundle")
+		public, _, err := vaultaddon.GenerateCA()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.TODO(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ca-bundle",
+			},
+			Data: map[string][]byte{
+				"ca.crt": public,
+			},
+		}, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validate that the issuer isn't ready anymore due to Vault still using the old certificate")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionFalse,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should be ready with a valid serviceAccountRef", func() {
+		// Note that we reuse the same service account as for the Kubernetes
+		// auth based on secretRef. There should be no problem doing so.
+		By("Creating the Role and RoleBinding to let cert-manager use TokenRequest for the ServiceAccount")
+		vaultaddon.CreateKubernetesRoleForServiceAccountRefAuth(f.KubeClientSet, setup.Role(), f.Namespace.Name, vaultSecretServiceAccount)
+		defer vaultaddon.CleanKubernetesRoleForServiceAccountRefAuth(f.KubeClientSet, setup.Role(), f.Namespace.Name, vaultSecretServiceAccount)
+
+		By("Creating an Issuer")
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(details.URL),
+			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
+			gen.SetIssuerVaultCABundle(details.VaultCA),
+			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
+			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
+			gen.SetIssuerVaultKubernetesAuthServiceAccount(vaultSecretServiceAccount, setup.Role(), setup.KubernetesAuthPath()))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -302,6 +302,36 @@ func SetIssuerVaultCABundleSecretRef(name, namespace, key string) IssuerModifier
 	}
 }
 
+func SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, key string) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		spec := iss.GetSpec()
+		if spec.Vault == nil {
+			spec.Vault = &v1.VaultIssuer{}
+		}
+		spec.Vault.ClientCertSecretRef = &cmmeta.SecretKeySelector{
+			LocalObjectReference: cmmeta.LocalObjectReference{
+				Name: vaultClientCertificateSecretName,
+			},
+			Key: key,
+		}
+	}
+}
+
+func SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, key string) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		spec := iss.GetSpec()
+		if spec.Vault == nil {
+			spec.Vault = &v1.VaultIssuer{}
+		}
+		spec.Vault.ClientKeySecretRef = &cmmeta.SecretKeySelector{
+			LocalObjectReference: cmmeta.LocalObjectReference{
+				Name: vaultClientCertificateSecretName,
+			},
+			Key: key,
+		}
+	}
+}
+
 func SetIssuerVaultTokenAuth(keyName, tokenName string) IssuerModifier {
 	return func(iss v1.GenericIssuer) {
 		spec := iss.GetSpec()


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Vault server can be configured to strictly enforce clients to present client certificates while connecting to the server in the HTTPs transport layer.

It is possible to configure Vault to use a client certificate to secure the transport layer ([tcp listener documentation](https://www.vaultproject.io/docs/configuration/listener/tcp#tcp-listener-examples)):
```
listener "tcp" {
  tls_disable = false
  tls_cert_file = "/vault/tls/server.crt"
  tls_key_file = "/vault/tls/server.key"
  tls_client_ca_file = "/vault/tls/ca.crt"
  tls_require_and_verify_client_cert = true
}
```
When Vault is configured in the way above, there is no possibility to properly configure Vault Issuer/ClusterIssuer by using existing CRDs.

Fixes #6613

### Kind

feature

### Release Note

```release-note
Add the ability to communicate with Vault via mTLS when strict client certificates is enabled at Vault server side
```
