### PR TITLE
no-op: add GOEXPERIMENT var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ include make/git.mk
 ## @category Build
 CGO_ENABLED ?= 0
 
+## This flag is passed to `go build` to enable Go experiments. It's empty by default
+## @category Build
+GOEXPERIMENT ?=  # empty by default
+
 ## Extra flags passed to 'go' when building. For example, use GOFLAGS=-v to turn on the
 ## verbose output.
 ## @category Build

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -182,11 +182,11 @@ export PATH := $(PWD)/$(BINDIR)/tools/goroot/bin:$(PATH)
 GO := $(PWD)/$(BINDIR)/tools/go
 endif
 
-GOBUILD := CGO_ENABLED=$(CGO_ENABLED) GOMAXPROCS=$(GOBUILDPROCS) $(GO) build
-GOTEST := CGO_ENABLED=$(CGO_ENABLED) $(GO) test
+GOBUILD := CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) GOMAXPROCS=$(GOBUILDPROCS) $(GO) build
+GOTEST := CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) $(GO) test
 
-# overwrite $(GOTESTSUM) and add CGO_ENABLED variable
-GOTESTSUM := CGO_ENABLED=$(CGO_ENABLED) $(GOTESTSUM)
+# overwrite $(GOTESTSUM) and add relevant environment variables
+GOTESTSUM := CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) $(GOTESTSUM)
 
 .PHONY: vendor-go
 ## By default, this Makefile uses the system's Go. You can use a "vendored"


### PR DESCRIPTION
### Pull Request Motivation

This will enable easy testing of different GOEXPERIMENT variables, such as `loopvar` to test the upcoming changes there.

Note that I've confirmed that this change is a no-op. The binaries we build are identical after this change.

I used the following patch to allow me to hardcode versions:

```patch
diff --git a/make/git.mk b/make/git.mk
index 27a523880..18a266b78 100644
--- a/make/git.mk
+++ b/make/git.mk
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RELEASE_VERSION := $(shell git describe --tags --match='v*' --abbrev=14)
+RELEASE_VERSION ?= $(shell git describe --tags --match='v*' --abbrev=14)
 
-GITCOMMIT := $(shell git rev-parse HEAD)
+GITCOMMIT ?= $(shell git rev-parse HEAD)
 
 IS_TAGGED_RELEASE := $(shell git describe --exact-match HEAD >/dev/null 2>&1 && echo "true" || echo "false")
```

Then I ran the following on `master`:

```console
$ make RELEASE_VERSION=v1 GITCOMMIT=abc123 controller
...
$ sha256sum _bin/server/*
74b620ceffc2c526cf0753a8e4318533dab98fee23cb29606c85b578fee31043  _bin/server/controller-linux-amd64
92ad4121028e1740cbe8d1fe7b41effad7ad46e4fcc4c2135859b44dc65d7dd3  _bin/server/controller-linux-arm
6cab4bfb22e58e9ac29fe2f69a450eb2a11a5382c11c9beb6d9c479063bbacec  _bin/server/controller-linux-arm64
9641ffc1af4dcc4ce857c8c734310f2b01b9927953b66fba928657659bd140ac  _bin/server/controller-linux-ppc64le
57ffa3c16046e44cf220663d3d3ee38b7bba4eaa828bbfcd1d8fa4b471a4292e  _bin/server/controller-linux-s390x
```

I then wrote this PR, ran `rm _bin/server/*` and then ran the same build and `sha256sum` again and got the same output.

I tested this so we could be confident that backporting this change to currently supported versions will have literally no effect if GOEXPERIMENT is not set.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
