### PR TITLE
[release-1.12] bump go to latest 1.20.x version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -56,7 +56,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.13
+VENDORED_GO_VERSION := 1.20.14
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
#6732 but for release-1.12

We'll have to make a plan about how to handle the go version here since 1.20 is EOL now that 1.22 is released, but that's a discussion for another place!

```release-note
Bump go to 1.20.14
```
