### PR TITLE
[Release 1.14] Ignore trivy failures for CVE-2019-25210

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,7 @@ CVE-2020-8911
 CVE-2020-8912
 GHSA-7f33-f4f5-xwgw
 GHSA-f5pg-7wfw-84q9
+# This is a new CVE created for an old Helm bug which the Helm maintainers have dismissed.
+# It only affects cmctl x install and is unlikely to be fixed.
+# https://github.com/advisories/GHSA-jw44-4f3j-q396
+CVE-2019-25210


### PR DESCRIPTION
trivy is reporting that ctl 1.14 is affected by https://avd.aquasec.com/nvd/2019/cve-2019-25210/:

> An issue was discovered in Cloud Native Computing Foundation (CNCF) Helm through 3.13.3. It displays values of secrets when the –dry-run flag is used. This is a security concern in some use cases, such as a –dry-run call by a CI/CD tool. NOTE: the vendors position is that this behavior was introduced intentionally, and cannot be removed without breaking backwards compatibility (some users may be relying on these values).


The change in this PR silences the resulting test grid failures for the release 1.14
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.14#ci-cert-manager-release-1.14-trivy-test-ctl
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-release-1.14-trivy-test-ctl/1767588890236948480
 * https://github.com/advisories/GHSA-jw44-4f3j-q396
 * https://github.com/helm/helm/issues/7275
 * https://github.com/cert-manager/cmctl/security/dependabot/3

Before:

```sh
$ make trivy-scan-ctl
...
  "Results": [
    {
      "Target": "_bin/containers/cert-manager-ctl-linux-amd64.tar (debian 12.5)",
      "Class": "os-pkgs",
      "Type": "debian"
    },
    {
      "Target": "app/cmd/ctl/ctl",
      "Class": "lang-pkgs",
      "Type": "gobinary",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2019-25210",
          "PkgName": "helm.sh/helm/v3",
          "InstalledVersion": "v3.14.2",
...
```

After:

```sh
$ make trivy-scan-ctl
...

$ echo $?
0
```

/kind cleanup

```release-note
Ignore trivy failures for CVE-2019-25210 and explain why
```
