### PR TITLE
Add process and go runtime metrics for controller

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,7 +28,6 @@ package metrics
 import (
 	"net"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -190,12 +189,9 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 
 	// Create Registry and register the recommended collectors
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(
-		collectors.NewGoCollector(
-			collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
-			collectors.WithoutGoCollectorRuntimeMetrics(regexp.MustCompile("^/godebug/.*")),
-		),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
 	)
 	// Create server and register Prometheus metrics handler
 	m := &Metrics{

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -145,7 +145,8 @@ func TestMetricsController(t *testing.T) {
 			return err
 		}
 
-		if strings.TrimSpace(string(output)) != strings.TrimSpace(expectedOutput) {
+		trimmedOutput := strings.SplitN(string(output), "# HELP go_gc_duration_seconds", 2)[0]
+		if strings.TrimSpace(trimmedOutput) != strings.TrimSpace(expectedOutput) {
 			return fmt.Errorf("got unexpected metrics output\nexp:\n%s\ngot:\n%s\n",
 				expectedOutput, output)
 		}


### PR DESCRIPTION
### Pull Request Motivation

These metrics are default when using Prometheus go client's pre-defined registry, but were missing as the controller creates it's own registry.

Useful many debug scenarios

### Kind

feature 

### Release Note

```release-note
Add process and go runtime metrics for controller
```
