### PR TITLE
Bump to latest go version (1.22.1)

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -79,7 +79,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.8
+VENDORED_GO_VERSION := 1.22.1
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(bin_dir)/downloaded to $(bin_dir)/tools.


### PR DESCRIPTION
Bump go to the latest version (1.22.1).

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade go to latest version 1.22.1
```
