### PR TITLE
Fix a memory bug in ldap's ParseDN function by disabling part of the functionality

### DIFF
--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -268,3 +268,12 @@ func TestMustKeepOrderInRawDerBytes(t *testing.T) {
 	assert.Equal(t, expectedRdnSeq, rdnSeq)
 	assert.Equal(t, subject, rdnSeq.String())
 }
+
+func TestShouldFailForHexDER(t *testing.T) {
+	_, err := ParseSubjectStringToRawDERBytes("DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF")
+	if err == nil {
+		t.Fatal("expected error, but got none")
+	}
+
+	assert.Contains(t, err.Error(), "unsupported distinguished name (DN) \"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF\": notation does not support x509.subject identities containing \"=#\"")
+}

--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -21,6 +21,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 )
@@ -66,6 +68,10 @@ var attributeTypeNames = map[string][]int{
 }
 
 func UnmarshalSubjectStringToRDNSequence(subject string) (pkix.RDNSequence, error) {
+	if strings.Contains(subject, "=#") {
+		return nil, fmt.Errorf("unsupported distinguished name (DN) %q: notation does not support x509.subject identities containing \"=#\"", subject)
+	}
+
 	dns, err := ldap.ParseDN(subject)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Quick fix for memory issues caused by github.com/go-asn1-ber/asn1-ber library.
Similar to https://github.com/notaryproject/notation-go/pull/275.
Will be superseded by #6761, the goal of this PR is to backport this quick fix to older cert-manager versions.

### Kind

/kind bug

### Release Note

```release-note
Bugfix: LiteralSubjects with a #= value can result in memory issues due to faulty DER parser (github.com/go-asn1-ber/asn1-ber).
```
