### PR TITLE
Replace deprecated functions

### DIFF
--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition)"
+      text: "(NewCertManagerBasicCertificateRequest|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition)"

--- a/.golangci.ci.yaml
+++ b/.golangci.ci.yaml
@@ -34,4 +34,4 @@ issues:
       text: "SA(1002|1006|4000|4006)"
     - linters:
         - staticcheck
-      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition|testCA.Subjects|RootCAs.Subjects|pki.GenerateTemplate)"
+      text: "(NewCertManagerBasicCertificate|DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition)"

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1162,17 +1162,11 @@ func TestNewConfig(t *testing.T) {
 			checkFunc: func(cfg *vault.Config, error error) error {
 				testCA := x509.NewCertPool()
 				testCA.AppendCertsFromPEM([]byte(testLeafCertificate))
-				subs := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs.Subjects()
+				clientCA := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs
 
-				err := fmt.Errorf("got unexpected root CAs in config, exp=%s got=%s",
-					testCA.Subjects(), subs)
-				if len(subs) != len(testCA.Subjects()) {
-					return err
-				}
-				for i := range subs {
-					if !bytes.Equal(subs[i], testCA.Subjects()[i]) {
-						return err
-					}
+				if !clientCA.Equal(testCA) {
+					return fmt.Errorf("got unexpected root CAs in config, exp=%v got=%v",
+						testCA, clientCA)
 				}
 
 				return nil
@@ -1198,17 +1192,11 @@ func TestNewConfig(t *testing.T) {
 
 				testCA := x509.NewCertPool()
 				testCA.AppendCertsFromPEM([]byte(testLeafCertificate))
-				subs := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs.Subjects()
+				clientCA := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs
 
-				err := fmt.Errorf("got unexpected root CAs in config, exp=%s got=%s",
-					testCA.Subjects(), subs)
-				if len(subs) != len(testCA.Subjects()) {
-					return err
-				}
-				for i := range subs {
-					if !bytes.Equal(subs[i], testCA.Subjects()[i]) {
-						return err
-					}
+				if !clientCA.Equal(testCA) {
+					return fmt.Errorf("got unexpected root CAs in config, exp=%v got=%v",
+						testCA, clientCA)
 				}
 
 				return nil
@@ -1233,17 +1221,11 @@ func TestNewConfig(t *testing.T) {
 
 				testCA := x509.NewCertPool()
 				testCA.AppendCertsFromPEM([]byte(testLeafCertificate))
-				subs := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs.Subjects()
+				clientCA := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs
 
-				err := fmt.Errorf("got unexpected root CAs in config, exp=%s got=%s",
-					testCA.Subjects(), subs)
-				if len(subs) != len(testCA.Subjects()) {
-					return err
-				}
-				for i := range subs {
-					if !bytes.Equal(subs[i], testCA.Subjects()[i]) {
-						return err
-					}
+				if !clientCA.Equal(testCA) {
+					return fmt.Errorf("got unexpected root CAs in config, exp=%v got=%v",
+						testCA, clientCA)
 				}
 
 				return nil

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -64,7 +64,7 @@ func Test_SecretsManager(t *testing.T) {
 	baseCert := gen.Certificate("test",
 		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
 		gen.SetCertificateSecretName("output"),
-		gen.SetCertificateRenewBefore(time.Hour*36),
+		gen.SetCertificateRenewBefore(&metav1.Duration{Duration: time.Hour * 36}),
 		gen.SetCertificateDNSNames("example.com"),
 		gen.SetCertificateUID(apitypes.UID("test-uid")),
 	)

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -67,7 +67,7 @@ func TestIssuingController(t *testing.T) {
 		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
 		gen.SetCertificateGeneration(3),
 		gen.SetCertificateSecretName("output"),
-		gen.SetCertificateRenewBefore(time.Hour*36),
+		gen.SetCertificateRenewBefore(&metav1.Duration{Duration: time.Hour * 36}),
 		gen.SetCertificateDNSNames("example.com"),
 		gen.SetCertificateRevision(1),
 		gen.SetCertificateNextPrivateKeySecretName(nextPrivateKeySecretName),

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -140,12 +140,11 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		// In "make/config/pebble/chart/templates/configmap.yaml"
 		// the "google.com" domain is configured in the pebble blocklist.
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
 			gen.SetCertificateDNSNames("google.com"),
 		)
-		cert.Namespace = f.Namespace.Name
-
 		cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -220,12 +219,11 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		// In "make/config/pebble/chart/templates/configmap.yaml"
 		// the "google.com" domain is configured in the pebble blocklist.
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
 			gen.SetCertificateDNSNames("google.com"),
 		)
-		cert.Namespace = f.Namespace.Name
-
 		cert, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -297,6 +295,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		const secretname = "dummy-tls-secret"
 
 		selfcert := gen.Certificate(dummycert,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(secretname),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{
 				Name: "selfsign",
@@ -410,15 +409,14 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		// class
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
+			gen.AddCertificateLabels(map[string]string{
+				"testing.cert-manager.io/fixed-ingress": "true",
+			}),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
 			gen.SetCertificateDNSNames(acmeIngressDomain),
 		)
-		cert.Namespace = f.Namespace.Name
-		cert.Labels = map[string]string{
-			"testing.cert-manager.io/fixed-ingress": "true",
-		}
-
 		cert, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -436,12 +434,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
 			gen.SetCertificateDNSNames(acmeIngressDomain),
 		)
-		cert.Namespace = f.Namespace.Name
-		cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("killing the solver pod")

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -296,7 +296,16 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		const dummycert = "dummy-tls"
 		const secretname = "dummy-tls-secret"
 
-		selfcert := util.NewCertManagerBasicCertificate("dummy-tls", secretname, "selfsign", v1.IssuerKind, nil, nil, acmeIngressDomain)
+		selfcert := gen.Certificate(dummycert,
+			gen.SetCertificateSecretName(secretname),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{
+				Name: "selfsign",
+				Kind: v1.IssuerKind,
+			}),
+			gen.SetCertificateCommonName(acmeIngressDomain),
+			gen.SetCertificateOrganization("test-org"),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+		)
 		selfcert, err = certClient.Create(context.TODO(), selfcert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -131,8 +131,8 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
-			gen.SetCertificateDuration(time.Hour),
-			gen.SetCertificateRenewBefore(45*time.Minute),
+			gen.SetCertificateDuration(&metav1.Duration{Duration: time.Hour}),
+			gen.SetCertificateRenewBefore(&metav1.Duration{Duration: 45 * time.Minute}),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
 			gen.SetCertificateDNSNames(acmeIngressDomain),

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -76,6 +76,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerName,
@@ -101,6 +102,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerName,
@@ -128,6 +130,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerName,
@@ -158,6 +161,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerName,
@@ -208,6 +212,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 				By("Creating a Certificate")
 				cert := gen.Certificate(certificateName,
+					gen.SetCertificateNamespace(f.Namespace.Name),
 					gen.SetCertificateSecretName(certificateSecretName),
 					gen.SetCertificateIssuer(cmmeta.ObjectReference{
 						Name: issuerName,
@@ -245,6 +250,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerName,

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -213,8 +213,8 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 						Name: issuerName,
 						Kind: v1.IssuerKind,
 					}),
-					gen.SetCertificateDuration(v.inputDuration.Duration),
-					gen.SetCertificateRenewBefore(v.inputRenewBefore.Duration),
+					gen.SetCertificateDuration(v.inputDuration),
+					gen.SetCertificateRenewBefore(v.inputRenewBefore),
 					gen.SetCertificateCommonName("test.domain.com"),
 					gen.SetCertificateOrganization("test-org"),
 				)

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -75,7 +75,16 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
 			By("Creating a Certificate")
-			cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil), metav1.CreateOptions{})
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+			)
+			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
 			By("Waiting for the Certificate to be issued...")
@@ -90,11 +99,18 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		It("should be able to obtain an ECDSA key from a RSA backed issuer", func() {
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-			cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)
-			cert.Spec.PrivateKey.Algorithm = v1.ECDSAKeyAlgorithm
-			cert.Spec.PrivateKey.Size = 521
-
 			By("Creating a Certificate")
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+				gen.SetCertificateKeyAlgorithm(v1.ECDSAKeyAlgorithm),
+				gen.SetCertificateKeySize(521),
+			)
 			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -110,10 +126,17 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		It("should be able to obtain an Ed25519 key from a RSA backed issuer", func() {
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-			cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)
-			cert.Spec.PrivateKey.Algorithm = v1.Ed25519KeyAlgorithm
-
 			By("Creating a Certificate")
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+				gen.SetCertificateKeyAlgorithm(v1.Ed25519KeyAlgorithm),
+			)
 			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -133,13 +156,20 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-			cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)
-			cert.Spec.AdditionalOutputFormats = []v1.CertificateAdditionalOutputFormat{
-				{Type: "DER"},
-				{Type: "CombinedPEM"},
-			}
-
 			By("Creating a Certificate")
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+				gen.SetCertificateAdditionalOutputFormats(
+					v1.CertificateAdditionalOutputFormat{Type: "DER"},
+					v1.CertificateAdditionalOutputFormat{Type: "CombinedPEM"},
+				),
+			)
 			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -177,7 +207,18 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 				certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
 				By("Creating a Certificate")
-				cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, v.inputDuration, v.inputRenewBefore), metav1.CreateOptions{})
+				cert := gen.Certificate(certificateName,
+					gen.SetCertificateSecretName(certificateSecretName),
+					gen.SetCertificateIssuer(cmmeta.ObjectReference{
+						Name: issuerName,
+						Kind: v1.IssuerKind,
+					}),
+					gen.SetCertificateDuration(v.inputDuration.Duration),
+					gen.SetCertificateRenewBefore(v.inputRenewBefore.Duration),
+					gen.SetCertificateCommonName("test.domain.com"),
+					gen.SetCertificateOrganization("test-org"),
+				)
+				cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				By("Waiting for the Certificate to be issued...")
 				cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*5)
@@ -203,7 +244,16 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
 			By("Creating a Certificate")
-			cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil), metav1.CreateOptions{})
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+			)
+			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for the Certificate to be issued...")
 			cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*5)

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -59,6 +59,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{
 				Name: issuerName,
@@ -120,6 +121,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 
 			By("Creating a Certificate")
 			cert := gen.Certificate(certificateName,
+				gen.SetCertificateNamespace(f.Namespace.Name),
 				gen.SetCertificateSecretName(certificateSecretName),
 				gen.SetCertificateIssuer(cmmeta.ObjectReference{
 					Name: issuerDurationName,
@@ -157,6 +159,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{
 				Name: issuerName,

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -58,7 +58,16 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 			})
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a Certificate")
-		cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil), metav1.CreateOptions{})
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{
+				Name: issuerName,
+				Kind: v1.IssuerKind,
+			}),
+			gen.SetCertificateCommonName("test.domain.com"),
+			gen.SetCertificateOrganization("test-org"),
+		)
+		cert, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for the Certificate to be issued...")
 		cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*5)
@@ -110,7 +119,18 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating a Certificate")
-			cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerDurationName, v1.IssuerKind, v.inputDuration, v.inputRenewBefore), metav1.CreateOptions{})
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{
+					Name: issuerDurationName,
+					Kind: v1.IssuerKind,
+				}),
+				gen.SetCertificateDuration(v.inputDuration.Duration),
+				gen.SetCertificateRenewBefore(v.inputRenewBefore.Duration),
+				gen.SetCertificateCommonName("test.domain.com"),
+				gen.SetCertificateOrganization("test-org"),
+			)
+			cert, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for the Certificate to be issued...")
 			cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*5)
@@ -135,10 +155,17 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)
-		cert.Spec.PrivateKey.Encoding = v1.PKCS8
-
 		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{
+				Name: issuerName,
+				Kind: v1.IssuerKind,
+			}),
+			gen.SetCertificateCommonName("test.domain.com"),
+			gen.SetCertificateOrganization("test-org"),
+			gen.SetCertificateKeyEncoding(v1.PKCS8),
+		)
 		cert, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -125,8 +125,8 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 					Name: issuerDurationName,
 					Kind: v1.IssuerKind,
 				}),
-				gen.SetCertificateDuration(v.inputDuration.Duration),
-				gen.SetCertificateRenewBefore(v.inputRenewBefore.Duration),
+				gen.SetCertificateDuration(v.inputDuration),
+				gen.SetCertificateRenewBefore(v.inputRenewBefore),
 				gen.SetCertificateCommonName("test.domain.com"),
 				gen.SetCertificateOrganization("test-org"),
 			)

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
@@ -77,10 +78,16 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 	It("should obtain a signed certificate for a single domain", func() {
 		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-		cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuer.Name, cmapi.IssuerKind, nil, nil)
-		cert.Spec.CommonName = rand.String(10) + ".venafi-e2e.example"
-
 		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{
+				Name: issuer.Name,
+				Kind: cmapi.IssuerKind,
+			}),
+			gen.SetCertificateCommonName(rand.String(10)+".venafi-e2e.example"),
+			gen.SetCertificateOrganization("test-org"),
+		)
 		cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -80,6 +80,7 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 
 		By("Creating a Certificate")
 		cert := gen.Certificate(certificateName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
 			gen.SetCertificateSecretName(certificateSecretName),
 			gen.SetCertificateIssuer(cmmeta.ObjectReference{
 				Name: issuer.Name,

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -89,8 +89,8 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				By("creating a certificate")
 				secretName := types.NamespacedName{Name: secretName, Namespace: f.Namespace.Name}
 				cert := gen.Certificate("serving-certs",
-					gen.SetCertificateSecretName(secretName.Name),
 					gen.SetCertificateNamespace(f.Namespace.Name),
+					gen.SetCertificateSecretName(secretName.Name),
 					gen.SetCertificateIssuer(cmmeta.ObjectReference{
 						Name: issuerName,
 						Kind: certmanager.IssuerKind,

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -88,8 +88,16 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 
 				By("creating a certificate")
 				secretName := types.NamespacedName{Name: secretName, Namespace: f.Namespace.Name}
-				cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
-				cert.Namespace = f.Namespace.Name
+				cert := gen.Certificate("serving-certs",
+					gen.SetCertificateSecretName(secretName.Name),
+					gen.SetCertificateNamespace(f.Namespace.Name),
+					gen.SetCertificateIssuer(cmmeta.ObjectReference{
+						Name: issuerName,
+						Kind: certmanager.IssuerKind,
+					}),
+					gen.SetCertificateCommonName("test.domain.com"),
+					gen.SetCertificateOrganization("test-org"),
+				)
 				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
 
 				cert, err := f.Helper().WaitForCertificateReadyAndDoneIssuing(cert, time.Minute*2)
@@ -294,8 +302,16 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				toCleanup = injectable
 
 				By("creating a certificate")
-				cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
-				cert.Namespace = f.Namespace.Name
+				cert := gen.Certificate("serving-certs",
+					gen.SetCertificateNamespace(f.Namespace.Name),
+					gen.SetCertificateSecretName(secretName.Name),
+					gen.SetCertificateIssuer(cmmeta.ObjectReference{
+						Name: issuerName,
+						Kind: certmanager.IssuerKind,
+					}),
+					gen.SetCertificateCommonName("test.domain.com"),
+					gen.SetCertificateOrganization("test-org"),
+				)
 				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
 
 				By("grabbing the corresponding secret")

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -162,34 +162,6 @@ func WaitForCRDToNotExist(client apiextensionsv1.CustomResourceDefinitionInterfa
 	})
 }
 
-// Deprecated: use test/unit/gen/Certificate in future
-func NewCertManagerBasicCertificate(name, secretName, issuerName string, issuerKind string, duration, renewBefore *metav1.Duration, dnsNames ...string) *v1.Certificate {
-	cn := "test.domain.com"
-	if len(dnsNames) > 0 {
-		cn = dnsNames[0]
-	}
-	return &v1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.CertificateSpec{
-			CommonName: cn,
-			DNSNames:   dnsNames,
-			Subject: &v1.X509Subject{
-				Organizations: []string{"test-org"},
-			},
-			SecretName:  secretName,
-			Duration:    duration,
-			RenewBefore: renewBefore,
-			PrivateKey:  &v1.CertificatePrivateKey{},
-			IssuerRef: cmmeta.ObjectReference{
-				Name: issuerName,
-				Kind: issuerKind,
-			},
-		},
-	}
-}
-
 // Deprecated: use test/unit/gen/CertificateRequest in future
 func NewCertManagerBasicCertificateRequest(name, issuerName string, issuerKind string, duration *metav1.Duration,
 	dnsNames []string, ips []net.IP, uris []string, keyAlgorithm x509.PublicKeyAlgorithm) (*v1.CertificateRequest, crypto.Signer, error) {

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -191,6 +191,9 @@ func SetCertificateRenewalTime(p metav1.Time) CertificateModifier {
 
 func SetCertificateOrganization(orgs ...string) CertificateModifier {
 	return func(ch *v1.Certificate) {
+		if ch.Spec.Subject == nil {
+			ch.Spec.Subject = &v1.X509Subject{}
+		}
 		ch.Spec.Subject.Organizations = orgs
 	}
 }

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -17,8 +17,6 @@ limitations under the License.
 package gen
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -126,15 +124,15 @@ func SetCertificateSecretTemplate(annotations, labels map[string]string) Certifi
 	}
 }
 
-func SetCertificateDuration(duration time.Duration) CertificateModifier {
+func SetCertificateDuration(duration *metav1.Duration) CertificateModifier {
 	return func(crt *v1.Certificate) {
-		crt.Spec.Duration = &metav1.Duration{Duration: duration}
+		crt.Spec.Duration = duration
 	}
 }
 
-func SetCertificateRenewBefore(renewBefore time.Duration) CertificateModifier {
+func SetCertificateRenewBefore(renewBefore *metav1.Duration) CertificateModifier {
 	return func(crt *v1.Certificate) {
-		crt.Spec.RenewBefore = &metav1.Duration{Duration: renewBefore}
+		crt.Spec.RenewBefore = renewBefore
 	}
 }
 


### PR DESCRIPTION
- `pki.GenerateTemplate` was already no longer used
- `testCA.Subjects`, `RootCAs.Subjects`: I replaced these with `clientCA.Equal(testCA)`
- `util.NewCertManagerBasicCertificate(`: I replaced this function with `gen.Certificate` (as described in the deprecation notice)

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
