### PR TITLE
Fix linters: misspell, gocritic, bodyclose, unused, unconvert, gosimple, ginkgolinter and wastedassign

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,6 @@ issues:
         - errname
         - tenv
         - exhaustive
-        - gocritic
         - nilerr
         - loggercheck
         - forbidigo

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ issues:
         - forbidigo
         - interfacebloat
         - predeclared
-        - unconvert
         - usestdlibvars
         - noctx
         - nilnil

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ issues:
         - usestdlibvars
         - noctx
         - nilnil
-        - gosimple
         - nakedret
         - asasalint
         - goprintffuncname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,6 @@ issues:
         - goprintffuncname
         - ineffassign
         - musttag
-        - wastedassign
         - nosprintfhostport
         - exportloopref
         - gomoddirectives

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ issues:
         - gosimple
         - nakedret
         - asasalint
-        - ginkgolinter
         - goprintffuncname
         - ineffassign
         - musttag

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ issues:
         - exhaustive
         - gocritic
         - nilerr
-        - bodyclose
         - loggercheck
         - forbidigo
         - interfacebloat

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@ issues:
     - linters:
         - dogsled
         - errcheck
-        - misspell
         - contextcheck
         - unparam
         - promlinter

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ issues:
         - forbidigo
         - interfacebloat
         - predeclared
-        - unused
         - unconvert
         - usestdlibvars
         - noctx

--- a/cmd/controller/app/options/options_test.go
+++ b/cmd/controller/app/options/options_test.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	//"github.com/cert-manager/cert-manager/controller-binary/app/options"
 	config "github.com/cert-manager/cert-manager/internal/apis/config/controller"
 	defaults "github.com/cert-manager/cert-manager/internal/apis/config/controller/v1alpha1"
 	"github.com/cert-manager/cert-manager/internal/apis/config/controller/validation"

--- a/cmd/controller/app/start.go
+++ b/cmd/controller/app/start.go
@@ -53,9 +53,7 @@ const componentController = "controller"
 func NewServerCommand(ctx context.Context) *cobra.Command {
 	return newServerCommand(
 		ctx,
-		func(ctx context.Context, cfg *config.ControllerConfiguration) error {
-			return Run(ctx, cfg)
-		},
+		Run,
 		os.Args[1:],
 	)
 }

--- a/hack/extractcrd/main.go
+++ b/hack/extractcrd/main.go
@@ -80,8 +80,8 @@ func main() {
 			continue
 		}
 
-		doc = string(strings.TrimPrefix(doc, "---"))
-		doc = string(strings.TrimSpace(doc))
+		doc = strings.TrimPrefix(doc, "---")
+		doc = strings.TrimSpace(doc)
 
 		if wantedCRDName == nil {
 			if foundAny {

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -254,7 +254,7 @@ func validateIssuerRef(issuerRef cmmeta.ObjectReference, fldPath *field.Path) fi
 }
 
 func validateIPAddresses(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
-	if len(a.IPAddresses) <= 0 {
+	if len(a.IPAddresses) == 0 {
 		return nil
 	}
 	el := field.ErrorList{}
@@ -268,7 +268,7 @@ func validateIPAddresses(a *internalcmapi.CertificateSpec, fldPath *field.Path) 
 }
 
 func validateEmailAddresses(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
-	if len(a.EmailAddresses) <= 0 {
+	if len(a.EmailAddresses) == 0 {
 		return nil
 	}
 	el := field.ErrorList{}

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -443,13 +443,10 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 				if p.AzureDNS.ManagedIdentity != nil {
 					el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managed identity can not be used at the same time as clientID, clientSecretSecretRef or tenantID"))
 				}
-			} else {
-				// using managed identity
-				if p.AzureDNS.ManagedIdentity != nil && len(p.AzureDNS.ManagedIdentity.ClientID) > 0 && len(p.AzureDNS.ManagedIdentity.ResourceID) > 0 {
-					el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID and managedIdentityResourceID cannot both be specified"))
-				}
-
+			} else if p.AzureDNS.ManagedIdentity != nil && len(p.AzureDNS.ManagedIdentity.ClientID) > 0 && len(p.AzureDNS.ManagedIdentity.ResourceID) > 0 {
+				el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID and managedIdentityResourceID cannot both be specified"))
 			}
+
 			// SubscriptionID must always be defined
 			if len(p.AzureDNS.SubscriptionID) == 0 {
 				el = append(el, field.Required(fldPath.Child("azureDNS", "subscriptionID"), ""))
@@ -569,7 +566,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			}
 
 			if len(ValidateSecretKeySelector(&p.RFC2136.TSIGSecret, fldPath.Child("rfc2136", "tsigSecretSecretRef"))) == 0 {
-				if len(p.RFC2136.TSIGKeyName) <= 0 {
+				if len(p.RFC2136.TSIGKeyName) == 0 {
 					el = append(el, field.Required(fldPath.Child("rfc2136", "tsigKeyName"), ""))
 				}
 

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -47,6 +47,7 @@ var (
 		Key: "validkey",
 	}
 	// TODO (JS): Missing test for validCloudflareProvider
+	// nolint: unused
 	validCloudflareProvider = cmacme.ACMEIssuerDNS01ProviderCloudflare{
 		APIKey: &validSecretKeyRef,
 		Email:  "valid",

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -277,7 +277,7 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 
 		renewIn := renewalTime.Time.Sub(c.Now())
 		if renewIn > 0 {
-			//renewal time is in future, no need to renew
+			// renewal time is in future, no need to renew
 			return "", "", false
 		}
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -457,7 +457,8 @@ func (v *Vault) requestTokenWithKubernetesAuth(client Client, kubernetesAuth *v1
 		}
 		defaultAudience += v.issuer.GetName()
 
-		audiences := append(kubernetesAuth.ServiceAccountRef.TokenAudiences, defaultAudience)
+		audiences := append([]string(nil), kubernetesAuth.ServiceAccountRef.TokenAudiences...)
+		audiences = append(audiences, defaultAudience)
 
 		tokenrequest, err := v.createToken(context.Background(), kubernetesAuth.ServiceAccountRef.Name, &authv1.TokenRequest{
 			Spec: authv1.TokenRequestSpec{

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -472,7 +472,7 @@ func (v *Vault) requestTokenWithKubernetesAuth(client Client, kubernetesAuth *v1
 				// Vault backend can bind the kubernetes auth backend role to the service account and specific namespace of the service account.
 				// Providing additional audiences is not considered a major non-mitigatable security risk
 				// as if someone creates an Issuer in another namespace/globally with the same audiences
-				// in attempt to highjack the certificate vault (if role config mandates sa:namespace) won't authorise the conneciton
+				// in attempt to highjack the certificate vault (if role config mandates sa:namespace) won't authorise the connection
 				// as token subject won't match vault role requirement to have SA originated from the specific namespace.
 				Audiences: audiences,
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1097,10 +1097,10 @@ type testNewConfigT struct {
 func TestNewConfig(t *testing.T) {
 	caBundleSecretRefFakeSecretLister := func(namespace, secret, key, cert string) *listers.FakeSecretLister {
 		return listers.FakeSecretListerFrom(listers.NewFakeSecretLister(), func(f *listers.FakeSecretLister) {
-			f.SecretsFn = func(namespace string) clientcorev1.SecretNamespaceLister {
+			f.SecretsFn = func(listerNamespace string) clientcorev1.SecretNamespaceLister {
 				return listers.FakeSecretNamespaceListerFrom(listers.NewFakeSecretNamespaceLister(), func(fn *listers.FakeSecretNamespaceLister) {
 					fn.GetFn = func(name string) (*corev1.Secret, error) {
-						if name == secret && namespace == namespace {
+						if name == secret && listerNamespace == namespace {
 							return &corev1.Secret{
 								Data: map[string][]byte{
 									key: []byte(cert),
@@ -1114,10 +1114,10 @@ func TestNewConfig(t *testing.T) {
 	}
 	clientCertificateSecretRefFakeSecretLister := func(namespace, secret, caKey, caCert, clientKey, clientCert, privateKey, privateKeyCert string) *listers.FakeSecretLister {
 		return listers.FakeSecretListerFrom(listers.NewFakeSecretLister(), func(f *listers.FakeSecretLister) {
-			f.SecretsFn = func(namespace string) clientcorev1.SecretNamespaceLister {
+			f.SecretsFn = func(listerNamespace string) clientcorev1.SecretNamespaceLister {
 				return listers.FakeSecretNamespaceListerFrom(listers.NewFakeSecretNamespaceLister(), func(fn *listers.FakeSecretNamespaceLister) {
 					fn.GetFn = func(name string) (*corev1.Secret, error) {
-						if name == secret && namespace == namespace {
+						if name == secret && listerNamespace == namespace {
 							return &corev1.Secret{
 								Data: map[string][]byte{
 									caKey:      []byte(caCert),

--- a/make/config/samplewebhook/sample/main.go
+++ b/make/config/samplewebhook/sample/main.go
@@ -56,7 +56,7 @@ type customDNSProviderSolver struct {
 	// 3. uncomment the relevant code in the Initialize method below
 	// 4. ensure your webhook's service account has the required RBAC role
 	//    assigned to it for interacting with the Kubernetes APIs you need.
-	//client kubernetes.Clientset
+	// client kubernetes.Clientset
 }
 
 // customDNSProviderConfig is a structure that is used to decode into when
@@ -79,8 +79,8 @@ type customDNSProviderConfig struct {
 	// These fields will be set by users in the
 	// `issuer.spec.acme.dns01.providers.webhook.config` field.
 
-	//Email           string `json:"email"`
-	//APIKeySecretRef cmmeta.SecretKeySelector `json:"apiKeySecretRef"`
+	// Email           string `json:"email"`
+	// APIKeySecretRef cmmeta.SecretKeySelector `json:"apiKeySecretRef"`
 }
 
 // Name is used as the name for this DNS solver when referencing it on the ACME
@@ -135,12 +135,12 @@ func (c *customDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, stop
 	///// UNCOMMENT THE BELOW CODE TO MAKE A KUBERNETES CLIENTSET AVAILABLE TO
 	///// YOUR CUSTOM DNS PROVIDER
 
-	//cl, err := kubernetes.NewForConfig(kubeClientConfig)
-	//if err != nil {
-	//	return err
-	//}
+	// cl, err := kubernetes.NewForConfig(kubeClientConfig)
+	// if err != nil {
+	// 	return err
+	// }
 	//
-	//c.client = cl
+	// c.client = cl
 
 	///// END OF CODE TO MAKE KUBERNETES CLIENTSET AVAILABLE
 	return nil

--- a/pkg/acme/util.go
+++ b/pkg/acme/util.go
@@ -28,8 +28,7 @@ import (
 // The 'valid' state is a special case, as it is a final state for Challenges but
 // not for Orders.
 func IsFinalState(s cmacme.State) bool {
-	switch s {
-	case cmacme.Valid:
+	if s == cmacme.Valid {
 		return true
 	}
 	return IsFailureState(s)

--- a/pkg/controller/acmechallenges/controller_test.go
+++ b/pkg/controller/acmechallenges/controller_test.go
@@ -29,11 +29,6 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-const (
-	randomFinalizer         = "random.acme.cert-manager.io"
-	maxConcurrentChallenges = 60
-)
-
 func TestRunScheduler(t *testing.T) {
 	tests := map[string]struct {
 		maxConcurrentChallenges int

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -222,18 +222,19 @@ func handleError(ch *cmacme.Challenge, err error) error {
 	if acmeErr, ok = err.(*acmeapi.Error); !ok {
 		return err
 	}
-	switch acmeErr.ProblemType {
+
 	// This response type is returned when an authorization has expired or the
 	// request is in some way malformed.
 	// In this case, we should mark the challenge as expired so that the order
 	// can be retried.
 	// TODO: don't mark *all* malformed errors as expired, we may be able to be
 	// more informative to the user by further inspecting the Error response.
-	case "urn:ietf:params:acme:error:malformed":
+	if acmeErr.ProblemType == "urn:ietf:params:acme:error:malformed" {
 		ch.Status.State = cmacme.Expired
 		// absorb the error as updating the challenge's status will trigger a sync
 		return nil
 	}
+
 	if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 		ch.Status.State = cmacme.Errored
 		ch.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -51,7 +51,7 @@ const (
 
 var (
 	// RequeuePeriod is the default period after which an Order should be re-queued.
-	// It can be overriden in tests.
+	// It can be overridden in tests.
 	RequeuePeriod = time.Second * 5
 )
 

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,12 +35,6 @@ import (
 
 const (
 	ControllerName = "gateway-shim"
-
-	// resyncPeriod is set to 10 hours across cert-manager. These 10 hours come
-	// from a discussion on the controller-runtime project that boils down to:
-	// never change this without an explicit reason.
-	// https://github.com/kubernetes-sigs/controller-runtime/pull/88#issuecomment-408500629
-	resyncPeriod = 10 * time.Hour
 )
 
 type controller struct {

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -92,8 +92,7 @@ func SyncFnFor(
 		// "kubernetes.io/tls-acme" annotation are only enabled for the Ingress
 		// resource.
 		var autoAnnotations []string
-		switch ingLike.(type) {
-		case *networkingv1.Ingress:
+		if _, ok := ingLike.(*networkingv1.Ingress); ok {
 			autoAnnotations = defaults.DefaultAutoCertificateAnnotations
 		}
 
@@ -284,11 +283,9 @@ func validateGatewayListenerBlock(path *field.Path, l gwapi.Listener, ingLike me
 	if l.TLS.Mode == nil {
 		errs = append(errs, field.Required(path.Child("tls").Child("mode"),
 			"the mode field is required"))
-	} else {
-		if *l.TLS.Mode != gwapi.TLSModeTerminate {
-			errs = append(errs, field.NotSupported(path.Child("tls").Child("mode"),
-				*l.TLS.Mode, []string{string(gwapi.TLSModeTerminate)}))
-		}
+	} else if *l.TLS.Mode != gwapi.TLSModeTerminate {
+		errs = append(errs, field.NotSupported(path.Child("tls").Child("mode"),
+			*l.TLS.Mode, []string{string(gwapi.TLSModeTerminate)}))
 	}
 
 	return errs

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -19,7 +19,6 @@ package shimhelper
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -3262,17 +3261,6 @@ func TestSync(t *testing.T) {
 		}
 	})
 
-}
-
-type fakeHelper struct {
-	issuer cmapi.GenericIssuer
-}
-
-func (f *fakeHelper) GetGenericIssuer(ref cmmeta.ObjectReference, ns string) (cmapi.GenericIssuer, error) {
-	if f.issuer == nil {
-		return nil, fmt.Errorf("no issuer specified on fake helper")
-	}
-	return f.issuer, nil
 }
 
 func TestIssuerForIngress(t *testing.T) {

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -66,13 +66,11 @@ func init() {
 
 func NewCA(ctx *controllerpkg.Context) certificaterequests.Issuer {
 	return &CA{
-		issuerOptions: ctx.IssuerOptions,
-		secretsLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
-		reporter:      crutil.NewReporter(ctx.Clock, ctx.Recorder),
-		templateGenerator: func(cr *cmapi.CertificateRequest) (*x509.Certificate, error) {
-			return pki.CertificateTemplateFromCertificateRequest(cr)
-		},
-		signingFn: pki.SignCSRTemplate,
+		issuerOptions:     ctx.IssuerOptions,
+		secretsLister:     ctx.KubeSharedInformerFactory.Secrets().Lister(),
+		reporter:          crutil.NewReporter(ctx.Clock, ctx.Recorder),
+		templateGenerator: pki.CertificateTemplateFromCertificateRequest,
+		signingFn:         pki.SignCSRTemplate,
 	}
 }
 

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -88,8 +88,8 @@ type Controller struct {
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
 
-	//registerExtraInformers is a list of functions that CertificateRequest
-	//controllers can use to register custom informers.
+	// registerExtraInformers is a list of functions that CertificateRequest
+	// controllers can use to register custom informers.
 	registerExtraInformers []RegisterExtraInformerFn
 
 	// Issuer to call sign function

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -403,7 +403,7 @@ func (c *controller) issueCertificate(ctx context.Context, nextRevision int, crt
 		return err
 	}
 
-	//Set status.revision to revision of the CertificateRequest
+	// Set status.revision to revision of the CertificateRequest
 	crt.Status.Revision = &nextRevision
 
 	// Remove Issuing status condition

--- a/pkg/controller/certificates/issuing/secret_manager.go
+++ b/pkg/controller/certificates/issuing/secret_manager.go
@@ -85,11 +85,11 @@ func (c *controller) ensureSecretData(ctx context.Context, log logr.Logger, crt 
 	if isViolation {
 		switch reason {
 		case policies.InvalidCertificate, policies.ManagedFieldsParseError:
-			//An error here indicates that the managed fields are malformed and the
-			//decoder doesn't understand the managed fields on the Secret, or the
-			//signed certificate data could not be decoded. There is nothing more the
-			//controller can do here, so we exit nil so this controller doesn't end in
-			//an infinite loop.
+			// An error here indicates that the managed fields are malformed and the
+			// decoder doesn't understand the managed fields on the Secret, or the
+			// signed certificate data could not be decoded. There is nothing more the
+			// controller can do here, so we exit nil so this controller doesn't end in
+			// an infinite loop.
 			log.Error(errors.New(message), "failed to determine whether the SecretTemplate matches Secret")
 			return nil
 		default:

--- a/pkg/controller/certificates/issuing/secret_manager.go
+++ b/pkg/controller/certificates/issuing/secret_manager.go
@@ -55,7 +55,7 @@ func (c *controller) ensureSecretData(ctx context.Context, log logr.Logger, crt 
 	log = log.WithValues("secret", secret.Name)
 
 	// If there is no certificate or private key data available at the target
-	// Secret then exit early. The absense of these keys should cause an issuance
+	// Secret then exit early. The absence of these keys should cause an issuance
 	// of the Certificate, so there is no need to run post issuance checks.
 	if secret.Data == nil ||
 		len(secret.Data[corev1.TLSCertKey]) == 0 ||

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -176,7 +176,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		renewBeforeHint := crt.Spec.RenewBefore
 		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, renewBeforeHint)
 
-		//update Certificate's Status
+		// update Certificate's Status
 		crt.Status.NotBefore = &notBefore
 		crt.Status.NotAfter = &notAfter
 		crt.Status.RenewalTime = renewalTime

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -216,7 +216,7 @@ func TestProcessItem(t *testing.T) {
 					Message: "ready message",
 				})),
 		},
-		"update status for a Certificate that has a Ready conditon and the policy evaluates to True- should remain True": {
+		"update status for a Certificate that has a Ready condition and the policy evaluates to True- should remain True": {
 			condition: cmapi.CertificateCondition{
 				Type:               cmapi.CertificateConditionReady,
 				Status:             cmmeta.ConditionTrue,

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -246,7 +246,7 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 // shouldBackOffReissuingOnFailure returns true if an issuance needs to be
 // delayed and the required delay after calculating the exponential backoff.
 // The backoff periods are 1h, 2h, 4h, 8h, 16h and 32h counting from when the last
-// failure occured,
+// failure occurred,
 // so the returned delay will be backoff_period - (current_time - last_failure_time)
 //
 // Notably, it returns no back-off when the certificate doesn't

--- a/pkg/controller/certificatesigningrequests/controller.go
+++ b/pkg/controller/certificatesigningrequests/controller.go
@@ -87,8 +87,8 @@ type Controller struct {
 	// the signer kind to react to when a certificate signing request is synced
 	signerType string
 
-	//registerExtraInformers is a list of functions that
-	//CertificateSigningRequest controllers can use to register custom informers.
+	// registerExtraInformers is a list of functions that
+	// CertificateSigningRequest controllers can use to register custom informers.
 	registerExtraInformers []RegisterExtraInformerFn
 
 	// used for testing

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -18,8 +18,6 @@ package vault
 
 import (
 	"context"
-	"crypto"
-	"crypto/x509"
 	"fmt"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -43,8 +41,6 @@ import (
 const (
 	CSRControllerName = "certificatesigningrequests-issuer-vault"
 )
-
-type signingFn func(*x509.Certificate, *x509.Certificate, crypto.PublicKey, interface{}) ([]byte, *x509.Certificate, error)
 
 // Vault is a controller for signing Kubernetes CertificateSigningRequest
 // using Vault Issuers.

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -243,11 +243,13 @@ func stabilizeError(err error) error {
 
 	var authErr *azidentity.AuthenticationFailedError
 	if errors.As(err, &authErr) {
+		//nolint: bodyclose // False positive, this already a processed body, probably just pointing to a buffer.
 		authErr.RawResponse = redactResponse(authErr.RawResponse)
 	}
 
 	var respErr *azcore.ResponseError
 	if errors.As(err, &respErr) {
+		//nolint: bodyclose // False positive, this already a processed body, probably just pointing to a buffer.
 		respErr.RawResponse = redactResponse(respErr.RawResponse)
 	}
 

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -236,9 +236,9 @@ func stabilizeError(err error) error {
 			return nil
 		}
 
-		reponse := *resp
-		reponse.Body = io.NopCloser(bytes.NewReader([]byte("<REDACTED>")))
-		return &reponse
+		response := *resp
+		response.Body = io.NopCloser(bytes.NewReader([]byte("<REDACTED>")))
+		return &response
 	}
 
 	var authErr *azidentity.AuthenticationFailedError

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -109,14 +109,14 @@ func FindNearestZoneForFQDN(c DNSProviderType, fqdn string) (DNSZone, error) {
 		return DNSZone{}, fmt.Errorf("FindNearestZoneForFQDN: FQDN-Parameter can't be empty, please specify a domain!")
 	}
 	mappedFQDN := strings.Split(fqdn, ".")
-	nextName := util.UnFqdn(fqdn) //remove the trailing dot
+	nextName := util.UnFqdn(fqdn) // remove the trailing dot
 	var lastErr error
 	for i := 0; i < len(mappedFQDN)-1; i++ {
 		var from, to = len(mappedFQDN[i]) + 1, len(nextName)
 		if from > to {
 			continue
 		}
-		if mappedFQDN[i] == "*" { //skip wildcard sub-domain-entries
+		if mappedFQDN[i] == "*" { // skip wildcard sub-domain-entries
 			nextName = string([]rune(nextName)[from:to])
 			continue
 		}
@@ -133,7 +133,7 @@ func FindNearestZoneForFQDN(c DNSProviderType, fqdn string) (DNSZone, error) {
 		}
 
 		if len(zones) > 0 {
-			return zones[0], nil //we're returning the first zone found, might need to test that further
+			return zones[0], nil // we're returning the first zone found, might need to test that further
 		}
 		nextName = string([]rune(nextName)[from:to])
 	}

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -35,7 +35,7 @@ type DNSProviderMock struct {
 }
 
 func (c *DNSProviderMock) makeRequest(method, uri string, body io.Reader) (json.RawMessage, error) {
-	//stub makeRequest
+	// stub makeRequest
 	args := c.Called(method, uri, nil)
 	return args.Get(0).([]uint8), args.Error(1)
 }

--- a/pkg/issuer/vault/setup_test.go
+++ b/pkg/issuer/vault/setup_test.go
@@ -45,8 +45,7 @@ import (
 func TestVault_Setup(t *testing.T) {
 	// Create a mock Vault HTTP server.
 	vaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/v1/auth/approle/login" || r.URL.Path == "/v1/auth/kubernetes/login":
+		if r.URL.Path == "/v1/auth/approle/login" || r.URL.Path == "/v1/auth/kubernetes/login" {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"auth":{"client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"}}`))
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/clock"
 )
 
-// We are writting our own time.AfterFunc to be able to mock the clock. The
+// We are writing our own time.AfterFunc to be able to mock the clock. The
 // cancel function can be called concurrently.
 func afterFunc(c clock.Clock, d time.Duration, f func()) (cancel func()) {
 	t := c.NewTimer(d)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_afterFunc(t *testing.T) {
-	// Note that re-implimenting AfterFunc is not a good idea, since testing it
+	// Note that re-implementing AfterFunc is not a good idea, since testing it
 	// is tricky as seen in time_test.go in the standard library. We will just
 	// focus on two important cases: "f" should be run after the duration
 

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -145,7 +145,7 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 					return false
 				}
 
-				// the renewal channel has a buffer of 1 - drop event if we are already issueing
+				// the renewal channel has a buffer of 1 - drop event if we are already issuing
 				select {
 				case renewalChan <- struct{}{}:
 				default:

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -238,7 +238,7 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 				template.NotAfter = template.NotBefore.Add(150 * time.Millisecond)
 
 				signedCert := signUsingTempCA(t, template)
-				// Reset the NotBefor and NotAfter so we have high percision values here
+				// Reset the NotBefor and NotAfter so we have high precision values here
 				signedCert.NotBefore = time.Now()
 				signedCert.NotAfter = signedCert.NotBefore.Add(150 * time.Millisecond)
 

--- a/pkg/util/cmapichecker/cmapichecker_test.go
+++ b/pkg/util/cmapichecker/cmapichecker_test.go
@@ -176,10 +176,8 @@ func runTest(t *testing.T, test testT) {
 		}
 
 		simpleError = TranslateToSimpleError(err)
-	} else {
-		if test.expectedVerboseError != "" {
-			t.Errorf("expected error did not occure:\n%s", test.expectedVerboseError)
-		}
+	} else if test.expectedVerboseError != "" {
+		t.Errorf("expected error did not occure:\n%s", test.expectedVerboseError)
 	}
 
 	if simpleError != nil {

--- a/pkg/util/configfile/configfile.go
+++ b/pkg/util/configfile/configfile.go
@@ -61,9 +61,7 @@ func NewConfigurationFSLoader(readFileFunc func(filename string) ([]byte, error)
 
 	// Default the readfile function to use os.Readfile for convenience.
 	if readFileFunc == nil {
-		f = func(filename string) ([]byte, error) {
-			return os.ReadFile(filename)
-		}
+		f = os.ReadFile
 	} else {
 		f = readFileFunc
 	}

--- a/pkg/util/pki/asn1_util.go
+++ b/pkg/util/pki/asn1_util.go
@@ -144,13 +144,14 @@ func UnmarshalUniversalValue(rawValue asn1.RawValue) (UniversalValue, error) {
 
 	var rest []byte
 	var err error
-	if rawValue.Tag == asn1.TagIA5String {
+	switch {
+	case rawValue.Tag == asn1.TagIA5String:
 		rest, err = asn1.UnmarshalWithParams(rawValue.FullBytes, &uv.IA5String, "ia5")
-	} else if rawValue.Tag == asn1.TagUTF8String {
+	case rawValue.Tag == asn1.TagUTF8String:
 		rest, err = asn1.UnmarshalWithParams(rawValue.FullBytes, &uv.UTF8String, "utf8")
-	} else if rawValue.Tag == asn1.TagPrintableString {
+	case rawValue.Tag == asn1.TagPrintableString:
 		rest, err = asn1.UnmarshalWithParams(rawValue.FullBytes, &uv.PrintableString, "printable")
-	} else {
+	default:
 		uv.Bytes = rawValue.FullBytes
 	}
 	if err != nil {

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -141,15 +141,6 @@ func (k printKeyUsage) String() string {
 	return sb.String()
 }
 
-// Deprecated: use CertificateTemplateValidateAndOverrideKeyUsages instead.
-func certificateTemplateOverrideKeyUsages(keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage) CertificateTemplateValidatorMutator {
-	return func(req *x509.CertificateRequest, cert *x509.Certificate) error {
-		cert.KeyUsage = keyUsage
-		cert.ExtKeyUsage = extKeyUsage
-		return nil
-	}
-}
-
 // CertificateTemplateFromCSR will create a x509.Certificate for the
 // given *x509.CertificateRequest.
 func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators ...CertificateTemplateValidatorMutator) (*x509.Certificate, error) {

--- a/pkg/util/pki/match_test.go
+++ b/pkg/util/pki/match_test.go
@@ -212,10 +212,8 @@ func TestCertificateRequestOtherNamesMatchSpec(t *testing.T) {
 			if err != nil {
 				if test.err == "" {
 					t.Errorf("Unexpected error: %s", err.Error())
-				} else {
-					if test.err != err.Error() {
-						t.Errorf("Expected error: %s but got: %s instead", err.Error(), test.err)
-					}
+				} else if test.err != err.Error() {
+					t.Errorf("Expected error: %s but got: %s instead", err.Error(), test.err)
 				}
 			}
 
@@ -298,10 +296,8 @@ func TestRequestMatchesSpecSubject(t *testing.T) {
 			if err != nil {
 				if test.err == "" {
 					t.Errorf("Unexpected error: %s", err.Error())
-				} else {
-					if test.err != err.Error() {
-						t.Errorf("Expected error: %s but got: %s instead", err.Error(), test.err)
-					}
+				} else if test.err != err.Error() {
+					t.Errorf("Expected error: %s but got: %s instead", err.Error(), test.err)
 				}
 			}
 

--- a/pkg/util/pki/sans.go
+++ b/pkg/util/pki/sans.go
@@ -126,7 +126,7 @@ func UnmarshalSANs(value []byte) (GeneralNames, error) {
 			if err := isIA5String(name); err != nil {
 				return errors.New("x509: SAN dNSName is malformed")
 			}
-			gns.DNSNames = append(gns.DNSNames, string(name))
+			gns.DNSNames = append(gns.DNSNames, name)
 		case nameTypeX400Address:
 			gns.X400Addresses = append(gns.X400Addresses, v)
 		case nameTypeDirectoryName:

--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -127,7 +127,7 @@ func ExtractCommonNameFromRDNSequence(rdns pkix.RDNSequence) string {
 	return ""
 }
 
-// DEPRECATED: this function will be removed in a future release.
+// Deprecated: this function will be removed in a future release.
 func ParseSubjectStringToRawDERBytes(subject string) ([]byte, error) {
 	rdnSequence, err := UnmarshalSubjectStringToRDNSequence(subject)
 	if err != nil {

--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -235,7 +235,8 @@ func (c *Chart) Logs() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	podList := append(oldLabelPods.Items, newLabelPods.Items...)
+	podList := append([]corev1.Pod(nil), oldLabelPods.Items...)
+	podList = append(podList, newLabelPods.Items...)
 
 	out := make(map[string]string)
 	for _, pod := range podList {

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -199,7 +199,7 @@ func (h *Helper) ValidateIssuedCertificateRequest(cr *cmapi.CertificateRequest, 
 		return nil, fmt.Errorf("CertificateRequest does not have an Approved condition set to True: %+v", cr.Status.Conditions)
 	}
 	if apiutil.CertificateRequestIsDenied(cr) {
-		return nil, fmt.Errorf("CertificateRequest has a Denied conditon set to True: %+v", cr.Status.Conditions)
+		return nil, fmt.Errorf("CertificateRequest has a Denied condition set to True: %+v", cr.Status.Conditions)
 	}
 
 	return cert, nil

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -22,7 +22,7 @@ import (
 
 // NewFeatureSet constructs a new feature set with the given features.
 func NewFeatureSet(feats ...Feature) FeatureSet {
-	return FeatureSet(sets.New(feats...))
+	return sets.New(feats...)
 }
 
 // FeatureSet represents a set of features.

--- a/test/e2e/framework/matcher/san_matchers.go
+++ b/test/e2e/framework/matcher/san_matchers.go
@@ -32,13 +32,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func HaveSameSANsAs(CertWithExpectedSAN string) types.GomegaMatcher {
-	return SANEquals(extractSANsFromCertificate(CertWithExpectedSAN))
+func HaveSameSANsAs(certWithExpectedSAN string) types.GomegaMatcher {
+	return SANEquals(extractSANsFromCertificate(certWithExpectedSAN))
 }
 
 // HaveSans will check that the PEM of the certificates
-func SANEquals(SANExtensionExpected interface{}) *SANMatcher {
-	extension, ok := SANExtensionExpected.(pkix.Extension)
+func SANEquals(sanExtensionExpected interface{}) *SANMatcher {
+	extension, ok := sanExtensionExpected.(pkix.Extension)
 	if !ok || !extension.Id.Equal(oidExtensionSubjectAltName) {
 		Fail("Invalid use of the SANEquals matcher, please supply a valid SAN pkix.Extension")
 	}

--- a/test/e2e/framework/matcher/san_matchers.go
+++ b/test/e2e/framework/matcher/san_matchers.go
@@ -39,8 +39,7 @@ func HaveSameSANsAs(CertWithExpectedSAN string) types.GomegaMatcher {
 // HaveSans will check that the PEM of the certificates
 func SANEquals(SANExtensionExpected interface{}) *SANMatcher {
 	extension, ok := SANExtensionExpected.(pkix.Extension)
-	ok = extension.Id.Equal(oidExtensionSubjectAltName)
-	if !ok {
+	if !ok || !extension.Id.Equal(oidExtensionSubjectAltName) {
 		Fail("Invalid use of the SANEquals matcher, please supply a valid SAN pkix.Extension")
 	}
 	return &SANMatcher{

--- a/test/e2e/framework/matcher/san_matchers.go
+++ b/test/e2e/framework/matcher/san_matchers.go
@@ -126,7 +126,7 @@ var oidExtensionSubjectAltName = []int{2, 5, 29, 17}
 
 func extractSANsFromCertificate(certDER string) pkix.Extension {
 	block, rest := pem.Decode([]byte(certDER))
-	Expect(len(rest)).To(Equal(0))
+	Expect(rest).To(BeEmpty())
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -26,7 +26,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/component-base/featuregate"
 
 	. "github.com/cert-manager/cert-manager/e2e-tests/framework/log"
@@ -92,8 +91,7 @@ func RbacClusterRoleHasAccessToResource(f *Framework, clusterRole string, verb s
 	time.Sleep(time.Second)
 
 	By("Impersonating the Service Account")
-	var impersonateConfig *rest.Config
-	impersonateConfig = f.KubeClientConfig
+	impersonateConfig := f.KubeClientConfig
 	impersonateConfig.Impersonate.UserName = "system:serviceaccount:" + f.Namespace.Name + ":" + viewServiceAccountName
 	impersonateClient, err := kubernetes.NewForConfig(impersonateConfig)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/certificaterequests/approval/approval.go
+++ b/test/e2e/suite/certificaterequests/approval/approval.go
@@ -199,7 +199,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 
 		kubeConfig.QPS = 9000
 		kubeConfig.Burst = 9000
-		kubeConfig.BearerToken = fmt.Sprintf("%s", token)
+		kubeConfig.BearerToken = string(token)
 		kubeConfig.CertData = nil
 		kubeConfig.KeyData = nil
 		kubeConfig.Timeout = time.Second * 20

--- a/test/e2e/suite/certificaterequests/approval/userinfo.go
+++ b/test/e2e/suite/certificaterequests/approval/userinfo.go
@@ -175,7 +175,7 @@ var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 
 		kubeConfig.QPS = 9000
 		kubeConfig.Burst = 9000
-		kubeConfig.BearerToken = fmt.Sprintf("%s", token)
+		kubeConfig.BearerToken = string(token)
 		kubeConfig.CertData = nil
 		kubeConfig.KeyData = nil
 

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -367,7 +367,7 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 					continue
 				}
 				var fieldset fieldpath.Set
-				Expect(fieldset.FromJSON(bytes.NewReader(managedField.FieldsV1.Raw)))
+				Expect(fieldset.FromJSON(bytes.NewReader(managedField.FieldsV1.Raw))).NotTo(HaveOccurred())
 				if fieldset.Has(fieldpath.Path{
 					{FieldName: ptr.To("data")},
 					{FieldName: ptr.To("tls-combined.pem")},

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -24,7 +24,6 @@ import (
 	"encoding/pem"
 	"time"
 
-	//. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -97,12 +97,12 @@ var _ = framework.CertManagerDescribe("literalsubject rdn parsing", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), secretName, metav1.GetOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(secret.Data).To(HaveKey("tls.crt"))
 		crtPEM := secret.Data["tls.crt"]
 		pemBlock, _ := pem.Decode(crtPEM)
 		cert, err := x509.ParseCertificate(pemBlock.Bytes)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(cert.Subject.Names).To(Equal([]pkix.AttributeTypeAndValue{
 			{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "Spain"},
@@ -121,7 +121,7 @@ var _ = framework.CertManagerDescribe("literalsubject rdn parsing", func() {
 
 	It("Should not allow unknown RDN component", func() {
 		_, err := createCertificate(f, "UNKNOWN=blah")
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Literal subject contains unrecognized key with value [blah]"))
 	})
 

--- a/test/e2e/suite/certificates/othernamesan.go
+++ b/test/e2e/suite/certificates/othernamesan.go
@@ -103,12 +103,12 @@ var _ = framework.CertManagerDescribe("othername san processing", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
 
 		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), secretName, metav1.GetOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(secret.Data).To(HaveKey("tls.crt"))
 		crtPEM := secret.Data["tls.crt"]
 		pemBlock, _ := pem.Decode(crtPEM)
 		cert, err := x509.ParseCertificate(pemBlock.Bytes)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Including the appropriate GeneralNames ( RFC822 email Address and OtherName) in generated Certificate")
 
@@ -151,7 +151,7 @@ YH0ROM05IRf2nOI6KInaiz4POk6JvdTb
 				UTF8Value: "user@example.org",
 			},
 		})
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("admission webhook \"webhook.cert-manager.io\" denied the request: spec.otherNames[0].oid: Invalid value: \"BAD_OID\": oid syntax invalid"))
 
 	})
@@ -166,7 +166,7 @@ YH0ROM05IRf2nOI6KInaiz4POk6JvdTb
 				UTF8Value: "user@example.org",
 			},
 		})
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("admission webhook \"webhook.cert-manager.io\" denied the request: spec.otherNames[0].utf8Value: Required value: must be set to a valid non-empty UTF8 string"))
 
 	})

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -332,7 +332,6 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(testCertificate, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
-			//type ValidationFunc func(certificate *cmapi.Certificate, secret *corev1.Secret) error
 			valFunc := func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
 				certBytes, ok := secret.Data[corev1.TLSCertKey]
 				if !ok {

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -267,7 +267,7 @@ func (s *Suite) Define() {
 
 				pemBlock, _ := pem.Decode(certBytes)
 				cert, err := x509.ParseCertificate(pemBlock.Bytes)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Including the appropriate GeneralNames ( RFC822 email Address and OtherName) in generated Certificate")
 				/* openssl req -nodes -newkey rsa:2048 -subj "/CN=someCN" \

--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -417,7 +417,8 @@ func (s *Suite) Define() {
 				// Validate that the request was signed as expected. Add extra
 				// validations which may be required for this test.
 				By("Validating the issued CertificateSigningRequest...")
-				validations := append(test.extraValidations, validation.CertificateSigningRequestSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
+				validations := append([]certificatesigningrequests.ValidationFunc(nil), test.extraValidations...)
+				validations = append(validations, validation.CertificateSigningRequestSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
 				err = f.Helper().ValidateCertificateSigningRequest(kubeCSR.Name, key, validations...)
 				Expect(err).NotTo(HaveOccurred())
 			}, test.requiredFeatures...)

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -39,7 +39,6 @@ import (
 
 var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 	f := framework.NewDefaultFramework("acme-dns01-sample-webhook")
-	//h := f.Helper()
 
 	Context("with the sample webhook solver deployed", func() {
 		issuerName := "test-acme-issuer"

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -161,7 +161,7 @@ var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 				for _, ch := range l {
 					logf("Found challenge named %q", ch.Name)
 
-					if ch.Status.Presented == false {
+					if !ch.Status.Presented {
 						logf("Challenge %q has not been 'Presented'", ch.Name)
 						allPresented = false
 					}

--- a/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
@@ -82,7 +82,7 @@ func testRFC2136DNSProvider() bool {
 					},
 				}))
 			issuer.Namespace = f.Namespace.Name
-			issuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+			_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for Issuer to become Ready")
 			err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
@@ -125,7 +125,7 @@ func testRFC2136DNSProvider() bool {
 				[]string{dnsDomain}, nil, nil, x509.RSA)
 			Expect(err).NotTo(HaveOccurred())
 
-			cr, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
+			_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = h.WaitCertificateRequestIssuedValid(f.Namespace.Name, certificateRequestName, time.Minute*5, key)
 			Expect(err).NotTo(HaveOccurred())
@@ -138,7 +138,7 @@ func testRFC2136DNSProvider() bool {
 				[]string{"*." + dnsDomain}, nil, nil, x509.RSA)
 			Expect(err).NotTo(HaveOccurred())
 
-			cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(context.TODO(), cr, metav1.CreateOptions{})
+			_, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(context.TODO(), cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = h.WaitCertificateRequestIssuedValid(f.Namespace.Name, certificateRequestName, time.Minute*5, key)
 			Expect(err).NotTo(HaveOccurred())
@@ -151,7 +151,7 @@ func testRFC2136DNSProvider() bool {
 				[]string{"*." + dnsDomain, dnsDomain}, nil, nil, x509.RSA)
 			Expect(err).NotTo(HaveOccurred())
 
-			cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(context.TODO(), cr, metav1.CreateOptions{})
+			_, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(context.TODO(), cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			// use a longer timeout for this, as it requires performing 2 dns validations in serial
 			err = h.WaitCertificateRequestIssuedValid(f.Namespace.Name, certificateRequestName, time.Minute*10, key)

--- a/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
-	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon"
 	"github.com/cert-manager/cert-manager/e2e-tests/suite/issuers/acme/dnsproviders"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -35,11 +34,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-type dns01Provider interface {
-	Details() *dnsproviders.Details
-	addon.Addon
-}
 
 const testingACMEEmail = "e2e@cert-manager.io"
 const testingACMEPrivateKey = "test-acme-private-key"

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -45,7 +45,6 @@ import (
 type injectableTest struct {
 	makeInjectable func(namePrefix string) client.Object
 	getCAs         func(runtime.Object) [][]byte
-	subject        string
 	disabled       string
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -385,8 +385,8 @@ func NewGateway(gatewayName, ns, secretName string, annotations map[string]strin
 
 // HasIngresses lets you know if an API exists in the discovery API
 // calling this function always performs a request to the API server.
-func HasIngresses(d discovery.DiscoveryInterface, GroupVersion string) bool {
-	resourceList, err := d.ServerResourcesForGroupVersion(GroupVersion)
+func HasIngresses(d discovery.DiscoveryInterface, groupVersion string) bool {
+	resourceList, err := d.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
 		return false
 	}

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -135,6 +135,7 @@ func TestMetricsController(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 
 		output, err := io.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
Fixes the linter issues returned by the following linters: misspell, gocritic, bodyclose, unused, unconvert, gosimple, ginkgolinter and wastedassign

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
