### PR TITLE
Clearify prometheus options and fix error in Helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.prometheus.enabled (not .Values.prometheus.servicemonitor.enabled) }}
+      {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
       {{- if not .Values.podAnnotations }}
       annotations:
       {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -420,10 +420,11 @@ enableServiceLinks: false
 
 prometheus:
   # Enable Prometheus monitoring for the cert-manager controller to use with the
-  # Prometheus Operator. Either `prometheus.servicemonitor.enabled` or
-  # `prometheus.podmonitor.enabled` can be used to create a ServiceMonitor/PodMonitor
-  # resource.
+  # Prometheus Operator. If this option is enabled without enabling `prometheus.servicemonitor.enabled` or
+  # `prometheus.podmonitor.enabled`, 'prometheus.io' annotations are added to the cert-manager Deployment resources.
+  # Otherwise, a ServiceMonitor/ PodMonitor is created.
   enabled: true
+
   servicemonitor:
     # Create a ServiceMonitor to add cert-manager to Prometheus.
     enabled: false


### PR DESCRIPTION
Clarifies the prometheus.enabled = true, prometheus.servicemonitor.enabled = false prometheus.podmonitor.enabled = false option using a comment.
Also makes the logic for adding the annotations aware of the podmonitor option (we missed this in https://github.com/cert-manager/cert-manager/pull/6459).

### Kind

/kind bug

### Release Note

```release-note
NONE
```
