### PR TITLE
[helm] Support custom spec.namespaceSelector for webhooks

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -42,3 +42,7 @@ webhooks:
         namespace: {{ include "cert-manager.namespace" . }}
         path: /mutate
       {{- end }}
+    namespaceSelector:
+    {{- with .Values.webhook.webhookConfigurationNamespaceSelector }}
+    {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- end }}
 webhooks:
   - name: webhook.cert-manager.io
+    {{- with .Values.webhook.mutatingWebhookConfiguration.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     rules:
       - apiGroups:
           - "cert-manager.io"
@@ -42,7 +46,3 @@ webhooks:
         namespace: {{ include "cert-manager.namespace" . }}
         path: /mutate
       {{- end }}
-    namespaceSelector:
-    {{- with .Values.webhook.webhookConfigurationNamespaceSelector }}
-    {{- toYaml . | nindent 6 }}
-    {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -15,18 +15,10 @@ metadata:
     {{- end }}
 webhooks:
   - name: webhook.cert-manager.io
+    {{- with .Values.webhook.validatingWebhookConfiguration.namespaceSelector }}
     namespaceSelector:
-      {{- with (omit .Values.webhook.webhookConfigurationNamespaceSelector "matchExpressions") }}
       {{- toYaml . | nindent 6 }}
-      {{- end }}
-      matchExpressions:
-      - key: "cert-manager.io/disable-validation"
-        operator: "NotIn"
-        values:
-        - "true"
-      {{- with .Values.webhook.webhookConfigurationNamespaceSelector.matchExpressions }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+    {{- end }}
     rules:
       - apiGroups:
           - "cert-manager.io"

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -16,11 +16,17 @@ metadata:
 webhooks:
   - name: webhook.cert-manager.io
     namespaceSelector:
+      {{- with (omit .Values.webhook.webhookConfigurationNamespaceSelector "matchExpressions") }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       matchExpressions:
       - key: "cert-manager.io/disable-validation"
         operator: "NotIn"
         values:
         - "true"
+      {{- with .Values.webhook.webhookConfigurationNamespaceSelector.matchExpressions }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
     rules:
       - apiGroups:
           - "cert-manager.io"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -401,15 +401,25 @@ webhook:
   # Optional additional annotations to add to the webhook ValidatingWebhookConfiguration
   # validatingWebhookConfigurationAnnotations: {}
 
-  # Configure spec.namespaceSelector for mutating and validating webhooks.
-  webhookConfigurationNamespaceSelector: {}
-  #  matchLabels:
-  #    key: value
-  #  matchExpressions:
-  #    - key: kubernetes.io/metadata.name
-  #      operator: NotIn
-  #      values:
-  #        - kube-system
+  validatingWebhookConfiguration:
+    # Configure spec.namespaceSelector for validating webhooks.
+    namespaceSelector:
+      matchExpressions:
+        - key: "cert-manager.io/disable-validation"
+          operator: "NotIn"
+          values:
+            - "true"
+
+  mutatingWebhookConfiguration:
+    # Configure spec.namespaceSelector for mutating webhooks.
+    namespaceSelector: {}
+    #  matchLabels:
+    #    key: value
+    #  matchExpressions:
+    #    - key: kubernetes.io/metadata.name
+    #      operator: NotIn
+    #      values:
+    #        - kube-system
 
 
   # Additional command line flags to pass to cert-manager webhook binary.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -401,6 +401,17 @@ webhook:
   # Optional additional annotations to add to the webhook ValidatingWebhookConfiguration
   # validatingWebhookConfigurationAnnotations: {}
 
+  # Configure spec.namespaceSelector for mutating and validating webhooks.
+  webhookConfigurationNamespaceSelector: {}
+  #  matchLabels:
+  #    key: value
+  #  matchExpressions:
+  #    - key: kubernetes.io/metadata.name
+  #      operator: NotIn
+  #      values:
+  #        - kube-system
+
+
   # Additional command line flags to pass to cert-manager webhook binary.
   # To see all available flags run docker run quay.io/jetstack/cert-manager-webhook:<version> --help
   extraArgs: []


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

We have to run multiple independent namespace level cert-manager in our cluster. While this works fine in general, we are not able to restrict webhooks to certain namespaces. Currently all webhooks are proceeded, if multiple cert-managers are installed.

Expose the `spec.namespaceSelector` settings for validating and mutating webhooks, resolves the issue.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Support custom spec.namespaceSelector for webhooks
```
