### PR TITLE
Refactor the webhook dynamic source and add unit tests

### DIFF
--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -146,7 +147,7 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 		// this poll only ends when stopCh is closed.
 		return false, nil
 	}); err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			// context was cancelled, return nil
 			return nil
 		}

--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -84,7 +84,7 @@ type DynamicAuthority struct {
 	ensureMutex sync.Mutex
 	// watchMutex gates access to the slice of watch channels
 	watchMutex sync.Mutex
-	watches    []chan struct{}
+	watches    []chan<- struct{}
 }
 
 type SignFunc func(template *x509.Certificate) (*x509.Certificate, error)
@@ -146,8 +146,15 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 		// this poll only ends when stopCh is closed.
 		return false, nil
 	}); err != nil {
+		if err == context.Canceled {
+			// context was cancelled, return nil
+			return nil
+		}
+
 		return err
 	}
+
+	factory.Shutdown()
 
 	return nil
 }
@@ -207,24 +214,25 @@ func (d *DynamicAuthority) Sign(template *x509.Certificate) (*x509.Certificate, 
 // certificate is rotated/updated.
 // This can be used to automatically trigger rotation of leaf certificates
 // when the root CA changes.
-func (d *DynamicAuthority) WatchRotation(stopCh <-chan struct{}) <-chan struct{} {
+func (d *DynamicAuthority) WatchRotation(output chan<- struct{}) {
 	d.watchMutex.Lock()
 	defer d.watchMutex.Unlock()
-	ch := make(chan struct{}, 1)
-	d.watches = append(d.watches, ch)
-	go func() {
-		defer close(ch)
-		<-stopCh
-		d.watchMutex.Lock()
-		defer d.watchMutex.Unlock()
-		for i, c := range d.watches {
-			if c == ch {
-				d.watches = append(d.watches[:i], d.watches[i+1:]...)
-				return
-			}
+
+	// Add the output channel to the list of watches
+	d.watches = append(d.watches, output)
+}
+
+func (d *DynamicAuthority) StopWatchingRotation(output chan<- struct{}) {
+	d.watchMutex.Lock()
+	defer d.watchMutex.Unlock()
+
+	// Remove the output channel from the list of watches
+	for i, c := range d.watches {
+		if c == output {
+			d.watches = append(d.watches[:i], d.watches[i+1:]...)
+			return
 		}
-	}()
-	return ch
+	}
 }
 
 func (d *DynamicAuthority) ensureCA(ctx context.Context) error {
@@ -253,21 +261,25 @@ func (d *DynamicAuthority) notifyWatches(newCertData, newPrivateKeyData []byte) 
 
 	d.log.V(logf.DebugLevel).Info("Detected change in CA secret data, notifying watchers...")
 
-	d.watchMutex.Lock()
-	defer d.watchMutex.Unlock()
-	for _, ch := range d.watches {
-		// the watch channels have a buffer of 1 - drop events to slow
-		// consumers
-		select {
-		case ch <- struct{}{}:
-		default:
+	func() {
+		d.watchMutex.Lock()
+		defer d.watchMutex.Unlock()
+		for _, ch := range d.watches {
+			// the watch channels have a buffer of 1 - drop events to slow
+			// consumers
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
 		}
-	}
+	}()
 
-	d.signMutex.Lock()
-	defer d.signMutex.Unlock()
-	d.currentCertData = newCertData
-	d.currentPrivateKeyData = newPrivateKeyData
+	func() {
+		d.signMutex.Lock()
+		defer d.signMutex.Unlock()
+		d.currentCertData = newCertData
+		d.currentPrivateKeyData = newPrivateKeyData
+	}()
 }
 
 // caRequiresRegeneration will check data in a Secret resource and return true
@@ -303,7 +315,7 @@ func (d *DynamicAuthority) caRequiresRegeneration(s *corev1.Secret) bool {
 		return true
 	}
 	// renew the root CA when the current one is 2/3 of the way through its life
-	if x509Cert.NotAfter.Sub(time.Now()) < (d.CADuration / 3) {
+	if time.Until(x509Cert.NotAfter) < (x509Cert.NotBefore.Sub(x509Cert.NotAfter) / 3) {
 		d.log.V(logf.InfoLevel).Info("Root CA certificate is nearing expiry. Regenerating...")
 		return true
 	}

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -108,7 +109,7 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 			return err
 		}
 
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 
@@ -191,7 +192,7 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 			return err
 		}
 
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -71,15 +71,7 @@ type DynamicSource struct {
 
 var _ CertificateSource = &DynamicSource{}
 
-// Copied from https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L287
-var _ interface {
-	Start(context.Context) error
-} = &DynamicSource{}
-
-var _ interface {
-	NeedLeaderElection() bool
-} = &DynamicSource{}
-
+// Implements Runnable (https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L287)
 func (f *DynamicSource) Start(ctx context.Context) error {
 	f.log = logf.FromContext(ctx)
 
@@ -209,6 +201,7 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 	return nil
 }
 
+// Implements LeaderElectionRunnable (https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L305)
 func (f *DynamicSource) NeedLeaderElection() bool {
 	return false
 }

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -26,13 +26,31 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/server/tls/authority"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
+
+type Authority interface {
+	// Run starts the authority and blocks until it is stopped or an error occurs.
+	Run(ctx context.Context) error
+
+	// WatchRotation adds a watcher to the authority that will notify the given
+	// channel when the root CA has been rotated. It is guaranteed to post a message
+	// to the channel when the root CA has been rotated and the channel is not full.
+	WatchRotation(ch chan<- struct{})
+
+	// StopWatchingRotation removes the watcher from the authority.
+	StopWatchingRotation(ch chan<- struct{})
+
+	// Sign signs the given certificate template and returns the signed certificate.
+	// WARNING: The WatchRotation method should be called before Sign to ensure that
+	// the rotation of the CA used to sign the certificate in this call is detected.
+	Sign(template *x509.Certificate) (*x509.Certificate, error)
+}
 
 // DynamicSource provides certificate data for a golang HTTP server by
 // automatically generating certificates using an authority.SignFunc.
@@ -41,7 +59,9 @@ type DynamicSource struct {
 	DNSNames []string
 
 	// The authority used to sign certificate templates.
-	Authority *authority.DynamicAuthority
+	Authority Authority
+
+	RetryInterval time.Duration
 
 	log logr.Logger
 
@@ -51,136 +71,146 @@ type DynamicSource struct {
 
 var _ CertificateSource = &DynamicSource{}
 
+// Copied from https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L287
+var _ interface {
+	Start(context.Context) error
+} = &DynamicSource{}
+
+var _ interface {
+	NeedLeaderElection() bool
+} = &DynamicSource{}
+
 func (f *DynamicSource) Start(ctx context.Context) error {
 	f.log = logf.FromContext(ctx)
 
-	// Run the authority in a separate goroutine
-	authorityErrChan := make(chan error)
-	go func() {
-		defer close(authorityErrChan)
-		authorityErrChan <- f.Authority.Run(ctx)
-	}()
+	if f.RetryInterval == 0 {
+		f.RetryInterval = 1 * time.Second
+	}
+
+	group, ctx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		if err := f.Authority.Run(ctx); err != nil {
+			return fmt.Errorf("failed to run certificate authority: %w", err)
+		}
+
+		if ctx.Err() == nil {
+			return fmt.Errorf("certificate authority stopped unexpectedly")
+		}
+
+		// Context was cancelled, return nil
+		return nil
+	})
+
+	// channel which will be notified when the authority has rotated its root CA
+	// We start watching the rotation of the root CA before we start generating
+	// certificates to ensure we don't miss any rotations.
+	rotationChan := make(chan struct{}, 1)
+	f.Authority.WatchRotation(rotationChan)
+	defer f.Authority.StopWatchingRotation(rotationChan)
 
 	nextRenewCh := make(chan time.Time, 1)
 
 	// initially fetch a certificate from the signing CA
-	interval := time.Second
-	if err := wait.PollUntilContextCancel(ctx, interval, true, func(ctx context.Context) (done bool, err error) {
-		// check for errors from the authority here too, to prevent retrying
-		// if the authority has failed to start
-		select {
-		case err, ok := <-authorityErrChan:
-			if err != nil {
-				return true, fmt.Errorf("failed to run certificate authority: %w", err)
-			}
-			if !ok {
-				return true, context.Canceled
-			}
-		default:
-			// this case avoids blocking if the authority is still running
+	if err := f.tryRegenerateCertificate(ctx, nextRenewCh); err != nil {
+		if err := group.Wait(); err != nil {
+			return err
 		}
 
-		if err := f.regenerateCertificate(nextRenewCh); err != nil {
-			f.log.Error(err, "Failed to generate initial serving certificate, retrying...", "interval", interval)
-			return false, nil
+		if err == context.Canceled {
+			return nil
 		}
-		return true, nil
-	}); err != nil {
-		// In case of an error, the stopCh is closed; wait for authorityErrChan to be closed too
-		<-authorityErrChan
 
 		return err
 	}
 
-	// watch for changes to the root CA
-	rotationChan := f.Authority.WatchRotation(ctx.Done())
-	renewalChan := func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			defer close(ch)
+	// channel which will be notified when the leaf certificate reaches 2/3 of its lifetime
+	// and needs to be renewed
+	renewalChan := make(chan struct{})
+	group.Go(func() error {
+		// At this point, we expect to have one renewal moment
+		// in the channel, so we can start the timer with that value
+		var renewMoment time.Time
+		select {
+		case renewMoment = <-nextRenewCh:
+			// We recevieved a renew moment
+		default:
+			// This should never happen
+			panic("Unreacheable")
+		}
 
-			var renewMoment time.Time
-			select {
-			case renewMoment = <-nextRenewCh:
-				// We recevieved a renew moment
-			default:
-				// This should never happen
-				panic("Unreacheable")
-			}
-
-			for {
+		for {
+			if done := func() bool {
 				timer := time.NewTimer(time.Until(renewMoment))
 				defer timer.Stop()
 
+				// Wait for the timer to expire, or for a new renewal moment to be received
 				select {
 				case <-ctx.Done():
-					return
+					// context was cancelled, return nil
+					return true
 				case <-timer.C:
-					// Try to send a message on ch, but also allow for a stop signal or
-					// a new renewMoment to be received
-					select {
-					case <-ctx.Done():
-						return
-					case ch <- struct{}{}:
-						// Message was sent on channel
-					case renewMoment = <-nextRenewCh:
-						// We recevieved a renew moment, next loop iteration will update the timer
-					}
+					// Continue to the next select to try to send a message on renewalChan
 				case renewMoment = <-nextRenewCh:
 					// We recevieved a renew moment, next loop iteration will update the timer
+					return false
 				}
-			}
-		}()
-		return ch
-	}()
 
-	// check the current certificate every 10s in case it needs updating
-	if err := wait.PollUntilContextCancel(ctx, time.Second*10, true, func(ctx context.Context) (done bool, err error) {
-		// regenerate the serving certificate if the root CA has been rotated
-		select {
-		// if the authority has stopped for whatever reason, exit and return the error
-		case err, ok := <-authorityErrChan:
-			if err != nil {
-				return true, fmt.Errorf("failed to run certificate authority: %w", err)
+				// Try to send a message on renewalChan, but also allow for the context to be
+				// cancelled.
+				select {
+				case <-ctx.Done():
+					// context was cancelled, return nil
+					return true
+				case renewalChan <- struct{}{}:
+					// Message was sent on channel
+				}
+
+				return false
+			}(); done {
+				return nil
 			}
-			if !ok {
-				return true, context.Canceled
-			}
-		// trigger regeneration if the root CA has been rotated
-		case _, ok := <-rotationChan:
-			if !ok {
-				return true, context.Canceled
-			}
-			f.log.V(logf.InfoLevel).Info("Detected root CA rotation - regenerating serving certificates")
-			if err := f.regenerateCertificate(nextRenewCh); err != nil {
-				f.log.Error(err, "Failed to regenerate serving certificate")
-				// Return an error here and stop the source running - this case should never
-				// occur, and if it does, indicates some form of internal error.
-				return false, err
-			}
-		// trigger regeneration if a renewal is required
-		case <-renewalChan:
-			f.log.V(logf.InfoLevel).Info("cert-manager webhook certificate requires renewal, regenerating", "DNSNames", f.DNSNames)
-			if err := f.regenerateCertificate(nextRenewCh); err != nil {
-				f.log.Error(err, "Failed to regenerate serving certificate")
-				// Return an error here and stop the source running - this case should never
-				// occur, and if it does, indicates some form of internal error.
-				return false, err
-			}
-		case <-ctx.Done():
-			return true, context.Canceled
 		}
-		return false, nil
-	}); err != nil {
-		// In case of an error, the stopCh is closed; wait for all channels to close
-		<-authorityErrChan
-		<-rotationChan
-		<-renewalChan
+	})
+
+	// check the current certificate in case it needs updating
+	if err := func() error {
+		for {
+			// regenerate the serving certificate if the root CA has been rotated
+			select {
+			// check if the context has been cancelled
+			case <-ctx.Done():
+				return ctx.Err()
+
+			// trigger regeneration if the root CA has been rotated
+			case <-rotationChan:
+				f.log.V(logf.InfoLevel).Info("Detected root CA rotation - regenerating serving certificates")
+
+			// trigger regeneration if a renewal is required
+			case <-renewalChan:
+				f.log.V(logf.InfoLevel).Info("cert-manager webhook certificate requires renewal, regenerating", "DNSNames", f.DNSNames)
+			}
+
+			if err := f.tryRegenerateCertificate(ctx, nextRenewCh); err != nil {
+				return err
+			}
+		}
+	}(); err != nil {
+		if err := group.Wait(); err != nil {
+			return err
+		}
+
+		if err == context.Canceled {
+			return nil
+		}
 
 		return err
 	}
 
 	return nil
+}
+
+func (f *DynamicSource) NeedLeaderElection() bool {
+	return false
 }
 
 func (f *DynamicSource) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -194,6 +224,17 @@ func (f *DynamicSource) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, 
 
 func (f *DynamicSource) Healthy() bool {
 	return f.cachedCertificate != nil
+}
+
+func (f *DynamicSource) tryRegenerateCertificate(ctx context.Context, nextRenewCh chan<- time.Time) error {
+	return wait.PollUntilContextCancel(ctx, f.RetryInterval, true, func(ctx context.Context) (done bool, err error) {
+		if err := f.regenerateCertificate(nextRenewCh); err != nil {
+			f.log.Error(err, "Failed to generate serving certificate, retrying...", "interval", f.RetryInterval)
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 // regenerateCertificate will trigger the cached certificate and private key to
@@ -223,13 +264,10 @@ func (f *DynamicSource) regenerateCertificate(nextRenew chan<- time.Time) error 
 
 	f.log.V(logf.DebugLevel).Info("Signed new serving certificate")
 
-	if err := f.updateCertificate(pk, cert, nextRenew); err != nil {
-		return err
-	}
-	return nil
+	return f.updateCertificate(pk, cert, nextRenew)
 }
 
-func (f *DynamicSource) updateCertificate(pk crypto.Signer, cert *x509.Certificate, nextRenew chan<- time.Time) error {
+func (f *DynamicSource) updateCertificate(pk crypto.Signer, cert *x509.Certificate, nextRenewCh chan<- time.Time) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -251,7 +289,7 @@ func (f *DynamicSource) updateCertificate(pk crypto.Signer, cert *x509.Certifica
 	f.cachedCertificate = &bundle
 	certDuration := cert.NotAfter.Sub(cert.NotBefore)
 	// renew the certificate 1/3 of the time before its expiry
-	nextRenew <- cert.NotAfter.Add(certDuration / -3)
+	nextRenewCh <- cert.NotAfter.Add(certDuration / -3)
 	f.log.V(logf.InfoLevel).Info("Updated cert-manager TLS certificate", "DNSNames", f.DNSNames)
 
 	return nil

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/pkg/server/tls/authority"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func signUsingTempCA(t *testing.T, template *x509.Certificate) *x509.Certificate {
+	// generate random ca private key
+	caPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caCRT := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	_, cert, err := pki.SignCertificate(template, caCRT, template.PublicKey.(crypto.PublicKey), caPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cert
+}
+
+type mockAuthority struct {
+	doneCh   chan error
+	notifyCh chan<- struct{}
+	signFunc authority.SignFunc
+}
+
+func (m *mockAuthority) Run(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-m.doneCh:
+		return err
+	}
+}
+
+func (m *mockAuthority) WatchRotation(ch chan<- struct{}) {
+	m.notifyCh = ch
+}
+
+func (m *mockAuthority) StopWatchingRotation(ch chan<- struct{}) {}
+
+func (m *mockAuthority) Sign(template *x509.Certificate) (*x509.Certificate, error) {
+	return m.signFunc(template)
+}
+
+func TestDynamicSource_FailingSign(t *testing.T) {
+	type testCase struct {
+		name        string
+		signFunc    authority.SignFunc
+		testFn      func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority)
+		cancelAtEnd bool
+		expStartErr string
+	}
+
+	tests := []testCase{
+		{
+			name: "sign function returns error",
+			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
+				return nil, fmt.Errorf("mock error")
+			},
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				// Call the GetCertificate method, should return a non-ready error
+				cert, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.Nil(t, cert)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "no tls.Certificate available")
+
+				// The authority is now failing because of the faulty sign function,
+				// we now stop the authority and wait for the DynamicSource to stop
+				mockAuth.doneCh <- fmt.Errorf("mock error")
+			},
+			expStartErr: "mock error",
+		},
+		{
+			name: "certificate authority stopped unexpectedly",
+			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
+				return nil, fmt.Errorf("mock error")
+			},
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				// Stop the authority
+				mockAuth.doneCh <- nil
+			},
+			expStartErr: "certificate authority stopped unexpectedly",
+		},
+		{
+			name: "sign function returns error (retry, then success)",
+			signFunc: func() authority.SignFunc {
+				var called int
+				return func(template *x509.Certificate) (*x509.Certificate, error) {
+					called++
+					if called != 5 {
+						return nil, fmt.Errorf("mock error")
+					}
+
+					template.Version = 3
+					template.SerialNumber = big.NewInt(10)
+					template.NotBefore = time.Now()
+					template.NotAfter = template.NotBefore.Add(time.Minute)
+
+					return signUsingTempCA(t, template), nil
+				}
+			}(),
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				for !source.Healthy() {
+					time.Sleep(50 * time.Millisecond)
+				}
+
+				// Call the GetCertificate method, should return a certificate
+				cert, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.NoError(t, err)
+				assert.NotNil(t, cert)
+			},
+			cancelAtEnd: true,
+		},
+		{
+			name: "don't rotate root",
+			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
+				template.Version = 3
+				template.SerialNumber = big.NewInt(10)
+				template.NotBefore = time.Now()
+				template.NotAfter = template.NotBefore.Add(time.Minute)
+
+				return signUsingTempCA(t, template), nil
+			},
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				for !source.Healthy() {
+					time.Sleep(50 * time.Millisecond)
+				}
+
+				// Call the GetCertificate method, should return a certificate
+				cert, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.NoError(t, err)
+				assert.NotNil(t, cert)
+
+				// Sleep for a short time to allow the DynamicSource to generate a new certificate
+				// Which it should not do, as the root CA has not been rotated
+				time.Sleep(50 * time.Millisecond)
+
+				// Call the GetCertificate method, should return a NEW certificate
+				cert2, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.NoError(t, err)
+				assert.NotNil(t, cert2)
+
+				assert.Equal(t, cert.Certificate[0], cert2.Certificate[0])
+			},
+			cancelAtEnd: true,
+		},
+		{
+			name: "rotate root",
+			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
+				template.Version = 3
+				template.SerialNumber = big.NewInt(10)
+				template.NotBefore = time.Now()
+				template.NotAfter = template.NotBefore.Add(time.Minute)
+
+				return signUsingTempCA(t, template), nil
+			},
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				for !source.Healthy() {
+					time.Sleep(50 * time.Millisecond)
+				}
+
+				// Call the GetCertificate method, should return a certificate
+				cert, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.NoError(t, err)
+				assert.NotNil(t, cert)
+
+				for i := 0; i < 10; i++ {
+					// Rotate the root
+					mockAuth.notifyCh <- struct{}{}
+
+					// Sleep for a short time to allow the DynamicSource to generate a new certificate
+					time.Sleep(50 * time.Millisecond)
+
+					// Call the GetCertificate method, should return a NEW certificate
+					cert2, err := source.GetCertificate(&tls.ClientHelloInfo{})
+					assert.NoError(t, err)
+					assert.NotNil(t, cert2)
+
+					assert.NotEqual(t, cert.Certificate[0], cert2.Certificate[0])
+				}
+			},
+			cancelAtEnd: true,
+		},
+		{
+			name: "expire leaf",
+			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
+				template.Version = 3
+				template.SerialNumber = big.NewInt(10)
+				template.NotBefore = time.Now()
+				template.NotAfter = template.NotBefore.Add(150 * time.Millisecond)
+
+				signedCert := signUsingTempCA(t, template)
+				// Reset the NotBefor and NotAfter so we have high percision values here
+				signedCert.NotBefore = time.Now()
+				signedCert.NotAfter = signedCert.NotBefore.Add(150 * time.Millisecond)
+
+				// Should renew at 100ms after the NotBefore time
+
+				return signedCert, nil
+			},
+			testFn: func(t *testing.T, source *DynamicSource, mockAuth *mockAuthority) {
+				for !source.Healthy() {
+					time.Sleep(50 * time.Millisecond)
+				}
+
+				// Call the GetCertificate method, should return a certificate
+				cert, err := source.GetCertificate(&tls.ClientHelloInfo{})
+				assert.NoError(t, err)
+				assert.NotNil(t, cert)
+
+				for i := 0; i < 5; i++ {
+					// Sleep for a short time to allow the DynamicSource to generate a new certificate
+					time.Sleep(100 * time.Millisecond)
+
+					// Call the GetCertificate method, should return a NEW certificate
+					cert2, err := source.GetCertificate(&tls.ClientHelloInfo{})
+					assert.NoError(t, err)
+					assert.NotNil(t, cert2)
+
+					assert.NotEqual(t, cert.Certificate[0], cert2.Certificate[0])
+				}
+			},
+			cancelAtEnd: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a mock authority
+			mockAuth := &mockAuthority{
+				doneCh:   make(chan error),
+				signFunc: tc.signFunc,
+			}
+
+			// Create a DynamicSource instance with the mock authority
+			source := &DynamicSource{
+				Authority:     mockAuth,
+				RetryInterval: 1 * time.Millisecond,
+			}
+
+			// Start the DynamicSource
+			ctx, cancel := context.WithCancel(context.Background())
+			group, gctx := errgroup.WithContext(ctx)
+			group.Go(func() error {
+				return source.Start(gctx)
+			})
+			t.Cleanup(func() {
+				if tc.cancelAtEnd {
+					cancel()
+				} else {
+					defer cancel()
+				}
+				err := group.Wait()
+				if tc.expStartErr == "" {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tc.expStartErr)
+				}
+			})
+
+			tc.testFn(t, source, mockAuth)
+		})
+	}
+}

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -113,9 +113,10 @@ func TestDynamicSource_CARotation(t *testing.T) {
 
 	kubeClient, _, _, _, _ := framework.NewClients(t, config)
 
-	namespace := "testns"
+	secretName := "testsecret"
+	secretNamespace := "testns"
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secretNamespace}}
 	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -124,8 +125,8 @@ func TestDynamicSource_CARotation(t *testing.T) {
 	source := tls.DynamicSource{
 		DNSNames: []string{"example.com"},
 		Authority: &authority.DynamicAuthority{
-			SecretNamespace: namespace,
-			SecretName:      "testsecret",
+			SecretName:      secretName,
+			SecretNamespace: secretNamespace,
 			RESTConfig:      config,
 		},
 	}
@@ -175,7 +176,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 	}
 
 	cl := kubernetes.NewForConfigOrDie(config)
-	if err := cl.CoreV1().Secrets(source.Authority.SecretNamespace).Delete(ctx, source.Authority.SecretName, metav1.DeleteOptions{}); err != nil {
+	if err := cl.CoreV1().Secrets(secretNamespace).Delete(ctx, secretName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete CA secret: %v", err)
 	}
 


### PR DESCRIPTION
- Adds unit tests to increase our confidence in the dynamic source logic.
- Simplifies the source by replacing a lot of the channels with an errgroup

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
