### PR TITLE
WIP: Added Default Ingress Class Name while creating a issuer without ingress Class Name Specified

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -40,6 +40,7 @@ const (
 	// in the networking/v1 package, so it is duplicated here
 	// to avoid an extra import of networking/v1beta1.
 	annotationIngressClass = "kubernetes.io/ingress.class"
+	defaultIngressName     = "default"
 )
 
 // getIngressesForChallenge returns a list of Ingresses that were created to solve
@@ -166,6 +167,10 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.I
 	}
 	if http01IngressCfg.IngressClassName != nil {
 		ingressClassName = http01IngressCfg.IngressClassName
+	}
+	if ingressClassName == nil {
+		ingressClassNameTemp := defaultIngressName
+		ingressClassName = &ingressClassNameTemp
 	}
 
 	ingPathToAdd := ingressPath(ch.Spec.Token, svcName)

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -483,7 +483,7 @@ func TestEnsureIngress(t *testing.T) {
 			},
 			CheckFn: checkOneIngress(func(t *testing.T, ingress *networkingv1.Ingress) {
 				assert.Equal(t, "nginx", ingress.Annotations["kubernetes.io/ingress.class"])
-				assert.Empty(t, ingress.Spec.IngressClassName)
+				assert.Equal(t, "default", *ingress.Spec.IngressClassName)
 			}),
 		},
 		"ingressClassName field is passed to the ingress": {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
We can create an Ingress without having IngressClassNAme specified. I am getting alerts messages that ingress Exists without IngressClassName Specified.

I propose that we can add default ingressClassName to issuer if ingressClassName is not specified.
### Kind
BUG


<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
