### PR TITLE
Add Helm options to extend auto-approval or disable it

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -243,6 +243,11 @@ func EnabledControllers(o *config.ControllerConfiguration) sets.Set[string] {
 		}
 	}
 
+	// Detect if "*" was implied (in case only disabled controllers were specified)
+	if len(disabled) > 0 && len(enabled) == 0 {
+		enabled = enabled.Insert(defaults.DefaultEnabledControllers...)
+	}
+
 	enabled = enabled.Delete(disabled...)
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalCertificateSigningRequestControllers) {

--- a/cmd/controller/app/options/options_test.go
+++ b/cmd/controller/app/options/options_test.go
@@ -50,6 +50,14 @@ func TestEnabledControllers(t *testing.T) {
 			controllers: []string{"*", "-clusterissuers", "-issuers"},
 			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
 		},
+		"if only disabled controllers are specified, implicitly enable all default controllers": {
+			controllers: []string{"-clusterissuers", "-issuers"},
+			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
+		},
+		"if both enabled and disabled controllers are specified, return specified controllers": {
+			controllers: []string{"foo", "-bar"},
+			expEnabled:  sets.New("foo"),
+		},
 	}
 
 	for name, test := range tests {

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -387,6 +387,23 @@ A comma-separated string with the host and port of the recursive nameservers cer
 > ```
 
 Forces cert-manager to use only the recursive nameservers for verification. Enabling this option could cause the DNS01 self check to take longer owing to caching performed by the recursive nameservers.
+#### **disableAutoApproval** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Option to disable cert-manager's build-in auto-approver. The auto-approver approves all CertificateRequests that reference issuers matching the 'approveSignerNames' option. This 'disableAutoApproval' option is useful when you want to make all approval decisions using a different approver (like approver-policy - https://github.com/cert-manager/approver-policy).
+#### **approveSignerNames** ~ `array`
+> Default value:
+> ```yaml
+> - issuers.cert-manager.io/*
+> - clusterissuers.cert-manager.io/*
+> ```
+
+List of signer names that cert-manager will approve by default. CertificateRequests referencing these signer names will be auto-approved by cert-manager. Defaults to just approving the cert-manager.io Issuer and ClusterIssuer issuers. When set to an empty array, ALL issuers will be auto-approved by cert-manager. To disable the auto-approval, because eg. you are using approver-policy, you can enable 'disableAutoApproval'.  
+ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
+
 #### **extraArgs** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -137,6 +137,9 @@ spec:
           {{- with .Values.dns01RecursiveNameservers }}
           - --dns01-recursive-nameservers={{ . }}
           {{- end }}
+          {{- if .Values.disableAutoApproval }}
+          - --controllers=-certificaterequests-approver
+          {{- end }}
           ports:
           - containerPort: 9402
             name: http-metrics

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -474,6 +474,8 @@ rules:
 
 ---
 
+{{- if not .Values.disableAutoApproval -}}
+
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -489,7 +491,12 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
     verbs: ["approve"]
-    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    {{- with .Values.approveSignerNames }}
+    resourceNames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end  }}
+    {{- end }}
 
 ---
 
@@ -513,6 +520,8 @@ subjects:
     kind: ServiceAccount
 
 ---
+
+{{- end -}}
 
 # Permission to:
 # - Update and sign CertificatSigningeRequests referencing cert-manager.io Issuers and ClusterIssuers

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -241,6 +241,23 @@ dns01RecursiveNameservers: ""
 # Enabling this option could cause the DNS01 self check to take longer owing to caching performed by the recursive nameservers.
 dns01RecursiveNameserversOnly: false
 
+# Option to disable cert-manager's build-in auto-approver. The auto-approver
+# approves all CertificateRequests that reference issuers matching the 'approveSignerNames'
+# option. This 'disableAutoApproval' option is useful when you want to make all approval decisions
+# using a different approver (like approver-policy - https://github.com/cert-manager/approver-policy).
+disableAutoApproval: false
+
+# List of signer names that cert-manager will approve by default. CertificateRequests
+# referencing these signer names will be auto-approved by cert-manager. Defaults to just
+# approving the cert-manager.io Issuer and ClusterIssuer issuers. When set to an empty
+# array, ALL issuers will be auto-approved by cert-manager. To disable the auto-approval,
+# because eg. you are using approver-policy, you can enable 'disableAutoApproval'.
+# ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
+# +docs:property
+approveSignerNames:
+- issuers.cert-manager.io/*
+- clusterissuers.cert-manager.io/*
+
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run `docker run quay.io/jetstack/cert-manager-controller:<version> --help`.
 #


### PR DESCRIPTION
This PR adds Helm options to simplify configuring the build-in cert-manager auto-approver.

1. It adds the option to approve external issuers (including an "approve all external issuers" options)
2. It adds the option to easily disable the auto-approver

This will simplify installing cert-manager combined with an external issuer or in combination with approver-policy (https://cert-manager.io/docs/policy/approval/approver-policy/installation/).

Fixes https://github.com/cert-manager/cert-manager/issues/6521

NOTE: We will keep the default "only approve cert-manager.io Issuer and ClusterIssuer" rule. In approver-policy and csi-driver-spiffe, we removed this constraint. The reason we keep the constraint here is because cert-manager's auto-approver will automatically approve all CertificateRequests that it can approve (which is not the case for approver-policy and csi-driver-spiffe). To prevent breaking existing setups (prevent two approvers from racing to approve the same resource), we will not expand the default set of issuers.

### Kind

/kind feature

### Release Note

```release-note
If the `--controllers` flag only specifies disabled controllers, the default controllers are now enabled implicitly.
Added `disableAutoApproval` and `approveSignerNames` Helm chart options.
```
