### PR TITLE
Add @ThatsMrTalbot as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - irbekrm
 - sgtcodfish
 - inteon
+- thatsmrtalbot
 reviewers:
 - munnerz
 - joshvanl


### PR DESCRIPTION
### Request to become cert-manager approver

I have been a reviewer for some time and reviewed more than the requirement for appover status, some examples:

- https://github.com/cert-manager/cert-manager/pull/6784
- https://github.com/cert-manager/cert-manager/pull/6751
- https://github.com/cert-manager/cert-manager/pull/6672
- https://github.com/cert-manager/cert-manager/pull/6631
- https://github.com/cert-manager/cert-manager/pull/6607
- https://github.com/cert-manager/cert-manager/pull/6606
- https://github.com/cert-manager/cert-manager/pull/6586

### Sponsors

- @sgtcodfish

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
