### PR TITLE
[release-1.12] bump go to latest patch version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -56,7 +56,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.12
+VENDORED_GO_VERSION := 1.20.13
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
/kind cleanup

```release-note
cert-manager is now built with Go 1.20.13
```
