### PR TITLE
Limit the memory allocation when parsing ber encoded components in the LiteralSubject field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go v1.49.13
 	github.com/cpu/goacmedns v0.1.1
 	github.com/digitalocean/godo v1.107.0
+	github.com/go-asn1-ber/asn1-ber v1.5.5
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-logr/logr v1.4.1
 	github.com/google/gnostic-models v0.6.8
@@ -77,7 +78,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/frankban/quicktest v1.14.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -275,5 +275,5 @@ func TestShouldFailForHexDER(t *testing.T) {
 		t.Fatal("expected error, but got none")
 	}
 
-	assert.Contains(t, err.Error(), "unsupported distinguished name (DN) \"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF\": notation does not support x509.subject identities containing \"=#\"")
+	assert.Contains(t, err.Error(), "failed to decode BER packet: length 1665734689 greater than maximum 65536")
 }


### PR DESCRIPTION
The go-ldap and asn-ber libraries both limit the message length in their fuzz tests because the default limit is 2GiB which crashes their test runners: 

* https://github.com/go-ldap/ldap/blob/25b14db0ff3f3c0e927771e4441cdf61400367fd/fuzz_test.go#L13-L21
* https://github.com/go-asn1-ber/asn1-ber/blob/master/fuzz_test.go#L33C1-L37

We can set the same limit before invoking `ParseDN` to avoid 2GiB memory being accidentally or maliciously allocated in the webhook component every time a LiteralSubject field value gets parsed.

I prefer this small change to the proposed re-implementation of `ParseDN` in https://github.com/cert-manager/cert-manager/pull/6761 because it allows us to continue using go-ldap library which I predict will do a better job than us of parsing these Subject strings which are compatible with a wide range of LDAP systems.

xref: 
 * https://github.com/cert-manager/cert-manager/pull/6761
 * https://github.com/cert-manager/cert-manager/pull/6770
 * https://github.com/go-ldap/ldap/issues/487

/kind bug

```release-note
Mitigate a potential DoS against the webhook component, by limiting the maximum length of `ber` encoded literal subject field to 64KiB. Only affects those using the LiteralSubject feature.
```
