### PR TITLE
Fix mistakenly changed cainjector image value

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1034,7 +1034,7 @@ cainjector:
 
     # The container image for the cert-manager cainjector
     # +docs:property
-    repository: quay.io/jetstack/cert-manager-controller
+    repository: quay.io/jetstack/cert-manager-cainjector
 
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion will be used.


### PR DESCRIPTION
Introduced in https://github.com/cert-manager/cert-manager/pull/6639

This was discovered during the release of cert-manager v1.14.0. See the summary [on Slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1706723744656039?thread_ts=1706713005.073879&cid=CDEQJ0Q8M)

### Kind

/kind bug

### Release Note

```release-note
Fix broken cainjector image value in Helm chart
```
