### PR TITLE
Bump go to 1.21.8

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -79,7 +79,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.7
+VENDORED_GO_VERSION := 1.21.8
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(bin_dir)/downloaded to $(bin_dir)/tools.


### PR DESCRIPTION
fixes CVE-2024-24783 (https://go.dev/doc/devel/release#go1.21.0)

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade go to 1.21.8: fixes CVE-2024-24783
```
