### PR TITLE
Fix backwards incompatible change: include a prometheus service by default

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- if and .Values.prometheus.enabled (not .Values.prometheus.podmonitor.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -422,7 +422,7 @@ prometheus:
   # Enable Prometheus monitoring for the cert-manager controller to use with the
   # Prometheus Operator. If this option is enabled without enabling `prometheus.servicemonitor.enabled` or
   # `prometheus.podmonitor.enabled`, 'prometheus.io' annotations are added to the cert-manager Deployment
-  # resources. Additionally, for backwards compatibility a service is created which can be used together
+  # resources. Additionally, a service is created which can be used together
   # with your own ServiceMonitor (managed outside of this Helm chart).
   # Otherwise, a ServiceMonitor/ PodMonitor is created.
   enabled: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -421,7 +421,9 @@ enableServiceLinks: false
 prometheus:
   # Enable Prometheus monitoring for the cert-manager controller to use with the
   # Prometheus Operator. If this option is enabled without enabling `prometheus.servicemonitor.enabled` or
-  # `prometheus.podmonitor.enabled`, 'prometheus.io' annotations are added to the cert-manager Deployment resources.
+  # `prometheus.podmonitor.enabled`, 'prometheus.io' annotations are added to the cert-manager Deployment
+  # resources. Additionally, for backwards compatibility a service is created which can be used together
+  # with your own ServiceMonitor (managed outside of this Helm chart).
   # Otherwise, a ServiceMonitor/ PodMonitor is created.
   enabled: true
 


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6459 the prometheus service was made conditional both on `.Values.prometheus.enabled` and `.Values.prometheus.servicemonitor.enabled`. This however conflicts with the original intentions of the author of this Service: https://github.com/cert-manager/cert-manager/pull/1942#discussion_r309007374.
For that reason, we decided to still include the service when only `.Values.prometheus.enabled` is set.
We do however remove the service when `.Values.prometheus.podmonitor.enabled` is true and aim to add an extra option in the future to disable this service.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
