### PR TITLE
Fix linters: unparam, tenv, loggercheck, forbidigo, predeclared, usestdlibvars, asasalint, goprintffuncname, ineffassign, nosprintfhostport and exportloopref

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ issues:
         - contextcheck
         - promlinter
         - errname
-        - tenv
         - exhaustive
         - nilerr
         - interfacebloat

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ issues:
         - nilnil
         - nakedret
         - musttag
-        - nosprintfhostport
         - exportloopref
         - gomoddirectives
       text: ".*"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ issues:
         - noctx
         - nilnil
         - nakedret
-        - asasalint
         - musttag
         - nosprintfhostport
         - exportloopref

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ issues:
         - nakedret
         - asasalint
         - goprintffuncname
-        - ineffassign
         - musttag
         - nosprintfhostport
         - exportloopref

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ issues:
         - tenv
         - exhaustive
         - nilerr
-        - loggercheck
         - forbidigo
         - interfacebloat
         - predeclared

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,6 @@ issues:
         - forbidigo
         - interfacebloat
         - predeclared
-        - usestdlibvars
         - noctx
         - nilnil
         - nakedret

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ issues:
         - nilnil
         - nakedret
         - asasalint
-        - goprintffuncname
         - musttag
         - nosprintfhostport
         - exportloopref

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,6 @@ issues:
         - nilnil
         - nakedret
         - musttag
-        - exportloopref
         - gomoddirectives
       text: ".*"
     - linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ issues:
         - tenv
         - exhaustive
         - nilerr
-        - forbidigo
         - interfacebloat
         - noctx
         - nilnil

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@ issues:
         - dogsled
         - errcheck
         - contextcheck
-        - unparam
         - promlinter
         - errname
         - tenv

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,6 @@ issues:
         - nilerr
         - forbidigo
         - interfacebloat
-        - predeclared
         - noctx
         - nilnil
         - nakedret

--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -173,7 +173,7 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 
 	err = cainjector.RegisterAllInjectors(ctx, mgr, setupOptions)
 	if err != nil {
-		log.Error(err, "failed to register controllers", err)
+		log.Error(err, "failed to register controllers")
 		return err
 	}
 

--- a/hack/extractcrd/main.go
+++ b/hack/extractcrd/main.go
@@ -61,6 +61,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	outWriter := os.Stdout
+
 	docs := docSeparatorRegexp.Split(string(rawYAMLBytes), -1)
 
 	decoder := crdDecoder()
@@ -85,15 +87,15 @@ func main() {
 
 		if wantedCRDName == nil {
 			if foundAny {
-				fmt.Println("---")
+				fmt.Fprintln(outWriter, "---")
 			}
-			fmt.Println(doc)
+			fmt.Fprintln(outWriter, doc)
 			foundAny = true
 			continue
 		} else {
 			crdName := strings.ToLower(crd.Spec.Names.Plural)
 			if crdName == *wantedCRDName {
-				fmt.Println(doc)
+				fmt.Fprintln(outWriter, doc)
 				return
 			}
 		}

--- a/hack/prune-junit-xml/prunexml_test.go
+++ b/hack/prune-junit-xml/prunexml_test.go
@@ -24,6 +24,8 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -92,8 +94,9 @@ func TestPruneXML(t *testing.T) {
 		<testcase classname="internal/controller/certificaterequests" name="Test_serializeApplyStatus" time="1.610000"></testcase>
 	</testsuite>
 </testsuites>`
+	logger := log.New(os.Stderr, "", 0)
 	suites, _ := fetchXML(strings.NewReader(sourceXML))
-	pruneXML(suites, 32)
+	pruneXML(logger, suites, 32)
 	var output bytes.Buffer
 	writer := bufio.NewWriter(&output)
 	_ = streamXML(writer, suites)

--- a/internal/apis/acme/validation/challenge.go
+++ b/internal/apis/acme/validation/challenge.go
@@ -27,15 +27,15 @@ import (
 )
 
 func ValidateChallengeUpdate(a *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
-	old, ok := oldObj.(*cmacme.Challenge)
-	new := newObj.(*cmacme.Challenge)
+	oldChallenge, ok := oldObj.(*cmacme.Challenge)
+	newChallenge := newObj.(*cmacme.Challenge)
 	// if oldObj is not set, the Update operation is always valid.
-	if !ok || old == nil {
+	if !ok || oldChallenge == nil {
 		return nil, nil
 	}
 
 	el := field.ErrorList{}
-	if !reflect.DeepEqual(old.Spec, new.Spec) {
+	if !reflect.DeepEqual(oldChallenge.Spec, newChallenge.Spec) {
 		el = append(el, field.Forbidden(field.NewPath("spec"), "challenge spec is immutable after creation"))
 	}
 	return el, nil

--- a/internal/apis/acme/validation/order_test.go
+++ b/internal/apis/acme/validation/order_test.go
@@ -55,11 +55,11 @@ func testImmutableOrderField(t *testing.T, fldPath *field.Path, setter func(*cma
 			field.Forbidden(fldPath, "field is immutable once set"),
 		}
 		var expectedWarnings []string
-		old := &cmacme.Order{}
-		new := &cmacme.Order{}
-		setter(old, testValueOptionOne)
-		setter(new, testValueOptionTwo)
-		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, old, new)
+		oldOrder := &cmacme.Order{}
+		newOrder := &cmacme.Order{}
+		setter(oldOrder, testValueOptionOne)
+		setter(newOrder, testValueOptionTwo)
+		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, oldOrder, newOrder)
 		if len(errs) != len(expectedErrs) {
 			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return
@@ -77,11 +77,11 @@ func testImmutableOrderField(t *testing.T, fldPath *field.Path, setter func(*cma
 	t.Run("should allow updates to "+fldPath.String()+" if not already set", func(t *testing.T) {
 		expectedErrs := []*field.Error{}
 		var expectedWarnings []string
-		old := &cmacme.Order{}
-		new := &cmacme.Order{}
-		setter(old, testValueNone)
-		setter(new, testValueOptionOne)
-		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, old, new)
+		oldOrder := &cmacme.Order{}
+		newOrder := &cmacme.Order{}
+		setter(oldOrder, testValueNone)
+		setter(newOrder, testValueOptionOne)
+		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, oldOrder, newOrder)
 		if len(errs) != len(expectedErrs) {
 			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return

--- a/internal/controller/certificates/policies/gatherer_test.go
+++ b/internal/controller/certificates/policies/gatherer_test.go
@@ -38,6 +38,13 @@ import (
 )
 
 func TestDataForCertificate(t *testing.T) {
+	cr := func(crName, ownerCertUID string, annot map[string]string) *cmapi.CertificateRequest {
+		return gen.CertificateRequest(crName, gen.SetCertificateRequestNamespace("ns-1"),
+			gen.AddCertificateRequestOwnerReferences(gen.CertificateRef("some-cert-name-that-does-not-matter", ownerCertUID)),
+			gen.AddCertificateRequestAnnotations(annot),
+		)
+	}
+
 	tests := map[string]struct {
 		builder    *testpkg.Builder
 		givenCert  *cmapi.Certificate
@@ -68,8 +75,8 @@ func TestDataForCertificate(t *testing.T) {
 				gen.SetCertificateRevision(1),
 			),
 			builder: &testpkg.Builder{CertManagerObjects: []runtime.Object{
-				cr("cr-unknown-rev1", "ns-1", "unknown-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-unknown-rev2", "ns-1", "unknown-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-unknown-rev1", "unknown-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-unknown-rev2", "unknown-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
 			}},
 			wantCurCR:  nil,
 			wantNextCR: nil,
@@ -79,17 +86,17 @@ func TestDataForCertificate(t *testing.T) {
 				gen.SetCertificateUID("cert-1-uid"),
 			),
 			builder: &testpkg.Builder{CertManagerObjects: []runtime.Object{
-				cr("cr-1-rev1", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-1-rev2", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-1-rev1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-1-rev2", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
 
 				// Edge cases.
-				cr("cr-1-norev", "ns-1", "cert-1-uid", nil),
-				cr("cr-1-empty", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": ""}),
-				cr("cr-unrelated-rev1", "ns-1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-unrelated-rev2", "ns-1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-1-norev", "cert-1-uid", nil),
+				cr("cr-1-empty", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": ""}),
+				cr("cr-unrelated-rev1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-unrelated-rev2", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
 			}},
 			wantCurCR:  nil,
-			wantNextCR: cr("cr-1-rev1", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+			wantNextCR: cr("cr-1-rev1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
 		},
 		"when cert revision=1, should return the current CR with revision=1 and the next CR with revision=2": {
 			givenCert: gen.Certificate("cert-1", gen.SetCertificateNamespace("ns-1"),
@@ -97,20 +104,20 @@ func TestDataForCertificate(t *testing.T) {
 				gen.SetCertificateRevision(1),
 			),
 			builder: &testpkg.Builder{CertManagerObjects: []runtime.Object{
-				cr("cr-1-rev1", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-1-rev2", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
-				cr("cr-1-rev3", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "3"}),
+				cr("cr-1-rev1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-1-rev2", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-1-rev3", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "3"}),
 
 				// Edge cases.
-				cr("cr-1-no-revision", "ns-1", "cert-1-uid", nil),
-				cr("cr-1-empty", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": ""}),
-				cr("cr-2-rev1", "ns-1", "cert-2-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-unrelated-rev1", "ns-1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-unrelated-rev2", "ns-1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
-				cr("cr-unrelated-rev3", "ns-1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "3"}),
+				cr("cr-1-no-revision", "cert-1-uid", nil),
+				cr("cr-1-empty", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": ""}),
+				cr("cr-2-rev1", "cert-2-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-unrelated-rev1", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-unrelated-rev2", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-unrelated-rev3", "cert-unrelated-uid", map[string]string{"cert-manager.io/certificate-revision": "3"}),
 			}},
-			wantCurCR:  cr("cr-1-rev1", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-			wantNextCR: cr("cr-1-rev2", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+			wantCurCR:  cr("cr-1-rev1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+			wantNextCR: cr("cr-1-rev2", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
 		},
 		"should error when duplicate current CRs are found": {
 			givenCert: gen.Certificate("cert-1", gen.SetCertificateNamespace("ns-1"),
@@ -118,8 +125,8 @@ func TestDataForCertificate(t *testing.T) {
 				gen.SetCertificateRevision(1),
 			),
 			builder: &testpkg.Builder{CertManagerObjects: []runtime.Object{
-				cr("cr-1-rev1a", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
-				cr("cr-1-rev1b", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-1-rev1a", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
+				cr("cr-1-rev1b", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "1"}),
 			}},
 			wantErr: `multiple CertificateRequests were found for the 'current' revision 1, issuance is skipped until there are no more duplicates`,
 		},
@@ -129,8 +136,8 @@ func TestDataForCertificate(t *testing.T) {
 				gen.SetCertificateRevision(1),
 			),
 			builder: &testpkg.Builder{CertManagerObjects: []runtime.Object{
-				cr("cr-1-rev2a", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
-				cr("cr-1-rev2b", "ns-1", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-1-rev2a", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
+				cr("cr-1-rev2b", "cert-1-uid", map[string]string{"cert-manager.io/certificate-revision": "2"}),
 			}},
 			wantErr: `multiple CertificateRequests were found for the 'next' revision 2, issuance is skipped until there are no more duplicates`,
 		},
@@ -139,7 +146,7 @@ func TestDataForCertificate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fakeClockStart, _ := time.Parse(time.RFC3339, "2021-01-02T15:04:05Z07:00")
 			log := logtesting.NewTestLogger(t)
-			turnOnKlogIfVerboseTest(t)
+			turnOnKlogIfVerboseTest()
 
 			test.builder.T = t
 			test.builder.Clock = fakeclock.NewFakeClock(fakeClockStart)
@@ -224,7 +231,7 @@ func TestDataForCertificate(t *testing.T) {
 // The logs are helpful for debugging client-go-related issues (informer
 // not starting...). This function passes the flag -v=4 to klog when the
 // tests are being run with -v. Otherwise, the default klog level is used.
-func turnOnKlogIfVerboseTest(t *testing.T) {
+func turnOnKlogIfVerboseTest() {
 	hasVerboseFlag := flag.Lookup("test.v").Value.String() == "true"
 	if !hasVerboseFlag {
 		return
@@ -233,11 +240,4 @@ func turnOnKlogIfVerboseTest(t *testing.T) {
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
 	_ = klogFlags.Set("v", "4")
-}
-
-func cr(crName, crNamespace, ownerCertUID string, annot map[string]string) *cmapi.CertificateRequest {
-	return gen.CertificateRequest(crName, gen.SetCertificateRequestNamespace(crNamespace),
-		gen.AddCertificateRequestOwnerReferences(gen.CertificateRef("some-cert-name-that-does-not-matter", ownerCertUID)),
-		gen.AddCertificateRequestAnnotations(annot),
-	)
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -569,6 +569,7 @@ func (v *Vault) IsVaultInitializedAndUnsealed() error {
 	// 473 = if performance standby
 	// 501 = if not initialized
 	// 503 = if sealed
+	// nolint: usestdlibvars // We use the numeric error codes here that we got from the Vault docs.
 	if err != nil {
 		switch {
 		case healthResp == nil:

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1159,7 +1159,7 @@ func TestNewConfig(t *testing.T) {
 				}),
 			),
 			expectedErr: nil,
-			checkFunc: func(cfg *vault.Config, error error) error {
+			checkFunc: func(cfg *vault.Config, err error) error {
 				testCA := x509.NewCertPool()
 				testCA.AppendCertsFromPEM([]byte(testLeafCertificate))
 				clientCA := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs
@@ -1185,9 +1185,9 @@ func TestNewConfig(t *testing.T) {
 					},
 				},
 				)),
-			checkFunc: func(cfg *vault.Config, error error) error {
-				if error != nil {
-					return error
+			checkFunc: func(cfg *vault.Config, err error) error {
+				if err != nil {
+					return err
 				}
 
 				testCA := x509.NewCertPool()
@@ -1214,9 +1214,9 @@ func TestNewConfig(t *testing.T) {
 					},
 				},
 				)),
-			checkFunc: func(cfg *vault.Config, error error) error {
-				if error != nil {
-					return error
+			checkFunc: func(cfg *vault.Config, err error) error {
+				if err != nil {
+					return err
 				}
 
 				testCA := x509.NewCertPool()
@@ -1291,9 +1291,9 @@ func TestNewConfig(t *testing.T) {
 					},
 				},
 				)),
-			checkFunc: func(cfg *vault.Config, error error) error {
-				if error != nil {
-					return error
+			checkFunc: func(cfg *vault.Config, err error) error {
+				if err != nil {
+					return err
 				}
 
 				certificates := cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.Certificates

--- a/make/config/samplewebhook/sample/main.go
+++ b/make/config/samplewebhook/sample/main.go
@@ -105,7 +105,7 @@ func (c *customDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	}
 
 	// TODO: do something more useful with the decoded configuration
-	fmt.Printf("Decoded configuration %v", cfg)
+	fmt.Fprintf(os.Stdout, "Decoded configuration %v", cfg)
 
 	// TODO: add code that sets a record in the DNS provider's console
 	return nil

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -82,8 +82,7 @@ func BenchmarkScheduleAscending(b *testing.B) {
 			s := &Scheduler{}
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				_, err := s.scheduleN(30, chs)
-				require.NoError(b, err)
+				_ = s.scheduleN(30, chs)
 			}
 		})
 	}
@@ -97,8 +96,7 @@ func BenchmarkScheduleRandom(b *testing.B) {
 			s := &Scheduler{}
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				_, err := s.scheduleN(30, chs)
-				require.NoError(b, err)
+				_ = s.scheduleN(30, chs)
 			}
 		})
 	}
@@ -112,8 +110,7 @@ func BenchmarkScheduleDuplicates(b *testing.B) {
 			s := &Scheduler{}
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				_, err := s.scheduleN(30, chs)
-				require.NoError(b, err)
+				_ = s.scheduleN(30, chs)
 			}
 		})
 	}

--- a/pkg/controller/acmechallenges/update_test.go
+++ b/pkg/controller/acmechallenges/update_test.go
@@ -129,9 +129,9 @@ func runUpdateObjectTests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-			old := gen.Challenge("c1")
-			new := gen.ChallengeFrom(old, tt.mods...)
-			objects := []runtime.Object{old}
+			oldChallenge := gen.Challenge("c1")
+			newChallenge := gen.ChallengeFrom(oldChallenge, tt.mods...)
+			objects := []runtime.Object{oldChallenge}
 			if tt.notFound {
 				t.Log("Simulating a situation where the target object has been deleted")
 				objects = nil
@@ -151,7 +151,7 @@ func runUpdateObjectTests(t *testing.T) {
 			}
 			updater := newObjectUpdater(cl, "test-fieldmanager")
 			t.Log("Calling updateObject")
-			updateObjectErr := updater.updateObject(ctx, old, new)
+			updateObjectErr := updater.updateObject(ctx, oldChallenge, newChallenge)
 			if tt.errorMessage == "" {
 				assert.NoError(t, updateObjectErr)
 			} else {
@@ -164,16 +164,16 @@ func runUpdateObjectTests(t *testing.T) {
 
 			if !tt.notFound {
 				t.Log("Checking whether the object was updated")
-				actual, err := cl.AcmeV1().Challenges(old.Namespace).Get(ctx, old.Name, metav1.GetOptions{})
+				actual, err := cl.AcmeV1().Challenges(oldChallenge.Namespace).Get(ctx, oldChallenge.Name, metav1.GetOptions{})
 				require.NoError(t, err)
 				if updateObjectErr == nil {
-					assert.Equal(t, new, actual, "updateObject did not return an error so the object in the API should have been updated")
+					assert.Equal(t, newChallenge, actual, "updateObject did not return an error so the object in the API should have been updated")
 				} else {
 					if !errors.Is(updateObjectErr, simulatedUpdateError) {
-						assert.Equal(t, new.Finalizers, actual.Finalizers, "The Update did not fail so the Finalizers  of the API object should have been updated")
+						assert.Equal(t, newChallenge.Finalizers, actual.Finalizers, "The Update did not fail so the Finalizers  of the API object should have been updated")
 					}
 					if !errors.Is(updateObjectErr, simulatedUpdateStatusError) {
-						assert.Equal(t, new.Status, actual.Status, "The UpdateStatus did not fail so the Status of the API object should have been updated")
+						assert.Equal(t, newChallenge.Status, actual.Status, "The UpdateStatus did not fail so the Status of the API object should have been updated")
 					}
 				}
 			}

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -202,7 +202,7 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 		// correctly. Do not change this unless there is a real need for
 		// it.
 		log.V(logf.DebugLevel).Info("Update Order status as at least one Challenge has failed")
-		_, err := c.updateOrderStatusFromACMEOrder(ctx, cl, o, acmeOrder)
+		_, err := c.updateOrderStatusFromACMEOrder(o, acmeOrder)
 		if acmeErr, ok := err.(*acmeapi.Error); ok {
 			if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 				log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
@@ -242,7 +242,7 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 
 	case !anyChallengesFailed(challenges) && allChallengesFinal(challenges):
 		log.V(logf.DebugLevel).Info("All challenges are in a final state, updating order state")
-		_, err := c.updateOrderStatusFromACMEOrder(ctx, cl, o, acmeOrder)
+		_, err := c.updateOrderStatusFromACMEOrder(o, acmeOrder)
 		if acmeErr, ok := err.(*acmeapi.Error); ok {
 			if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 				log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
@@ -312,10 +312,10 @@ func (c *controller) updateOrderStatus(ctx context.Context, cl acmecl.Interface,
 		return nil, err
 	}
 
-	return c.updateOrderStatusFromACMEOrder(ctx, cl, o, acmeOrder)
+	return c.updateOrderStatusFromACMEOrder(o, acmeOrder)
 }
 
-func (c *controller) updateOrderStatusFromACMEOrder(ctx context.Context, cl acmecl.Interface, o *cmacme.Order, acmeOrder *acmeapi.Order) (*acmeapi.Order, error) {
+func (c *controller) updateOrderStatusFromACMEOrder(o *cmacme.Order, acmeOrder *acmeapi.Order) (*acmeapi.Order, error) {
 	// Workaround bug in golang.org/x/crypto/acme implementation whereby the
 	// order's URI field will be empty when calling GetOrder due to the
 	// 'Location' header not being set on the response from the ACME server.

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -724,7 +724,9 @@ func getPreferredCertChain(
 		if cert.Issuer.CommonName == preferredChain {
 			// if the issuer's CN matched the preferred chain it means this bundle is
 			// signed by the requested chain
-			log.V(logf.DebugLevel).WithValues("Issuer CN", cert.Issuer.CommonName).Info("Selecting preferred ACME bundle with a matching Common Name from %s", name)
+			log.V(logf.DebugLevel).
+				WithValues("Issuer CN", cert.Issuer.CommonName).
+				Info("Selecting preferred ACME bundle with a matching Common Name from chain", "chainName", name)
 			return true, nil
 		}
 

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -297,11 +297,7 @@ func buildCertificates(
 	cmLister cmlisters.CertificateLister,
 	ingLike metav1.Object,
 	issuerName, issuerKind, issuerGroup string,
-) (new, update []*cmapi.Certificate, _ error) {
-
-	var newCrts []*cmapi.Certificate
-	var updateCrts []*cmapi.Certificate
-
+) (newCrts, updateCrts []*cmapi.Certificate, _ error) {
 	tlsHosts := make(map[corev1.ObjectReference][]string)
 	switch ingLike := ingLike.(type) {
 	case *networkingv1.Ingress:

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -35,7 +35,6 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/controller"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -129,7 +128,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -179,7 +178,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:    []string{"example.com", "www.example.com"},
@@ -230,7 +229,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:    []string{"example.com", "www.example.com"},
@@ -281,7 +280,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:    []string{"example.com", "www.example.com"},
@@ -336,7 +335,7 @@ func TestSync(t *testing.T) {
 							cmacme.ACMECertificateHTTP01IngressNameOverride: "ingress-name",
 							cmapi.IssueTemporaryCertificateAnnotation:       "true",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -389,7 +388,7 @@ func TestSync(t *testing.T) {
 							cmacme.ACMECertificateHTTP01IngressNameOverride: "ingress-name",
 							cmapi.IssueTemporaryCertificateAnnotation:       "true",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -431,7 +430,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -474,7 +473,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -518,7 +517,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 						Annotations: map[string]string{
 							cmacme.ACMECertificateHTTP01IngressClassOverride: "cert-ing",
 						},
@@ -564,7 +563,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -664,7 +663,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -706,7 +705,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -751,7 +750,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -800,7 +799,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -849,7 +848,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -905,7 +904,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -945,7 +944,7 @@ func TestSync(t *testing.T) {
 			CertificateLister: []runtime.Object{
 				buildCertificate("existing-crt",
 					gen.DefaultTestNamespace,
-					buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					buildIngressOwnerReferences("ingress-name"),
 				),
 			},
 			DefaultIssuerKind: "Issuer",
@@ -955,7 +954,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1003,7 +1002,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"a-different-value": "should be removed",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1025,7 +1024,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1068,7 +1067,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1088,7 +1087,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1133,7 +1132,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1156,7 +1155,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1204,7 +1203,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1227,7 +1226,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1276,7 +1275,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1299,7 +1298,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1350,7 +1349,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1373,7 +1372,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "cert-secret-name",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1463,7 +1462,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("not-ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("not-ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1496,7 +1495,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1515,7 +1514,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1557,7 +1556,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1578,7 +1577,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1692,7 +1691,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -1747,7 +1746,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildIngressOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -1824,7 +1823,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1886,7 +1885,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1950,7 +1949,7 @@ func TestSync(t *testing.T) {
 							cmacme.ACMECertificateHTTP01IngressNameOverride: "gateway-name",
 							cmapi.IssueTemporaryCertificateAnnotation:       "true",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2013,7 +2012,7 @@ func TestSync(t *testing.T) {
 							cmacme.ACMECertificateHTTP01IngressNameOverride: "gateway-name",
 							cmapi.IssueTemporaryCertificateAnnotation:       "true",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2065,7 +2064,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2118,7 +2117,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2172,7 +2171,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 						Annotations: map[string]string{
 							cmacme.ACMECertificateHTTP01IngressClassOverride: "cert-ing",
 						},
@@ -2229,7 +2228,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2281,7 +2280,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2386,7 +2385,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2449,7 +2448,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"www.example.com"},
@@ -2515,7 +2514,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2565,7 +2564,7 @@ func TestSync(t *testing.T) {
 			CertificateLister: []runtime.Object{
 				buildCertificate("existing-crt",
 					gen.DefaultTestNamespace,
-					buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+					buildGatewayOwnerReferences("gateway-name"),
 				),
 			},
 			DefaultIssuerKind: "Issuer",
@@ -2575,7 +2574,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2633,7 +2632,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"a-different-value": "should be removed",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2655,7 +2654,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2759,7 +2758,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildIngressOwnerReferences("not-gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildIngressOwnerReferences("not-gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2792,7 +2791,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2811,7 +2810,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "existing-crt",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2863,7 +2862,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2884,7 +2883,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -2969,7 +2968,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com", "foo.example.com"},
@@ -3041,7 +3040,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "foo-example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"foo.example.com"},
@@ -3058,7 +3057,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "bar-example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"bar.example.com"},
@@ -3155,7 +3154,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: buildGatewayOwnerReferences("gateway-name", gen.DefaultTestNamespace),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -3226,7 +3225,7 @@ func TestSync(t *testing.T) {
 			}
 			b.Init()
 			defer b.Stop()
-			sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controller.IngressShimOptions{
+			sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controllerpkg.IngressShimOptions{
 				DefaultIssuerName:                 test.DefaultIssuerName,
 				DefaultIssuerKind:                 test.DefaultIssuerKind,
 				DefaultIssuerGroup:                test.DefaultIssuerGroup,
@@ -3381,20 +3380,21 @@ func buildGateway(name, namespace string, annotations map[string]string) *gwapi.
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: annotations,
+			UID:         types.UID(name),
 		},
 	}
 }
 
-func buildIngressOwnerReferences(name, namespace string) []metav1.OwnerReference {
+func buildIngressOwnerReferences(name string) []metav1.OwnerReference {
 	return []metav1.OwnerReference{
-		*metav1.NewControllerRef(buildIngress(name, namespace, nil), ingressV1GVK),
+		*metav1.NewControllerRef(buildIngress(name, gen.DefaultTestNamespace, nil), ingressV1GVK),
 	}
 }
 
 // The Gateway name and UID are set to the same.
-func buildGatewayOwnerReferences(name, namespace string) []metav1.OwnerReference {
+func buildGatewayOwnerReferences(name string) []metav1.OwnerReference {
 	return []metav1.OwnerReference{
-		*metav1.NewControllerRef(buildIngress(name, namespace, nil), gatewayGVK),
+		*metav1.NewControllerRef(buildGateway(name, gen.DefaultTestNamespace, nil), gatewayGVK),
 	}
 }
 
@@ -3419,7 +3419,7 @@ func Test_validateGatewayListenerBlock(t *testing.T) {
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gateway",
-					Namespace: "default",
+					Namespace: gen.DefaultTestNamespace,
 				},
 			},
 			listener: gwapi.Listener{
@@ -3434,7 +3434,7 @@ func Test_validateGatewayListenerBlock(t *testing.T) {
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gateway",
-					Namespace: "default",
+					Namespace: gen.DefaultTestNamespace,
 				},
 			},
 			listener: gwapi.Listener{
@@ -3459,7 +3459,7 @@ func Test_validateGatewayListenerBlock(t *testing.T) {
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "example",
-					Namespace: "default",
+					Namespace: gen.DefaultTestNamespace,
 				},
 			},
 			listener: gwapi.Listener{
@@ -3523,7 +3523,7 @@ func Test_validateGatewayListenerBlock(t *testing.T) {
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "example",
-					Namespace: "default",
+					Namespace: gen.DefaultTestNamespace,
 				},
 			},
 			listener: gwapi.Listener{
@@ -3595,14 +3595,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: "ingress-2", Namespace: "default", UID: "ingress-2"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ingress-2", Namespace: gen.DefaultTestNamespace, UID: "ingress-2"},
 				Spec:       networkingv1.IngressSpec{TLS: []networkingv1.IngressTLS{{SecretName: "secret-name"}}},
 			},
 			wantToBeRemoved: nil,
@@ -3612,14 +3612,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: "default", UID: "ingress-1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: gen.DefaultTestNamespace, UID: "ingress-1"},
 				Spec:       networkingv1.IngressSpec{TLS: []networkingv1.IngressTLS{{SecretName: "secret-name"}}},
 			},
 			wantToBeRemoved: nil,
@@ -3629,14 +3629,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: "default", UID: "ingress-1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: gen.DefaultTestNamespace, UID: "ingress-1"},
 			},
 			wantToBeRemoved: []string{"cert-1"},
 		},
@@ -3645,14 +3645,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("gw-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &gwapi.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw-2", Namespace: "default", UID: "gw-2"},
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-2", Namespace: gen.DefaultTestNamespace, UID: "gw-2"},
 				Spec: gwapi.GatewaySpec{Listeners: []gwapi.Listener{{
 					TLS: &gwapi.GatewayTLSConfig{CertificateRefs: []gwapi.SecretObjectReference{
 						{
@@ -3668,14 +3668,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("gw-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &gwapi.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default", UID: "gw-1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
 				Spec: gwapi.GatewaySpec{Listeners: []gwapi.Listener{
 					{TLS: &gwapi.GatewayTLSConfig{CertificateRefs: []gwapi.SecretObjectReference{{Name: "not-secret-name"}}}},
 				}},
@@ -3687,14 +3687,14 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 			givenCerts: []*cmapi.Certificate{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "cert-1",
-					Namespace:       "default",
-					OwnerReferences: buildGatewayOwnerReferences("gw-1", "default"),
+					Namespace:       gen.DefaultTestNamespace,
+					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
 				}, Spec: cmapi.CertificateSpec{
 					SecretName: "secret-name",
 				}},
 			},
 			ingLike: &gwapi.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default", UID: "gw-1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
 				Spec: gwapi.GatewaySpec{Listeners: []gwapi.Listener{
 					{TLS: &gwapi.GatewayTLSConfig{CertificateRefs: []gwapi.SecretObjectReference{{Name: "secret-name"}}}},
 				}},
@@ -3712,7 +3712,7 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 
 func Test_secretNameUsedIn_nilPointerGateway(t *testing.T) {
 	got := secretNameUsedIn("secret-name", &gwapi.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default", UID: "gw-1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
 		Spec: gwapi.GatewaySpec{Listeners: []gwapi.Listener{
 			{TLS: nil},
 			{TLS: &gwapi.GatewayTLSConfig{CertificateRefs: nil}},
@@ -3722,7 +3722,7 @@ func Test_secretNameUsedIn_nilPointerGateway(t *testing.T) {
 	assert.Equal(t, true, got)
 
 	got = secretNameUsedIn("secret-name", &gwapi.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: "default", UID: "gw-1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
 		Spec: gwapi.GatewaySpec{Listeners: []gwapi.Listener{
 			{TLS: nil},
 			{TLS: &gwapi.GatewayTLSConfig{CertificateRefs: nil}},

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -168,21 +168,21 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	return nil
 }
 
-func (c *Controller) updateCertificateRequestStatusAndAnnotations(ctx context.Context, old, new *cmapi.CertificateRequest) error {
+func (c *Controller) updateCertificateRequestStatusAndAnnotations(ctx context.Context, oldCR, newCR *cmapi.CertificateRequest) error {
 	log := logf.FromContext(ctx, "updateStatus")
 
 	// if annotations changed we have to call .Update() and not .UpdateStatus()
-	if !reflect.DeepEqual(old.Annotations, new.Annotations) {
-		log.V(logf.DebugLevel).Info("updating resource due to change in annotations", "diff", pretty.Diff(old.Annotations, new.Annotations))
-		return c.updateOrApply(ctx, new)
+	if !reflect.DeepEqual(oldCR.Annotations, newCR.Annotations) {
+		log.V(logf.DebugLevel).Info("updating resource due to change in annotations", "diff", pretty.Diff(oldCR.Annotations, newCR.Annotations))
+		return c.updateOrApply(ctx, newCR)
 	}
 
-	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
+	if apiequality.Semantic.DeepEqual(oldCR.Status, newCR.Status) {
 		return nil
 	}
 
-	log.V(logf.DebugLevel).Info("updating resource due to change in status", "diff", pretty.Diff(old.Status, new.Status))
-	return c.updateStatusOrApply(ctx, new)
+	log.V(logf.DebugLevel).Info("updating resource due to change in status", "diff", pretty.Diff(oldCR.Status, newCR.Status))
+	return c.updateStatusOrApply(ctx, newCR)
 }
 
 func (c *Controller) updateOrApply(ctx context.Context, cr *cmapi.CertificateRequest) error {

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -64,8 +64,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 	return csr
 }
 
-func generateSelfSignedCertFromCR(cr *cmapi.CertificateRequest, key crypto.Signer,
-	duration time.Duration) ([]byte, error) {
+func generateSelfSignedCertFromCR(cr *cmapi.CertificateRequest, key crypto.Signer) ([]byte, error) {
 	template, err := pki.CertificateTemplateFromCertificateRequest(cr)
 	if err != nil {
 		return nil, fmt.Errorf("error generating template: %v", err)
@@ -134,7 +133,7 @@ func TestSign(t *testing.T) {
 		}),
 	)
 
-	rsaPEMCert, err := generateSelfSignedCertFromCR(baseCR, rsaSK, time.Hour*24*60)
+	rsaPEMCert, err := generateSelfSignedCertFromCR(baseCR, rsaSK)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/pkg/controller/certificaterequests/venafi/venafi.go
+++ b/pkg/controller/certificaterequests/venafi/venafi.go
@@ -115,12 +115,11 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 		}
 	}
 
-	duration := apiutil.DefaultCertDuration(cr.Spec.Duration)
 	pickupID := cr.ObjectMeta.Annotations[cmapi.VenafiPickupIDAnnotationKey]
 
 	// check if the pickup ID annotation is there, if not set it up.
 	if pickupID == "" {
-		pickupID, err = client.RequestCertificate(cr.Spec.Request, duration, customFields)
+		pickupID, err = client.RequestCertificate(cr.Spec.Request, customFields)
 		// Check some known error types
 		if err != nil {
 			switch err.(type) {
@@ -148,7 +147,7 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 		return nil, nil
 	}
 
-	certPem, err := client.RetrieveCertificate(pickupID, cr.Spec.Request, duration, customFields)
+	certPem, err := client.RetrieveCertificate(pickupID, cr.Spec.Request, customFields)
 	if err != nil {
 		switch err.(type) {
 		case endpoint.ErrCertificatePending, endpoint.ErrRetrieveCertificateTimeout:

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -222,10 +222,10 @@ func TestSign(t *testing.T) {
 	}
 
 	clientReturnsPending := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
 			return "test", nil
 		},
-		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
 			return nil, endpoint.ErrCertificatePending{
 				CertificateID: "test-cert-id",
 				Status:        "test-status-pending",
@@ -233,33 +233,33 @@ func TestSign(t *testing.T) {
 		},
 	}
 	clientReturnsGenericError := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
 			return "", errors.New("this is an error")
 		},
 	}
 	clientReturnsCert := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
 			return "test", nil
 		},
-		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
 			return append(certPEM, rootPEM...), nil
 		},
 	}
 
 	clientReturnsCertIfCustomField := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, fields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, fields []api.CustomField) (string, error) {
 			if len(fields) > 0 && fields[0].Name == "cert-manager-test" && fields[0].Value == "test ok" {
 				return "test", nil
 			}
 			return "", errors.New("Custom field not set")
 		},
-		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
 			return append(certPEM, rootPEM...), nil
 		},
 	}
 
 	clientReturnsInvalidCustomFieldType := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, fields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, fields []api.CustomField) (string, error) {
 			return "", client.ErrCustomFieldsType{Type: fields[0].Type}
 		},
 	}

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -48,10 +48,8 @@ func mustGeneratePrivateKey(t *testing.T, encoding cmapi.PrivateKeyEncoding) []b
 	return pkBytes
 }
 
-func mustSelfSignCertificate(t *testing.T, pkBytes []byte) []byte {
-	if pkBytes == nil {
-		pkBytes = mustGeneratePrivateKey(t, cmapi.PKCS8)
-	}
+func mustSelfSignCertificate(t *testing.T) []byte {
+	pkBytes := mustGeneratePrivateKey(t, cmapi.PKCS8)
 	pk, err := pki.DecodePrivateKeyBytes(pkBytes)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +72,7 @@ func mustSelfSignCertificate(t *testing.T, pkBytes []byte) []byte {
 func mustSelfSignCertificates(t *testing.T, count int) []byte {
 	var buf bytes.Buffer
 	for i := 0; i < count; i++ {
-		buf.Write(mustSelfSignCertificate(t, nil))
+		buf.Write(mustSelfSignCertificate(t))
 	}
 	return buf.Bytes()
 }
@@ -165,7 +163,7 @@ func TestEncodeJKSKeystore(t *testing.T) {
 			password: "password",
 			alias:    "alias",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS1),
-			certPEM:  mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -192,7 +190,7 @@ func TestEncodeJKSKeystore(t *testing.T) {
 			password: "password",
 			alias:    "alias",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
-			certPEM:  mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -217,8 +215,8 @@ func TestEncodeJKSKeystore(t *testing.T) {
 			password: "password",
 			alias:    "alias",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
-			certPEM:  mustSelfSignCertificate(t, nil),
-			caPEM:    mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
+			caPEM:    mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -242,7 +240,7 @@ func TestEncodeJKSKeystore(t *testing.T) {
 			password: "password",
 			alias:    "alias",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
-			certPEM:  mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
 			caPEM:    mustSelfSignCertificates(t, 3),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
@@ -356,7 +354,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		"encode a JKS bundle for a PKCS1 key and certificate only": {
 			password: "password",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS1),
-			certPEM:  mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -377,7 +375,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		"encode a JKS bundle for a PKCS8 key and certificate only": {
 			password: "password",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
-			certPEM:  mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -398,8 +396,8 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		"encode a JKS bundle for a key, certificate and ca": {
 			password: "password",
 			rawKey:   mustGeneratePrivateKey(t, cmapi.PKCS8),
-			certPEM:  mustSelfSignCertificate(t, nil),
-			caPEM:    mustSelfSignCertificate(t, nil),
+			certPEM:  mustSelfSignCertificate(t),
+			caPEM:    mustSelfSignCertificate(t),
 			verify: func(t *testing.T, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
@@ -450,7 +448,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 	})
 	t.Run("encodePKCS12Keystore *prepends* non-leaf certificates to the supplied CA certificate chain", func(t *testing.T) {
 		const password = "password"
-		caChainInPEM := mustSelfSignCertificate(t, nil)
+		caChainInPEM := mustSelfSignCertificate(t)
 		caChainIn, err := pki.DecodeX509CertificateChainBytes(caChainInPEM)
 		require.NoError(t, err)
 
@@ -534,8 +532,8 @@ func TestEncodePKCS12Truststore(t *testing.T) {
 
 func TestManyPasswordLengths(t *testing.T) {
 	rawKey := mustGeneratePrivateKey(t, cmapi.PKCS8)
-	certPEM := mustSelfSignCertificate(t, nil)
-	caPEM := mustSelfSignCertificate(t, nil)
+	certPEM := mustSelfSignCertificate(t)
+	caPEM := mustSelfSignCertificate(t)
 
 	const testN = 10000
 

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -86,7 +86,7 @@ func NewSecretsManager(
 // If the Secret resource does not exist, it will be created on Apply.
 // UpdateData will also update deprecated annotations if they exist.
 func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate, data SecretData) error {
-	secret, err := s.getCertificateSecret(ctx, crt)
+	secret, err := s.getCertificateSecret(crt)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 
 // getCertificateSecret will return a secret which is ready for fields to be
 // applied. Only the Secret Type will be persisted from the original Secret.
-func (s *SecretsManager) getCertificateSecret(ctx context.Context, crt *cmapi.Certificate) (*corev1.Secret, error) {
+func (s *SecretsManager) getCertificateSecret(crt *cmapi.Certificate) (*corev1.Secret, error) {
 	// Get existing secret if it exists.
 	existingSecret, err := s.secretLister.Secrets(crt.Namespace).Get(crt.Spec.SecretName)
 

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -865,7 +865,7 @@ func Test_getCertificateSecret(t *testing.T) {
 			builder.Start()
 			defer builder.Stop()
 
-			gotSecret, err := s.getCertificateSecret(context.Background(), crt)
+			gotSecret, err := s.getCertificateSecret(crt)
 			assert.NoError(t, err)
 
 			assert.Equal(t, test.expSecret, gotSecret, "unexpected returned secret")

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -75,10 +75,6 @@ func NewController(ctx *controllerpkg.Context) (*controller, workqueue.RateLimit
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	// Set context deadline for full sync in 10 seconds
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
-
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return nil
@@ -95,7 +91,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	// Update that Certificates metrics
-	c.metrics.UpdateCertificate(ctx, crt)
+	c.metrics.UpdateCertificate(crt)
 
 	return nil
 }

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -43,8 +43,8 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func mustGenerateRSA(t *testing.T, keySize int) []byte {
-	pk, err := pki.GenerateRSAPrivateKey(keySize)
+func mustGenerateRSA(t *testing.T) []byte {
+	pk, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestProcessItem(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
-					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t, 2048)},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -326,7 +326,7 @@ func TestProcessItem(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
-					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t, 2048)},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -414,7 +414,7 @@ func TestProcessItem(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
-					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t, 2048)},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -453,7 +453,7 @@ func TestProcessItem(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
-					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t, 2048)},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -538,7 +538,7 @@ func TestProcessItem(t *testing.T) {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
-					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t, 2048)},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,

--- a/pkg/controller/certificatesigningrequests/venafi/venafi.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi.go
@@ -40,7 +40,6 @@ import (
 	venafiapi "github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
-	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -130,16 +129,6 @@ func (v *Venafi) Sign(ctx context.Context, csr *certificatesv1.CertificateSignin
 		}
 	}
 
-	duration, err := pki.DurationFromCertificateSigningRequest(csr)
-	if err != nil {
-		message := fmt.Sprintf("Failed to parse requested duration: %s", err)
-		log.Error(err, message)
-		v.recorder.Event(csr, corev1.EventTypeWarning, "ErrorParseDuration", message)
-		util.CertificateSigningRequestSetFailed(csr, "ErrorParseDuration", message)
-		_, userr := util.UpdateOrApplyStatus(ctx, v.certClient, csr, certificatesv1.CertificateFailed, v.fieldManager)
-		return userr
-	}
-
 	// The signing process with Venafi is slow. The "pickupID" allows us to track
 	// the progress of the certificate signing. It is set as an annotation the
 	// first time the Certificate is reconciled.
@@ -147,7 +136,7 @@ func (v *Venafi) Sign(ctx context.Context, csr *certificatesv1.CertificateSignin
 
 	// check if the pickup ID annotation is there, if not set it up.
 	if len(pickupID) == 0 {
-		pickupID, err := client.RequestCertificate(csr.Spec.Request, duration, customFields)
+		pickupID, err := client.RequestCertificate(csr.Spec.Request, customFields)
 		// Check some known error types
 		if err != nil {
 			switch err.(type) {
@@ -177,7 +166,7 @@ func (v *Venafi) Sign(ctx context.Context, csr *certificatesv1.CertificateSignin
 		return uerr
 	}
 
-	certPem, err := client.RetrieveCertificate(pickupID, csr.Spec.Request, duration, customFields)
+	certPem, err := client.RetrieveCertificate(pickupID, csr.Spec.Request, customFields)
 	if err != nil {
 		switch err.(type) {
 		case endpoint.ErrCertificatePending:

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -390,7 +390,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
 						return "", venaficlient.ErrCustomFieldsType{Type: "test-type"}
 					},
 				}, nil
@@ -461,7 +461,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
 						return "", errors.New("generic error")
 					},
 				}, nil
@@ -532,7 +532,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
 						return "test-pickup-id", nil
 					},
 				}, nil
@@ -594,7 +594,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrCertificatePending{}
 					},
 				}, nil
@@ -645,7 +645,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrRetrieveCertificateTimeout{}
 					},
 				}, nil
@@ -696,7 +696,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, errors.New("generic error")
 					},
 				}, nil
@@ -747,7 +747,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte("garbage"), nil
 					},
 				}, nil
@@ -820,7 +820,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte(fmt.Sprintf("%s%s", certBundle.ChainPEM, certBundle.CAPEM)), nil
 					},
 				}, nil

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -67,14 +67,14 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.ClusterIssuer) (err er
 	return nil
 }
 
-func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.ClusterIssuer) error {
-	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
+func (c *controller) updateIssuerStatus(ctx context.Context, oldIssuer, newIssuer *cmapi.ClusterIssuer) error {
+	if apiequality.Semantic.DeepEqual(oldIssuer.Status, newIssuer.Status) {
 		return nil
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-		return internalissuers.ApplyClusterIssuerStatus(ctx, c.cmClient, c.fieldManager, new)
+		return internalissuers.ApplyClusterIssuerStatus(ctx, c.cmClient, c.fieldManager, newIssuer)
 	} else {
-		_, err := c.cmClient.CertmanagerV1().ClusterIssuers().UpdateStatus(ctx, new, metav1.UpdateOptions{})
+		_, err := c.cmClient.CertmanagerV1().ClusterIssuers().UpdateStatus(ctx, newIssuer, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -67,15 +67,15 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 	return nil
 }
 
-func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.Issuer) error {
-	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
+func (c *controller) updateIssuerStatus(ctx context.Context, oldIssuer, newIssuer *cmapi.Issuer) error {
+	if apiequality.Semantic.DeepEqual(oldIssuer.Status, newIssuer.Status) {
 		return nil
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-		return internalissuers.ApplyIssuerStatus(ctx, c.cmClient, c.fieldManager, new)
+		return internalissuers.ApplyIssuerStatus(ctx, c.cmClient, c.fieldManager, newIssuer)
 	} else {
-		_, err := c.cmClient.CertmanagerV1().Issuers(new.Namespace).UpdateStatus(ctx, new, metav1.UpdateOptions{})
+		_, err := c.cmClient.CertmanagerV1().Issuers(newIssuer.Namespace).UpdateStatus(ctx, newIssuer, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/pkg/controller/test/recorder.go
+++ b/pkg/controller/test/recorder.go
@@ -42,5 +42,5 @@ func (f *FakeRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, 
 }
 
 func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.Eventf(object, eventtype, reason, messageFmt, args)
+	f.Eventf(object, eventtype, reason, messageFmt, args...)
 }

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -120,11 +120,11 @@ func (q *QueuingEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 // OnUpdate adds an updated object to the workqueue.
-func (q *QueuingEventHandler) OnUpdate(old, new interface{}) {
-	if reflect.DeepEqual(old, new) {
+func (q *QueuingEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	if reflect.DeepEqual(oldObj, newObj) {
 		return
 	}
-	q.Enqueue(new)
+	q.Enqueue(newObj)
 }
 
 // OnDelete adds a deleted object to the workqueue for processing.
@@ -154,11 +154,11 @@ func (b *BlockingEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 // OnUpdate synchronously adds an updated object to the workqueue.
-func (b *BlockingEventHandler) OnUpdate(old, new interface{}) {
-	if reflect.DeepEqual(old, new) {
+func (b *BlockingEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	if reflect.DeepEqual(oldObj, newObj) {
 		return
 	}
-	b.WorkFunc(new)
+	b.WorkFunc(newObj)
 }
 
 // OnDelete synchronously adds a deleted object to the workqueue.

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -145,7 +145,7 @@ func (c *DNSProvider) Present(domain, fqdn, value string) error {
 func (c *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	z, err := c.getHostedZoneName(fqdn)
 	if err != nil {
-		c.log.Error(err, "Error getting hosted zone name for:", fqdn)
+		c.log.Error(err, "Error getting hosted zone name for fqdn", "fqdn", fqdn)
 		return err
 	}
 

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -265,7 +265,7 @@ func (c *DNSProvider) getHostedZone(domain string) (string, error) {
 		}
 	}
 
-	c.log.V(logf.DebugLevel).Info("No matching public GoogleCloud managed-zone for domain, falling back to a private managed-zone", authZone)
+	c.log.V(logf.DebugLevel).Info("No matching public GoogleCloud managed-zone for domain, falling back to a private managed-zone", "authZone", authZone)
 	// fall back to first available zone, if none public
 	return zones.ManagedZones[0].Name, nil
 }

--- a/pkg/issuer/acme/dns/clouddns/clouddns_test.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns_test.go
@@ -36,35 +36,28 @@ func init() {
 	}
 }
 
-func restoreGCloudEnv() {
-	os.Setenv("GCE_PROJECT", gcloudProject)
-}
-
 func TestNewDNSProviderValid(t *testing.T) {
 	if !gcloudLiveTest {
 		t.Skip("skipping live test (requires credentials)")
 	}
-	os.Setenv("GCE_PROJECT", "")
+	t.Setenv("GCE_PROJECT", "")
 	_, err := NewDNSProviderCredentials("my-project", util.RecursiveNameservers, "")
 	assert.NoError(t, err)
-	restoreGCloudEnv()
 }
 
 func TestNewDNSProviderValidEnv(t *testing.T) {
 	if !gcloudLiveTest {
 		t.Skip("skipping live test (requires credentials)")
 	}
-	os.Setenv("GCE_PROJECT", "my-project")
+	t.Setenv("GCE_PROJECT", "my-project")
 	_, err := NewDNSProviderEnvironment(util.RecursiveNameservers, "")
 	assert.NoError(t, err)
-	restoreGCloudEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
-	os.Setenv("GCE_PROJECT", "")
+	t.Setenv("GCE_PROJECT", "")
 	_, err := NewDNSProviderEnvironment(util.RecursiveNameservers, "")
 	assert.EqualError(t, err, "Google Cloud project name missing")
-	restoreGCloudEnv()
 }
 
 func TestLiveGoogleCloudPresent(t *testing.T) {

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -50,49 +50,39 @@ func init() {
 	}
 }
 
-func restoreCloudFlareEnv() {
-	os.Setenv("CLOUDFLARE_EMAIL", cflareEmail)
-	os.Setenv("CLOUDFLARE_API_KEY", cflareAPIKey)
-}
-
 func TestNewDNSProviderValidAPIKey(t *testing.T) {
-	os.Setenv("CLOUDFLARE_EMAIL", "")
-	os.Setenv("CLOUDFLARE_API_KEY", "")
+	t.Setenv("CLOUDFLARE_EMAIL", "")
+	t.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProviderCredentials("123", "123", "", util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
-	restoreCloudFlareEnv()
 }
 
 func TestNewDNSProviderValidAPIToken(t *testing.T) {
-	os.Setenv("CLOUDFLARE_EMAIL", "")
-	os.Setenv("CLOUDFLARE_API_KEY", "")
+	t.Setenv("CLOUDFLARE_EMAIL", "")
+	t.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProviderCredentials("123", "", "123", util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
-	restoreCloudFlareEnv()
 }
 
 func TestNewDNSProviderKeyAndTokenProvided(t *testing.T) {
-	os.Setenv("CLOUDFLARE_EMAIL", "")
-	os.Setenv("CLOUDFLARE_API_KEY", "")
+	t.Setenv("CLOUDFLARE_EMAIL", "")
+	t.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProviderCredentials("123", "123", "123", util.RecursiveNameservers, "cert-manager-test")
 	assert.EqualError(t, err, "the Cloudflare API key and API token cannot be both present simultaneously")
-	restoreCloudFlareEnv()
 }
 
 func TestNewDNSProviderValidApiKeyEnv(t *testing.T) {
-	os.Setenv("CLOUDFLARE_EMAIL", "test@example.com")
-	os.Setenv("CLOUDFLARE_API_KEY", "123")
+	t.Setenv("CLOUDFLARE_EMAIL", "test@example.com")
+	t.Setenv("CLOUDFLARE_API_KEY", "123")
 	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
-	restoreCloudFlareEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
-	os.Setenv("CLOUDFLARE_EMAIL", "")
-	os.Setenv("CLOUDFLARE_API_KEY", "")
+	t.Setenv("CLOUDFLARE_EMAIL", "")
+	t.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.EqualError(t, err, "no Cloudflare credential has been given (can be either an API key or an API token)")
-	restoreCloudFlareEnv()
 }
 
 func TestFindNearestZoneForFQDN(t *testing.T) {

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -40,29 +40,22 @@ func init() {
 	}
 }
 
-func restoreEnv() {
-	os.Setenv("DIGITALOCEAN_TOKEN", doToken)
-}
-
 func TestNewDNSProviderValid(t *testing.T) {
-	os.Setenv("DIGITALOCEAN_TOKEN", "")
+	t.Setenv("DIGITALOCEAN_TOKEN", "")
 	_, err := NewDNSProviderCredentials("123", util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
-	restoreEnv()
 }
 
 func TestNewDNSProviderValidEnv(t *testing.T) {
-	os.Setenv("DIGITALOCEAN_TOKEN", "123")
+	t.Setenv("DIGITALOCEAN_TOKEN", "123")
 	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err)
-	restoreEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
-	os.Setenv("DIGITALOCEAN_TOKEN", "")
+	t.Setenv("DIGITALOCEAN_TOKEN", "")
 	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
 	assert.EqualError(t, err, "DigitalOcean token missing")
-	restoreEnv()
 }
 
 func TestDigitalOceanPresent(t *testing.T) {

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 )
 
-func newIssuer(name, namespace string) *v1.Issuer {
+func newIssuer() *v1.Issuer {
 	return &v1.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      "test",
+			Namespace: "default",
 		},
 		Spec: v1.IssuerSpec{
 			IssuerConfig: v1.IssuerConfig{
@@ -50,11 +50,11 @@ func newIssuer(name, namespace string) *v1.Issuer {
 	}
 }
 
-func newSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
+func newSecret(name string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 		},
 		Data: data,
 	}
@@ -71,12 +71,12 @@ func TestSolverFor(t *testing.T) {
 			solverFixture: &solverFixture{
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
-						newSecret("cloudflare-key", "default", map[string][]byte{
+						newSecret("cloudflare-key", map[string][]byte{
 							"api-key": []byte("a-cloudflare-api-key"),
 						}),
 					},
 				},
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
@@ -102,12 +102,12 @@ func TestSolverFor(t *testing.T) {
 			solverFixture: &solverFixture{
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
-						newSecret("cloudflare-token", "default", map[string][]byte{
+						newSecret("cloudflare-token", map[string][]byte{
 							"api-token": []byte("a-cloudflare-api-token"),
 						}),
 					},
 				},
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
@@ -131,7 +131,7 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider with a missing secret": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
@@ -156,7 +156,7 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider when key and token are provided": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
@@ -189,12 +189,12 @@ func TestSolverFor(t *testing.T) {
 			solverFixture: &solverFixture{
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
-						newSecret("cloudflare-key", "default", map[string][]byte{
+						newSecret("cloudflare-key", map[string][]byte{
 							"api-key-oops": []byte("a-cloudflare-api-key"),
 						}),
 					},
 				},
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
@@ -220,12 +220,12 @@ func TestSolverFor(t *testing.T) {
 			solverFixture: &solverFixture{
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
-						newSecret("cloudflare-token", "default", map[string][]byte{
+						newSecret("cloudflare-token", map[string][]byte{
 							"api-key-oops": []byte("a-cloudflare-api-token"),
 						}),
 					},
 				},
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
@@ -251,12 +251,12 @@ func TestSolverFor(t *testing.T) {
 			solverFixture: &solverFixture{
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
-						newSecret("acmedns-key", "default", map[string][]byte{
+						newSecret("acmedns-key", map[string][]byte{
 							"acmedns.json": []byte("{}"),
 						}),
 					},
 				},
-				Issuer: newIssuer("test", "default"),
+				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
@@ -305,12 +305,12 @@ func TestSolveForDigitalOcean(t *testing.T) {
 	f := &solverFixture{
 		Builder: &test.Builder{
 			KubeObjects: []runtime.Object{
-				newSecret("digitalocean", "default", map[string][]byte{
+				newSecret("digitalocean", map[string][]byte{
 					"token": []byte("FAKE-TOKEN"),
 				}),
 			},
 		},
-		Issuer: newIssuer("test", "default"),
+		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
@@ -356,12 +356,12 @@ func TestRoute53TrimCreds(t *testing.T) {
 	f := &solverFixture{
 		Builder: &test.Builder{
 			KubeObjects: []runtime.Object{
-				newSecret("route53", "default", map[string][]byte{
+				newSecret("route53", map[string][]byte{
 					"secret": []byte("AKIENDINNEWLINE \n"),
 				}),
 			},
 		},
-		Issuer: newIssuer("test", "default"),
+		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
@@ -408,13 +408,13 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 	f := &solverFixture{
 		Builder: &test.Builder{
 			KubeObjects: []runtime.Object{
-				newSecret("route53", "default", map[string][]byte{
+				newSecret("route53", map[string][]byte{
 					"accessKeyID":     []byte("AWSACCESSKEYID"),
 					"secretAccessKey": []byte("AKIENDINNEWLINE \n"),
 				}),
 			},
 		},
-		Issuer: newIssuer("test", "default"),
+		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
@@ -484,7 +484,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer("test", "default"),
+				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
@@ -517,7 +517,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer("test", "default"),
+				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
@@ -580,7 +580,7 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer("test", "default"),
+				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{
@@ -614,7 +614,7 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer("test", "default"),
+				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
 					Spec: cmacme.ChallengeSpec{

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -122,7 +122,7 @@ func (d *sessionProvider) GetSession() (aws.Config, error) {
 	return cfg, nil
 }
 
-func newSessionProvider(accessKeyID, secretAccessKey, region, role string, ambient bool, userAgent string) (*sessionProvider, error) {
+func newSessionProvider(accessKeyID, secretAccessKey, region, role string, ambient bool, userAgent string) *sessionProvider {
 	return &sessionProvider{
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
@@ -132,7 +132,7 @@ func newSessionProvider(accessKeyID, secretAccessKey, region, role string, ambie
 		StsProvider:     defaultSTSProvider,
 		log:             logf.Log.WithName("route53-session-provider"),
 		userAgent:       userAgent,
-	}, nil
+	}
 }
 
 func defaultSTSProvider(cfg aws.Config) StsClient {
@@ -147,10 +147,7 @@ func NewDNSProvider(accessKeyID, secretAccessKey, hostedZoneID, region, role str
 	dns01Nameservers []string,
 	userAgent string,
 ) (*DNSProvider, error) {
-	provider, err := newSessionProvider(accessKeyID, secretAccessKey, region, role, ambient, userAgent)
-	if err != nil {
-		return nil, err
-	}
+	provider := newSessionProvider(accessKeyID, secretAccessKey, region, role, ambient, userAgent)
 
 	cfg, err := provider.GetSession()
 	if err != nil {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -251,10 +251,9 @@ func TestAssumeRole(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			provider, err := makeMockSessionProvider(func(aws.Config) StsClient {
+			provider := makeMockSessionProvider(func(aws.Config) StsClient {
 				return c.mockSTS
 			}, c.key, c.secret, c.region, c.role, c.ambient)
-			assert.NoError(t, err)
 			cfg, err := provider.GetSession()
 			if c.expErr {
 				assert.NotNil(t, err)
@@ -287,7 +286,7 @@ func makeMockSessionProvider(
 	defaultSTSProvider func(aws.Config) StsClient,
 	accessKeyID, secretAccessKey, region, role string,
 	ambient bool,
-) (*sessionProvider, error) {
+) *sessionProvider {
 	return &sessionProvider{
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
@@ -296,7 +295,7 @@ func makeMockSessionProvider(
 		Role:            role,
 		StsProvider:     defaultSTSProvider,
 		log:             logf.Log.WithName("route53-session"),
-	}, nil
+	}
 }
 
 func Test_removeReqID(t *testing.T) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -32,24 +31,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
-
-var (
-	route53Secret string
-	route53Key    string
-	route53Region string
-)
-
-func init() {
-	route53Key = os.Getenv("AWS_ACCESS_KEY_ID")
-	route53Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	route53Region = os.Getenv("AWS_REGION")
-}
-
-func restoreRoute53Env() {
-	os.Setenv("AWS_ACCESS_KEY_ID", route53Key)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", route53Secret)
-	os.Setenv("AWS_REGION", route53Region)
-}
 
 func makeRoute53Provider(ts *httptest.Server) (*DNSProvider, error) {
 	cfg, err := config.LoadDefaultConfig(
@@ -73,10 +54,9 @@ func makeRoute53Provider(ts *httptest.Server) (*DNSProvider, error) {
 }
 
 func TestAmbientCredentialsFromEnv(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "123")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "123")
-	os.Setenv("AWS_REGION", "us-east-1")
-	defer restoreRoute53Env()
+	t.Setenv("AWS_ACCESS_KEY_ID", "123")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "123")
+	t.Setenv("AWS_REGION", "us-east-1")
 
 	provider, err := NewDNSProvider("", "", "", "", "", true, util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
@@ -88,18 +68,16 @@ func TestAmbientCredentialsFromEnv(t *testing.T) {
 }
 
 func TestNoCredentialsFromEnv(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "123")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "123")
-	os.Setenv("AWS_REGION", "us-east-1")
-	defer restoreRoute53Env()
+	t.Setenv("AWS_ACCESS_KEY_ID", "123")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "123")
+	t.Setenv("AWS_REGION", "us-east-1")
 
 	_, err := NewDNSProvider("", "", "", "", "", false, util.RecursiveNameservers, "cert-manager-test")
 	assert.Error(t, err, "Expected error constructing DNSProvider with no credentials and not ambient")
 }
 
 func TestAmbientRegionFromEnv(t *testing.T) {
-	os.Setenv("AWS_REGION", "us-east-1")
-	defer restoreRoute53Env()
+	t.Setenv("AWS_REGION", "us-east-1")
 
 	provider, err := NewDNSProvider("", "", "", "", "", true, util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
@@ -108,8 +86,7 @@ func TestAmbientRegionFromEnv(t *testing.T) {
 }
 
 func TestNoRegionFromEnv(t *testing.T) {
-	os.Setenv("AWS_REGION", "us-east-1")
-	defer restoreRoute53Env()
+	t.Setenv("AWS_REGION", "us-east-1")
 
 	provider, err := NewDNSProvider("marx", "swordfish", "", "", "", false, util.RecursiveNameservers, "cert-manager-test")
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")

--- a/pkg/issuer/venafi/client/fake/venafi.go
+++ b/pkg/issuer/venafi/client/fake/venafi.go
@@ -17,8 +17,6 @@ limitations under the License.
 package fake
 
 import (
-	"time"
-
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
@@ -26,8 +24,8 @@ import (
 
 type Venafi struct {
 	PingFn                  func() error
-	RequestCertificateFn    func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
-	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
+	RequestCertificateFn    func(csrPEM []byte, customFields []api.CustomField) (string, error)
+	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error)
 	ReadZoneConfigurationFn func() (*endpoint.ZoneConfiguration, error)
 	VerifyCredentialsFn     func() error
 }
@@ -36,12 +34,12 @@ func (v *Venafi) Ping() error {
 	return v.PingFn()
 }
 
-func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
-	return v.RequestCertificateFn(csrPEM, duration, customFields)
+func (v *Venafi) RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error) {
+	return v.RequestCertificateFn(csrPEM, customFields)
 }
 
-func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error) {
-	return v.RetrieveCertificateFn(pickupID, csrPEM, duration, customFields)
+func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error) {
+	return v.RetrieveCertificateFn(pickupID, csrPEM, customFields)
 }
 
 func (v *Venafi) ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error) {

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -45,8 +45,8 @@ var ErrorMissingSubject = errors.New("Certificate requests submitted to Venafi i
 // The CSR will be decoded to be validated against the zone configuration policy.
 // Upon the template being successfully defaulted and validated, the CSR will be sent, as is.
 // It will return a pickup ID which can be used with RetrieveCertificate to get the certificate
-func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
-	vreq, err := v.buildVReq(csrPEM, duration, customFields)
+func (v *Venafi) RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error) {
+	vreq, err := v.buildVReq(csrPEM, customFields)
 	if err != nil {
 		return "", err
 	}
@@ -81,8 +81,8 @@ func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, custo
 	return v.vcertClient.RequestCertificate(vreq)
 }
 
-func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error) {
-	vreq, err := v.buildVReq(csrPEM, duration, customFields)
+func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error) {
+	vreq, err := v.buildVReq(csrPEM, customFields)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, duration ti
 	return []byte(chain), nil
 }
 
-func (v *Venafi) buildVReq(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (*certificate.Request, error) {
+func (v *Venafi) buildVReq(csrPEM []byte, customFields []api.CustomField) (*certificate.Request, error) {
 	// Retrieve a copy of the Venafi zone.
 	// This contains default values and policy control info that we can apply
 	// and check against locally.

--- a/pkg/issuer/venafi/client/request_test.go
+++ b/pkg/issuer/venafi/client/request_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
@@ -215,7 +214,7 @@ func TestVenafi_RequestCertificate(t *testing.T) {
 					"foo.example.com", "bar.example.com"})
 			}
 
-			got, err := v.RequestCertificate(tt.args.csrPEM, time.Minute, tt.args.customFields)
+			got, err := v.RequestCertificate(tt.args.csrPEM, tt.args.customFields)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RequestCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -236,7 +235,6 @@ func TestVenafi_RetrieveCertificate(t *testing.T) {
 
 	type args struct {
 		csrPEM       []byte
-		duration     time.Duration
 		customFields []api.CustomField
 	}
 	tests := []struct {
@@ -280,11 +278,11 @@ func TestVenafi_RetrieveCertificate(t *testing.T) {
 			// this is needed to provide the fake venafi client with a "valid" pickup id
 			// testing errors in this should be done in TestVenafi_RequestCertificate
 			// any error returned in these tests is a hard fail
-			pickupID, err := v.RequestCertificate(tt.args.csrPEM, tt.args.duration, tt.args.customFields)
+			pickupID, err := v.RequestCertificate(tt.args.csrPEM, tt.args.customFields)
 			if err != nil {
 				t.Errorf("RequestCertificate() should but error but got error = %v", err)
 			}
-			got, err := v.RetrieveCertificate(pickupID, tt.args.csrPEM, tt.args.duration, tt.args.customFields)
+			got, err := v.RetrieveCertificate(pickupID, tt.args.csrPEM, tt.args.customFields)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RetrieveCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -52,8 +52,8 @@ type VenafiClientBuilder func(namespace string, secretsLister internalinformers.
 
 // Interface implements a Venafi client
 type Interface interface {
-	RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
-	RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
+	RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error)
+	RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error)
 	Ping() error
 	ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error)
 	SetClient(endpoint.Connector)

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -17,33 +17,23 @@ limitations under the License.
 package metrics
 
 import (
-	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
 // UpdateCertificate will update the given Certificate's metrics for its expiry, renewal, and status
 // condition.
-func (m *Metrics) UpdateCertificate(ctx context.Context, crt *cmapi.Certificate) {
-	key, err := cache.MetaNamespaceKeyFunc(crt)
-	if err != nil {
-		log := logf.WithRelatedResource(m.log, crt)
-		log.Error(err, "failed to get key from certificate object")
-		return
-	}
-
-	m.updateCertificateStatus(key, crt)
-	m.updateCertificateExpiry(ctx, key, crt)
+func (m *Metrics) UpdateCertificate(crt *cmapi.Certificate) {
+	m.updateCertificateStatus(crt)
+	m.updateCertificateExpiry(crt)
 	m.updateCertificateRenewalTime(crt)
 }
 
 // updateCertificateExpiry updates the expiry time of a certificate
-func (m *Metrics) updateCertificateExpiry(ctx context.Context, key string, crt *cmapi.Certificate) {
+func (m *Metrics) updateCertificateExpiry(crt *cmapi.Certificate) {
 	expiryTime := 0.0
 
 	if crt.Status.NotAfter != nil {
@@ -76,7 +66,7 @@ func (m *Metrics) updateCertificateRenewalTime(crt *cmapi.Certificate) {
 }
 
 // updateCertificateStatus will update the metric for that Certificate
-func (m *Metrics) updateCertificateStatus(key string, crt *cmapi.Certificate) {
+func (m *Metrics) updateCertificateStatus(crt *cmapi.Certificate) {
 	for _, c := range crt.Status.Conditions {
 		if c.Type == cmapi.CertificateConditionReady {
 			m.updateCertificateReadyStatus(crt, c.Status)

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -195,7 +194,7 @@ func TestCertificateMetrics(t *testing.T) {
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
 			m := New(logtesting.NewTestLogger(t), clock.RealClock{})
-			m.UpdateCertificate(context.TODO(), test.crt)
+			m.UpdateCertificate(test.crt)
 
 			if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
 				strings.NewReader(expiryMetadata+test.expectedExpiry),
@@ -279,9 +278,9 @@ func TestCertificateCache(t *testing.T) {
 	)
 
 	// Observe all three Certificate metrics
-	m.UpdateCertificate(context.TODO(), crt1)
-	m.UpdateCertificate(context.TODO(), crt2)
-	m.UpdateCertificate(context.TODO(), crt3)
+	m.UpdateCertificate(crt1)
+	m.UpdateCertificate(crt2)
+	m.UpdateCertificate(crt3)
 
 	// Check all three metrics exist
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,

--- a/pkg/util/pki/certificatetemplate_test.go
+++ b/pkg/util/pki/certificatetemplate_test.go
@@ -36,7 +36,7 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 	sansGenerator := func(t *testing.T, generalNames []asn1.RawValue, critical bool) pkix.Extension {
 		val, err := asn1.Marshal(generalNames)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		return pkix.Extension{

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -379,7 +379,7 @@ func TestGenerateCSR(t *testing.T) {
 	sansGenerator := func(t *testing.T, generalNames []asn1.RawValue, critical bool) pkix.Extension {
 		val, err := asn1.Marshal(generalNames)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		return pkix.Extension{

--- a/pkg/util/pki/kube_test.go
+++ b/pkg/util/pki/kube_test.go
@@ -42,7 +42,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 
 		val, err := asn1.Marshal(generalNames)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		return pkix.Extension{

--- a/pkg/util/pki/match.go
+++ b/pkg/util/pki/match.go
@@ -47,7 +47,7 @@ func PrivateKeyMatchesSpec(pk crypto.PrivateKey, spec cmapi.CertificateSpec) ([]
 	case "", cmapi.RSAKeyAlgorithm:
 		return rsaPrivateKeyMatchesSpec(pk, spec)
 	case cmapi.Ed25519KeyAlgorithm:
-		return ed25519PrivateKeyMatchesSpec(pk, spec)
+		return ed25519PrivateKeyMatchesSpec(pk)
 	case cmapi.ECDSAKeyAlgorithm:
 		return ecdsaPrivateKeyMatchesSpec(pk, spec)
 	default:
@@ -97,7 +97,7 @@ func ecdsaPrivateKeyMatchesSpec(pk crypto.PrivateKey, spec cmapi.CertificateSpec
 	return violations, nil
 }
 
-func ed25519PrivateKeyMatchesSpec(pk crypto.PrivateKey, spec cmapi.CertificateSpec) ([]string, error) {
+func ed25519PrivateKeyMatchesSpec(pk crypto.PrivateKey) ([]string, error) {
 	_, ok := pk.(ed25519.PrivateKey)
 	if !ok {
 		return []string{"spec.privateKey.algorithm"}, nil

--- a/pkg/util/pki/nameconstraints_test.go
+++ b/pkg/util/pki/nameconstraints_test.go
@@ -198,8 +198,8 @@ func getExtensionFromPem(pemData string) (pkix.Extension, error) {
 	if pemData == "" {
 		return pkix.Extension{}, nil
 	}
+
 	pemData = strings.TrimSpace(pemData)
-	fmt.Println(pemData)
 	csrPEM := []byte(pemData)
 
 	block, _ := pem.Decode(csrPEM)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -129,8 +129,8 @@ func TestEqualIPsUnsorted(t *testing.T) {
 	}
 
 	for name, spec := range specs {
-		s1 := parseIPs(t, spec.s1)
-		s2 := parseIPs(t, spec.s2)
+		s1 := parseIPs(spec.s1)
+		s2 := parseIPs(spec.s2)
 
 		t.Run(name, func(t *testing.T) {
 			got := EqualIPsUnsorted(s1, s2)
@@ -244,7 +244,7 @@ func parseURLs(t *testing.T, urlStrs []string) []*url.URL {
 	return urls
 }
 
-func parseIPs(t *testing.T, ipStrs []string) []net.IP {
+func parseIPs(ipStrs []string) []net.IP {
 	var ips []net.IP
 
 	for _, i := range ipStrs {

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -287,15 +287,9 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 		}
 		v.details.VaultCA = vaultCA
 
-		v.vaultCert, v.vaultCertPrivateKey, err = generateVaultServingCert(vaultCA, vaultCAPrivateKey, dnsName)
-		if err != nil {
-			return nil, err
-		}
+		v.vaultCert, v.vaultCertPrivateKey = generateVaultServingCert(vaultCA, vaultCAPrivateKey, dnsName)
 
-		vaultClientCertificate, vaultClientPrivateKey, err := generateVaultClientCert(vaultCA, vaultCAPrivateKey)
-		if err != nil {
-			return nil, err
-		}
+		vaultClientCertificate, vaultClientPrivateKey := generateVaultClientCert(vaultCA, vaultCAPrivateKey)
 		v.details.VaultClientCertificate = vaultClientCertificate
 		v.details.VaultClientPrivateKey = vaultClientPrivateKey
 		v.details.EnforceMtls = v.EnforceMtls
@@ -447,7 +441,7 @@ func (v *Vault) Logs() (map[string]string, error) {
 	return v.chart.Logs()
 }
 
-func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName string) ([]byte, []byte, error) {
+func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName string) ([]byte, []byte) {
 	catls, _ := tls.X509KeyPair(vaultCA, vaultCAPrivateKey)
 	ca, _ := x509.ParseCertificate(catls.Certificate[0])
 
@@ -470,10 +464,10 @@ func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName 
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	certBytes, _ := x509.CreateCertificate(rand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
 
-	return encodePublicKey(certBytes), encodePrivateKey(privateKey), nil
+	return encodePublicKey(certBytes), encodePrivateKey(privateKey)
 }
 
-func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, []byte, error) {
+func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, []byte) {
 	catls, _ := tls.X509KeyPair(vaultCA, vaultCAPrivateKey)
 	ca, _ := x509.ParseCertificate(catls.Certificate[0])
 
@@ -494,7 +488,7 @@ func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, 
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	certBytes, _ := x509.CreateCertificate(rand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
 
-	return encodePublicKey(certBytes), encodePrivateKey(privateKey), nil
+	return encodePublicKey(certBytes), encodePrivateKey(privateKey)
 }
 
 func GenerateCA() ([]byte, []byte, error) {

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -311,8 +311,8 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 			vaultCA,
 		)
 
-		v.details.URL = fmt.Sprintf("https://%s:8200", dnsName)
-		v.details.ProxyURL = fmt.Sprintf("https://127.0.0.1:%d", v.proxy.listenPort)
+		v.details.URL = fmt.Sprintf("https://%s", net.JoinHostPort(dnsName, "8200"))
+		v.details.ProxyURL = fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", strconv.Itoa(v.proxy.listenPort)))
 	}
 
 	return v.details, nil

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -308,7 +308,6 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 			v.Base.Details().KubeConfig,
 			v.Namespace,
 			fmt.Sprintf("%s-0", v.chart.ReleaseName),
-			vaultCA,
 		)
 
 		v.details.URL = fmt.Sprintf("https://%s", net.JoinHostPort(dnsName, "8200"))

--- a/test/e2e/framework/log/log.go
+++ b/test/e2e/framework/log/log.go
@@ -31,12 +31,12 @@ func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
 
-func log(level string, format string, args ...interface{}) {
+func logf(level string, format string, args ...interface{}) {
 	fmt.Fprintf(Writer, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
 func Logf(format string, args ...interface{}) {
-	log("INFO", format, args...)
+	logf("INFO", format, args...)
 }
 
 // LogBackoff gives you a logger with an exponential backoff. If the

--- a/test/e2e/suite/certificaterequests/selfsigned/secret.go
+++ b/test/e2e/suite/certificaterequests/selfsigned/secret.go
@@ -119,6 +119,7 @@ var _ = framework.CertManagerDescribe("CertificateRequests SelfSigned Secret", f
 			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: f.Namespace.Name},
 			Data:       map[string][]byte{},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), &cmapi.Issuer{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "selfsigned-", Namespace: f.Namespace.Name},
@@ -221,6 +222,7 @@ var _ = framework.CertManagerDescribe("CertificateRequests SelfSigned Secret", f
 			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: f.Namespace.Name},
 			Data:       map[string][]byte{},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), &cmapi.ClusterIssuer{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "selfsigned-"},

--- a/test/e2e/suite/certificates/secrettemplate.go
+++ b/test/e2e/suite/certificates/secrettemplate.go
@@ -282,6 +282,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 				WithAnnotations(secret.Annotations).
 				WithLabels(secret.Labels),
 			metav1.ApplyOptions{FieldManager: "e2e-test-client"})
+		Expect(err).NotTo(HaveOccurred())
 
 		By("expect those Annotations and Labels to be present on the Secret")
 		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.Background(), secretName, metav1.GetOptions{})

--- a/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
@@ -133,6 +133,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: f.Namespace.Name},
 			Data:       map[string][]byte{},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), &cmapi.Issuer{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "selfsigned-", Namespace: f.Namespace.Name},
@@ -259,6 +260,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: "cert-manager"},
 			Data:       map[string][]byte{},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), &cmapi.ClusterIssuer{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "selfsigned-"},

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -91,7 +91,7 @@ func (v *vaultAppRoleProvisioner) createIssuer(f *framework.Framework) cmmeta.Ob
 	appRoleSecretGeneratorName := "vault-approle-secret-"
 	By("Creating a VaultAppRole Issuer")
 
-	v.vaultSecrets = v.initVault(f)
+	v.vaultSecrets = v.initVault()
 
 	sec, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vault.NewVaultAppRoleSecret(appRoleSecretGeneratorName, v.secretID), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
@@ -103,7 +103,7 @@ func (v *vaultAppRoleProvisioner) createIssuer(f *framework.Framework) cmmeta.Ob
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vault-issuer-",
 		},
-		Spec: v.createIssuerSpec(f),
+		Spec: v.createIssuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
@@ -123,7 +123,7 @@ func (v *vaultAppRoleProvisioner) createClusterIssuer(f *framework.Framework) cm
 	appRoleSecretGeneratorName := "vault-approle-secret-"
 	By("Creating a VaultAppRole ClusterIssuer")
 
-	v.vaultSecrets = v.initVault(f)
+	v.vaultSecrets = v.initVault()
 
 	sec, err := f.KubeClientSet.CoreV1().Secrets(f.Config.Addons.CertManager.ClusterResourceNamespace).Create(context.TODO(), vault.NewVaultAppRoleSecret(appRoleSecretGeneratorName, v.secretID), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
@@ -135,7 +135,7 @@ func (v *vaultAppRoleProvisioner) createClusterIssuer(f *framework.Framework) cm
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vault-cluster-issuer-",
 		},
-		Spec: v.createIssuerSpec(f),
+		Spec: v.createIssuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
@@ -151,7 +151,7 @@ func (v *vaultAppRoleProvisioner) createClusterIssuer(f *framework.Framework) cm
 	}
 }
 
-func (v *vaultAppRoleProvisioner) initVault(f *framework.Framework) *vaultSecrets {
+func (v *vaultAppRoleProvisioner) initVault() *vaultSecrets {
 	By("Configuring the VaultAppRole server")
 	v.setup = vault.NewVaultInitializerAppRole(
 		addon.Base.Details().KubeClient,
@@ -170,7 +170,7 @@ func (v *vaultAppRoleProvisioner) initVault(f *framework.Framework) *vaultSecret
 	}
 }
 
-func (v *vaultAppRoleProvisioner) createIssuerSpec(f *framework.Framework) cmapi.IssuerSpec {
+func (v *vaultAppRoleProvisioner) createIssuerSpec() cmapi.IssuerSpec {
 	return cmapi.IssuerSpec{
 		IssuerConfig: cmapi.IssuerConfig{
 			Vault: &cmapi.VaultIssuer{

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/approle.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/approle.go
@@ -123,7 +123,7 @@ func (a *approle) createIssuer(f *framework.Framework) string {
 	appRoleSecretGeneratorName := "vault-approle-secret-"
 	By("Creating a VaultAppRole Issuer")
 
-	a.secrets = a.initVault(f)
+	a.secrets = a.initVault()
 
 	sec, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vault.NewVaultAppRoleSecret(appRoleSecretGeneratorName, a.secretID), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
@@ -135,7 +135,7 @@ func (a *approle) createIssuer(f *framework.Framework) string {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vault-issuer-",
 		},
-		Spec: a.createIssuerSpec(f),
+		Spec: a.createIssuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
@@ -151,7 +151,7 @@ func (a *approle) createClusterIssuer(f *framework.Framework) string {
 	appRoleSecretGeneratorName := "vault-approle-secret-"
 	By("Creating a VaultAppRole ClusterIssuer")
 
-	a.secrets = a.initVault(f)
+	a.secrets = a.initVault()
 
 	sec, err := f.KubeClientSet.CoreV1().Secrets(f.Config.Addons.CertManager.ClusterResourceNamespace).Create(context.TODO(), vault.NewVaultAppRoleSecret(appRoleSecretGeneratorName, a.secretID), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
@@ -163,7 +163,7 @@ func (a *approle) createClusterIssuer(f *framework.Framework) string {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vault-cluster-issuer-",
 		},
-		Spec: a.createIssuerSpec(f),
+		Spec: a.createIssuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
@@ -175,7 +175,7 @@ func (a *approle) createClusterIssuer(f *framework.Framework) string {
 	return fmt.Sprintf("clusterissuers.cert-manager.io/%s", issuer.Name)
 }
 
-func (a *approle) initVault(f *framework.Framework) *secrets {
+func (a *approle) initVault() *secrets {
 	By("Configuring the VaultAppRole server")
 	a.setup = vault.NewVaultInitializerAppRole(
 		addon.Base.Details().KubeClient,
@@ -194,7 +194,7 @@ func (a *approle) initVault(f *framework.Framework) *secrets {
 	}
 }
 
-func (a *approle) createIssuerSpec(f *framework.Framework) cmapi.IssuerSpec {
+func (a *approle) createIssuerSpec() cmapi.IssuerSpec {
 	return cmapi.IssuerSpec{
 		IssuerConfig: cmapi.IssuerConfig{
 			Vault: &cmapi.VaultIssuer{

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
@@ -82,7 +82,7 @@ func (k *kubernetes) createIssuer(f *framework.Framework) string {
 			GenerateName: "vault-issuer-",
 			Namespace:    f.Namespace.Name,
 		},
-		Spec: k.issuerSpec(f),
+		Spec: k.issuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -102,7 +102,7 @@ func (k *kubernetes) createClusterIssuer(f *framework.Framework) string {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vault-issuer-",
 		},
-		Spec: k.issuerSpec(f),
+		Spec: k.issuerSpec(),
 	}, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -150,7 +150,7 @@ func (k *kubernetes) initVault(f *framework.Framework, boundNS string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (k *kubernetes) issuerSpec(f *framework.Framework) cmapi.IssuerSpec {
+func (k *kubernetes) issuerSpec() cmapi.IssuerSpec {
 	return cmapi.IssuerSpec{
 		IssuerConfig: cmapi.IssuerConfig{
 			Vault: &cmapi.VaultIssuer{

--- a/test/e2e/suite/issuers/acme/certificaterequest/http01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/http01.go
@@ -128,7 +128,7 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 			[]string{acmeIngressDomain}, nil, nil, x509.RSA)
 		Expect(err).NotTo(HaveOccurred())
 
-		cr, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
+		_, err = crClient.Create(context.TODO(), cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying the Certificate is valid")

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -136,7 +136,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 		t.Fatalf("failed to update certificate: %v", err)
 	}
 
-	var secondReq *cmapi.CertificateRequest
+	var secondReq cmapi.CertificateRequest
 	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -151,7 +151,7 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 				continue
 			}
 
-			secondReq = &req // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
+			secondReq = req
 			return true, nil
 		}
 
@@ -273,7 +273,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 		t.Fatalf("failed to update certificate: %v", err)
 	}
 
-	var secondReq *cmapi.CertificateRequest
+	var secondReq cmapi.CertificateRequest
 	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
 		reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -288,7 +288,7 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 				continue
 			}
 
-			secondReq = &req // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
+			secondReq = req
 			return true, nil
 		}
 

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -60,7 +60,7 @@ func TestTriggerController(t *testing.T) {
 	// Build, instantiate and run the trigger controller.
 	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
 
-	namespace := "testns"
+	namespace := "testns-trigger"
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -96,7 +96,7 @@ func TestTriggerController(t *testing.T) {
 
 	// Create a Certificate resource and wait for it to have the 'Issuing' condition.
 	cert, err := cmCl.CertmanagerV1().Certificates(namespace).Create(ctx, &cmapi.Certificate{
-		ObjectMeta: metav1.ObjectMeta{Name: "testcrt", Namespace: "testns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "testcrt", Namespace: namespace},
 		Spec: cmapi.CertificateSpec{
 			SecretName: "example",
 			CommonName: "example.com",
@@ -125,7 +125,7 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 	// Build, instantiate and run the trigger controller.
 	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
 
-	namespace := "testns"
+	namespace := "testns-renew-near-expiry"
 	secretName := "example"
 	certName := "testcrt"
 
@@ -247,7 +247,7 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 	// Build, instantiate and run the trigger controller.
 	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
 
-	namespace := "testns"
+	namespace := "testns-expbackoff"
 	secretName := "example"
 	certName := "testcrt"
 

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -253,6 +253,7 @@ func TestDynamicSource_leaderelection(t *testing.T) {
 			if err := mgr.Add(&tls.DynamicSource{
 				DNSNames: []string{"example.com"},
 				Authority: &testAuthority{
+					t:       t,
 					id:      fmt.Sprintf("manager-%d", i),
 					started: &started,
 				},
@@ -280,6 +281,7 @@ func TestDynamicSource_leaderelection(t *testing.T) {
 }
 
 type testAuthority struct {
+	t       *testing.T
 	id      string
 	started *int64
 }
@@ -289,7 +291,7 @@ func (m *testAuthority) Run(ctx context.Context) error {
 		return nil // context was cancelled, we are shutting down
 	}
 
-	fmt.Println("Starting authority with id", m.id)
+	m.t.Log("Starting authority with id", m.id)
 	atomic.AddInt64(m.started, 1)
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
Similar to https://github.com/cert-manager/cert-manager/pull/6952 and https://github.com/cert-manager/cert-manager/pull/6972.
Fixes all found issues for the following linters and enables them as a restriction: unparam, tenv, loggercheck, forbidigo, predeclared, usestdlibvars, asasalint, goprintffuncname, ineffassign, nosprintfhostport and exportloopref.

Note for reviewer: each commit fixes one linter.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
