### PR TITLE
LiteralSubject: Add support for numeric OID subject attribute type

### DIFF
--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -79,8 +79,19 @@ func UnmarshalSubjectStringToRDNSequence(subject string) (pkix.RDNSequence, erro
 
 		atvs := make([]pkix.AttributeTypeAndValue, 0, len(ldapRelativeDN.Attributes))
 		for _, ldapATV := range ldapRelativeDN.Attributes {
+			oid, ok := attributeTypeNames[ldapATV.Type]
+			if !ok {
+				// If the attribute type is not known, we try to parse it as an OID.
+				// If it is not an OID, we set Type=nil
+
+				oid, err = ParseObjectIdentifier(ldapATV.Type)
+				if err != nil {
+					oid = nil
+				}
+			}
+
 			atvs = append(atvs, pkix.AttributeTypeAndValue{
-				Type:  attributeTypeNames[ldapATV.Type],
+				Type:  oid,
 				Value: ldapATV.Value,
 			})
 		}


### PR DESCRIPTION
This PR adds a missing feature to the UnmarshalSubjectStringToRDNSequence function: the ability to specify numeric OIDs as subject attribute type. Right now, an attribute type has to be chosen by name and only a small set of names is supported: https://github.com/cert-manager/cert-manager/blob/8d15b5e6a8d92803c286a3b55a0108ece4f3aee8/pkg/util/pki/subject.go#L55-L66

### Kind

/kind feature

### Release Note

```release-note
Add support for numeric OID types in LiteralSubject. Eg. "1.2.3.4=String Value"
```
