### PR TITLE
Rename `$(BINDIR)` to `$(bin_dir)` in preparation for makefile modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ SHELL := /usr/bin/env bash
 .DELETE_ON_ERROR:
 .SUFFIXES:
 
-BINDIR := _bin
+bin_dir := _bin
 
 include make/util.mk
 
-# SOURCES contains all go files except those in $(BINDIR), the old bindir `bin`, or in
+# SOURCES contains all go files except those in $(bin_dir), the old bindir `bin`, or in
 # the make dir.
 # NB: we skip `bin/` since users might have a `bin` directory left over in repos they were
 # using before the bin dir was renamed
@@ -84,13 +84,13 @@ include make/help.mk
 ## @category Development
 clean: | $(NEEDS_KIND)
 	@$(eval KIND_CLUSTER_NAME ?= kind)
-	$(KIND) delete cluster --name=$(shell cat $(BINDIR)/scratch/kind-exists 2>/dev/null || echo $(KIND_CLUSTER_NAME)) -q 2>/dev/null || true
-	rm -rf $(filter-out $(BINDIR)/downloaded,$(wildcard $(BINDIR)/*))
+	$(KIND) delete cluster --name=$(shell cat $(bin_dir)/scratch/kind-exists 2>/dev/null || echo $(KIND_CLUSTER_NAME)) -q 2>/dev/null || true
+	rm -rf $(filter-out $(bin_dir)/downloaded,$(wildcard $(bin_dir)/*))
 	rm -rf bazel-bin bazel-cert-manager bazel-out bazel-testlogs
 
 .PHONY: clean-all
 clean-all: clean
-	rm -rf $(BINDIR)/
+	rm -rf $(bin_dir)/
 
 # FORCE is a helper target to force a file to be rebuilt whenever its
 # target is invoked.

--- a/make/README.md
+++ b/make/README.md
@@ -84,14 +84,14 @@ Otherwise, your dependency should be normal.
 For example:
 
 ```make
-$(BINDIR)/awesome-stuff/my-file: README.md | $(BINDIR)/awesome-stuff $(NEEDS_KIND)
-	# write the kind version to $(BINDIR)/awesome-stuff/my-file
+$(bin_dir)/awesome-stuff/my-file: README.md | $(bin_dir)/awesome-stuff $(NEEDS_KIND)
+	# write the kind version to $(bin_dir)/awesome-stuff/my-file
 	$(KIND) --version > $@
 	# append README.md
 	cat README.md >> $@
 ```
 
-This target will be rebuilt if `README.md` changes, but not if the installed version of kind changes or the `$(BINDIR)/awesome-stuff` folder changes.
+This target will be rebuilt if `README.md` changes, but not if the installed version of kind changes or the `$(bin_dir)/awesome-stuff` folder changes.
 
 The dependencies you'll need will inevitably depend on the target you're writing. If in doubt, feel free to ask!
 

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -21,7 +21,7 @@ ci-presubmit: verify-imports verify-errexit verify-boilerplate verify-codegen ve
 
 .PHONY: verify-golangci-lint
 verify-golangci-lint: | $(NEEDS_GOLANGCI-LINT)
-	find . -name go.mod -not \( -path "./$(BINDIR)/*" -prune \)  -execdir $(GOLANGCI-LINT) run --timeout=30m --config=$(CURDIR)/.golangci.ci.yaml \;
+	find . -name go.mod -not \( -path "./$(bin_dir)/*" -prune \)  -execdir $(GOLANGCI-LINT) run --timeout=30m --config=$(CURDIR)/.golangci.ci.yaml \;
 
 .PHONY: verify-modules
 verify-modules: | $(NEEDS_CMREL)
@@ -32,7 +32,7 @@ verify-imports: | $(NEEDS_GOIMPORTS)
 	./hack/verify-goimports.sh $(GOIMPORTS)
 
 .PHONY: verify-chart
-verify-chart: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
+verify-chart: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz
 	DOCKER=$(CTR) ./hack/verify-chart-version.sh $<
 
 .PHONY: verify-errexit
@@ -47,15 +47,15 @@ verify-boilerplate: | $(NEEDS_BOILERSUITE)
 ## Check that the LICENSES file is up to date; must pass before a change to go.mod can be merged
 ##
 ## @category CI
-verify-licenses: $(BINDIR)/scratch/LATEST-LICENSES $(BINDIR)/scratch/LATEST-LICENSES-acmesolver $(BINDIR)/scratch/LATEST-LICENSES-cainjector $(BINDIR)/scratch/LATEST-LICENSES-controller $(BINDIR)/scratch/LATEST-LICENSES-startupapicheck $(BINDIR)/scratch/LATEST-LICENSES-webhook $(BINDIR)/scratch/LATEST-LICENSES-integration-tests $(BINDIR)/scratch/LATEST-LICENSES-e2e-tests
-	@diff $(BINDIR)/scratch/LATEST-LICENSES LICENSES >/dev/null || (echo -e "\033[0;33mLICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-acmesolver cmd/acmesolver/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/acmesolver/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-cainjector cmd/cainjector/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/cainjector/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-startupapicheck        cmd/startupapicheck/LICENSES        >/dev/null || (echo -e "\033[0;33mcmd/startupapicheck/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-controller cmd/controller/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/controller/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-webhook    cmd/webhook/LICENSES    >/dev/null || (echo -e "\033[0;33mcmd/webhook/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-integration-tests test/integration/LICENSES >/dev/null || (echo -e "\033[0;33mtest/integration/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
-	@diff $(BINDIR)/scratch/LATEST-LICENSES-e2e-tests         test/e2e/LICENSES         >/dev/null || (echo -e "\033[0;33mtest/e2e/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+verify-licenses: $(bin_dir)/scratch/LATEST-LICENSES $(bin_dir)/scratch/LATEST-LICENSES-acmesolver $(bin_dir)/scratch/LATEST-LICENSES-cainjector $(bin_dir)/scratch/LATEST-LICENSES-controller $(bin_dir)/scratch/LATEST-LICENSES-startupapicheck $(bin_dir)/scratch/LATEST-LICENSES-webhook $(bin_dir)/scratch/LATEST-LICENSES-integration-tests $(bin_dir)/scratch/LATEST-LICENSES-e2e-tests
+	@diff $(bin_dir)/scratch/LATEST-LICENSES LICENSES >/dev/null || (echo -e "\033[0;33mLICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-acmesolver cmd/acmesolver/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/acmesolver/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-cainjector cmd/cainjector/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/cainjector/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-startupapicheck        cmd/startupapicheck/LICENSES        >/dev/null || (echo -e "\033[0;33mcmd/startupapicheck/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-controller cmd/controller/LICENSES >/dev/null || (echo -e "\033[0;33mcmd/controller/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-webhook    cmd/webhook/LICENSES    >/dev/null || (echo -e "\033[0;33mcmd/webhook/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-integration-tests test/integration/LICENSES >/dev/null || (echo -e "\033[0;33mtest/integration/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
+	@diff $(bin_dir)/scratch/LATEST-LICENSES-e2e-tests         test/e2e/LICENSES         >/dev/null || (echo -e "\033[0;33mtest/e2e/LICENSES seems to be out of date; update with 'make update-licenses'\033[0m" && exit 1)
 
 .PHONY: verify-crds
 verify-crds: | $(NEEDS_GO) $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
@@ -88,25 +88,25 @@ patch-crds: | $(NEEDS_CONTROLLER-GEN)
 verify-codegen: | k8s-codegen-tools $(NEEDS_GO)
 	VERIFY_ONLY="true" ./hack/k8s-codegen.sh \
 		$(GO) \
-		./$(BINDIR)/tools/client-gen \
-		./$(BINDIR)/tools/deepcopy-gen \
-		./$(BINDIR)/tools/informer-gen \
-		./$(BINDIR)/tools/lister-gen \
-		./$(BINDIR)/tools/defaulter-gen \
-		./$(BINDIR)/tools/conversion-gen \
-		./$(BINDIR)/tools/openapi-gen
+		./$(bin_dir)/tools/client-gen \
+		./$(bin_dir)/tools/deepcopy-gen \
+		./$(bin_dir)/tools/informer-gen \
+		./$(bin_dir)/tools/lister-gen \
+		./$(bin_dir)/tools/defaulter-gen \
+		./$(bin_dir)/tools/conversion-gen \
+		./$(bin_dir)/tools/openapi-gen
 
 .PHONY: update-codegen
 update-codegen: | k8s-codegen-tools $(NEEDS_GO)
 	./hack/k8s-codegen.sh \
 		$(GO) \
-		./$(BINDIR)/tools/client-gen \
-		./$(BINDIR)/tools/deepcopy-gen \
-		./$(BINDIR)/tools/informer-gen \
-		./$(BINDIR)/tools/lister-gen \
-		./$(BINDIR)/tools/defaulter-gen \
-		./$(BINDIR)/tools/conversion-gen \
-		./$(BINDIR)/tools/openapi-gen
+		./$(bin_dir)/tools/client-gen \
+		./$(bin_dir)/tools/deepcopy-gen \
+		./$(bin_dir)/tools/informer-gen \
+		./$(bin_dir)/tools/lister-gen \
+		./$(bin_dir)/tools/defaulter-gen \
+		./$(bin_dir)/tools/conversion-gen \
+		./$(bin_dir)/tools/openapi-gen
 
 # inject_helm_docs performs `helm-tool inject` using $1 as the output file and $2 as the values input
 define inject_helm_docs
@@ -123,8 +123,8 @@ verify-helm-docs: | $(NEEDS_HELM-TOOL)
 		echo "\033[0;33mdeploy/charts/cert-manager/README.template.md has been modified and could be out of date; update with 'make update-helm-docs'\033[0m" ; \
 		exit 1 ; \
 	fi
-	@cp deploy/charts/cert-manager/README.template.md $(BINDIR)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION) && $(call inject_helm_docs,$(BINDIR)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION),deploy/charts/cert-manager/values.yaml)
-	@diff $(BINDIR)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION) deploy/charts/cert-manager/README.template.md || (echo -e "\033[0;33mdeploy/charts/cert-manager/README.template.md seems to be out of date; update with 'make update-helm-docs'\033[0m" && exit 1)
+	@cp deploy/charts/cert-manager/README.template.md $(bin_dir)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION) && $(call inject_helm_docs,$(bin_dir)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION),deploy/charts/cert-manager/values.yaml)
+	@diff $(bin_dir)/scratch/LATEST_HELM_README-$(HELM-TOOL_VERSION) deploy/charts/cert-manager/README.template.md || (echo -e "\033[0;33mdeploy/charts/cert-manager/README.template.md seems to be out of date; update with 'make update-helm-docs'\033[0m" && exit 1)
 
 .PHONY: update-all
 ## Update CRDs, code generation and licenses to the latest versions.

--- a/make/containers.mk
+++ b/make/containers.mk
@@ -52,9 +52,9 @@ BASE_IMAGE_startupapicheck-linux-arm:=$($(BASE_IMAGE_TYPE)_BASE_IMAGE_arm)
 all-containers: cert-manager-controller-linux cert-manager-webhook-linux cert-manager-acmesolver-linux cert-manager-cainjector-linux cert-manager-startupapicheck-linux
 
 .PHONY: cert-manager-controller-linux
-cert-manager-controller-linux: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-arm.tar.gz
+cert-manager-controller-linux: $(bin_dir)/containers/cert-manager-controller-linux-amd64.tar.gz $(bin_dir)/containers/cert-manager-controller-linux-arm64.tar.gz $(bin_dir)/containers/cert-manager-controller-linux-s390x.tar.gz $(bin_dir)/containers/cert-manager-controller-linux-ppc64le.tar.gz $(bin_dir)/containers/cert-manager-controller-linux-arm.tar.gz
 
-$(BINDIR)/containers/cert-manager-controller-linux-amd64.tar $(BINDIR)/containers/cert-manager-controller-linux-arm64.tar $(BINDIR)/containers/cert-manager-controller-linux-s390x.tar $(BINDIR)/containers/cert-manager-controller-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-controller-linux-arm.tar: $(BINDIR)/containers/cert-manager-controller-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/controller hack/containers/Containerfile.controller $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
+$(bin_dir)/containers/cert-manager-controller-linux-amd64.tar $(bin_dir)/containers/cert-manager-controller-linux-arm64.tar $(bin_dir)/containers/cert-manager-controller-linux-s390x.tar $(bin_dir)/containers/cert-manager-controller-linux-ppc64le.tar $(bin_dir)/containers/cert-manager-controller-linux-arm.tar: $(bin_dir)/containers/cert-manager-controller-linux-%.tar: $(bin_dir)/scratch/build-context/cert-manager-controller-linux-%/controller hack/containers/Containerfile.controller $(bin_dir)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.license $(bin_dir)/scratch/build-context/cert-manager-controller-linux-%/cert-manager.licenses_notice $(bin_dir)/release-version | $(bin_dir)/containers
 	@$(eval TAG := cert-manager-controller-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_controller-linux-$*)
 	$(CTR) build --quiet \
@@ -65,9 +65,9 @@ $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar $(BINDIR)/container
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-webhook-linux
-cert-manager-webhook-linux: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-arm.tar.gz
+cert-manager-webhook-linux: $(bin_dir)/containers/cert-manager-webhook-linux-amd64.tar.gz $(bin_dir)/containers/cert-manager-webhook-linux-arm64.tar.gz $(bin_dir)/containers/cert-manager-webhook-linux-s390x.tar.gz $(bin_dir)/containers/cert-manager-webhook-linux-ppc64le.tar.gz $(bin_dir)/containers/cert-manager-webhook-linux-arm.tar.gz
 
-$(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar $(BINDIR)/containers/cert-manager-webhook-linux-arm64.tar $(BINDIR)/containers/cert-manager-webhook-linux-s390x.tar $(BINDIR)/containers/cert-manager-webhook-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-webhook-linux-arm.tar: $(BINDIR)/containers/cert-manager-webhook-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/webhook hack/containers/Containerfile.webhook $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
+$(bin_dir)/containers/cert-manager-webhook-linux-amd64.tar $(bin_dir)/containers/cert-manager-webhook-linux-arm64.tar $(bin_dir)/containers/cert-manager-webhook-linux-s390x.tar $(bin_dir)/containers/cert-manager-webhook-linux-ppc64le.tar $(bin_dir)/containers/cert-manager-webhook-linux-arm.tar: $(bin_dir)/containers/cert-manager-webhook-linux-%.tar: $(bin_dir)/scratch/build-context/cert-manager-webhook-linux-%/webhook hack/containers/Containerfile.webhook $(bin_dir)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.license $(bin_dir)/scratch/build-context/cert-manager-webhook-linux-%/cert-manager.licenses_notice $(bin_dir)/release-version | $(bin_dir)/containers
 	@$(eval TAG := cert-manager-webhook-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_webhook-linux-$*)
 	$(CTR) build --quiet \
@@ -78,9 +78,9 @@ $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar $(BINDIR)/containers/c
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-cainjector-linux
-cert-manager-cainjector-linux: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-arm.tar.gz
+cert-manager-cainjector-linux: $(bin_dir)/containers/cert-manager-cainjector-linux-amd64.tar.gz $(bin_dir)/containers/cert-manager-cainjector-linux-arm64.tar.gz $(bin_dir)/containers/cert-manager-cainjector-linux-s390x.tar.gz $(bin_dir)/containers/cert-manager-cainjector-linux-ppc64le.tar.gz $(bin_dir)/containers/cert-manager-cainjector-linux-arm.tar.gz
 
-$(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar $(BINDIR)/containers/cert-manager-cainjector-linux-arm64.tar $(BINDIR)/containers/cert-manager-cainjector-linux-s390x.tar $(BINDIR)/containers/cert-manager-cainjector-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-cainjector-linux-arm.tar: $(BINDIR)/containers/cert-manager-cainjector-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cainjector hack/containers/Containerfile.cainjector $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
+$(bin_dir)/containers/cert-manager-cainjector-linux-amd64.tar $(bin_dir)/containers/cert-manager-cainjector-linux-arm64.tar $(bin_dir)/containers/cert-manager-cainjector-linux-s390x.tar $(bin_dir)/containers/cert-manager-cainjector-linux-ppc64le.tar $(bin_dir)/containers/cert-manager-cainjector-linux-arm.tar: $(bin_dir)/containers/cert-manager-cainjector-linux-%.tar: $(bin_dir)/scratch/build-context/cert-manager-cainjector-linux-%/cainjector hack/containers/Containerfile.cainjector $(bin_dir)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.license $(bin_dir)/scratch/build-context/cert-manager-cainjector-linux-%/cert-manager.licenses_notice $(bin_dir)/release-version | $(bin_dir)/containers
 	@$(eval TAG := cert-manager-cainjector-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_cainjector-linux-$*)
 	$(CTR) build --quiet \
@@ -91,9 +91,9 @@ $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar $(BINDIR)/container
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-acmesolver-linux
-cert-manager-acmesolver-linux: $(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-acmesolver-linux-arm.tar.gz
+cert-manager-acmesolver-linux: $(bin_dir)/containers/cert-manager-acmesolver-linux-amd64.tar.gz $(bin_dir)/containers/cert-manager-acmesolver-linux-arm64.tar.gz $(bin_dir)/containers/cert-manager-acmesolver-linux-s390x.tar.gz $(bin_dir)/containers/cert-manager-acmesolver-linux-ppc64le.tar.gz $(bin_dir)/containers/cert-manager-acmesolver-linux-arm.tar.gz
 
-$(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-arm64.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-s390x.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-acmesolver-linux-arm.tar: $(BINDIR)/containers/cert-manager-acmesolver-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/acmesolver hack/containers/Containerfile.acmesolver $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
+$(bin_dir)/containers/cert-manager-acmesolver-linux-amd64.tar $(bin_dir)/containers/cert-manager-acmesolver-linux-arm64.tar $(bin_dir)/containers/cert-manager-acmesolver-linux-s390x.tar $(bin_dir)/containers/cert-manager-acmesolver-linux-ppc64le.tar $(bin_dir)/containers/cert-manager-acmesolver-linux-arm.tar: $(bin_dir)/containers/cert-manager-acmesolver-linux-%.tar: $(bin_dir)/scratch/build-context/cert-manager-acmesolver-linux-%/acmesolver hack/containers/Containerfile.acmesolver $(bin_dir)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.license $(bin_dir)/scratch/build-context/cert-manager-acmesolver-linux-%/cert-manager.licenses_notice $(bin_dir)/release-version | $(bin_dir)/containers
 	@$(eval TAG := cert-manager-acmesolver-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_acmesolver-linux-$*)
 	$(CTR) build --quiet \
@@ -104,9 +104,9 @@ $(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar $(BINDIR)/container
 	$(CTR) save $(TAG) -o $@ >/dev/null
 
 .PHONY: cert-manager-startupapicheck-linux
-cert-manager-startupapicheck-linux: $(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar.gz $(BINDIR)/containers/cert-manager-startupapicheck-linux-arm64.tar.gz $(BINDIR)/containers/cert-manager-startupapicheck-linux-s390x.tar.gz $(BINDIR)/containers/cert-manager-startupapicheck-linux-ppc64le.tar.gz $(BINDIR)/containers/cert-manager-startupapicheck-linux-arm.tar.gz
+cert-manager-startupapicheck-linux: $(bin_dir)/containers/cert-manager-startupapicheck-linux-amd64.tar.gz $(bin_dir)/containers/cert-manager-startupapicheck-linux-arm64.tar.gz $(bin_dir)/containers/cert-manager-startupapicheck-linux-s390x.tar.gz $(bin_dir)/containers/cert-manager-startupapicheck-linux-ppc64le.tar.gz $(bin_dir)/containers/cert-manager-startupapicheck-linux-arm.tar.gz
 
-$(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar $(BINDIR)/containers/cert-manager-startupapicheck-linux-arm64.tar $(BINDIR)/containers/cert-manager-startupapicheck-linux-s390x.tar $(BINDIR)/containers/cert-manager-startupapicheck-linux-ppc64le.tar $(BINDIR)/containers/cert-manager-startupapicheck-linux-arm.tar: $(BINDIR)/containers/cert-manager-startupapicheck-linux-%.tar: $(BINDIR)/scratch/build-context/cert-manager-startupapicheck-linux-%/startupapicheck hack/containers/Containerfile.startupapicheck $(BINDIR)/scratch/build-context/cert-manager-startupapicheck-linux-%/cert-manager.license $(BINDIR)/scratch/build-context/cert-manager-startupapicheck-linux-%/cert-manager.licenses_notice $(BINDIR)/release-version | $(BINDIR)/containers
+$(bin_dir)/containers/cert-manager-startupapicheck-linux-amd64.tar $(bin_dir)/containers/cert-manager-startupapicheck-linux-arm64.tar $(bin_dir)/containers/cert-manager-startupapicheck-linux-s390x.tar $(bin_dir)/containers/cert-manager-startupapicheck-linux-ppc64le.tar $(bin_dir)/containers/cert-manager-startupapicheck-linux-arm.tar: $(bin_dir)/containers/cert-manager-startupapicheck-linux-%.tar: $(bin_dir)/scratch/build-context/cert-manager-startupapicheck-linux-%/startupapicheck hack/containers/Containerfile.startupapicheck $(bin_dir)/scratch/build-context/cert-manager-startupapicheck-linux-%/cert-manager.license $(bin_dir)/scratch/build-context/cert-manager-startupapicheck-linux-%/cert-manager.licenses_notice $(bin_dir)/release-version | $(bin_dir)/containers
 	@$(eval TAG := cert-manager-startupapicheck-$*:$(RELEASE_VERSION))
 	@$(eval BASE := BASE_IMAGE_startupapicheck-linux-$*)
 	$(CTR) build --quiet \
@@ -119,10 +119,10 @@ $(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar $(BINDIR)/cont
 # At first, we used .INTERMEDIATE to remove the intermediate .tar files.
 # But it meant "make install" would always have to rebuild
 # the tar files.
-$(BINDIR)/containers/cert-manager-%.tar.gz: $(BINDIR)/containers/cert-manager-%.tar
+$(bin_dir)/containers/cert-manager-%.tar.gz: $(bin_dir)/containers/cert-manager-%.tar
 	gzip -c $< > $@
 
-$(BINDIR)/containers:
+$(bin_dir)/containers:
 	@mkdir -p $@
 
 # When running "docker build .", the "build context" was getting too big (1.1 GB
@@ -134,16 +134,16 @@ $(BINDIR)/containers:
 #
 # Note that we can't use symlinks in the build context. In order to avoid the
 # cost of multiple copies of the same binary, we use hard links which shouldn't
-# be a problem since the $(BINDIR)/ folder is entirely managed by make.
+# be a problem since the $(bin_dir)/ folder is entirely managed by make.
 
-$(foreach arch,$(ARCHS),$(foreach bin,$(BINS), $(BINDIR)/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
+$(foreach arch,$(ARCHS),$(foreach bin,$(BINS), $(bin_dir)/scratch/build-context/cert-manager-$(bin)-linux-$(arch))):
 	@mkdir -p $@
 
-$(BINDIR)/scratch/build-context/cert-manager-%/cert-manager.license: $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/scratch/build-context/cert-manager-%
+$(bin_dir)/scratch/build-context/cert-manager-%/cert-manager.license: $(bin_dir)/scratch/cert-manager.license | $(bin_dir)/scratch/build-context/cert-manager-%
 	@ln -f $< $@
 
-$(BINDIR)/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: $(BINDIR)/scratch/cert-manager.licenses_notice | $(BINDIR)/scratch/build-context/cert-manager-%
+$(bin_dir)/scratch/build-context/cert-manager-%/cert-manager.licenses_notice: $(bin_dir)/scratch/cert-manager.licenses_notice | $(bin_dir)/scratch/build-context/cert-manager-%
 	@ln -f $< $@
 
-$(BINDIR)/scratch/build-context/cert-manager-%/controller $(BINDIR)/scratch/build-context/cert-manager-%/acmesolver $(BINDIR)/scratch/build-context/cert-manager-%/cainjector $(BINDIR)/scratch/build-context/cert-manager-%/webhook $(BINDIR)/scratch/build-context/cert-manager-%/startupapicheck: $(BINDIR)/server/% | $(BINDIR)/scratch/build-context/cert-manager-%
+$(bin_dir)/scratch/build-context/cert-manager-%/controller $(bin_dir)/scratch/build-context/cert-manager-%/acmesolver $(bin_dir)/scratch/build-context/cert-manager-%/cainjector $(bin_dir)/scratch/build-context/cert-manager-%/webhook $(bin_dir)/scratch/build-context/cert-manager-%/startupapicheck: $(bin_dir)/server/% | $(bin_dir)/scratch/build-context/cert-manager-%
 	@ln -f $< $@

--- a/make/git.mk
+++ b/make/git.mk
@@ -32,18 +32,18 @@ release-version:
 	@echo "$(RELEASE_VERSION)"
 
 # The file "release-version" gets updated whenever git describe --tags changes.
-# This is used by the $(BINDIR)/containers/*.tar.gz targets to make sure that the
+# This is used by the $(bin_dir)/containers/*.tar.gz targets to make sure that the
 # containers, which use the output of "git describe --tags" as their tag, get
 # rebuilt whenever you check out a different commit. If we didn't do this, the
-# Helm chart $(BINDIR)/cert-manager-*.tgz would refer to an image tag that doesn't
-# exist in $(BINDIR)/containers/*.tar.gz.
+# Helm chart $(bin_dir)/cert-manager-*.tgz would refer to an image tag that doesn't
+# exist in $(bin_dir)/containers/*.tar.gz.
 #
 # We use FORCE instead of .PHONY because this is a real file that can be used as
 # a prerequisite. If we were to use .PHONY, then the file's timestamp would not
 # be used to check whether targets should be rebuilt, and they would get
 # constantly rebuilt.
-$(BINDIR)/release-version: FORCE | $(BINDIR)
+$(bin_dir)/release-version: FORCE | $(bin_dir)
 	@test "$(RELEASE_VERSION)" == "$(shell cat $@ 2>/dev/null)" || echo $(RELEASE_VERSION) > $@
 
-$(BINDIR)/scratch/git:
+$(bin_dir)/scratch/git:
 	@mkdir -p $@

--- a/make/ko.mk
+++ b/make/ko.mk
@@ -50,7 +50,7 @@ KO_BINS ?= controller acmesolver cainjector webhook startupapicheck
 ## @category Experimental/ko
 KO_HELM_VALUES_FILES ?=
 
-export KOCACHE = $(BINDIR)/scratch/ko/cache
+export KOCACHE = $(bin_dir)/scratch/ko/cache
 
 KO_IMAGE_REFS = $(foreach bin,$(KO_BINS),_bin/scratch/ko/$(bin).yaml)
 $(KO_IMAGE_REFS): _bin/scratch/ko/%.yaml: FORCE | $(NEEDS_KO) $(NEEDS_YQ)
@@ -71,21 +71,21 @@ ko-images-push: $(KO_IMAGE_REFS)
 .PHONY: ko-deploy-certmanager
 ## Deploy cert-manager after pushing docker images to an OCI registry using ko.
 ## @category Experimental/ko
-ko-deploy-certmanager: $(BINDIR)/cert-manager.tgz $(KO_IMAGE_REFS)
-	@$(eval ACME_HTTP01_SOLVER_IMAGE = $(shell $(YQ) '.repository + "@" + .digest' $(BINDIR)/scratch/ko/acmesolver.yaml))
+ko-deploy-certmanager: $(bin_dir)/cert-manager.tgz $(KO_IMAGE_REFS)
+	@$(eval ACME_HTTP01_SOLVER_IMAGE = $(shell $(YQ) '.repository + "@" + .digest' $(bin_dir)/scratch/ko/acmesolver.yaml))
 	$(HELM) upgrade cert-manager $< \
 		--install \
 		--create-namespace \
 		--wait \
 		--namespace cert-manager \
 		$(and $(KO_HELM_VALUES_FILES),--values $(KO_HELM_VALUES_FILES)) \
-		--set image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/controller.yaml)" \
-		--set image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/controller.yaml)" \
-		--set cainjector.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/cainjector.yaml)" \
-		--set cainjector.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/cainjector.yaml)" \
-		--set webhook.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/webhook.yaml)" \
-		--set webhook.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/webhook.yaml)" \
-		--set startupapicheck.image.repository="$(shell $(YQ) .repository $(BINDIR)/scratch/ko/startupapicheck.yaml)" \
-		--set startupapicheck.image.digest="$(shell $(YQ) .digest $(BINDIR)/scratch/ko/startupapicheck.yaml)" \
+		--set image.repository="$(shell $(YQ) .repository $(bin_dir)/scratch/ko/controller.yaml)" \
+		--set image.digest="$(shell $(YQ) .digest $(bin_dir)/scratch/ko/controller.yaml)" \
+		--set cainjector.image.repository="$(shell $(YQ) .repository $(bin_dir)/scratch/ko/cainjector.yaml)" \
+		--set cainjector.image.digest="$(shell $(YQ) .digest $(bin_dir)/scratch/ko/cainjector.yaml)" \
+		--set webhook.image.repository="$(shell $(YQ) .repository $(bin_dir)/scratch/ko/webhook.yaml)" \
+		--set webhook.image.digest="$(shell $(YQ) .digest $(bin_dir)/scratch/ko/webhook.yaml)" \
+		--set startupapicheck.image.repository="$(shell $(YQ) .repository $(bin_dir)/scratch/ko/startupapicheck.yaml)" \
+		--set startupapicheck.image.digest="$(shell $(YQ) .digest $(bin_dir)/scratch/ko/startupapicheck.yaml)" \
 		--set installCRDs=true \
 		--set "extraArgs={--acme-http01-solver-image=$(ACME_HTTP01_SOLVER_IMAGE)}"

--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -19,20 +19,20 @@
 LICENSE_YEAR=2022
 
 # Creates the boilerplate header for YAML files from the template in hack/
-$(BINDIR)/scratch/license.yaml: hack/boilerplate-yaml.txt | $(BINDIR)/scratch
+$(bin_dir)/scratch/license.yaml: hack/boilerplate-yaml.txt | $(bin_dir)/scratch
 	sed -e "s/YEAR/$(LICENSE_YEAR)/g" < $< > $@
 
 # The references LICENSES file is 1.4MB at the time of writing. Bundling it into every container image
 # seems wasteful in terms of bytes stored and bytes transferred on the wire just to add a file
 # which presumably nobody will ever read or care about. Instead, just add a little footnote pointing
 # to the cert-manager repo in case anybody actually decides that they care.
-$(BINDIR)/scratch/license-footnote.yaml: | $(BINDIR)/scratch
+$(bin_dir)/scratch/license-footnote.yaml: | $(bin_dir)/scratch
 	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/cert-manager/cert-manager/blob/$(GITCOMMIT)/LICENSES" > $@
 
-$(BINDIR)/scratch/cert-manager.license: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
+$(bin_dir)/scratch/cert-manager.license: $(bin_dir)/scratch/license.yaml $(bin_dir)/scratch/license-footnote.yaml | $(bin_dir)/scratch
 	cat $^ > $@
 
-$(BINDIR)/scratch/cert-manager.licenses_notice: $(BINDIR)/scratch/license-footnote.yaml | $(BINDIR)/scratch
+$(bin_dir)/scratch/cert-manager.licenses_notice: $(bin_dir)/scratch/license-footnote.yaml | $(bin_dir)/scratch
 	cp $< $@
 
 # Create a go.work file so that go-licenses can discover the LICENCE file of the
@@ -45,18 +45,18 @@ $(BINDIR)/scratch/cert-manager.licenses_notice: $(BINDIR)/scratch/license-footno
 # The go.work file is in a non-standard location, because we made a decision not
 # to commit a go.work file to the repository root for reasons given in:
 # https://github.com/cert-manager/cert-manager/pull/5935
-LICENSES_GO_WORK := $(BINDIR)/scratch/LICENSES.go.work
-$(LICENSES_GO_WORK): $(BINDIR)/scratch
+LICENSES_GO_WORK := $(bin_dir)/scratch/LICENSES.go.work
+$(LICENSES_GO_WORK): $(bin_dir)/scratch
 	$(MAKE) go-workspace GOWORK=$(abspath $@)
 
-LICENSES $(BINDIR)/scratch/LATEST-LICENSES: export GOWORK=$(abspath $(LICENSES_GO_WORK))
-LICENSES $(BINDIR)/scratch/LATEST-LICENSES: $(LICENSES_GO_WORK) go.mod go.sum | $(NEEDS_GO-LICENSES)
+LICENSES $(bin_dir)/scratch/LATEST-LICENSES: export GOWORK=$(abspath $(LICENSES_GO_WORK))
+LICENSES $(bin_dir)/scratch/LATEST-LICENSES: $(LICENSES_GO_WORK) go.mod go.sum | $(NEEDS_GO-LICENSES)
 	GOOS=linux GOARCH=amd64 $(GO-LICENSES) csv ./...  > $@
 
-cmd/%/LICENSES $(BINDIR)/scratch/LATEST-LICENSES-%: export GOWORK=$(abspath $(LICENSES_GO_WORK))
-cmd/%/LICENSES $(BINDIR)/scratch/LATEST-LICENSES-%: $(LICENSES_GO_WORK) cmd/%/go.mod cmd/%/go.sum | $(NEEDS_GO-LICENSES)
+cmd/%/LICENSES $(bin_dir)/scratch/LATEST-LICENSES-%: export GOWORK=$(abspath $(LICENSES_GO_WORK))
+cmd/%/LICENSES $(bin_dir)/scratch/LATEST-LICENSES-%: $(LICENSES_GO_WORK) cmd/%/go.mod cmd/%/go.sum | $(NEEDS_GO-LICENSES)
 	cd cmd/$* && GOOS=linux GOARCH=amd64 $(GO-LICENSES) csv ./...  > ../../$@
 
-test/%/LICENSES $(BINDIR)/scratch/LATEST-LICENSES-%-tests: export GOWORK=$(abspath $(LICENSES_GO_WORK))
-test/%/LICENSES $(BINDIR)/scratch/LATEST-LICENSES-%-tests: $(LICENSES_GO_WORK) test/%/go.mod test/%/go.sum | $(NEEDS_GO-LICENSES)
+test/%/LICENSES $(bin_dir)/scratch/LATEST-LICENSES-%-tests: export GOWORK=$(abspath $(LICENSES_GO_WORK))
+test/%/LICENSES $(bin_dir)/scratch/LATEST-LICENSES-%-tests: $(LICENSES_GO_WORK) test/%/go.mod test/%/go.sum | $(NEEDS_GO-LICENSES)
 	cd test/$* && GOOS=linux GOARCH=amd64 $(GO-LICENSES) csv ./...  > ../../$@

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 CRDS_SOURCES=$(wildcard deploy/crds/*.yaml)
-CRDS_TEMPLATED=$(CRDS_SOURCES:deploy/crds/%.yaml=$(BINDIR)/yaml/templated-crds/%.templated.yaml)
+CRDS_TEMPLATED=$(CRDS_SOURCES:deploy/crds/%.yaml=$(bin_dir)/yaml/templated-crds/%.templated.yaml)
 
 HELM_TEMPLATE_SOURCES=$(wildcard deploy/charts/cert-manager/templates/*.yaml)
-HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,$(BINDIR)/helm/cert-manager/templates/%,$(HELM_TEMPLATE_SOURCES))
+HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,$(bin_dir)/helm/cert-manager/templates/%,$(HELM_TEMPLATE_SOURCES))
 
 ####################
 # Friendly Targets #
@@ -25,16 +25,16 @@ HELM_TEMPLATE_TARGETS=$(patsubst deploy/charts/cert-manager/templates/%,$(BINDIR
 # These targets provide friendly names for the various manifests / charts we build
 
 .PHONY: helm-chart
-helm-chart: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
+helm-chart: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz
 
-$(BINDIR)/cert-manager.tgz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz
+$(bin_dir)/cert-manager.tgz: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz
 	@ln -s -f $(notdir $<) $@
 
 .PHONY: helm-chart-signature
-helm-chart-signature: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov
+helm-chart-signature: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz.prov
 
 .PHONY: static-manifests
-static-manifests: $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml
+static-manifests: $(bin_dir)/yaml/cert-manager.crds.yaml $(bin_dir)/yaml/cert-manager.yaml
 
 ###################
 # Release Targets #
@@ -44,7 +44,7 @@ static-manifests: $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-mana
 ## Build YAML manifests and helm charts (but not the helm chart signature)
 ##
 ## @category Release
-release-manifests: $(BINDIR)/scratch/cert-manager-manifests-unsigned.tar.gz
+release-manifests: $(bin_dir)/scratch/cert-manager-manifests-unsigned.tar.gz
 
 .PHONY: release-manifests-signed
 ## Build YAML manifests and helm charts including the helm chart signature
@@ -53,29 +53,29 @@ release-manifests: $(BINDIR)/scratch/cert-manager-manifests-unsigned.tar.gz
 ## Prefer `make release-manifests` locally.
 ##
 ## @category Release
-release-manifests-signed: $(BINDIR)/release/cert-manager-manifests.tar.gz $(BINDIR)/metadata/cert-manager-manifests.tar.gz.metadata.json
+release-manifests-signed: $(bin_dir)/release/cert-manager-manifests.tar.gz $(bin_dir)/metadata/cert-manager-manifests.tar.gz.metadata.json
 
-$(BINDIR)/release/cert-manager-manifests.tar.gz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov | $(BINDIR)/scratch/manifests-signed $(BINDIR)/release
-	mkdir -p $(BINDIR)/scratch/manifests-signed/deploy/chart/
-	mkdir -p $(BINDIR)/scratch/manifests-signed/deploy/manifests/
-	cp $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov $(BINDIR)/scratch/manifests-signed/deploy/chart/
-	cp $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/scratch/manifests-signed/deploy/manifests/
+$(bin_dir)/release/cert-manager-manifests.tar.gz: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz $(bin_dir)/yaml/cert-manager.crds.yaml $(bin_dir)/yaml/cert-manager.yaml $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz.prov | $(bin_dir)/scratch/manifests-signed $(bin_dir)/release
+	mkdir -p $(bin_dir)/scratch/manifests-signed/deploy/chart/
+	mkdir -p $(bin_dir)/scratch/manifests-signed/deploy/manifests/
+	cp $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz.prov $(bin_dir)/scratch/manifests-signed/deploy/chart/
+	cp $(bin_dir)/yaml/cert-manager.crds.yaml $(bin_dir)/yaml/cert-manager.yaml $(bin_dir)/scratch/manifests-signed/deploy/manifests/
 	# removes leading ./ from archived paths
-	find $(BINDIR)/scratch/manifests-signed -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(BINDIR)/scratch/manifests-signed -T -
-	rm -rf $(BINDIR)/scratch/manifests-signed
+	find $(bin_dir)/scratch/manifests-signed -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(bin_dir)/scratch/manifests-signed -T -
+	rm -rf $(bin_dir)/scratch/manifests-signed
 
-$(BINDIR)/scratch/cert-manager-manifests-unsigned.tar.gz: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml | $(BINDIR)/scratch/manifests-unsigned
-	mkdir -p $(BINDIR)/scratch/manifests-unsigned/deploy/chart/
-	mkdir -p $(BINDIR)/scratch/manifests-unsigned/deploy/manifests/
-	cp $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz $(BINDIR)/scratch/manifests-unsigned/deploy/chart/
-	cp $(BINDIR)/yaml/cert-manager.crds.yaml $(BINDIR)/yaml/cert-manager.yaml $(BINDIR)/scratch/manifests-unsigned/deploy/manifests/
+$(bin_dir)/scratch/cert-manager-manifests-unsigned.tar.gz: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz $(bin_dir)/yaml/cert-manager.crds.yaml $(bin_dir)/yaml/cert-manager.yaml | $(bin_dir)/scratch/manifests-unsigned
+	mkdir -p $(bin_dir)/scratch/manifests-unsigned/deploy/chart/
+	mkdir -p $(bin_dir)/scratch/manifests-unsigned/deploy/manifests/
+	cp $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz $(bin_dir)/scratch/manifests-unsigned/deploy/chart/
+	cp $(bin_dir)/yaml/cert-manager.crds.yaml $(bin_dir)/yaml/cert-manager.yaml $(bin_dir)/scratch/manifests-unsigned/deploy/manifests/
 	# removes leading ./ from archived paths
-	find $(BINDIR)/scratch/manifests-unsigned -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(BINDIR)/scratch/manifests-unsigned -T -
-	rm -rf $(BINDIR)/scratch/manifests-unsigned
+	find $(bin_dir)/scratch/manifests-unsigned -maxdepth 1 -mindepth 1 | sed 's|.*/||' | tar czf $@ -C $(bin_dir)/scratch/manifests-unsigned -T -
+	rm -rf $(bin_dir)/scratch/manifests-unsigned
 
 # This metadata blob is constructed slightly differently and doesn't use hack/artifact-metadata.template.json directly;
 # this is because the bazel staged releases didn't include an "os" or "architecture" field for this artifact
-$(BINDIR)/metadata/cert-manager-manifests.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-manifests.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
+$(bin_dir)/metadata/cert-manager-manifests.tar.gz.metadata.json: $(bin_dir)/release/cert-manager-manifests.tar.gz hack/artifact-metadata.template.json | $(bin_dir)/metadata
 	jq -n --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		'.name = $$name | .sha256 = $$sha256' > $@
@@ -86,36 +86,36 @@ $(BINDIR)/metadata/cert-manager-manifests.tar.gz.metadata.json: $(BINDIR)/releas
 
 # These targets provide for building and signing the cert-manager helm chart.
 
-$(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz: $(BINDIR)/helm/cert-manager/README.md $(BINDIR)/helm/cert-manager/Chart.yaml $(BINDIR)/helm/cert-manager/values.yaml $(HELM_TEMPLATE_TARGETS) $(BINDIR)/helm/cert-manager/templates/NOTES.txt $(BINDIR)/helm/cert-manager/templates/_helpers.tpl $(BINDIR)/helm/cert-manager/templates/crds.yaml | $(NEEDS_HELM) $(BINDIR)/helm/cert-manager
-	$(HELM) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./$(BINDIR)/helm/cert-manager
+$(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz: $(bin_dir)/helm/cert-manager/README.md $(bin_dir)/helm/cert-manager/Chart.yaml $(bin_dir)/helm/cert-manager/values.yaml $(HELM_TEMPLATE_TARGETS) $(bin_dir)/helm/cert-manager/templates/NOTES.txt $(bin_dir)/helm/cert-manager/templates/_helpers.tpl $(bin_dir)/helm/cert-manager/templates/crds.yaml | $(NEEDS_HELM) $(bin_dir)/helm/cert-manager
+	$(HELM) package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(dir $@)" ./$(bin_dir)/helm/cert-manager
 
-$(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz.prov: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_CMREL) $(BINDIR)/helm/cert-manager
+$(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz.prov: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_CMREL) $(bin_dir)/helm/cert-manager
 ifeq ($(strip $(CMREL_KEY)),)
 	$(error Trying to sign helm chart but CMREL_KEY is empty)
 endif
 	cd $(dir $<) && $(CMREL) sign helm --chart-path "$(notdir $<)" --key "$(CMREL_KEY)"
 
-$(BINDIR)/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | $(BINDIR)/helm/cert-manager/templates
+$(bin_dir)/helm/cert-manager/templates/%.yaml: deploy/charts/cert-manager/templates/%.yaml | $(bin_dir)/helm/cert-manager/templates
 	cp -f $^ $@
 
-$(BINDIR)/helm/cert-manager/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | $(BINDIR)/helm/cert-manager/templates
+$(bin_dir)/helm/cert-manager/templates/_helpers.tpl: deploy/charts/cert-manager/templates/_helpers.tpl | $(bin_dir)/helm/cert-manager/templates
 	cp $< $@
 
-$(BINDIR)/helm/cert-manager/templates/NOTES.txt: deploy/charts/cert-manager/templates/NOTES.txt | $(BINDIR)/helm/cert-manager/templates
+$(bin_dir)/helm/cert-manager/templates/NOTES.txt: deploy/charts/cert-manager/templates/NOTES.txt | $(bin_dir)/helm/cert-manager/templates
 	cp $< $@
 
-$(BINDIR)/helm/cert-manager/templates/crds.yaml: $(CRDS_SOURCES) | $(BINDIR)/helm/cert-manager/templates
+$(bin_dir)/helm/cert-manager/templates/crds.yaml: $(CRDS_SOURCES) | $(bin_dir)/helm/cert-manager/templates
 	echo '{{- if .Values.installCRDs }}' > $@
 	./hack/concat-yaml.sh $^ >> $@
 	echo '{{- end }}' >> $@
 
-$(BINDIR)/helm/cert-manager/values.yaml: deploy/charts/cert-manager/values.yaml | $(BINDIR)/helm/cert-manager
+$(bin_dir)/helm/cert-manager/values.yaml: deploy/charts/cert-manager/values.yaml | $(bin_dir)/helm/cert-manager
 	cp $< $@
 
-$(BINDIR)/helm/cert-manager/README.md: deploy/charts/cert-manager/README.template.md | $(BINDIR)/helm/cert-manager
+$(bin_dir)/helm/cert-manager/README.md: deploy/charts/cert-manager/README.template.md | $(bin_dir)/helm/cert-manager
 	sed -e "s:{{RELEASE_VERSION}}:$(RELEASE_VERSION):g" < $< > $@
 
-$(BINDIR)/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml deploy/charts/cert-manager/signkey_annotation.txt | $(NEEDS_YQ) $(BINDIR)/helm/cert-manager
+$(bin_dir)/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.template.yaml deploy/charts/cert-manager/signkey_annotation.txt | $(NEEDS_YQ) $(bin_dir)/helm/cert-manager
 	@# this horrible mess is taken from the YQ manual's example of multiline string blocks from a file:
 	@# https://mikefarah.gitbook.io/yq/operators/string-operators#string-blocks-bash-and-newlines
 	@# we set a bash variable called SIGNKEY_ANNOTATION using read, and then use that bash variable in yq
@@ -133,27 +133,27 @@ $(BINDIR)/helm/cert-manager/Chart.yaml: deploy/charts/cert-manager/Chart.templat
 # with templating completed, and then concatenate with the cert-manager namespace and the CRDs.
 
 # Renders all resources except the namespace and the CRDs
-$(BINDIR)/scratch/yaml/cert-manager.noncrd.unlicensed.yaml: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_HELM) $(BINDIR)/scratch/yaml
+$(bin_dir)/scratch/yaml/cert-manager.noncrd.unlicensed.yaml: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_HELM) $(bin_dir)/scratch/yaml
 	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM) template --api-versions="" --namespace=cert-manager --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
 
-$(BINDIR)/scratch/yaml/cert-manager.all.unlicensed.yaml: $(BINDIR)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_HELM) $(BINDIR)/scratch/yaml
+$(bin_dir)/scratch/yaml/cert-manager.all.unlicensed.yaml: $(bin_dir)/cert-manager-$(RELEASE_VERSION).tgz | $(NEEDS_HELM) $(bin_dir)/scratch/yaml
 	@# The sed command removes the first line but only if it matches "---", which helm adds
 	$(HELM) template --api-versions="" --namespace=cert-manager --set="installCRDs=true" --set="creator=static" --set="startupapicheck.enabled=false" cert-manager $< | \
 		sed -e "1{/^---$$/d;}" > $@
 
-$(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml: $(BINDIR)/scratch/yaml/cert-manager.all.unlicensed.yaml | $(NEEDS_GO) $(BINDIR)/scratch/yaml
+$(bin_dir)/scratch/yaml/cert-manager.crds.unlicensed.yaml: $(bin_dir)/scratch/yaml/cert-manager.all.unlicensed.yaml | $(NEEDS_GO) $(bin_dir)/scratch/yaml
 	$(GO) run hack/extractcrd/main.go $< > $@
 
-$(BINDIR)/yaml/cert-manager.yaml: $(BINDIR)/scratch/license.yaml deploy/manifests/namespace.yaml $(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml $(BINDIR)/scratch/yaml/cert-manager.noncrd.unlicensed.yaml | $(BINDIR)/yaml
+$(bin_dir)/yaml/cert-manager.yaml: $(bin_dir)/scratch/license.yaml deploy/manifests/namespace.yaml $(bin_dir)/scratch/yaml/cert-manager.crds.unlicensed.yaml $(bin_dir)/scratch/yaml/cert-manager.noncrd.unlicensed.yaml | $(bin_dir)/yaml
 	@# NB: filter-out removes the license (the first dependency, $<) from the YAML concatenation
 	./hack/concat-yaml.sh $(filter-out $<, $^) | cat $< - > $@
 
-$(BINDIR)/yaml/cert-manager.crds.yaml: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml | $(BINDIR)/yaml
+$(bin_dir)/yaml/cert-manager.crds.yaml: $(bin_dir)/scratch/license.yaml $(bin_dir)/scratch/yaml/cert-manager.crds.unlicensed.yaml | $(bin_dir)/yaml
 	cat $^ > $@
 
-$(CRDS_TEMPLATED): $(BINDIR)/yaml/templated-crds/crd-%.templated.yaml: $(BINDIR)/scratch/license.yaml $(BINDIR)/scratch/yaml/cert-manager.crds.unlicensed.yaml | $(NEEDS_GO) $(BINDIR)/yaml/templated-crds
+$(CRDS_TEMPLATED): $(bin_dir)/yaml/templated-crds/crd-%.templated.yaml: $(bin_dir)/scratch/license.yaml $(bin_dir)/scratch/yaml/cert-manager.crds.unlicensed.yaml | $(NEEDS_GO) $(bin_dir)/yaml/templated-crds
 	cat $< > $@
 	$(GO) run hack/extractcrd/main.go $(word 2,$^) $* >> $@
 
@@ -166,23 +166,23 @@ templated-crds: $(CRDS_TEMPLATED)
 
 # These targets are trivial, to ensure that dirs exist
 
-$(BINDIR)/yaml:
+$(bin_dir)/yaml:
 	@mkdir -p $@
 
-$(BINDIR)/helm/cert-manager:
+$(bin_dir)/helm/cert-manager:
 	@mkdir -p $@
 
-$(BINDIR)/helm/cert-manager/templates:
+$(bin_dir)/helm/cert-manager/templates:
 	@mkdir -p $@
 
-$(BINDIR)/scratch/yaml:
+$(bin_dir)/scratch/yaml:
 	@mkdir -p $@
 
-$(BINDIR)/scratch/manifests-unsigned:
+$(bin_dir)/scratch/manifests-unsigned:
 	@mkdir -p $@
 
-$(BINDIR)/scratch/manifests-signed:
+$(bin_dir)/scratch/manifests-signed:
 	@mkdir -p $@
 
-$(BINDIR)/yaml/templated-crds:
+$(bin_dir)/yaml/templated-crds:
 	@mkdir -p $@

--- a/make/release.mk
+++ b/make/release.mk
@@ -53,7 +53,7 @@ release-artifacts-signed: release-artifacts release-manifests-signed
 ##
 ## @category Release
 release: release-artifacts-signed
-	$(MAKE) --no-print-directory $(BINDIR)/release/metadata.json
+	$(MAKE) --no-print-directory $(bin_dir)/release/metadata.json
 
 .PHONY: upload-release
 ## Create a complete release and then upload it to a target GCS bucket specified by
@@ -64,11 +64,11 @@ upload-release: release | $(NEEDS_RCLONE)
 ifeq ($(strip $(RELEASE_TARGET_BUCKET)),)
 	$(error Trying to upload-release but RELEASE_TARGET_BUCKET is empty)
 endif
-	$(RCLONE) copyto ./$(BINDIR)/release :gcs:$(RELEASE_TARGET_BUCKET)/stage/gcb/release/$(RELEASE_VERSION)
+	$(RCLONE) copyto ./$(bin_dir)/release :gcs:$(RELEASE_TARGET_BUCKET)/stage/gcb/release/$(RELEASE_VERSION)
 
-# Takes all metadata files in $(BINDIR)/metadata and combines them into one.
+# Takes all metadata files in $(bin_dir)/metadata and combines them into one.
 
-$(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDIR)/release
+$(bin_dir)/release/metadata.json: $(wildcard $(bin_dir)/metadata/*.json) | $(bin_dir)/release
 	jq -n \
 		--arg releaseVersion "$(RELEASE_VERSION)" \
 		--arg buildSource "make" \
@@ -79,12 +79,12 @@ $(BINDIR)/release/metadata.json: $(wildcard $(BINDIR)/metadata/*.json) | $(BINDI
 release-containers: release-container-bundles release-container-metadata
 
 .PHONY: release-container-bundles
-release-container-bundles: $(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-server-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-server-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm.tar.gz
+release-container-bundles: $(bin_dir)/release/cert-manager-server-linux-amd64.tar.gz $(bin_dir)/release/cert-manager-server-linux-arm64.tar.gz $(bin_dir)/release/cert-manager-server-linux-s390x.tar.gz $(bin_dir)/release/cert-manager-server-linux-ppc64le.tar.gz $(bin_dir)/release/cert-manager-server-linux-arm.tar.gz
 
-$(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm64.tar.gz $(BINDIR)/release/cert-manager-server-linux-s390x.tar.gz $(BINDIR)/release/cert-manager-server-linux-ppc64le.tar.gz $(BINDIR)/release/cert-manager-server-linux-arm.tar.gz: $(BINDIR)/release/cert-manager-server-linux-%.tar.gz: $(BINDIR)/containers/cert-manager-acmesolver-linux-%.tar.gz $(BINDIR)/containers/cert-manager-cainjector-linux-%.tar.gz $(BINDIR)/containers/cert-manager-controller-linux-%.tar.gz $(BINDIR)/containers/cert-manager-webhook-linux-%.tar.gz $(BINDIR)/containers/cert-manager-startupapicheck-linux-%.tar.gz $(BINDIR)/scratch/cert-manager.license | $(BINDIR)/release $(BINDIR)/scratch
+$(bin_dir)/release/cert-manager-server-linux-amd64.tar.gz $(bin_dir)/release/cert-manager-server-linux-arm64.tar.gz $(bin_dir)/release/cert-manager-server-linux-s390x.tar.gz $(bin_dir)/release/cert-manager-server-linux-ppc64le.tar.gz $(bin_dir)/release/cert-manager-server-linux-arm.tar.gz: $(bin_dir)/release/cert-manager-server-linux-%.tar.gz: $(bin_dir)/containers/cert-manager-acmesolver-linux-%.tar.gz $(bin_dir)/containers/cert-manager-cainjector-linux-%.tar.gz $(bin_dir)/containers/cert-manager-controller-linux-%.tar.gz $(bin_dir)/containers/cert-manager-webhook-linux-%.tar.gz $(bin_dir)/containers/cert-manager-startupapicheck-linux-%.tar.gz $(bin_dir)/scratch/cert-manager.license | $(bin_dir)/release $(bin_dir)/scratch
 	@# use basename twice to strip both "tar" and "gz"
 	@$(eval CTR_BASENAME := $(basename $(basename $(notdir $@))))
-	@$(eval CTR_SCRATCHDIR := $(BINDIR)/scratch/release-container-bundle/$(CTR_BASENAME))
+	@$(eval CTR_SCRATCHDIR := $(bin_dir)/scratch/release-container-bundle/$(CTR_BASENAME))
 	mkdir -p $(CTR_SCRATCHDIR)/server/images
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/version
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/acmesolver.docker_tag
@@ -92,20 +92,20 @@ $(BINDIR)/release/cert-manager-server-linux-amd64.tar.gz $(BINDIR)/release/cert-
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/controller.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/webhook.docker_tag
 	echo "$(RELEASE_VERSION)" > $(CTR_SCRATCHDIR)/server/images/startupapicheck.docker_tag
-	cp $(BINDIR)/scratch/cert-manager.license $(CTR_SCRATCHDIR)/LICENSES
-	gunzip -c $(BINDIR)/containers/cert-manager-acmesolver-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/acmesolver.tar
-	gunzip -c $(BINDIR)/containers/cert-manager-cainjector-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/cainjector.tar
-	gunzip -c $(BINDIR)/containers/cert-manager-controller-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/controller.tar
-	gunzip -c $(BINDIR)/containers/cert-manager-webhook-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/webhook.tar
-	gunzip -c $(BINDIR)/containers/cert-manager-startupapicheck-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/startupapicheck.tar
+	cp $(bin_dir)/scratch/cert-manager.license $(CTR_SCRATCHDIR)/LICENSES
+	gunzip -c $(bin_dir)/containers/cert-manager-acmesolver-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/acmesolver.tar
+	gunzip -c $(bin_dir)/containers/cert-manager-cainjector-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/cainjector.tar
+	gunzip -c $(bin_dir)/containers/cert-manager-controller-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/controller.tar
+	gunzip -c $(bin_dir)/containers/cert-manager-webhook-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/webhook.tar
+	gunzip -c $(bin_dir)/containers/cert-manager-startupapicheck-linux-$*.tar.gz >$(CTR_SCRATCHDIR)/server/images/startupapicheck.tar
 	chmod -R 755 $(CTR_SCRATCHDIR)/server/images/*
-	tar czf $@ -C $(BINDIR)/scratch/release-container-bundle $(CTR_BASENAME)
+	tar czf $@ -C $(bin_dir)/scratch/release-container-bundle $(CTR_BASENAME)
 	rm -rf $(CTR_SCRATCHDIR)
 
 .PHONY: release-container-metadata
-release-container-metadata: $(BINDIR)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json
+release-container-metadata: $(bin_dir)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json
 
-$(BINDIR)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(BINDIR)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json: $(BINDIR)/metadata/cert-manager-server-linux-%.tar.gz.metadata.json: $(BINDIR)/release/cert-manager-server-linux-%.tar.gz hack/artifact-metadata.template.json | $(BINDIR)/metadata
+$(bin_dir)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-arm64.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-s390x.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-ppc64le.tar.gz.metadata.json $(bin_dir)/metadata/cert-manager-server-linux-arm.tar.gz.metadata.json: $(bin_dir)/metadata/cert-manager-server-linux-%.tar.gz.metadata.json: $(bin_dir)/release/cert-manager-server-linux-%.tar.gz hack/artifact-metadata.template.json | $(bin_dir)/metadata
 	jq --arg name "$(notdir $<)" \
 		--arg sha256 "$(shell ./hack/util/hash.sh $<)" \
 		--arg os "linux" \
@@ -116,17 +116,17 @@ $(BINDIR)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json $(BINDIR
 # This target allows us to set all the modified times for all files in bin to the same time, which
 # is similar to what bazel does. We might not want this, and it's not currently used.
 .PHONY: forcetime
-forcetime: | $(BINDIR)
-	find $(BINDIR) | xargs touch -d "2000-01-01 00:00:00" -
+forcetime: | $(bin_dir)
+	find $(bin_dir) | xargs touch -d "2000-01-01 00:00:00" -
 
-$(BINDIR)/release $(BINDIR)/metadata:
+$(bin_dir)/release $(bin_dir)/metadata:
 	@mkdir -p $@
 
 # Example of how we can generate a SHA256SUMS file and sign it using cosign
-#$(BINDIR)/SHA256SUMS: $(wildcard ...)
-#	@# The patsubst means "all dependencies, but with "$(BINDIR)/" trimmed off the beginning
+#$(bin_dir)/SHA256SUMS: $(wildcard ...)
+#	@# The patsubst means "all dependencies, but with "$(bin_dir)/" trimmed off the beginning
 #	@# We cd into bin so that SHA256SUMS file doesn't have a prefix of `bin` on everything
-#	cd $(dir $@) && sha256sum $(patsubst $(BINDIR)/%,%,$^) > $(notdir $@)
+#	cd $(dir $@) && sha256sum $(patsubst $(bin_dir)/%,%,$^) > $(notdir $@)
 
-#$(BINDIR)/SHA256SUMS.sig: $(BINDIR)/SHA256SUMS | $(NEEDS_COSIGN)
+#$(bin_dir)/SHA256SUMS.sig: $(bin_dir)/SHA256SUMS | $(NEEDS_COSIGN)
 #	$(COSIGN) sign-blob --key $(COSIGN_KEY) $< > $@

--- a/make/scan.mk
+++ b/make/scan.mk
@@ -22,21 +22,21 @@
 trivy-scan-all: trivy-scan-controller trivy-scan-acmesolver trivy-scan-webhook trivy-scan-cainjector trivy-scan-startupapicheck
 
 .PHONY: trivy-scan-controller
-trivy-scan-controller: $(BINDIR)/containers/cert-manager-controller-linux-amd64.tar | $(NEEDS_TRIVY)
+trivy-scan-controller: $(bin_dir)/containers/cert-manager-controller-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1
 
 .PHONY: trivy-scan-acmesolver
-trivy-scan-acmesolver: $(BINDIR)/containers/cert-manager-acmesolver-linux-amd64.tar | $(NEEDS_TRIVY)
+trivy-scan-acmesolver: $(bin_dir)/containers/cert-manager-acmesolver-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1
 
 .PHONY: trivy-scan-webhook
-trivy-scan-webhook: $(BINDIR)/containers/cert-manager-webhook-linux-amd64.tar | $(NEEDS_TRIVY)
+trivy-scan-webhook: $(bin_dir)/containers/cert-manager-webhook-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1
 
 .PHONY: trivy-scan-cainjector
-trivy-scan-cainjector: $(BINDIR)/containers/cert-manager-cainjector-linux-amd64.tar | $(NEEDS_TRIVY)
+trivy-scan-cainjector: $(bin_dir)/containers/cert-manager-cainjector-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1
 
 .PHONY: trivy-scan-startupapicheck
-trivy-scan-startupapicheck: $(BINDIR)/containers/cert-manager-startupapicheck-linux-amd64.tar | $(NEEDS_TRIVY)
+trivy-scan-startupapicheck: $(bin_dir)/containers/cert-manager-startupapicheck-linux-amd64.tar | $(NEEDS_TRIVY)
 	$(TRIVY) image --input $< --format json --exit-code 1

--- a/make/server.mk
+++ b/make/server.mk
@@ -15,95 +15,95 @@
 .PHONY: server-binaries
 server-binaries: controller acmesolver webhook cainjector
 
-$(BINDIR)/server:
+$(bin_dir)/server:
 	@mkdir -p $@
 
 .PHONY: controller
-controller: $(BINDIR)/server/controller-linux-amd64 $(BINDIR)/server/controller-linux-arm64 $(BINDIR)/server/controller-linux-s390x $(BINDIR)/server/controller-linux-ppc64le $(BINDIR)/server/controller-linux-arm | $(NEEDS_GO) $(BINDIR)/server
+controller: $(bin_dir)/server/controller-linux-amd64 $(bin_dir)/server/controller-linux-arm64 $(bin_dir)/server/controller-linux-s390x $(bin_dir)/server/controller-linux-ppc64le $(bin_dir)/server/controller-linux-arm | $(NEEDS_GO) $(bin_dir)/server
 
-$(BINDIR)/server/controller-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/controller-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/controller && GOOS=linux GOARCH=amd64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/controller-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/controller-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/controller && GOOS=linux GOARCH=arm64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/controller-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/controller-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/controller && GOOS=linux GOARCH=s390x $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/controller-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/controller-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/controller && GOOS=linux GOARCH=ppc64le $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/controller-linux-arm: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/controller-linux-arm: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/controller && GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
 .PHONY: acmesolver
-acmesolver: $(BINDIR)/server/acmesolver-linux-amd64 $(BINDIR)/server/acmesolver-linux-arm64 $(BINDIR)/server/acmesolver-linux-s390x $(BINDIR)/server/acmesolver-linux-ppc64le $(BINDIR)/server/acmesolver-linux-arm | $(NEEDS_GO) $(BINDIR)/server
+acmesolver: $(bin_dir)/server/acmesolver-linux-amd64 $(bin_dir)/server/acmesolver-linux-arm64 $(bin_dir)/server/acmesolver-linux-s390x $(bin_dir)/server/acmesolver-linux-ppc64le $(bin_dir)/server/acmesolver-linux-arm | $(NEEDS_GO) $(bin_dir)/server
 
-$(BINDIR)/server/acmesolver-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/acmesolver-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/acmesolver && GOOS=linux GOARCH=amd64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/acmesolver-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/acmesolver-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/acmesolver && GOOS=linux GOARCH=arm64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/acmesolver-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/acmesolver-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/acmesolver && GOOS=linux GOARCH=s390x $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/acmesolver-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/acmesolver-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/acmesolver && GOOS=linux GOARCH=ppc64le $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/acmesolver-linux-arm: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/acmesolver-linux-arm: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/acmesolver && GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
 .PHONY: webhook
-webhook: $(BINDIR)/server/webhook-linux-amd64 $(BINDIR)/server/webhook-linux-arm64 $(BINDIR)/server/webhook-linux-s390x $(BINDIR)/server/webhook-linux-ppc64le $(BINDIR)/server/webhook-linux-arm | $(NEEDS_GO) $(BINDIR)/server
+webhook: $(bin_dir)/server/webhook-linux-amd64 $(bin_dir)/server/webhook-linux-arm64 $(bin_dir)/server/webhook-linux-s390x $(bin_dir)/server/webhook-linux-ppc64le $(bin_dir)/server/webhook-linux-arm | $(NEEDS_GO) $(bin_dir)/server
 
-$(BINDIR)/server/webhook-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/webhook-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/webhook && GOOS=linux GOARCH=amd64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/webhook-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/webhook-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/webhook && GOOS=linux GOARCH=arm64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/webhook-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/webhook-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/webhook && GOOS=linux GOARCH=s390x $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/webhook-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/webhook-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/webhook && GOOS=linux GOARCH=ppc64le $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/webhook-linux-arm: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/webhook-linux-arm: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/webhook && GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
 .PHONY: cainjector
-cainjector: $(BINDIR)/server/cainjector-linux-amd64 $(BINDIR)/server/cainjector-linux-arm64 $(BINDIR)/server/cainjector-linux-s390x $(BINDIR)/server/cainjector-linux-ppc64le $(BINDIR)/server/cainjector-linux-arm | $(NEEDS_GO) $(BINDIR)/server
+cainjector: $(bin_dir)/server/cainjector-linux-amd64 $(bin_dir)/server/cainjector-linux-arm64 $(bin_dir)/server/cainjector-linux-s390x $(bin_dir)/server/cainjector-linux-ppc64le $(bin_dir)/server/cainjector-linux-arm | $(NEEDS_GO) $(bin_dir)/server
 
-$(BINDIR)/server/cainjector-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/cainjector-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/cainjector && GOOS=linux GOARCH=amd64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/cainjector-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/cainjector-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/cainjector && GOOS=linux GOARCH=arm64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/cainjector-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/cainjector-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/cainjector && GOOS=linux GOARCH=s390x $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/cainjector-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/cainjector-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/cainjector && GOOS=linux GOARCH=ppc64le $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/cainjector-linux-arm: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/cainjector-linux-arm: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/cainjector && GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
 .PHONY: startupapicheck
-cainjector: $(BINDIR)/server/startupapicheck-linux-amd64 $(BINDIR)/server/startupapicheck-linux-arm64 $(BINDIR)/server/startupapicheck-linux-s390x $(BINDIR)/server/startupapicheck-linux-ppc64le $(BINDIR)/server/startupapicheck-linux-arm | $(NEEDS_GO) $(BINDIR)/server
+cainjector: $(bin_dir)/server/startupapicheck-linux-amd64 $(bin_dir)/server/startupapicheck-linux-arm64 $(bin_dir)/server/startupapicheck-linux-s390x $(bin_dir)/server/startupapicheck-linux-ppc64le $(bin_dir)/server/startupapicheck-linux-arm | $(NEEDS_GO) $(bin_dir)/server
 
-$(BINDIR)/server/startupapicheck-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/startupapicheck-linux-amd64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/startupapicheck && GOOS=linux GOARCH=amd64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/startupapicheck-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/startupapicheck-linux-arm64: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/startupapicheck && GOOS=linux GOARCH=arm64 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/startupapicheck-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/startupapicheck-linux-s390x: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/startupapicheck && GOOS=linux GOARCH=s390x $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/startupapicheck-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/startupapicheck-linux-ppc64le: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/startupapicheck && GOOS=linux GOARCH=ppc64le $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go
 
-$(BINDIR)/server/startupapicheck-linux-arm: $(SOURCES) | $(NEEDS_GO) $(BINDIR)/server
+$(bin_dir)/server/startupapicheck-linux-arm: $(SOURCES) | $(NEEDS_GO) $(bin_dir)/server
 	cd cmd/startupapicheck && GOOS=linux GOARCH=arm GOARM=7 $(GOBUILD) -o ../../$@ $(GOFLAGS) -ldflags '$(GOLDFLAGS)' main.go

--- a/make/test.mk
+++ b/make/test.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEBUILDER_ASSETS=$(PWD)/$(BINDIR)/tools
+export KUBEBUILDER_ASSETS=$(PWD)/$(bin_dir)/tools
 
 # GOTESTSUM_CI_FLAGS contains flags which are common to invocations of gotestsum in CI environments
 GOTESTSUM_CI_FLAGS := --junitfile-testsuite-name short --junitfile-testcase-classname relative
@@ -118,8 +118,9 @@ E2E_OPENSHIFT ?= false
 ## For more information about GINKGO_FOCUS, see "make/e2e.sh --help".
 ##
 ## @category Development
-e2e: $(BINDIR)/scratch/kind-exists | $(NEEDS_KUBECTL) $(NEEDS_GINKGO)
-	make/e2e.sh
+e2e: $(bin_dir)/scratch/kind-exists | $(NEEDS_KUBECTL) $(NEEDS_GINKGO)
+	BINDIR=$(bin_dir) \
+		make/e2e.sh
 
 .PHONY: e2e-ci
 e2e-ci: | $(NEEDS_GO)
@@ -127,9 +128,9 @@ e2e-ci: | $(NEEDS_GO)
 	$(MAKE) e2e-setup-kind e2e-setup
 	make/e2e-ci.sh
 
-$(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test
+$(bin_dir)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(bin_dir)/test
 	CGO_ENABLED=0 $(GINKGO) build --ldflags="-w -s" --trimpath --tags e2e_test test/e2e
-	mv test/e2e/e2e.test $(BINDIR)/test/e2e.test
+	mv test/e2e/e2e.test $(bin_dir)/test/e2e.test
 
 .PHONY: e2e-build
 ## Build an end-to-end test binary
@@ -153,14 +154,14 @@ $(BINDIR)/test/e2e.test: FORCE | $(NEEDS_GINKGO) $(BINDIR)/test
 ##  ./_bin/test/e2e.test --repo-root=/dev/null --ginkgo.focus="CA\ Issuer" --ginkgo.skip="Gateway"
 ##
 ## @category Development
-e2e-build: $(BINDIR)/test/e2e.test
+e2e-build: $(bin_dir)/test/e2e.test
 
 .PHONY: test-upgrade
 test-upgrade: | $(NEEDS_HELM) $(NEEDS_KIND) $(NEEDS_YTT) $(NEEDS_KUBECTL) $(NEEDS_CMCTL)
 	./hack/verify-upgrade.sh $(HELM) $(KIND) $(YTT) $(KUBECTL) $(CMCTL)
 
-$(BINDIR)/test:
+$(bin_dir)/test:
 	@mkdir -p $@
 
-$(BINDIR)/testlogs:
+$(bin_dir)/testlogs:
 	@mkdir -p $@

--- a/make/util.mk
+++ b/make/util.mk
@@ -18,12 +18,12 @@
 # understand. It causes find to prune entire search branches and not search inside the path.
 # If we used "-not -path X" instead, find would _still look inside X_.
 define get-sources
-$(shell find . -not \( -path "./$(BINDIR)/*" -prune \) -not \( -path "./bin/*" -prune \) -not \( -path "./make/*" -prune \) -name "*.go" | $(1))
+$(shell find . -not \( -path "./$(bin_dir)/*" -prune \) -not \( -path "./bin/*" -prune \) -not \( -path "./make/*" -prune \) -name "*.go" | $(1))
 endef
 
 .PHONY: print-bindir
 print-bindir:
-	@echo $(BINDIR)
+	@echo $(bin_dir)
 
 .PHONY: print-sources
 print-sources:


### PR DESCRIPTION
This change will make it easier to start using makefile modules in the future: https://github.com/cert-manager/makefile-modules/blob/main/modules/repository-base/base/Makefile#L80

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
