### PR TITLE
Bump go to latest version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -75,7 +75,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.5
+VENDORED_GO_VERSION := 1.21.6
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

No reason to not use the latest for a new release!

### Kind

/kind cleanup

### Release Note

```release-note
cert-manager is now built with Go 1.21.6
```
