### PR TITLE
Fix script error: "make/e2e-ci.sh: line 27: K8S_VERSION: command not found"

### DIFF
--- a/make/e2e-ci.sh
+++ b/make/e2e-ci.sh
@@ -24,4 +24,4 @@ trap 'make kind-logs' EXIT
 # (i.e. "I want to run the exact same e2e test that will be run in CI")
 # and because it allows us to be explicit about where it's getting set when we call "make e2e-ci"
 
-make --no-print-directory e2e FLAKE_ATTEMPTS=2 CI=true K8S_VERSION="$(K8S_VERSION)"
+make --no-print-directory e2e FLAKE_ATTEMPTS=2 CI=true K8S_VERSION="$K8S_VERSION"


### PR DESCRIPTION
We saw the following error in our logs "make/e2e-ci.sh: line 27: K8S_VERSION: command not found".
This is caused by a typo in the `make/e2e-ci.sh` script, where we tried to use Makefile syntax instead of bash syntax.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
