### PR TITLE
[Release v1.14.0-alpha.1] Update cmd/cmctl's go.mod to v1.14.0-alpha.1

### DIFF
--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -10,6 +10,7 @@ replace github.com/cert-manager/cert-manager => ../../
 
 require (
 	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000
+	github.com/go-logr/logr v1.4.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.5.0
@@ -46,7 +47,6 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.6 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect

--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -16,7 +16,7 @@ go 1.21
 // or a branch name (master).
 
 require (
-	github.com/cert-manager/cert-manager v1.14.0-alpha.0
+	github.com/cert-manager/cert-manager v1.14.0-alpha.1
 	github.com/go-logr/logr v1.4.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -148,7 +148,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/cmd/ctl/go.sum
+++ b/cmd/ctl/go.sum
@@ -50,8 +50,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.14.0-alpha.0 h1:yDHNoxjhWaoiDhK9NgXDySAKgAIp3J+LaqFjWo1Sqg4=
-github.com/cert-manager/cert-manager v1.14.0-alpha.0/go.mod h1:AVDWjufadrm5gw8N+H9Mi7b4NkkSxU91CjL2zQHjgPs=
+github.com/cert-manager/cert-manager v1.14.0-alpha.1 h1:RSr4NlYe9afKNGWaQiZRJucDlme75oECqZC5epnkocc=
+github.com/cert-manager/cert-manager v1.14.0-alpha.1/go.mod h1:pik7K6jXfgh++lfVJ/i1HzEnDluSUtTVLXSHikj8Lho=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -13,7 +13,7 @@ replace github.com/cert-manager/cert-manager/cmd/ctl => ../../cmd/ctl/
 replace github.com/cert-manager/cert-manager/webhook-binary => ../../cmd/webhook/
 
 require (
-	github.com/cert-manager/cert-manager v1.14.0-alpha.0
+	github.com/cert-manager/cert-manager v1.14.0-alpha.1
 	github.com/cert-manager/cert-manager/cmd/ctl v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.4.1
 	github.com/miekg/dns v1.1.57


### PR DESCRIPTION
This PR cmd/cmctl's go.mod to v1.14.0-alpha.1 as part of the release process.

**To the reviewer:** the version changes in `go.mod` must be reviewed.

```release-note
NONE
```
