### PR TITLE
Remove deprecated ParseSubjectStringToRawDERBytes function

### DIFF
--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -19,13 +19,9 @@ package pki
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/pem"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
@@ -177,104 +173,4 @@ func TestDecodePrivateKeyBytes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, testFn(test))
 	}
-}
-
-func TestMustParseRDN(t *testing.T) {
-	subject := "SERIALNUMBER=42, L=some-locality, ST=some-state-or-province, STREET=some-street, CN=foo-long.com, OU=FooLong, OU=Barq, OU=Baz, OU=Dept., O=Corp., C=US"
-	rdnSeq, err := UnmarshalSubjectStringToRDNSequence(subject)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedRdnSeq :=
-		pkix.RDNSequence{
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Country, Value: "US"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Organization, Value: "Corp."},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Dept."},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Baz"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Barq"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "FooLong"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.CommonName, Value: "foo-long.com"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.StreetAddress, Value: "some-street"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Province, Value: "some-state-or-province"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Locality, Value: "some-locality"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.SerialNumber, Value: "42"},
-			},
-		}
-
-	assert.Equal(t, expectedRdnSeq, rdnSeq)
-}
-
-func TestMustKeepOrderInRawDerBytes(t *testing.T) {
-	subject := "CN=foo-long.com,OU=FooLong,OU=Barq,OU=Baz,OU=Dept.,O=Corp.,C=US"
-	bytes, err := ParseSubjectStringToRawDERBytes(subject)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var rdnSeq pkix.RDNSequence
-	_, err2 := asn1.Unmarshal(bytes, &rdnSeq)
-	if err2 != nil {
-		t.Fatal(err2)
-	}
-
-	t.Log(bytes)
-
-	expectedRdnSeq :=
-		pkix.RDNSequence{
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Country, Value: "US"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.Organization, Value: "Corp."},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Dept."},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Baz"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "Barq"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.OrganizationalUnit, Value: "FooLong"},
-			},
-			[]pkix.AttributeTypeAndValue{
-				{Type: OIDConstants.CommonName, Value: "foo-long.com"},
-			},
-		}
-
-	assert.Equal(t, expectedRdnSeq, rdnSeq)
-	assert.Equal(t, subject, rdnSeq.String())
-}
-
-func TestShouldFailForHexDER(t *testing.T) {
-	_, err := ParseSubjectStringToRawDERBytes("DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF")
-	if err == nil {
-		t.Fatal("expected error, but got none")
-	}
-
-	assert.Contains(t, err.Error(), "failed to unmarshal hex-encoded string: asn1: syntax error: data truncated")
 }

--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -126,13 +126,3 @@ func ExtractCommonNameFromRDNSequence(rdns pkix.RDNSequence) string {
 
 	return ""
 }
-
-// Deprecated: this function will be removed in a future release.
-func ParseSubjectStringToRawDERBytes(subject string) ([]byte, error) {
-	rdnSequence, err := UnmarshalSubjectStringToRDNSequence(subject)
-	if err != nil {
-		return nil, err
-	}
-
-	return MarshalRDNSequenceToRawDERBytes(rdnSequence)
-}

--- a/pkg/util/pki/subject_test.go
+++ b/pkg/util/pki/subject_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustParseRDN(t *testing.T) {
+	subject := "SERIALNUMBER=42, L=some-locality, ST=some-state-or-province, STREET=some-street, CN=foo-long.com, OU=FooLong, OU=Barq, OU=Baz, OU=Dept., O=Corp., C=US"
+	rdnSeq, err := UnmarshalSubjectStringToRDNSequence(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRdnSeq :=
+		pkix.RDNSequence{
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Country, Value: "US"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Organization, Value: "Corp."},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Dept."},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Baz"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Barq"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "FooLong"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.CommonName, Value: "foo-long.com"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.StreetAddress, Value: "some-street"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Province, Value: "some-state-or-province"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Locality, Value: "some-locality"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.SerialNumber, Value: "42"},
+			},
+		}
+
+	assert.Equal(t, expectedRdnSeq, rdnSeq)
+}
+
+func TestMustKeepOrderInRawDerBytes(t *testing.T) {
+	subject := "CN=foo-long.com,OU=FooLong,OU=Barq,OU=Baz,OU=Dept.,O=Corp.,C=US"
+	rdnSeq, err := UnmarshalSubjectStringToRDNSequence(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRdnSeq :=
+		pkix.RDNSequence{
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Country, Value: "US"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Organization, Value: "Corp."},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Dept."},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Baz"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "Barq"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.OrganizationalUnit, Value: "FooLong"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.CommonName, Value: "foo-long.com"},
+			},
+		}
+
+	assert.Equal(t, expectedRdnSeq, rdnSeq)
+	assert.Equal(t, subject, rdnSeq.String())
+}
+
+func TestShouldFailForHexDER(t *testing.T) {
+	_, err := UnmarshalSubjectStringToRDNSequence("DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF")
+	if err == nil {
+		t.Fatal("expected error, but got none")
+	}
+
+	assert.Contains(t, err.Error(), "failed to unmarshal hex-encoded string: asn1: syntax error: data truncated")
+}


### PR DESCRIPTION
There were still some tests that were using this function, I updated the tests to test the underlying function instead.
These tests were also moved to a test file that matches the file in which the functions are defined.

**Migration guide:**
Use the underlying `UnmarshalSubjectStringToRDNSequence(subject)` and `MarshalRDNSequenceToRawDERBytes(rdnSequence)` functions instead.

branched from https://github.com/cert-manager/cert-manager/pull/6775

### Kind

/kind cleanup

### Release Note

```release-note
Remove deprecated `pkg/util/pki/ParseSubjectStringToRawDERBytes` function.
```
