### PR TITLE
Remove unnecessary Azure workload identity setting: DisableInstanceDiscovery: true

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -103,8 +103,7 @@ func getAuthorization(clientOpt policy.ClientOptions, clientID, clientSecret, te
 	// Use Workload Identity if present
 	if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
 		wcOpt := &azidentity.WorkloadIdentityCredentialOptions{
-			DisableInstanceDiscovery: true,
-			ClientOptions:            clientOpt,
+			ClientOptions: clientOpt,
 		}
 		if managedIdentity != nil {
 			if managedIdentity.ClientID != "" {

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -130,7 +130,15 @@ func TestGetAuthorizationFederatedSPT(t *testing.T) {
 	// Prepare environment variables adal will rely on. Skip changes for some envs if they are already defined (=live environment)
 	// Envs themselves are described here: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
 	if os.Getenv("AZURE_TENANT_ID") == "" {
-		t.Setenv("AZURE_TENANT_ID", "fakeTenantID")
+		// TODO(wallrj): This is a hack. It is a quick way to `DisableInstanceDiscovery` during tests,
+		// to avoid the client attempting to connect to https://login.microsoftonline.com/common/discovery/instance.
+		// It works because there is a special case in azure-sdk-for-go which
+		// disables the instance discovery when the tenant ID is `adfs`. See:
+		// https://github.com/Azure/azure-sdk-for-go/blob/7288bda422654bde520a09034dd755b8f2dd4168/sdk/azidentity/public_client.go#L237-L239
+		// https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/ad-fs-overview
+		//
+		// Find a better way to test this code.
+		t.Setenv("AZURE_TENANT_ID", "adfs")
 	}
 
 	if os.Getenv("AZURE_CLIENT_ID") == "" {


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/5452#issuecomment-1914793219 @weisdd wrote:
> * Earlier, you asked whether "DisableInstanceDiscovery" should be set to `true` or `false`. - I think it's better to not use `DisableInstanceDiscovery: true` (like in the code now), better to stick to defaults. I haven't seen it being disabled in other projects.

So I've removed it.

The field is documented as follows: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#ClientAssertionCredentialOptions

> 	// DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or
> 	// private clouds such as Azure Stack. It determines whether the credential requests Microsoft Entra instance metadata
> 	// from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making
> 	// the application responsible for ensuring the configured authority is valid and trustworthy.
> 	DisableInstanceDiscovery bool

Which further convinces me that this should not be set to true by default.
Perhaps it should be configurable in some circumstances though? 
And if so we can tackle that in another PR.

/kind cleanup

```release-note
NONE
```
