### PR TITLE
feat: graduate gateway-api to beta and enable by default

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -259,7 +259,7 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 	ctx.KubeSharedInformerFactory.Start(rootCtx.Done())
 	ctx.HTTP01ResourceMetadataInformersFactory.Start(rootCtx.Done())
 
-	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) && opts.EnableGatewayAPI {
 		ctx.GWShared.Start(rootCtx.Done())
 	}
 
@@ -357,6 +357,10 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 		CertificateOptions: controller.CertificateOptions{
 			EnableOwnerRef:           opts.EnableCertificateOwnerRef,
 			CopiedAnnotationPrefixes: opts.CopiedAnnotationPrefixes,
+		},
+
+		ConfigOptions: controller.ConfigOptions{
+			EnableGatewayAPI: opts.EnableGatewayAPI,
 		},
 	})
 	if err != nil {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -170,6 +170,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.BoolVar(&c.EnableCertificateOwnerRef, "enable-certificate-owner-ref", c.EnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
+	fs.BoolVar(&c.EnableGatewayAPI, "enable-gateway-api", c.EnableGatewayAPI, ""+
+		"Whether gateway API integration is enabled within cert-manager. The ExperimentalGatewayAPISupport "+
+		"feature gate must also be enabled (default as of 1.15).")
 	fs.StringSliceVar(&c.CopiedAnnotationPrefixes, "copied-annotation-prefixes", c.CopiedAnnotationPrefixes, "Specify which annotations should/shouldn't be copied"+
 		"from Certificate to CertificateRequest and Order, as well as from CertificateSigningRequest to Order, by passing a list of annotation key prefixes."+
 		"A prefix starting with a dash(-) specifies an annotation that shouldn't be copied. Example: '*,-kubectl.kuberenetes.io/'- all annotations"+
@@ -249,7 +252,7 @@ func EnabledControllers(o *config.ControllerConfiguration) sets.Set[string] {
 		enabled = enabled.Insert(defaults.ExperimentalCertificateSigningRequestControllers...)
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) && o.EnableGatewayAPI {
 		logf.Log.Info("enabling the sig-network Gateway API certificate-shim and HTTP-01 solver")
 		enabled = enabled.Insert(shimgatewaycontroller.ControllerName)
 	}

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -79,6 +79,11 @@ type ControllerConfiguration struct {
 	// automatically removed when the certificate resource is deleted.
 	EnableCertificateOwnerRef bool
 
+	// Whether gateway API integration is enabled within cert-manager. The
+	// ExperimentalGatewayAPISupport feature gate must also be enabled (default
+	// as of 1.15).
+	EnableGatewayAPI bool
+
 	// Specify which annotations should/shouldn't be copied from Certificate to
 	// CertificateRequest and Order, as well as from CertificateSigningRequest to
 	// Order, by passing a list of annotation key prefixes. A prefix starting with

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -78,6 +78,7 @@ var (
 	defaultTLSACMEIssuerKind         = "Issuer"
 	defaultTLSACMEIssuerGroup        = cm.GroupName
 	defaultEnableCertificateOwnerRef = false
+	defaultEnableGatewayAPI          = false
 
 	defaultDNS01RecursiveNameserversOnly = false
 	defaultDNS01RecursiveNameservers     = []string{}
@@ -211,6 +212,10 @@ func SetDefaults_ControllerConfiguration(obj *v1alpha1.ControllerConfiguration) 
 
 	if obj.EnableCertificateOwnerRef == nil {
 		obj.EnableCertificateOwnerRef = &defaultEnableCertificateOwnerRef
+	}
+
+	if obj.EnableGatewayAPI == nil {
+		obj.EnableGatewayAPI = &defaultEnableGatewayAPI
 	}
 
 	if len(obj.CopiedAnnotationPrefixes) == 0 {

--- a/internal/apis/config/controller/v1alpha1/testdata/defaults.json
+++ b/internal/apis/config/controller/v1alpha1/testdata/defaults.json
@@ -16,6 +16,7 @@
 	"issuerAmbientCredentials": false,
 	"clusterIssuerAmbientCredentials": true,
 	"enableCertificateOwnerRef": false,
+	"enableGatewayAPI": false,
 	"copiedAnnotationPrefixes": [
 		"*",
 		"-kubectl.kubernetes.io/",

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -230,6 +230,9 @@ func autoConvert_v1alpha1_ControllerConfiguration_To_controller_ControllerConfig
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableCertificateOwnerRef, &out.EnableCertificateOwnerRef, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableGatewayAPI, &out.EnableGatewayAPI, s); err != nil {
+		return err
+	}
 	out.CopiedAnnotationPrefixes = *(*[]string)(unsafe.Pointer(&in.CopiedAnnotationPrefixes))
 	if err := Convert_Pointer_int32_To_int(&in.NumberOfConcurrentWorkers, &out.NumberOfConcurrentWorkers, s); err != nil {
 		return err
@@ -287,6 +290,9 @@ func autoConvert_controller_ControllerConfiguration_To_v1alpha1_ControllerConfig
 		return err
 	}
 	if err := v1.Convert_bool_To_Pointer_bool(&in.EnableCertificateOwnerRef, &out.EnableCertificateOwnerRef, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_bool_To_Pointer_bool(&in.EnableGatewayAPI, &out.EnableGatewayAPI, s); err != nil {
 		return err
 	}
 	out.CopiedAnnotationPrefixes = *(*[]string)(unsafe.Pointer(&in.CopiedAnnotationPrefixes))

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -56,6 +56,7 @@ const (
 
 	// Owner: N/A
 	// Alpha: v1.5
+	// Beta: v1.15
 	//
 	// ExperimentalGatewayAPISupport enables the gateway-shim controller and adds support for
 	// the Gateway API to the HTTP-01 challenge solver.
@@ -150,7 +151,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 
 	ValidateCAA: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
-	ExperimentalGatewayAPISupport:                    {Default: false, PreRelease: featuregate.Alpha},
+	ExperimentalGatewayAPISupport:                    {Default: true, PreRelease: featuregate.Beta},
 	AdditionalCertificateOutputFormats:               {Default: false, PreRelease: featuregate.Alpha},
 	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
 	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -306,7 +306,7 @@ e2e-setup-certmanager: e2e-setup-gatewayapi $(E2E_SETUP_OPTION_DEPENDENCIES) $(b
 		$(addprefix --version,$(E2E_CERT_MANAGER_VERSION)) \
 		--set crds.enabled=true \
 		--set featureGates="$(feature_gates_controller)" \
-		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200}" \
+		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200,--enable-gateway-api}" \
 		--set webhook.featureGates="$(feature_gates_webhook)" \
 		--set "cainjector.extraArgs={--feature-gates=$(feature_gates_cainjector)}" \
 		--set "dns01RecursiveNameservers=$(SERVICE_IP_PREFIX).16:53" \
@@ -334,7 +334,7 @@ e2e-setup-certmanager: $(bin_dir)/cert-manager.tgz $(foreach binaryname,controll
 		--set startupapicheck.image.tag="$(TAG)" \
 		--set crds.enabled=true \
 		--set featureGates="$(feature_gates_controller)" \
-		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200}" \
+		--set "extraArgs={--kube-api-qps=9000,--kube-api-burst=9000,--concurrent-workers=200,--enable-gateway-api}" \
 		--set webhook.featureGates="$(feature_gates_webhook)" \
 		--set "cainjector.extraArgs={--feature-gates=$(feature_gates_cainjector)}" \
 		--set "dns01RecursiveNameservers=$(SERVICE_IP_PREFIX).16:53" \

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -81,6 +81,11 @@ type ControllerConfiguration struct {
 	// automatically removed when the certificate resource is deleted.
 	EnableCertificateOwnerRef *bool `json:"enableCertificateOwnerRef,omitempty"`
 
+	// Whether gateway API integration is enabled within cert-manager. The
+	// ExperimentalGatewayAPISupport feature gate must also be enabled (default
+	// as of 1.15).
+	EnableGatewayAPI *bool `json:"enableGatewayAPI,omitempty"`
+
 	// Specify which annotations should/shouldn't be copied from Certificate to
 	// CertificateRequest and Order, as well as from CertificateSigningRequest to
 	// Order, by passing a list of annotation key prefixes. A prefix starting with

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -112,6 +112,11 @@ func (in *ControllerConfiguration) DeepCopyInto(out *ControllerConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableGatewayAPI != nil {
+		in, out := &in.EnableGatewayAPI, &out.EnableGatewayAPI
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CopiedAnnotationPrefixes != nil {
 		in, out := &in.CopiedAnnotationPrefixes, &out.CopiedAnnotationPrefixes
 		*out = make([]string, len(*in))


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR graduates the GatewayAPI support to *BETA*:
- The ExperimentalGatewayAPISupport feature flag is now enabled by default
- An `--enable-gateway-api` flag / config file option has been added, this is disabled by default.

Fixes #6882

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
GatewayAPI support has graduated to Beta. Add the `--enable-gateway-api` flag to enable the integration.
```
