### PR TITLE
[release-1.14] CLI flags parsing bugfix

### DIFF
--- a/cmd/ctl/pkg/factory/factory.go
+++ b/cmd/ctl/pkg/factory/factory.go
@@ -31,15 +31,12 @@ import (
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 )
 
-var (
-	kubeConfigFlags = genericclioptions.NewConfigFlags(true)
-	factory         = util.NewFactory(kubeConfigFlags)
-)
-
 // Factory provides a set of clients and configurations to authenticate and
 // access a target Kubernetes cluster. Factory will ensure that its fields are
 // populated and valid during command execution.
 type Factory struct {
+	factory util.Factory
+
 	// Namespace is the namespace that the user has requested with the
 	// "--namespace" / "-n" flag. Defaults to "default" if the flag was not
 	// provided.
@@ -72,17 +69,24 @@ type Factory struct {
 func New(ctx context.Context, cmd *cobra.Command) *Factory {
 	f := new(Factory)
 
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
+	f.factory = util.NewFactory(kubeConfigFlags)
+
 	kubeConfigFlags.AddFlags(cmd.Flags())
 	cmd.RegisterFlagCompletionFunc("namespace", validArgsListNamespaces(ctx, f))
 
-	// Setup a PreRun to populate the Factory. Catch the existing PreRun command
+	// Setup a PreRunE to populate the Factory. Catch the existing PreRunE command
 	// if one was defined, and execute it second.
-	existingPreRun := cmd.PreRun
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		util.CheckErr(f.complete())
-		if existingPreRun != nil {
-			existingPreRun(cmd, args)
+	existingPreRunE := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := f.complete(); err != nil {
+			return err
 		}
+
+		if existingPreRunE != nil {
+			return existingPreRunE(cmd, args)
+		}
+		return nil
 	}
 
 	return f
@@ -93,12 +97,12 @@ func New(ctx context.Context, cmd *cobra.Command) *Factory {
 func (f *Factory) complete() error {
 	var err error
 
-	f.Namespace, f.EnforceNamespace, err = factory.ToRawKubeConfigLoader().Namespace()
+	f.Namespace, f.EnforceNamespace, err = f.factory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
 
-	f.RESTConfig, err = factory.ToRESTConfig()
+	f.RESTConfig, err = f.factory.ToRESTConfig()
 	if err != nil {
 		return err
 	}
@@ -113,7 +117,7 @@ func (f *Factory) complete() error {
 		return err
 	}
 
-	f.RESTClientGetter = factory
+	f.RESTClientGetter = f.factory
 
 	return nil
 }


### PR DESCRIPTION
Manual backport of https://github.com/cert-manager/cmctl/pull/14 and https://github.com/cert-manager/cmctl/pull/13.

Fixes two issues introduced in https://github.com/cert-manager/cert-manager/pull/6562:

1. We were mixing PreRun and PreRunE functions. However, cobra will not execute PreRun when PreRunE is set. (see https://github.com/cert-manager/cmctl/pull/14/files#r1467623809)
2. Flags were parsed and set on a global variable, which was shared across all sub-commands. This caused the namespace default overwrite for the install subcommand to apply to all commands. (see https://github.com/cert-manager/cert-manager/pull/6706/files#diff-6afa2ae6fa2d57e759177e96b60d01f7cc307f1ac5a197466476314b79524343L34-L37 and https://github.com/cert-manager/cert-manager/blob/241e64fd3019c23e7d087b732f4ebd400d2c9039/cmd/ctl/pkg/install/helm/settings.go#L76-L77)

### Kind

/kind bug

### Release Note

```release-note
NONE
```
