### PR TITLE
BUGFIX: cainjector leaderelection defaults are missing

### DIFF
--- a/internal/apis/config/cainjector/fuzzer/fuzzer.go
+++ b/internal/apis/config/cainjector/fuzzer/fuzzer.go
@@ -34,6 +34,19 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				s.PprofAddress = "something:1234"
 			}
 
+			if s.LeaderElectionConfig.Namespace == "" {
+				s.LeaderElectionConfig.Namespace = "something"
+			}
+			if s.LeaderElectionConfig.LeaseDuration == 0 {
+				s.LeaderElectionConfig.LeaseDuration = 1234
+			}
+			if s.LeaderElectionConfig.RenewDeadline == 0 {
+				s.LeaderElectionConfig.RenewDeadline = 1234
+			}
+			if s.LeaderElectionConfig.RetryPeriod == 0 {
+				s.LeaderElectionConfig.RetryPeriod = 1234
+			}
+
 			logsapi.SetRecommendedLoggingConfiguration(&s.Logging)
 		},
 	}

--- a/internal/apis/config/cainjector/v1alpha1/defaults.go
+++ b/internal/apis/config/cainjector/v1alpha1/defaults.go
@@ -17,11 +17,21 @@ limitations under the License.
 package v1alpha1
 
 import (
+	time "time"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/cert-manager/cert-manager/pkg/apis/config/cainjector/v1alpha1"
+)
+
+var (
+	defaultLeaderElect                 = true
+	defaultLeaderElectionNamespace     = "kube-system"
+	defaultLeaderElectionLeaseDuration = 60 * time.Second
+	defaultLeaderElectionRenewDeadline = 40 * time.Second
+	defaultLeaderElectionRetryPeriod   = 15 * time.Second
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -34,6 +44,29 @@ func SetDefaults_CAInjectorConfiguration(obj *v1alpha1.CAInjectorConfiguration) 
 	}
 
 	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)
+}
+
+func SetDefaults_LeaderElectionConfig(obj *v1alpha1.LeaderElectionConfig) {
+	if obj.Enabled == nil {
+		obj.Enabled = &defaultLeaderElect
+	}
+
+	if obj.Namespace == "" {
+		obj.Namespace = defaultLeaderElectionNamespace
+	}
+
+	// TODO: Does it make sense to have a duration of 0?
+	if obj.LeaseDuration == time.Duration(0) {
+		obj.LeaseDuration = defaultLeaderElectionLeaseDuration
+	}
+
+	if obj.RenewDeadline == time.Duration(0) {
+		obj.RenewDeadline = defaultLeaderElectionRenewDeadline
+	}
+
+	if obj.RetryPeriod == time.Duration(0) {
+		obj.RetryPeriod = defaultLeaderElectionRetryPeriod
+	}
 }
 
 func SetDefaults_EnableDataSourceConfig(obj *v1alpha1.EnableDataSourceConfig) {

--- a/internal/apis/config/cainjector/v1alpha1/zz_generated.defaults.go
+++ b/internal/apis/config/cainjector/v1alpha1/zz_generated.defaults.go
@@ -38,6 +38,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_CAInjectorConfiguration(in *v1alpha1.CAInjectorConfiguration) {
 	SetDefaults_CAInjectorConfiguration(in)
+	SetDefaults_LeaderElectionConfig(&in.LeaderElectionConfig)
 	SetDefaults_EnableDataSourceConfig(&in.EnableDataSourceConfig)
 	SetDefaults_EnableInjectableConfig(&in.EnableInjectableConfig)
 }


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6345, I forgot to add the defaults for the cainjector leaderelection options.

The original defaults can be found here: https://github.com/cert-manager/cert-manager/blob/ba6268135d0f2ebea5f8eb29a57934f1acae15e2/internal/cmd/util/defaults.go.

Fixes https://github.com/cert-manager/cert-manager/issues/6808

```
$ _bin/server/cainjector-linux-amd64 --help
...
      --leader-elect                                        If true, cainjector will perform leader election between instances to ensure no more than one instance of cainjector operates at a time (default true)
      --leader-election-lease-duration duration             The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 1m0s)
      --leader-election-namespace string                    Namespace used to perform leader election. Only used if leader election is enabled (default "kube-system")
      --leader-election-renew-deadline duration             The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 40s)
      --leader-election-retry-period duration               The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 15s)
...
```

```
$ k -n cert-manager logs cert-manager-cainjector-7f8bfb6865-d2hkn | grep leader
I0306 09:32:53.829792       1 leaderelection.go:250] attempting to acquire leader lease kube-system/cert-manager-cainjector-leader-election...
I0306 09:32:53.843439       1 leaderelection.go:260] successfully acquired lease kube-system/cert-manager-cainjector-leader-election
I0306 09:32:53.843613       1 recorder.go:104] "cert-manager-cainjector-7f8bfb6865-d2hkn_845b6bd8-82ae-4dbf-a0e9-a2cee4006852 became leader" logger="cert-manager.events" type="Normal" object={"kind":"Lease","namespace":"kube-system","name":"cert-manager-cainjector-leader-election","uid":"7b45984d-5a05-427f-b482-9d9bb9cad161","apiVersion":"coordination.k8s.io/v1","resourceVersion":"795"} reason="LeaderElection"
```

### Kind

/kind bug

### Release Note

```release-note
BUGFIX: cainjector leaderelection flag/ config option defaults are missing
```
