### PR TITLE
[release-1.12] bugfix: include all CA certificates in encoded pkcs12/jks stores

### DIFF
--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -51,7 +51,7 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 	}
 	var cas []*x509.Certificate
 	if len(caPem) > 0 {
-		cas, err = pki.DecodeX509CertificateChainBytes(caPem)
+		cas, err = pki.DecodeX509CertificateSetBytes(caPem)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +65,7 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 }
 
 func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
-	cas, err := pki.DecodeX509CertificateChainBytes(caPem)
+	cas, err := pki.DecodeX509CertificateSetBytes(caPem)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func encodeJKSTruststore(password []byte, caPem []byte) ([]byte, error) {
 }
 
 func addCAsToJKSStore(ks *jks.KeyStore, caPem []byte) error {
-	cas, err := pki.DecodeX509CertificateChainBytes(caPem)
+	cas, err := pki.DecodeX509CertificateSetBytes(caPem)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/x509"
+	"fmt"
 	"time"
 
 	jks "github.com/pavlo-v-chernykh/keystore-go/v4"
@@ -64,12 +65,11 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 }
 
 func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
-	ca, err := pki.DecodeX509CertificateBytes(caPem)
+	cas, err := pki.DecodeX509CertificateChainBytes(caPem)
 	if err != nil {
 		return nil, err
 	}
 
-	var cas = []*x509.Certificate{ca}
 	return pkcs12.EncodeTrustStore(rand.Reader, cas, password)
 }
 
@@ -98,25 +98,19 @@ func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []b
 	}
 
 	ks := jks.New()
-	ks.SetPrivateKeyEntry("certificate", jks.PrivateKeyEntry{
+	if err = ks.SetPrivateKeyEntry("certificate", jks.PrivateKeyEntry{
 		CreationTime:     time.Now(),
 		PrivateKey:       keyDER,
 		CertificateChain: certs,
-	}, password)
+	}, password); err != nil {
+		return nil, err
+	}
 
 	// add the CA certificate, if set
 	if len(caPem) > 0 {
-		ca, err := pki.DecodeX509CertificateBytes(caPem)
-		if err != nil {
+		if err := addCAsToJKSStore(&ks, caPem); err != nil {
 			return nil, err
 		}
-		ks.SetTrustedCertificateEntry("ca", jks.TrustedCertificateEntry{
-			CreationTime: time.Now(),
-			Certificate: jks.Certificate{
-				Type:    "X509",
-				Content: ca.Raw,
-			}},
-		)
 	}
 
 	buf := &bytes.Buffer{}
@@ -127,23 +121,38 @@ func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []b
 }
 
 func encodeJKSTruststore(password []byte, caPem []byte) ([]byte, error) {
-	ca, err := pki.DecodeX509CertificateBytes(caPem)
-	if err != nil {
+	ks := jks.New()
+	if err := addCAsToJKSStore(&ks, caPem); err != nil {
 		return nil, err
 	}
-
-	ks := jks.New()
-	ks.SetTrustedCertificateEntry("ca", jks.TrustedCertificateEntry{
-		CreationTime: time.Now(),
-		Certificate: jks.Certificate{
-			Type:    "X509",
-			Content: ca.Raw,
-		}},
-	)
-
 	buf := &bytes.Buffer{}
 	if err := ks.Store(buf, password); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func addCAsToJKSStore(ks *jks.KeyStore, caPem []byte) error {
+	cas, err := pki.DecodeX509CertificateChainBytes(caPem)
+	if err != nil {
+		return err
+	}
+
+	creationTime := time.Now()
+	for i, ca := range cas {
+		alias := fmt.Sprintf("ca-%d", i)
+		if i == 0 {
+			alias = "ca"
+		}
+		if err = ks.SetTrustedCertificateEntry(alias, jks.TrustedCertificateEntry{
+			CreationTime: creationTime,
+			Certificate: jks.Certificate{
+				Type:    "X509",
+				Content: ca.Raw,
+			}},
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -71,6 +71,14 @@ func mustSelfSignCertificate(t *testing.T, pkBytes []byte) []byte {
 	return certBytes
 }
 
+func mustSelfSignCertificates(t *testing.T, count int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < count; i++ {
+		buf.Write(mustSelfSignCertificate(t, nil))
+	}
+	return buf.Bytes()
+}
+
 type keyAndCert struct {
 	key     crypto.Signer
 	keyPEM  []byte
@@ -226,10 +234,108 @@ func TestEncodeJKSKeystore(t *testing.T) {
 				}
 			},
 		},
+		"encode a JKS bundle for a key, certificate and multiple cas": {
+			password: "password",
+			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
+			certPEM:  mustSelfSignCertificate(t, nil),
+			caPEM:    mustSelfSignCertificates(t, 3),
+			verify: func(t *testing.T, out []byte, err error) {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				buf := bytes.NewBuffer(out)
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
+				if err != nil {
+					t.Errorf("error decoding keystore: %v", err)
+					return
+				}
+				if !ks.IsPrivateKeyEntry("certificate") {
+					t.Errorf("no certificate data found in keystore")
+				}
+				if !ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if !ks.IsTrustedCertificateEntry("ca-1") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if !ks.IsTrustedCertificateEntry("ca-2") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if len(ks.Aliases()) != 4 {
+					t.Errorf("expected 4 aliases in keystore, got %d", len(ks.Aliases()))
+				}
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			out, err := encodeJKSKeystore([]byte(test.password), test.rawKey, test.certPEM, test.caPEM)
+			test.verify(t, out, err)
+		})
+	}
+}
+
+func TestEncodeJKSTruststore(t *testing.T) {
+	tests := map[string]struct {
+		password string
+		caCount  int
+		verify   func(t *testing.T, out []byte, err error)
+	}{
+		"encode a JKS truststore for a single ca": {
+			password: "password",
+			caCount:  1,
+			verify: func(t *testing.T, out []byte, err error) {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				buf := bytes.NewBuffer(out)
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
+				if err != nil {
+					t.Errorf("error decoding keystore: %v", err)
+					return
+				}
+				if !ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if len(ks.Aliases()) != 1 {
+					t.Errorf("expected 1 alias in keystore, got %d", len(ks.Aliases()))
+				}
+			},
+		},
+		"encode a JKS truststore for multiple cas": {
+			password: "password",
+			caCount:  3,
+			verify: func(t *testing.T, out []byte, err error) {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				buf := bytes.NewBuffer(out)
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
+				if err != nil {
+					t.Errorf("error decoding keystore: %v", err)
+					return
+				}
+				if !ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if !ks.IsTrustedCertificateEntry("ca-1") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if !ks.IsTrustedCertificateEntry("ca-2") {
+					t.Errorf("no ca data found in truststore")
+				}
+				if len(ks.Aliases()) != 3 {
+					t.Errorf("expected 3 aliases in keystore, got %d", len(ks.Aliases()))
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := encodeJKSTruststore([]byte(test.password), mustSelfSignCertificates(t, test.caCount))
 			test.verify(t, out, err)
 		})
 	}
@@ -364,7 +470,7 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 	}{
 		"encode a PKCS12 bundle for a CA": {
 			password: "password",
-			caPEM:    mustSelfSignCertificate(t, nil),
+			caPEM:    mustSelfSignCertificates(t, 1),
 			verify: func(t *testing.T, caPEM []byte, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -381,6 +487,26 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 					ca, err := pki.DecodeX509CertificateBytes(caPEM)
 					require.NoError(t, err)
 					assert.Equal(t, ca.Signature, certs[0].Signature, "Trusted CA certificate signature does not match")
+				}
+			},
+		},
+		"encode a PKCS12 bundle for multiple CAs": {
+			password: "password",
+			caPEM:    mustSelfSignCertificates(t, 3),
+			verify: func(t *testing.T, caPEM []byte, out []byte, err error) {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				certs, err := pkcs12.DecodeTrustStore(out, "password")
+				if err != nil {
+					t.Errorf("error decoding truststore: %v", err)
+					return
+				}
+				if certs == nil {
+					t.Errorf("no certificates found in truststore")
+				}
+				if len(certs) != 3 {
+					t.Errorf("Trusted CA certificates should include 3 entries, got %d", len(certs))
 				}
 			},
 		},

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -90,6 +90,11 @@ func DecodePKCS1PrivateKeyBytes(keyBytes []byte) (*rsa.PrivateKey, error) {
 
 // DecodeX509CertificateChainBytes will decode a PEM encoded x509 Certificate chain.
 func DecodeX509CertificateChainBytes(certBytes []byte) ([]*x509.Certificate, error) {
+	return DecodeX509CertificateSetBytes(certBytes)
+}
+
+// DecodeX509CertificateSetBytes will decode a concatenated set of PEM encoded x509 Certificates.
+func DecodeX509CertificateSetBytes(certBytes []byte) ([]*x509.Certificate, error) {
 	certs := []*x509.Certificate{}
 
 	var block *pem.Block
@@ -118,7 +123,7 @@ func DecodeX509CertificateChainBytes(certBytes []byte) ([]*x509.Certificate, err
 
 // DecodeX509CertificateBytes will decode a PEM encoded x509 Certificate.
 func DecodeX509CertificateBytes(certBytes []byte) (*x509.Certificate, error) {
-	certs, err := DecodeX509CertificateChainBytes(certBytes)
+	certs, err := DecodeX509CertificateSetBytes(certBytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Manual backport of https://github.com/cert-manager/cert-manager/pull/6806

### Kind

/kind bug

### Release Note

```release-note
BUGFIX: JKS and PKCS12 stores now contain the full set of CAs specified by an issuer
```
