### PR TITLE
Fix broken json logging

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -32,13 +32,12 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 
 	"github.com/cert-manager/cert-manager/pkg/api"
 )
 
 var (
-	Log = textlogger.NewLogger(textlogger.NewConfig()).WithName("cert-manager")
+	Log = klog.TODO().WithName("cert-manager")
 )
 
 const (


### PR DESCRIPTION
Fixes https://github.com/cert-manager/cert-manager/issues/6768

In https://github.com/cert-manager/cert-manager/pull/6587 (https://github.com/cert-manager/cert-manager/pull/6587/files#diff-8f2f7b96261d29c4991c0025fde03c2edb0411a9aa7afaa834b5cf19837b5b2eL41), I updated the global `Log` definition in `log.go`.
I based the updated code on the deprecation message of the `klogr.NewWithOptions()` command that we were using.
It seems like the proposed replacement `textlogger.NewLogger(textlogger.NewConfig())` does not get updated when we parse & set the logging flags.

This PR fixes this bug by using `klog.Background()` instead.

Before:
```console
$ k -n cert-manager logs cert-manager-78dd8d6947-br2h8 
{"ts":1708504242845.5793,"caller":"clientcmd/client_config.go:618","msg":"Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.","v":0}
I0221 08:30:42.851118       1 options.go:248] "enabling all experimental certificatesigningrequest controllers" logger="cert-manager"
I0221 08:30:42.851135       1 options.go:253] "enabling the sig-network Gateway API certificate-shim and HTTP-01 solver" logger="cert-manager"
I0221 08:30:42.851148       1 controller.go:89] "enabled controllers: [certificaterequests-approver certificaterequests-issuer-acme certificaterequests-issuer-ca certificaterequests-issuer-selfsigned certificaterequests-issuer-vault certificaterequests-issuer-venafi certificates-issuing certificates-key-manager certificates-metrics certificates-readiness certificates-request-manager certificates-revision-manager certificates-trigger certificatesigningrequests-issuer-acme certificatesigningrequests-issuer-ca certificatesigningrequests-issuer-selfsigned certificatesigningrequests-issuer-vault certificatesigningrequests-issuer-venafi challenges clusterissuers gateway-shim ingress-shim issuers orders]" logger="cert-manager.controller"
{"ts":1708504242853.3452,"caller":"leaderelection/leaderelection.go:250","msg":"attempting to acquire leader lease kube-system/cert-manager-controller...","v":0}
```

After:
```console
$ k -n cert-manager logs cert-manager-78dd8d6947-64kcb 
{"ts":1708504356076.2844,"caller":"app/controller.go:288","msg":"configured acme dns01 nameservers","v":2,"logger":"cert-manager.controller.build-context","nameservers":["10.0.0.16:53"]}
{"ts":1708504356076.3547,"caller":"clientcmd/client_config.go:618","msg":"Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.","v":0}
{"ts":1708504356085.3008,"caller":"options/options.go:248","msg":"enabling all experimental certificatesigningrequest controllers","v":0,"logger":"cert-manager"}
{"ts":1708504356085.322,"caller":"options/options.go:253","msg":"enabling the sig-network Gateway API certificate-shim and HTTP-01 solver","v":0,"logger":"cert-manager"}
{"ts":1708504356085.3352,"caller":"app/controller.go:89","msg":"enabled controllers: [certificaterequests-approver certificaterequests-issuer-acme certificaterequests-issuer-ca certificaterequests-issuer-selfsigned certificaterequests-issuer-vault certificaterequests-issuer-venafi certificates-issuing certificates-key-manager certificates-metrics certificates-readiness certificates-request-manager certificates-revision-manager certificates-trigger certificatesigningrequests-issuer-acme certificatesigningrequests-issuer-ca certificatesigningrequests-issuer-selfsigned certificatesigningrequests-issuer-vault certificatesigningrequests-issuer-venafi challenges clusterissuers gateway-shim ingress-shim issuers orders]","v":0,"logger":"cert-manager.controller"}
{"ts":1708504356085.3403,"caller":"app/controller.go:435","msg":"serving insecurely as tls certificate data not provided","v":1,"logger":"cert-manager.controller"}
{"ts":1708504356085.345,"caller":"app/controller.go:102","msg":"listening for insecure connections","v":2,"logger":"cert-manager.controller","address":"0.0.0.0:9402"}
{"ts":1708504356085.5166,"caller":"app/controller.go:182","msg":"starting leader election","v":2,"logger":"cert-manager.controller"}
{"ts":1708504356085.534,"caller":"app/controller.go:129","msg":"starting metrics server","v":2,"logger":"cert-manager.controller","address":"[::]:9402"}
{"ts":1708504356085.5508,"caller":"app/controller.go:175","msg":"starting healthz server","v":2,"logger":"cert-manager.controller","address":"[::]:9403"}
{"ts":1708504356087.196,"caller":"leaderelection/leaderelection.go:250","msg":"attempting to acquire leader lease kube-system/cert-manager-controller...","v":0}
```


### Kind

/kind bug

### Release Note

```release-note
BUGFIX: Fixes issue with JSON-logging, where only a subset of the log messages were output as JSON.
```
