### PR TITLE
WIP: Include shasums file in release uploaded to GCS

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -35,7 +35,7 @@ RELEASE_TARGET_BUCKET ?=
 ## built without errors. Not useful for an actual release - instead, use `make release` for that.
 ##
 ## @category Release
-release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart release-containers release-manifests
+release-artifacts: server-binaries cmctl kubectl-cert_manager helm-chart release-containers release-manifests release-shasums
 
 .PHONY: release-artifacts-signed
 # Same as `release-artifacts`, except also signs the Helm chart. Requires CMREL_KEY
@@ -74,6 +74,14 @@ $(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDI
 		--arg buildSource "make" \
 		--arg gitCommitRef "$(GITCOMMIT)" \
 		'.releaseVersion = $$releaseVersion | .gitCommitRef = $$gitCommitRef | .buildSource = $$buildSource | .artifacts += [inputs]' $^ > $@
+
+# Generate a shasums file for all binaries
+
+.PHONY: release-shasums
+release-shasums: $(BINDIR)/release/cert-manager-shasums.txt
+
+$(BINDIR)/release/cert-manager-shasums.txt: cmctl kubectl-cert_manager
+	sha256sum $(wildcard $(BINDIR)/release/cert-manager-cmctl-*.tar.gz) $(wildcard $(BINDIR)/release/cert-manager-kubectl-cert_manager-*.tar.gz) | sed 's|$(BINDIR)/release/cert-manager-||' > $@
 
 .PHONY: release-containers
 release-containers: release-container-bundles release-container-metadata


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

In order to include a shasums file in the Github release we need to generate this file as part of the make release targets. This adds the targets to generate the shasums file which will be included in the upload to GCS. A separate PR to the releases repo to take this file and publish it to Github when `cmrel publish` is called.

### TODO

- [ ] Add capability to `cmrel sign` to sign the shasums file
- [ ] Add makefile target to also generate a shasums signature file using `cmrel sign`
- [ ] Update `cmrel publish` to also publish the shasums and signature files to the Github release

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
