### PR TITLE
[release-1.12] Update cmd/ctl's go.mod to v1.12.9

### DIFF
--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -12,7 +12,7 @@ go 1.20
 // or a branch name (master).
 
 require (
-	github.com/cert-manager/cert-manager v1.12.8
+	github.com/cert-manager/cert-manager v1.12.9
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/cmd/ctl/go.sum
+++ b/cmd/ctl/go.sum
@@ -93,8 +93,8 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZ
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.12.8 h1:zIKorg3DPAHqKk48p02EP5ZiHqGzjb8gWAYtLeGyyzE=
-github.com/cert-manager/cert-manager v1.12.8/go.mod h1:BDb2LfCbtRZnuqoU9qctPgGvG61ztY8r+H6wew48Px8=
+github.com/cert-manager/cert-manager v1.12.9 h1:GJmjqVGuIQrWct0viLMqT6BuXo3Au8dTQzybkL61s9M=
+github.com/cert-manager/cert-manager v1.12.9/go.mod h1:EfqKaA4hZ5iVuR7SLSVdQvrKr9earHZaq/SHbGU9gj8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -9,7 +9,7 @@ replace github.com/cert-manager/cert-manager/cmd/ctl => ../../cmd/ctl/
 replace github.com/cert-manager/cert-manager/webhook-binary => ../../cmd/webhook/
 
 require (
-	github.com/cert-manager/cert-manager v1.12.8
+	github.com/cert-manager/cert-manager v1.12.9
 	github.com/cert-manager/cert-manager/cmd/ctl v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.3.0
 	github.com/miekg/dns v1.1.50


### PR DESCRIPTION
This PR cmd/cmctl's go.mod to v1.12.9 as part of the release process.

**To the reviewer:** the version changes in `go.mod` must be reviewed.

### Release Note

```release-note
NONE
```