### PR TITLE
Promote the LiteralCertificateSubject feature to Beta

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -308,9 +308,6 @@ spec:
 
 
                     Cannot be set if the `subject` or `commonName` field is set.
-                    This is an Alpha Feature and is only enabled with the
-                    `--feature-gates=LiteralCertificateSubject=true` option set on both
-                    the controller and webhook components.
                   type: string
                 nameConstraints:
                   description: |-

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -117,9 +117,6 @@ type CertificateSpec struct {
 	// More info: https://github.com/cert-manager/cert-manager/issues/4424
 	//
 	// Cannot be set if the `subject` or `commonName` field is set.
-	// This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=LiteralCertificateSubject=true` option set on both
-	// the controller and webhook components.
 	LiteralSubject string
 
 	// Requested common name X509 certificate subject attribute.

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -84,9 +84,16 @@ type CertificateSpec struct {
 	// +optional
 	Subject *X509Subject `json:"subject,omitempty"`
 
-	// LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6).
-	// Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424.
-	// This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.
+	// Requested X.509 certificate subject, represented using the LDAP "String
+	// Representation of a Distinguished Name" [1].
+	// Important: the LDAP string format also specifies the order of the attributes
+	// in the subject, this is important when issuing certs for LDAP authentication.
+	// Example: `CN=foo,DC=corp,DC=example,DC=com`
+	// More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+	// More info: https://github.com/cert-manager/cert-manager/issues/3203
+	// More info: https://github.com/cert-manager/cert-manager/issues/4424
+	//
+	// Cannot be set if the `subject` or `commonName` field is set.
 	// +optional
 	LiteralSubject string `json:"literalSubject,omitempty"`
 

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -86,9 +86,16 @@ type CertificateSpec struct {
 	// +optional
 	Subject *X509Subject `json:"subject,omitempty"`
 
-	// LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6).
-	// Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424.
-	// This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.
+	// Requested X.509 certificate subject, represented using the LDAP "String
+	// Representation of a Distinguished Name" [1].
+	// Important: the LDAP string format also specifies the order of the attributes
+	// in the subject, this is important when issuing certs for LDAP authentication.
+	// Example: `CN=foo,DC=corp,DC=example,DC=com`
+	// More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+	// More info: https://github.com/cert-manager/cert-manager/issues/3203
+	// More info: https://github.com/cert-manager/cert-manager/issues/4424
+	//
+	// Cannot be set if the `subject` or `commonName` field is set.
 	// +optional
 	LiteralSubject string `json:"literalSubject,omitempty"`
 

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -87,9 +87,16 @@ type CertificateSpec struct {
 	// +optional
 	Subject *X509Subject `json:"subject,omitempty"`
 
-	// LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6).
-	// Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424.
-	// This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.
+	// Requested X.509 certificate subject, represented using the LDAP "String
+	// Representation of a Distinguished Name" [1].
+	// Important: the LDAP string format also specifies the order of the attributes
+	// in the subject, this is important when issuing certs for LDAP authentication.
+	// Example: `CN=foo,DC=corp,DC=example,DC=com`
+	// More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+	// More info: https://github.com/cert-manager/cert-manager/issues/3203
+	// More info: https://github.com/cert-manager/cert-manager/issues/4424
+	//
+	// Cannot be set if the `subject` or `commonName` field is set.
 	// +optional
 	LiteralSubject string `json:"literalSubject,omitempty"`
 

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -156,7 +156,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	ExperimentalGatewayAPISupport:                    {Default: true, PreRelease: featuregate.Beta},
 	AdditionalCertificateOutputFormats:               {Default: true, PreRelease: featuregate.Beta},
 	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
-	LiteralCertificateSubject:                        {Default: false, PreRelease: featuregate.Alpha},
+	LiteralCertificateSubject:                        {Default: true, PreRelease: featuregate.Beta},
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
 	NameConstraints:                                  {Default: false, PreRelease: featuregate.Alpha},
 	OtherNames:                                       {Default: false, PreRelease: featuregate.Alpha},

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -96,7 +96,7 @@ var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisallowInsecureCSRUsageDefinition: {Default: true, PreRelease: featuregate.GA},
 
 	AdditionalCertificateOutputFormats: {Default: true, PreRelease: featuregate.Beta},
-	LiteralCertificateSubject:          {Default: false, PreRelease: featuregate.Alpha},
+	LiteralCertificateSubject:          {Default: true, PreRelease: featuregate.Beta},
 	NameConstraints:                    {Default: false, PreRelease: featuregate.Alpha},
 	OtherNames:                         {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -128,9 +128,6 @@ type CertificateSpec struct {
 	// More info: https://github.com/cert-manager/cert-manager/issues/4424
 	//
 	// Cannot be set if the `subject` or `commonName` field is set.
-	// This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=LiteralCertificateSubject=true` option set on both
-	// the controller and webhook components.
 	// +optional
 	LiteralSubject string `json:"literalSubject,omitempty"`
 


### PR DESCRIPTION
We improved this feature a lot in this release:
- https://github.com/cert-manager/cert-manager/pull/6761
- https://github.com/cert-manager/cert-manager/pull/6775
- https://github.com/cert-manager/cert-manager/pull/6995
- https://github.com/go-ldap/ldap/pull/504
- https://github.com/go-ldap/ldap/pull/505
- https://github.com/go-ldap/ldap/pull/497
- https://github.com/go-asn1-ber/asn1-ber/pull/42

### Kind

/kind feature

### Release Note

```release-note
Promote the `LiteralCertificateSubject` feature to Beta.
```
