### PR TITLE
[release-1.14] ignore two false positive vulns

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,10 @@ CVE-2020-8911
 CVE-2020-8912
 GHSA-7f33-f4f5-xwgw
 GHSA-f5pg-7wfw-84q9
+
+# CVE-2019-25210 is a problem in `helm --dry-run` which the Helm maintainers say was intentional and isn't a bug
+# It certainly doesn't seem like a risk for our uses of Helm.
+CVE-2019-25210
+
+# CVE-2024-24557 is a CVE in the docker CLI, which we're not using
+CVE-2024-24557


### PR DESCRIPTION
These were causing the trivy tests to fail.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
