### PR TITLE
Fix broken best-practice e2e tests

### DIFF
--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -32,6 +32,7 @@ patches:
             namespaces:
               - bind
               - e2e-vault
+              - e2e-vault-mtls
               - gateway-system
               - ingress-nginx
               - pebble

--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -15,8 +15,8 @@
 #
 resources:
   - https://github.com/kyverno/policies/pod-security/enforce
-  - https://raw.githubusercontent.com/kyverno/policies/main/other/res/restrict-automount-sa-token/restrict-automount-sa-token.yaml
-  - https://github.com/kyverno/policies/raw/main//best-practices/require-ro-rootfs/require-ro-rootfs.yaml
+  - https://github.com/kyverno/policies/raw/main/other/restrict-automount-sa-token/restrict-automount-sa-token.yaml
+  - https://github.com/kyverno/policies/raw/main/best-practices/require-ro-rootfs/require-ro-rootfs.yaml
 
 patches:
   - target:

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -20,6 +20,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -85,6 +86,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -161,6 +163,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -206,6 +209,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -249,6 +253,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -302,6 +307,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -357,6 +363,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -408,6 +415,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -460,6 +468,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -512,6 +521,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -606,6 +616,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -649,6 +660,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -704,6 +716,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -771,6 +784,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -817,6 +831,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -864,6 +879,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -925,6 +941,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -998,6 +1015,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble
@@ -1047,6 +1065,7 @@ spec:
         namespaces:
         - bind
         - e2e-vault
+        - e2e-vault-mtls
         - gateway-system
         - ingress-nginx
         - pebble


### PR DESCRIPTION
The [ci-cert-manager-master-e2e-v1-28-bestpractice-install](https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-28-bestpractice-install) tests have been failing since we merged https://github.com/cert-manager/cert-manager/pull/6614 
The problem is that that Kyverno is blocking the installation of the additional vault server, configured for mTLS, which was introduced in that PR.

```sh
$ make E2E_SETUP_OPTION_BESTPRACTICE=true e2e-setup
...
$ make e2e GINKGO_FOCUS='Vault Issuer [mtls]'
...
resource StatefulSet/e2e-vault-mtls/chart-vault-vault-mtls was blocked due to the following policies

disallow-capabilities-strict:
  autogen-require-drop-all: 'validation failure: Containers must drop `ALL` capabilities.'
require-ro-rootfs:
  autogen-validate-readOnlyRootFilesystem: 'validation error: Root filesystem must
    be read-only. rule autogen-validate-readOnlyRootFilesystem failed at path /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem/'
restrict-automount-sa-token:
  autogen-validate-automountServiceAccountToken: 'validation error: Auto-mounting
    of Service Account tokens is not allowed. rule autogen-validate-automountServiceAccountToken
    failed at path /spec/template/spec/automountServiceAccountToken/'
restrict-seccomp-strict:
  autogen-check-seccomp-strict: 'validation error: Use of custom Seccomp profiles
    is disallowed. The fields spec.securityContext.seccompProfile.type, spec.containers[*].securityContext.seccompProfile.type,
    spec.initContainers[*].securityContext.seccompProfile.type, and spec.ephemeralContainers[*].securityContext.seccompProfile.type
    must be set to `RuntimeDefault` or `Localhost`. rule autogen-check-seccomp-strict[0]
    failed at path /spec/template/spec/securityContext/seccompProfile/ rule autogen-check-seccomp-strict[1]
    failed at path /spec/template/spec/containers/0/securityContext/seccompProfile/'
```

I've added it to the kustomization file, updated a broken URL and regenerated the policy.yaml file.

Tested locally as follows:

```sh
make E2E_SETUP_OPTION_BESTPRACTICE=true e2e-setup
make e2e GINKGO_FOCUS='Vault Issuer [mtls]'
```
 
```
...
Ran 9 of 801 Specs in 34.066 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 792 Skipped
--- PASS: TestE2E (34.20s)
PASS

Ginkgo ran 1 suite in 45.673100391s
Test Suite Passed
```
```release-note
NONE
```
