### PR TITLE
Re-add hash.sh, which was also used by the release Make target

### DIFF
--- a/hack/util/hash.sh
+++ b/hack/util/hash.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is used by the $(bin_dir)/metadata/cert-manager-manifests.tar.gz.metadata.json
+# and $(bin_dir)/metadata/cert-manager-server-linux-amd64.tar.gz.metadata.json Make targets.
+
+# This script is a wrapper for outputting purely the sha256 hash of the input file,
+# ideally in a portable way.
+
+case "$(uname -s)" in
+    Darwin*)    shasum -a 256 "$1";;
+    *)          sha256sum "$1" 
+esac | cut -d" " -f1


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6749, we removed/ moved the `hash.sh` script.
However, I did not notice that the script is also used during the release process:
- https://github.com/cert-manager/cert-manager/blob/a26a0a856f17db768224adfdd3e56bdaef45a991/make/release.mk#L110
- https://github.com/cert-manager/cert-manager/blob/a26a0a856f17db768224adfdd3e56bdaef45a991/make/manifests.mk#L80
This PR re-adds the script with a notice that it is still used by those Make targets.
This should fix the release process.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
