### PR TITLE
Fix the Helm trick that we use to differentiate between 0 and an empty value

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.cainjector.replicaCount }}
-  {{- if ne (quote .Values.global.revisionHistoryLimit) (quote "") }}
+  {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
   selector:
@@ -61,7 +61,7 @@ spec:
           image: "{{ template "image" (tuple .Values.cainjector.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
-          {{- if ne (quote .Values.global.logLevel) (quote "") }}
+          {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
           {{- with .Values.global.leaderElection }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.cainjector.replicaCount }}
+  {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
   {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
@@ -61,6 +62,7 @@ spec:
           image: "{{ template "image" (tuple .Values.cainjector.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
+          {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
           {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
   {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
@@ -79,6 +80,7 @@ spec:
           image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+          {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
           {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  {{- if ne (quote .Values.global.revisionHistoryLimit) (quote "") }}
+  {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
   selector:
@@ -79,7 +79,7 @@ spec:
           image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-          {{- if ne (quote .Values.global.logLevel) (quote "") }}
+          {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
           {{- if .Values.config }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
-  {{- if ne (quote .Values.global.revisionHistoryLimit) (quote "") }}
+  {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
   selector:
@@ -66,7 +66,7 @@ spec:
           image: "{{ template "image" (tuple .Values.webhook.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
-          {{- if ne (quote .Values.global.logLevel) (quote "") }}
+          {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
           {{- if .Values.webhook.config }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -15,6 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
+  {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
   {{- if not (has (quote .Values.global.revisionHistoryLimit) (list "" (quote ""))) }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   {{- end }}
@@ -66,6 +67,7 @@ spec:
           image: "{{ template "image" (tuple .Values.webhook.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
+          {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
           {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}


### PR DESCRIPTION
Closes https://github.com/cert-manager/cert-manager/issues/6712

This trick was introduced in https://github.com/cert-manager/cert-manager/pull/5860 and https://github.com/cert-manager/cert-manager/pull/6248.
The root issue is that `{{ if "" }}` and `{{ if 0 }}` both return `false`. The trick was introduced to fix this issue.

The trick uses the `quote` function to differentiate between a empty string and 0 or "0".
The result from `quote` can be compared with `(quote "")` to detect empty strings.

However, the fix is not complete. In case the value is empty/ null, the result from quote is an empty string not `(quote "")`.

The final solution that fixes the original and the new problem is to:
1. use `(quote value)`: yields these strings `"0"`, `""` and an empty string
3. compare the strings with `""` or an empty string

before:
```console
$ helm template . --set global.revisionHistoryLimit=0 | grep revisionHistoryLimit
  revisionHistoryLimit: 0
  revisionHistoryLimit: 0
  revisionHistoryLimit: 0
$ helm template . --set global.revisionHistoryLimit=5 | grep revisionHistoryLimit
  revisionHistoryLimit: 5
  revisionHistoryLimit: 5
  revisionHistoryLimit: 5
$ helm template  . --set global.revisionHistoryLimit= | grep revisionHistoryLimit
$ helm template  . | grep revisionHistoryLimit
  revisionHistoryLimit: 
  revisionHistoryLimit: 
  revisionHistoryLimit: 
```

after:
```console
$ helm template . --set global.revisionHistoryLimit=0 | grep revisionHistoryLimit
  revisionHistoryLimit: 0
  revisionHistoryLimit: 0
  revisionHistoryLimit: 0
$ helm template . --set global.revisionHistoryLimit=5 | grep revisionHistoryLimit
  revisionHistoryLimit: 5
  revisionHistoryLimit: 5
  revisionHistoryLimit: 5
$ helm template  . --set global.revisionHistoryLimit= | grep revisionHistoryLimit
$ helm template  . | grep revisionHistoryLimit
```

### Kind

/kind bug

### Release Note

```release-note
Helm: Fix a bug in the logic that differentiates between 0 and an empty value.
```
