### PR TITLE
Add secretTemplate to Certificate resources created by ingress-shim

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -145,6 +145,11 @@ const (
 	// controller only processes Ingresses with this annotation either unset, or
 	// set to either the configured value or the empty string.
 	IngressClassAnnotationKey = "kubernetes.io/ingress.class"
+
+	// IngressSecretTemplateAnnotations specifies arbitrary annotations on the Ingress resource to be set in the
+	// generated Certificate resource's secretTemplate. Existing annotations with the same key are overridden.
+	// The value is a regex that must fully match the annotation key.
+	IngressSecretTemplateAnnotations = "cert-manager.io/secret-template-annotations"
 )
 
 // Annotation names for CertificateRequests

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -146,10 +146,9 @@ const (
 	// set to either the configured value or the empty string.
 	IngressClassAnnotationKey = "kubernetes.io/ingress.class"
 
-	// IngressSecretTemplateAnnotations specifies arbitrary annotations on the Ingress resource to be set in the
-	// generated Certificate resource's secretTemplate. Existing annotations with the same key are overridden.
-	// The value is a regex that must fully match the annotation key.
-	IngressSecretTemplateAnnotations = "cert-manager.io/secret-template-annotations"
+	// IngressSecretTemplate can be used to set the secretTemplate field in the generated Certificate.
+	// The value is a JSON representation of secretTemplate and must not have any unknown fields.
+	IngressSecretTemplate = "cert-manager.io/secret-template"
 )
 
 // Annotation names for CertificateRequests

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -537,6 +537,107 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			Name:   "return a single HTTP01 Certificate for an ingress with a single valid TLS entry and valid secret template annotation",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey:          "issuer-name",
+						cmapi.IngressSecretTemplateAnnotations:               "secret-reflector.com.*",
+						"secret-replicator.com/ignored-annotation":           "ignored-value",
+						"www.secret-reflector.com/ignored-annotation":        "ignored-value",
+						"secret-reflector.com/reflection-enabled":            "true",
+						"secret-reflector.com/reflection-enabled-namespaces": "example-namespace",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com", "www.example.com"},
+						SecretName: "example-com-tls",
+						SecretTemplate: &cmapi.CertificateSecretTemplate{
+							Annotations: map[string]string{
+								"secret-reflector.com/reflection-enabled":            "true",
+								"secret-reflector.com/reflection-enabled-namespaces": "example-namespace",
+							},
+						},
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:   "secret template annotation should not match cert-manager.io/ annotations",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IngressSecretTemplateAnnotations:      ".*cert-manager.io/.*",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			Err: true,
+		},
+		{
+			Name:   "secret template annotation should have valid regex",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IngressSecretTemplateAnnotations:      ")invalid] [regex(",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			Err: true,
+		},
+		{
 			Name:   "edit-in-place set to false should not trigger editing the ingress in-place",
 			Issuer: acmeClusterIssuer,
 			IngressLike: &networkingv1.Ingress{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

These are the changes for implementing https://github.com/cert-manager/cert-manager/issues/6838.

This allows ingress-shim users to set the `secretTemplate` field on generated `Certificate` resources. This makes using [secret sync tools](https://cert-manager.io/docs/devops-tips/syncing-secrets-across-namespaces/) (e.g. [kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector)) much simpler for ingress-shim users.

Added a new Ingress annotation `cert-manager.io/secret-template` whose value is a JSON representation of `secretTemplate`.

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added a new Ingress annotation for copying specific Ingress annotations to Certificate's secretTemplate
```
