### PR TITLE
🐛 Remove extra space/line from cert-manager release manifest

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -88,7 +88,7 @@ spec:
           - --dynamic-serving-dns-names={{ template "webhook.fullname" . }}
           - --dynamic-serving-dns-names={{ template "webhook.fullname" . }}.$(POD_NAMESPACE)
           - --dynamic-serving-dns-names={{ template "webhook.fullname" . }}.$(POD_NAMESPACE).svc
-          {{ if .Values.webhook.url.host }}
+          {{- if .Values.webhook.url.host }}
           - --dynamic-serving-dns-names={{ .Values.webhook.url.host }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
### Pull Request Motivation

cert-manager.yaml manifest in [recent releases](https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml) have an extra line/ trailing whitespaces which is being objected by some linters. This is originated in webhook-deployment manifest. This PR sends a small fix for that. 

### Kind
bug

### Release Note

```
Fix trailing space issue in cert-manager.yaml release manifest
```