### PR TITLE
[release-1.14] Add Make target for trivy startupapicheck image scan

### DIFF
--- a/make/scan.mk
+++ b/make/scan.mk
@@ -19,7 +19,7 @@
 ## container, use "trivy-scan-<name>", e.g. "make trivy-scan-controller"
 ##
 ## @category Development
-trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector trivy-scan-ctl
+trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector trivy-scan-ctl trivy-scan-startupapicheck
 
 .PHONY: trivy-scan-controller
 trivy-scan-controller: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar | $(NEEDS_TRIVY)
@@ -35,6 +35,10 @@ trivy-scan-webhook: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar | 
 
 .PHONY: trivy-scan-cainjector
 trivy-scan-cainjector: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar | $(NEEDS_TRIVY)
+	$(TRIVY) image --input $< --format json --exit-code 1
+
+.PHONY: trivy-scan-startupapicheck
+trivy-scan-startupapicheck: $(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1
 
 .PHONY: trivy-scan-ctl


### PR DESCRIPTION
This is a **manual** cherry-pick of #6685.
(cherry picked from commit 3d406a087b5dae842f2bef5fbf64351d3c2575a0)

The automated cherry pick failed, due to a merge conflict:
 * https://github.com/cert-manager/cert-manager/pull/6685#issuecomment-1918882775

## Testing

```sh
$ make trivy-scan-startupapicheck
...
$ echo $?
0

$ make trivy-scan-ctl
...
$ echo $?
0

$ make trivy-scan-all
...
$ echo $?
0

```

/kind cleanup

```release-note
NONE
```
