### PR TITLE
feat: limit the size of the body read back from http requests

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -28,6 +28,10 @@ import (
 // TODO: Unexport?
 const CloudFlareAPIURL = "https://api.cloudflare.com/client/v4"
 
+// cloudFlareMaxBodySize is the max size of a received response body. The value is arbitrary
+// and is chosen to be large enough that any reasonable response would fit.
+const cloudFlareMaxBodySize = 1024 * 1024 // 1mb
+
 // DNSProviderType is the Mockable Interface
 type DNSProviderType interface {
 	makeRequest(method, uri string, body io.Reader) (json.RawMessage, error)
@@ -275,7 +279,7 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 	defer resp.Body.Close()
 
 	var r APIResponse
-	err = json.NewDecoder(resp.Body).Decode(&r)
+	err = json.NewDecoder(io.LimitReader(resp.Body, cloudFlareMaxBodySize)).Decode(&r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -49,6 +49,11 @@ const (
 	acmeSolverListenPort = 8089
 
 	loggerName = "http01"
+
+	// maxAcmeChallengeBodySize is the max size of a received response body for an
+	// acme http challenge. The value is arbitrary and is chosen to be large enough
+	// that any reasonable response would fit.
+	maxAcmeChallengeBodySize = 1024 * 1024 // 1mb
 )
 
 var (
@@ -301,7 +306,7 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 		return fmt.Errorf("wrong status code '%d', expected '%d'", response.StatusCode, http.StatusOK)
 	}
 
-	presentedKey, err := io.ReadAll(response.Body)
+	presentedKey, err := io.ReadAll(io.LimitReader(response.Body, maxAcmeChallengeBodySize))
 	if err != nil {
 		log.V(logf.DebugLevel).Info("failed to decode response body", "error", err)
 		return fmt.Errorf("failed to read response body: %v", err)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Limit the size of the response body read from http requests performed by cert-manager. 

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
