### PR TITLE
glimmit DigitalOcean records for cleanup to TXT only

### DIFF
--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -138,9 +138,10 @@ func (c *DNSProvider) findTxtRecord(fqdn string) ([]godo.DomainRecord, error) {
 		return nil, err
 	}
 
-	allRecords, _, err := c.client.Domains.Records(
+	allRecords, _, err := c.client.Domains.RecordsByType(
 		context.Background(),
 		util.UnFqdn(zoneName),
+		"TXT",
 		nil,
 	)
 


### PR DESCRIPTION
There was [a slack report](https://kubernetes.slack.com/archives/C4NV3DWUC/p1710931217207459) that in cleanup, the digitalocean webhook would delete A records if the domain had a CNAME.

> I’m using DNS01 validation (with DigitalOcean as the provider) for a domain which is CNAME’d. Every time there’s a challenge which succeeds, in the clean up process, the A record where the verification domain is pointing to gets deleted. This causes many sites to fall over.

I don't really have the bandwidth to dig too much into that right now, but it seems a pretty severe bug so it seems worth trying a fix.

This PR should ensure that only TXT records can be considered for deletion.

### Kind

/kind bug

### Release Note

```release-note
DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge
```
