### PR TITLE
Add Make target for trivy startupapicheck image scan

### DIFF
--- a/make/scan.mk
+++ b/make/scan.mk
@@ -19,7 +19,7 @@
 ## container, use "trivy-scan-<name>", e.g. "make trivy-scan-controller"
 ##
 ## @category Development
-trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector
+trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector trivy-scan-startupapicheck
 
 .PHONY: trivy-scan-controller
 trivy-scan-controller: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar | $(NEEDS_TRIVY)
@@ -35,4 +35,8 @@ trivy-scan-webhook: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar | 
 
 .PHONY: trivy-scan-cainjector
 trivy-scan-cainjector: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar | $(NEEDS_TRIVY)
+	$(TRIVY) image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-startupapicheck
+trivy-scan-startupapicheck: $(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1


### PR DESCRIPTION
This trivy scan Makefile target was missing.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
