### PR TITLE
Add missing verify-licenses target

### DIFF
--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -57,3 +57,6 @@ update-base-images: | $(NEEDS_CRANE)
 
 .PHONY: update-licenses
 update-licenses: generate-licenses
+
+.PHONY: verify-licenses
+verify-licenses: verify-generate-licenses


### PR DESCRIPTION
This missing target causes the following CI failures: https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/6917/pull-cert-manager-master-license/1781364751985545216

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
