### PR TITLE
[release-1.14] Bump go to 1.21.10

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -77,7 +77,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.9
+VENDORED_GO_VERSION := 1.21.10
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
Fixes GO-2024-2824 (https://github.com/advisories/GHSA-2jwv-jmq4-4j3r).

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade Go to 1.21.10, fixing GO-2024-2824 (https://github.com/advisories/GHSA-2jwv-jmq4-4j3r).
```
