### PR TITLE
Use ParseRevocationList instead of deprecated x509.ParseCRL 

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight|x509.ParseCRL)"
+      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|adal.NewServicePrincipalTokenFromFederatedToken|azure-sdk-for-go|c.SingleInflight)"

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -108,14 +108,14 @@ func checkCRLValidCert(cert *x509.Certificate, url string) (bool, error) {
 	}
 	resp.Body.Close()
 
-	crl, err := x509.ParseCRL(body)
+	crl, err := x509.ParseRevocationList(body)
 	if err != nil {
 		return false, fmt.Errorf("error parsing HTTP body: %w", err)
 	}
 
 	// TODO: check CRL signature
 
-	for _, revoked := range crl.TBSCertList.RevokedCertificates {
+	for _, revoked := range crl.RevokedCertificateEntries {
 		if cert.SerialNumber.Cmp(revoked.SerialNumber) == 0 {
 			return false, nil
 		}


### PR DESCRIPTION
> cmd/ctl/pkg/inspect/secret/util.go:111:14: SA1019: x509.ParseCRL has been deprecated since Go 1.19: Use ParseRevocationList instead. (staticcheck)

Deprecated in:
 * https://github.com/golang/go/issues/50674

--- 

- Unhide the warning
  - https://github.com/cert-manager/cert-manager/actions/runs/7491727797?pr=6631
- Use ParseRevocationList instead of deprecated x509.ParseCRL

/kind cleanup

```release-note
NONE
```
