### PR TITLE
Skip gateway TLS listener in passthrough mode

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -320,6 +320,11 @@ func buildCertificates(
 				continue
 			}
 
+			// We never issue certificates for TLS Passthrough mode
+			if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwapi.TLSModePassthrough {
+				continue
+			}
+
 			err := validateGatewayListenerBlock(field.NewPath("spec", "listeners").Index(i), l, ingLike).ToAggregate()
 			if err != nil {
 				rec.Eventf(ingLike, corev1.EventTypeWarning, reasonBadConfig, "Skipped a listener block: "+err.Error())

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -257,13 +257,14 @@ func validateGatewayListenerBlock(path *field.Path, l gwapi.Listener, ingLike me
 		return errs
 	}
 
-	if l.TLS.Mode == nil {
+	switch {
+	case l.TLS.Mode == nil:
 		errs = append(errs, field.Required(path.Child("tls").Child("mode"),
 			"the mode field is required"))
-	} else if l.Protocol == gwapi.TLSProtocolType && *l.TLS.Mode == gwapi.TLSModePassthrough {
+	case l.Protocol == gwapi.TLSProtocolType && *l.TLS.Mode == gwapi.TLSModePassthrough:
 		// skip TLS-listener in TLS-passthrough mode
 		return errs
-	} else if *l.TLS.Mode != gwapi.TLSModeTerminate {
+	case *l.TLS.Mode != gwapi.TLSModeTerminate:
 		errs = append(errs, field.NotSupported(path.Child("tls").Child("mode"),
 			*l.TLS.Mode, []string{string(gwapi.TLSModeTerminate)}))
 	}

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -257,18 +257,6 @@ func validateGatewayListenerBlock(path *field.Path, l gwapi.Listener, ingLike me
 		return errs
 	}
 
-	switch {
-	case l.TLS.Mode == nil:
-		errs = append(errs, field.Required(path.Child("tls").Child("mode"),
-			"the mode field is required"))
-	case l.Protocol == gwapi.TLSProtocolType && *l.TLS.Mode == gwapi.TLSModePassthrough:
-		// skip TLS-listener in TLS-passthrough mode
-		return errs
-	case *l.TLS.Mode != gwapi.TLSModeTerminate:
-		errs = append(errs, field.NotSupported(path.Child("tls").Child("mode"),
-			*l.TLS.Mode, []string{string(gwapi.TLSModeTerminate)}))
-	}
-
 	if len(l.TLS.CertificateRefs) == 0 {
 		errs = append(errs, field.Required(path.Child("tls").Child("certificateRef"),
 			"listener has no certificateRefs"))
@@ -290,6 +278,14 @@ func validateGatewayListenerBlock(path *field.Path, l gwapi.Listener, ingLike me
 					*secretRef.Namespace, "cross-namespace secret references are not allowed in listeners"))
 			}
 		}
+	}
+
+	if l.TLS.Mode == nil {
+		errs = append(errs, field.Required(path.Child("tls").Child("mode"),
+			"the mode field is required"))
+	} else if *l.TLS.Mode != gwapi.TLSModeTerminate {
+		errs = append(errs, field.NotSupported(path.Child("tls").Child("mode"),
+			*l.TLS.Mode, []string{string(gwapi.TLSModeTerminate)}))
 	}
 
 	return errs


### PR DESCRIPTION
### Pull Request Motivation

I've tried to fix #6985 combining HTTPS listeners with TLS-termination and TLS listeners with TLS-passthrough that I reported earlier.

I'm unsure if this change will introduce unwanted behaviour, though all the tests are passing.

### Kind

bug

### Release Note

```release-note
Skip Gateway TLS-listeners in passthrough mode
```
