### PR TITLE
Helm: fix matchLabels selector - select on minimum subset of labels that uniquely identifies the resources

### DIFF
--- a/deploy/charts/cert-manager/templates/networkpolicy-egress.yaml
+++ b/deploy/charts/cert-manager/templates/networkpolicy-egress.yaml
@@ -11,13 +11,9 @@ spec:
     {{- end }}
   podSelector:
     matchLabels:
-      app: {{ include "webhook.name" . }}
       app.kubernetes.io/name: {{ include "webhook.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
-      {{- with .Values.webhook.podLabels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
   policyTypes:
   - Egress
 {{- end }}

--- a/deploy/charts/cert-manager/templates/networkpolicy-webhooks.yaml
+++ b/deploy/charts/cert-manager/templates/networkpolicy-webhooks.yaml
@@ -12,13 +12,9 @@ spec:
     {{- end }}
   podSelector:
     matchLabels:
-      app: {{ include "webhook.name" . }}
       app.kubernetes.io/name: {{ include "webhook.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: "webhook"
-      {{- with .Values.webhook.podLabels }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
   policyTypes:
   - Ingress
 


### PR DESCRIPTION
The NetworkPolicy `podSelector.matchLabels` contains too many labels, which makes it more brittle.
Ideally, we specify a minimum subset of labels that uniquely identifies the resources it should select.

This is a safe change, matchLabels on a NetworkPolicy is much less of a beast than matchLabels on a Deployment.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
