### PR TITLE
Stop using the deprecated SingleInflight field of miekg/dns

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate|c.SingleInflight)"
+      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate)"

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -127,7 +127,6 @@ func (r *DNSProvider) changeRecord(action, fqdn, zone, value string, ttl int) er
 	// Setup client
 	c := new(dns.Client)
 	c.TsigProvider = tsigHMACProvider(r.tsigSecret)
-	c.SingleInflight = true
 	// TSIG authentication / msg signing
 	if len(r.tsigKeyName) > 0 && len(r.tsigSecret) > 0 {
 		m.SetTsig(dns.Fqdn(r.tsigKeyName), r.tsigAlgorithm, 300, time.Now().Unix())


### PR DESCRIPTION
> pkg/issuer/acme/dns/rfc2136/rfc2136.go:130:2: SA1019: c.SingleInflight is deprecated: This is a no-op. Callers should implement their own in flight query caching if needed. See github.com/miekg/dns/issues/1449. (staticcheck)
>         c.SingleInflight = true
>         ^

* https://github.com/miekg/dns/issues/1449
* https://github.com/cert-manager/cert-manager/actions/runs/7671543590?pr=6669

@splashx set this field to true in https://github.com/cert-manager/cert-manager/pull/661:
* https://github.com/cert-manager/cert-manager/pull/661/files#diff-5d460d422bf99472fcf52c0d56acc002758aa3fdf3089d5e164ce6b41f931611R207

https://github.com/cert-manager/cert-manager/blob/f340d9afeb779cf4ed434f39a48c3316d1b15550/pkg/issuer/acme/dns/rfc2136/rfc2136.go#L130

And that PR was based on an earlier PR (#245) by @simonfuhrer:
 * https://github.com/cert-manager/cert-manager/pull/245/files#diff-5d460d422bf99472fcf52c0d56acc002758aa3fdf3089d5e164ce6b41f931611R135

Perhaps it was copy-pasted from an example somewhere. Do either of you know the purpose of SingleInflight?
I have removed that line of code and the tests still pass.

/kind cleanup

```release-note
NONE
```
