### PR TITLE
feat: add support for dual stack clusters

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -19,6 +19,12 @@ metadata:
     {{- end }}
 spec:
   type: ClusterIP
+  {{- if .Values.serviceIpFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.serviceIpFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.serviceIpFamilies }}
+  ipFamilies: {{ .Values.serviceIpFamilies | toYaml | nindent 2 }}
+  {{- end }}
   ports:
   - protocol: TCP
     port: 9402

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -18,6 +18,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.webhook.serviceType }}
+  {{- if .Values.webhook.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.webhook.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.webhook.ipFamilies }}
+  ipFamilies: {{ .Values.webhook.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
   {{- with .Values.webhook.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -309,6 +309,14 @@ podLabels: {}
 # +docs:property
 # serviceLabels: {}
 
+# Optional set the ip family policy to the controller Service to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+# +docs:property
+# serviceIpFamilyPolicy: ""
+
+# Optional sets the families to the controller Service that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+# +docs:property
+# serviceIpFamilies: []
+
 # Optional DNS settings. These are useful if you have a public and private DNS zone for
 # the same domain on Route 53. The following is an example of ensuring
 # cert-manager can access an ingress or DNS TXT records at all times.
@@ -758,6 +766,12 @@ webhook:
 
   # Optional additional labels to add to the Webhook Service.
   serviceLabels: {}
+
+  # Optional set the ip family policy to the Webhook Service to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+  ipFamilyPolicy: ""
+
+  # Optional sets the families to the Webhook Service that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+  ipFamilies: []
 
   image:
     # The container registry to pull the webhook image from.


### PR DESCRIPTION
### Pull Request Motivation

Fixes #6885

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The Helm chart now allows you to configure `ipFamilyPolicy` and `ipFamilies` for services to support dual-stack clusters
```
