### PR TITLE
Stop using deprecated f.environment.ControlPlane.KubeCtl function 

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(KubeCtl|NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL|)"
+      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL)"

--- a/test/acme/util.go
+++ b/test/acme/util.go
@@ -46,6 +46,11 @@ func (f *fixture) setupNamespace(t *testing.T, name string) (string, func()) {
 		t.Fatalf("error creating test namespace %q: %v", name, err)
 	}
 
+	kubectl, err := f.adminUser.Kubectl()
+	if err != nil {
+		t.Fatalf("enable to create kubectl instance: %s", err)
+	}
+
 	if f.kubectlManifestsPath != "" {
 		if err := filepath.Walk(f.kubectlManifestsPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -61,8 +66,7 @@ func (f *fixture) setupNamespace(t *testing.T, name string) (string, func()) {
 				t.Logf("skipping file %q with unrecognised extension", path)
 				return nil
 			}
-
-			_, _, err = f.environment.ControlPlane.KubeCtl().Run("apply", "--namespace", name, "-f", path)
+			_, _, err = kubectl.Run("apply", "--namespace", name, "-f", path)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
> test/acme/util.go:65:16: SA1019: f.environment.ControlPlane.KubeCtl is deprecated: use AddUser & AuthenticatedUser.Kubectl instead. (staticcheck)

The deprecation was introduced in:
* https://github.com/kubernetes-sigs/controller-runtime/pull/1486

---

- Unhide the KubeCtl deprecation warning
  - See the golangci-lint warning here: https://github.com/cert-manager/cert-manager/actions/runs/7490910752
- Use a dedicated Authenticated envtest user instead of the deprecated default user

```release-note
NONE
```
