### PR TITLE
Graduate 'DisallowInsecureCSRUsageDefinition' to GA

### DIFF
--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -55,7 +55,7 @@ const (
 	LiteralCertificateSubject featuregate.Feature = "LiteralCertificateSubject"
 
 	// Owner: @inteon
-	// Beta: v1.13
+	// GA: v1.15
 	//
 	// DisallowInsecureCSRUsageDefinition will prevent the webhook from allowing
 	// CertificateRequest's usages to be only defined in the CSR, while leaving
@@ -91,7 +91,7 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.Beta},
+	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
 
 	AdditionalCertificateOutputFormats: {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:          {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -24,7 +24,6 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -34,7 +33,6 @@ import (
 	issuerpkg "github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/kube"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
@@ -72,10 +70,6 @@ func NewCA(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:      crutil.NewReporter(ctx.Clock, ctx.Recorder),
 		templateGenerator: func(cr *cmapi.CertificateRequest) (*x509.Certificate, error) {
-			if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DisallowInsecureCSRUsageDefinition) {
-				return pki.DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition(cr)
-			}
-
 			return pki.CertificateTemplateFromCertificateRequest(cr)
 		},
 		signingFn: pki.SignCSRTemplate,

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -39,7 +38,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/kube"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/go-logr/logr"
@@ -150,11 +148,7 @@ func (s *SelfSigned) Sign(ctx context.Context, cr *cmapi.CertificateRequest, iss
 	}
 
 	var template *x509.Certificate
-	if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.DisallowInsecureCSRUsageDefinition) {
-		template, err = pki.DeprecatedCertificateTemplateFromCertificateRequestAndAllowInsecureCSRUsageDefinition(cr)
-	} else {
-		template, err = pki.CertificateTemplateFromCertificateRequest(cr)
-	}
+	template, err = pki.CertificateTemplateFromCertificateRequest(cr)
 	if err != nil {
 		message := "Error generating certificate template"
 		s.reporter.Failed(cr, err, "ErrorGenerating", message)


### PR DESCRIPTION
### Pull Request Motivation

This feature gate was introduced in https://github.com/cert-manager/cert-manager/pull/6300 (released in v1.13).
This PR graduates this feature to GA, so the deprecated code can be removed.

### Kind

/kind cleanup

### Release Note

```release-note
Graduate the 'DisallowInsecureCSRUsageDefinition' feature gate to GA.
```