### PR TITLE
Add user-agent header in requests to Venafi API

### DIFF
--- a/pkg/controller/certificaterequests/venafi/venafi.go
+++ b/pkg/controller/certificaterequests/venafi/venafi.go
@@ -54,6 +54,9 @@ type Venafi struct {
 	clientBuilder venaficlient.VenafiClientBuilder
 
 	metrics *metrics.Metrics
+
+	// userAgent is the string used as the UserAgent when making HTTP calls.
+	userAgent string
 }
 
 func init() {
@@ -73,6 +76,7 @@ func NewVenafi(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		clientBuilder: venaficlient.New,
 		metrics:       ctx.Metrics,
 		cmClient:      ctx.CMClient,
+		userAgent:     ctx.RESTConfig.UserAgent,
 	}
 }
 
@@ -80,7 +84,7 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 	log := logf.FromContext(ctx, "sign")
 	log = logf.WithRelatedResource(log, issuerObj)
 
-	client, err := v.clientBuilder(v.issuerOptions.ResourceNamespace(issuerObj), v.secretsLister, issuerObj, v.metrics, log)
+	client, err := v.clientBuilder(v.issuerOptions.ResourceNamespace(issuerObj), v.secretsLister, issuerObj, v.metrics, log, v.userAgent)
 	if k8sErrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -824,7 +824,7 @@ func runTest(t *testing.T, test testT) {
 
 	if test.fakeClient != nil {
 		v.clientBuilder = func(namespace string, secretsLister internalinformers.SecretLister,
-			issuer cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (client.Interface, error) {
+			issuer cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (client.Interface, error) {
 			return test.fakeClient, nil
 		}
 	}

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -813,7 +813,7 @@ type testT struct {
 
 func runTest(t *testing.T, test testT) {
 	test.builder.T = t
-	test.builder.Init()
+	test.builder.InitWithRESTConfig()
 	defer test.builder.Stop()
 
 	v := NewVenafi(test.builder.Context).(*Venafi)

--- a/pkg/controller/certificatesigningrequests/venafi/venafi.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi.go
@@ -63,6 +63,9 @@ type Venafi struct {
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
+
+	// userAgent is the string used as the UserAgent when making HTTP calls.
+	userAgent string
 }
 
 func init() {
@@ -82,6 +85,7 @@ func NewVenafi(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 		clientBuilder: venaficlient.New,
 		fieldManager:  ctx.FieldManager,
 		metrics:       ctx.Metrics,
+		userAgent:     ctx.RESTConfig.UserAgent,
 	}
 }
 
@@ -99,7 +103,7 @@ func (v *Venafi) Sign(ctx context.Context, csr *certificatesv1.CertificateSignin
 
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
-	client, err := v.clientBuilder(resourceNamespace, v.secretsLister, issuerObj, v.metrics, log)
+	client, err := v.clientBuilder(resourceNamespace, v.secretsLister, issuerObj, v.metrics, log, v.userAgent)
 	if apierrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 		v.recorder.Event(csr, corev1.EventTypeWarning, "SecretNotFound", message)

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -884,7 +884,7 @@ func TestProcessItem(t *testing.T) {
 			fixedClock.SetTime(fixedClockStart)
 			test.builder.Clock = fixedClock
 			test.builder.T = t
-			test.builder.Init()
+			test.builder.InitWithRESTConfig()
 
 			// Always return true for SubjectAccessReviews in tests
 			test.builder.FakeKubeClient().PrependReactor("create", "*", func(action coretesting.Action) (bool, runtime.Object, error) {

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -164,7 +164,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -206,7 +206,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -252,7 +252,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{}, nil
 			},
 			builder: &testpkg.Builder{
@@ -320,7 +320,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{}, nil
 			},
 			builder: &testpkg.Builder{
@@ -388,7 +388,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", venaficlient.ErrCustomFieldsType{Type: "test-type"}
@@ -459,7 +459,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", errors.New("generic error")
@@ -530,7 +530,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "test-pickup-id", nil
@@ -592,7 +592,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrCertificatePending{}
@@ -643,7 +643,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrRetrieveCertificateTimeout{}
@@ -694,7 +694,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, errors.New("generic error")
@@ -745,7 +745,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte("garbage"), nil
@@ -818,7 +818,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger) (venaficlient.Interface, error) {
+			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
 					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte(fmt.Sprintf("%s%s", certBundle.ChainPEM, certBundle.CAPEM)), nil

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -47,7 +47,7 @@ const (
 )
 
 type VenafiClientBuilder func(namespace string, secretsLister internalinformers.SecretLister,
-	issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger) (Interface, error)
+	issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger, userAgent string) (Interface, error)
 
 // Interface implements a Venafi client
 type Interface interface {
@@ -86,8 +86,8 @@ type connector interface {
 
 // New constructs a Venafi client Interface. Errors may be network errors and
 // should be considered for retrying.
-func New(namespace string, secretsLister internalinformers.SecretLister, issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger) (Interface, error) {
-	cfg, err := configForIssuer(issuer, secretsLister, namespace)
+func New(namespace string, secretsLister internalinformers.SecretLister, issuer cmapi.GenericIssuer, metrics *metrics.Metrics, logger logr.Logger, userAgent string) (Interface, error) {
+	cfg, err := configForIssuer(issuer, secretsLister, namespace, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func New(namespace string, secretsLister internalinformers.SecretLister, issuer 
 
 // configForIssuer will convert a cert-manager Venafi issuer into a vcert.Config
 // that can be used to instantiate an API client.
-func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.SecretLister, namespace string) (*vcert.Config, error) {
+func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.SecretLister, namespace string, userAgent string) (*vcert.Config, error) {
 	venCfg := iss.GetSpec().Venafi
 	var vcertConfig *vcert.Config
 
@@ -195,7 +195,7 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.Se
 	}
 
 	// Set the user-agent header
-	vcertConfig.Client.Transport = util.UserAgentRoundTripper(vcertConfig.Client.Transport, "cert-manager/v0.0.0")
+	vcertConfig.Client.Transport = util.UserAgentRoundTripper(vcertConfig.Client.Transport, userAgent)
 
 	return vcertConfig, nil
 

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -223,7 +223,9 @@ type httpClientForVcertOptions struct {
 //  2. We need to customize the User-Agent header for all HTTP requests to Venafi
 //     REST API endpoints.
 //  3. The vcert package does not currently provide an easier way to change those
-//     settings.
+//     settings. See:
+//     * https://github.com/Venafi/vcert/issues/437
+//     * https://github.com/Venafi/vcert/issues/438
 //
 // Why is it necessary to customize the client TLS renegotiation?
 //

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -223,7 +223,7 @@ type testConfigForIssuerT struct {
 }
 
 func (c *testConfigForIssuerT) runTest(t *testing.T) {
-	resp, err := configForIssuer(c.iss, c.secretsLister, "test-namespace")
+	resp, err := configForIssuer(c.iss, c.secretsLister, "test-namespace", "cert-manager/v0.0.0")
 	if err != nil && !c.expectedErr {
 		t.Errorf("expected to not get an error, but got: %v", err)
 	}

--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -38,7 +38,7 @@ func (v *Venafi) Setup(ctx context.Context) (err error) {
 		}
 	}()
 
-	client, err := v.clientBuilder(v.resourceNamespace, v.secretsLister, v.issuer, v.Metrics, v.log)
+	client, err := v.clientBuilder(v.resourceNamespace, v.secretsLister, v.issuer, v.Metrics, v.log, v.userAgent)
 	if err != nil {
 		return fmt.Errorf("error building client: %v", err)
 	}

--- a/pkg/issuer/venafi/setup_test.go
+++ b/pkg/issuer/venafi/setup_test.go
@@ -41,12 +41,12 @@ func TestSetup(t *testing.T) {
 	baseIssuer := gen.Issuer("test-issuer")
 
 	failingClientBuilder := func(string, internalinformers.SecretLister,
-		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger, string) (client.Interface, error) {
 		return nil, errors.New("this is an error")
 	}
 
 	failingPingClient := func(string, internalinformers.SecretLister,
-		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger, string) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return errors.New("this is a ping error")
@@ -55,7 +55,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	pingClient := func(string, internalinformers.SecretLister,
-		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+		cmapi.GenericIssuer, *metrics.Metrics, logr.Logger, string) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return nil
@@ -63,7 +63,7 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
-	verifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+	verifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger, string) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return nil
@@ -74,7 +74,7 @@ func TestSetup(t *testing.T) {
 		}, nil
 	}
 
-	failingVerifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger) (client.Interface, error) {
+	failingVerifyCredentialsClient := func(string, internalinformers.SecretLister, cmapi.GenericIssuer, *metrics.Metrics, logr.Logger, string) (client.Interface, error) {
 		return &internalvenafifake.Venafi{
 			PingFn: func() error {
 				return nil

--- a/pkg/issuer/venafi/venafi.go
+++ b/pkg/issuer/venafi/venafi.go
@@ -43,6 +43,9 @@ type Venafi struct {
 	clientBuilder client.VenafiClientBuilder
 
 	log logr.Logger
+
+	// userAgent is the string used as the UserAgent when making HTTP calls.
+	userAgent string
 }
 
 func NewVenafi(ctx *controller.Context, issuer cmapi.GenericIssuer) (issuer.Interface, error) {
@@ -53,6 +56,7 @@ func NewVenafi(ctx *controller.Context, issuer cmapi.GenericIssuer) (issuer.Inte
 		clientBuilder:     client.New,
 		Context:           ctx,
 		log:               logf.Log.WithName("venafi"),
+		userAgent:         ctx.RESTConfig.UserAgent,
 	}, nil
 }
 

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -57,4 +58,26 @@ func PrefixFromUserAgent(u string) string {
 		buf.WriteRune(r)
 	}
 	return buf.String()
+}
+
+// UserAgentRoundTripper implements the http.RoundTripper interface and adds a User-Agent
+// header.
+type userAgentRoundTripper struct {
+	inner     http.RoundTripper
+	userAgent string
+}
+
+// UserAgentRoundTripper returns a RoundTripper that functions identically to
+// the provided 'inner' round tripper, other than also setting a user agent.
+func UserAgentRoundTripper(inner http.RoundTripper, userAgent string) http.RoundTripper {
+	return userAgentRoundTripper{
+		inner:     inner,
+		userAgent: userAgent,
+	}
+}
+
+// RoundTrip implements http.RoundTripper
+func (u userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", u.userAgent)
+	return u.inner.RoundTrip(req)
 }


### PR DESCRIPTION
## TLDR
- **Purpose**: Improve Venafi API interactions by adding a custom `User-Agent` header to requests from cert-manager.
- **Issue Addressed**: Allows Venafi TPP server administrators to identify cert-manager as the source of API requests, aiding in troubleshooting and bug reporting.
- **Implementation**: The `User-Agent` string mirrors that used for the ACME issuer and includes cert-manager version details.
- **Testing**: Local and E2E tests conducted, including verification of `User-Agent` header presence in TPP server logs.

## Details
As an administrator of a Venafi TPP server or of Venafi Cloud , I want to know which software is being used to connect to the REST API.

Right now the vcert SDK will use the [default Go HTTP client User-Agent header](https://github.com/golang/go/blob/db423dde85ad4923c2c4addb1cd96f119c7b6dc6/src/net/http/request.go#L534-L538): Go-http-client/1.1 and the requests from cert-manager will be indistinguishable with those from the `vcert` cli or any other vcert-sdk using software.

For example, if the TPP API server is being overwhelmed by a rapid repeated requests, I would like to be able to look at the IIS server logs, find the User-Agent of the offending requests and learn that the requests may be being generated by cert-manager.

As a maintainer of the cert-manager Venafi Issuer, I want it to send User-Agent: cert-manager/vX.Y.Z so that the administrator of a Venafi TPP server or Venafi Cloud service, can know which software is being used to connect to the REST API. Why? Because if there is a bug in the cert-manager Venafi issuer, which causes it to not back off in the event of a failed API request, the Venafi server administrator can quickly know that cert-manager is the culprit and quickly report the bug so that it be quickly fixed.

In this PR I've used the same User-Agent that is being used for the ACME issuer since: https://github.com/cert-manager/cert-manager/pull/4773. 

The User-Agent headers will be:
* Health checks from the Venafi Issuer controller:
> cert-manager-certificaterequests-issuer-venafi/v1.14.0-beta.0-198-gef068a59008f6e+(linux/amd64)+cert-manager/ef068a59008f6ed919b98a7177921ddc9e297200
* Signing and retrieve requests from the Venafi CertificateRequest and CertificateSigningRequest controllers:
> cert-manager-certificaterequests-issuer-venafi/v1.14.0-beta.0-198-gef068a59008f6e+(linux/amd64)+cert-manager/ef068a59008f6ed919b98a7177921ddc9e297200

Fixes: #5803 
 * #5803


## Testing

### Local testing
Run [mitmproxy](https://mitmproxy.org/):
```sh
mitmproxy
```

Run the cert-manager controller locally:
```sh
make e2e-setup
kubectl scale -n cert-manager deployment cert-manager --replicas 0
HTTPS_PROXY=localhost:8080 go run ./cmd/controller --kubeconfig ~/.kube/config  --cluster-resource-namespace cert-manager
```

```yaml
# example.yaml
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: venafi
spec:
  venafi:
    zone: fake-zone
    tpp:
      url: https://httpbin.org
      caBundle: ${MITMPROXY_CA}
      credentialsRef:
        name: venafi-credentials
---
apiVersion: v1
kind: Secret
metadata:
  name: venafi-credentials
  namespace: cert-manager
stringData:
  username: fake-username
  password: fake-password

```

```sh
export MITMPROXY_CA=$(base64 -w 0 ~/.mitmproxy/mitmproxy-ca-cert.pem)
envsubst < example.yaml | kubectl apply -f -
```

![image](https://github.com/cert-manager/cert-manager/assets/978965/e89e1345-93ba-4edb-88ea-fe6c53a3762b)


### E2E tests

1. I triggered the Venafi TPP E2E tests by [commenting on this PR](https://github.com/cert-manager/cert-manager/pull/6865#issuecomment-2009709661) with: `/test pull-cert-manager-master-e2e-v1-28-issuers-venafi-tpp` in 
2. Logged into the cert-manager TPP server using RDP and examined the IIS logs of the TPP server.

Before:
(logs created by periodic tests using the existing cert-manager code)
> #Software: Microsoft Internet Information Services 10.0
> #Version: 1.0
> #Date: 2024-03-20 04:47:53
> #Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
> 

> 2024-03-20 04:47:54 10.132.0.2 POST /vedsdk/certificates/checkpolicy - 443 - 10.8.0.52 Go-http-client/1.1 - 200 0 0 12
> 2024-03-20 04:47:54 10.132.0.2 POST /vedsdk/certificates/retrieve - 443 - 10.8.0.52 Go-http-client/1.1 - 202 0 0 9

After:
(logs created by cert-manager built from this branch)
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/6865/pull-cert-manager-master-e2e-v1-28-issuers-venafi-tpp/1770457571052752896
> 2024-03-20 14:34:02 10.132.0.2 POST /vedsdk/certificates/checkpolicy - 443 - 10.8.0.8 cert-manager-certificaterequests-issuer-venafi/v1.14.0-beta.0-198-gef068a59008f6e+(linux/amd64)+cert-manager/ef068a59008f6ed919b98a7177921ddc9e297200 - 200 0 0 11
> 2024-03-20 14:34:02 10.132.0.2 POST /vedsdk/certificates/retrieve - 443 - 10.8.0.8 cert-manager-certificaterequests-issuer-venafi/v1.14.0-beta.0-198-gef068a59008f6e+(linux/amd64)+cert-manager/ef068a59008f6ed919b98a7177921ddc9e297200 - 202 0 0 6

```release-note
Venafi Issuer now sends a cert-manager HTTP User-Agent header in all Venafi Rest API requests.
For example: `cert-manager-certificaterequests-issuer-venafi/v1.15.0+(linux/amd64)+cert-manager/ef068a59008f6ed919b98a7177921ddc9e297200`.
```
