### PR TITLE
Makefile bugfix

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -99,8 +99,8 @@ shared_generate_targets += generate-helm-docs
 ## request or change is merged.
 ##
 ## @category CI
-ci-presubmit:
-	$(MAKE) -j1 $(findstring vendor-go,$(MAKECMDGOALS)) verify
+ci-presubmit: $(NEEDS_GO)
+	$(MAKE) -j1 verify
 
 .PHONY: generate-all
 ## Update CRDs, code generation and licenses to the latest versions.
@@ -108,5 +108,4 @@ ci-presubmit:
 ## that everything is up-to-date.
 ##
 ## @category Development
-generate-all:
-	$(MAKE) -j1 $(findstring vendor-go,$(MAKECMDGOALS)) generate
+generate-all: generate


### PR DESCRIPTION
Running `$(MAKE)` in the make target with concurrency >1 can cause multiple make instances to download the same tools/ dependencies at the same time. This results in faulty files and broken tests.
Long-term solution is to change the entry points called by prow.

These `$(MAKE)` calls were introduced in https://github.com/cert-manager/cert-manager/pull/6749.

Example CI failure: https://storage.googleapis.com/cert-manager-prow-artifacts/logs/ci-cert-manager-master-make-test/1781225581912788992/build-log.txt

### Kind

/kind bug

### Release Note

```release-note
NONE
```
