### PR TITLE
fix: SecretName description for DynamicServingConfig

### DIFF
--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -279,7 +279,7 @@ type DynamicServingConfig struct {
 	// used as a CA to sign dynamic serving certificates.
 	SecretNamespace string
 
-	// Namespace of the Kubernetes Secret resource containing the TLS certificate
+	// Secret resource name containing the TLS certificate
 	// used as a CA to sign dynamic serving certificates.
 	SecretName string
 

--- a/internal/apis/config/webhook/types.go
+++ b/internal/apis/config/webhook/types.go
@@ -111,7 +111,7 @@ type DynamicServingConfig struct {
 	// used as a CA to sign dynamic serving certificates.
 	SecretNamespace string
 
-	// Namespace of the Kubernetes Secret resource containing the TLS certificate
+	// Kubernetes Secret resource containing the TLS certificate
 	// used as a CA to sign dynamic serving certificates.
 	SecretName string
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -285,7 +285,7 @@ type DynamicServingConfig struct {
 	// used as a CA to sign dynamic serving certificates.
 	SecretNamespace string `json:"secretNamespace,omitempty"`
 
-	// Namespace of the Kubernetes Secret resource containing the TLS certificate
+	// Secret resource name containing the TLS certificate
 	// used as a CA to sign dynamic serving certificates.
 	SecretName string `json:"secretName,omitempty"`
 

--- a/pkg/apis/config/webhook/v1alpha1/types.go
+++ b/pkg/apis/config/webhook/v1alpha1/types.go
@@ -99,7 +99,7 @@ type DynamicServingConfig struct {
 	// used as a CA to sign dynamic serving certificates.
 	SecretNamespace string `json:"secretNamespace,omitempty"`
 
-	// Namespace of the Kubernetes Secret resource containing the TLS certificate
+	// Secret resource name containing the TLS certificate
 	// used as a CA to sign dynamic serving certificates.
 	SecretName string `json:"secretName,omitempty"`
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

On the DynamicServingConfig/TLSConfig are specifying the same secretNamespace description for the secretName attribute.
[DynamicServingConfig](https://cert-manager.io/docs/reference/api-docs/#webhook.config.cert-manager.io/v1alpha1.DynamicServingConfig)
replace: [cert-manager/website PR 1419](https://github.com/cert-manager/website/pull/1419)

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->
documentation

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
