### PR TITLE
BUGFIX: correctly mount config files for components

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -66,6 +66,9 @@ spec:
           {{- if not (has (quote .Values.global.logLevel) (list "" (quote ""))) }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
+          {{- if .Values.cainjector.config }}
+          - --config=/var/cert-manager/config/config.yaml
+          {{- end }}
           {{- with .Values.global.leaderElection }}
           - --leader-election-namespace={{ .namespace }}
           {{- if .leaseDuration }}
@@ -97,9 +100,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.cainjector.volumeMounts }}
+          {{- if or .Values.cainjector.config .Values.cainjector.volumeMounts }}
           volumeMounts:
+            {{- if .Values.cainjector.config }}
+            - name: config 
+              mountPath: /var/cert-manager/config
+            {{- end }}
+            {{- with .Values.cainjector.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:
@@ -117,8 +126,15 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cainjector.volumes }}
+      {{- if or .Values.cainjector.volumes .Values.cainjector.config }}
       volumes:
+        {{- if .Values.cainjector.config }}
+        - name: config 
+          configMap: 
+            name: {{ include "cainjector.fullname" . }}
+        {{- end }}
+        {{ with .Values.cainjector.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
       {{- end }}
       {{- if or .Values.volumes .Values.config}}
       volumes:
-        {{- if .Values.config }} 
+        {{- if .Values.config }}
         - name: config 
           configMap: 
-            name: {{ include "cert-manager.fullname" . }} 
+            name: {{ include "cert-manager.fullname" . }}
         {{- end }}
         {{ with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
@@ -150,11 +150,11 @@ spec:
           {{- end }}
           {{- if or .Values.config .Values.volumeMounts }}
           volumeMounts:
-            {{- if .Values.config}} 
+            {{- if .Values.config }}
             - name: config 
               mountPath: /var/cert-manager/config
             {{- end }}
-            {{- with .Values.volumeMounts }} 
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -159,8 +159,8 @@ spec:
             - name: config
               mountPath: /var/cert-manager/config
             {{- end }}
-            {{- if .Values.webhook.volumeMounts }}
-            {{- toYaml .Values.webhook.volumeMounts | nindent 12 }}
+            {{- with .Values.webhook.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
       {{- with .Values.webhook.nodeSelector }}
@@ -186,7 +186,7 @@ spec:
           configMap:
             name: {{ include "webhook.fullname" . }}
         {{- end }}
-        {{- if .Values.webhook.volumes }}
-        {{- toYaml .Values.webhook.volumes | nindent 8 }}
+        {{- with .Values.webhook.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
### Pull Request Motivation

We were not yet mounting the cainjector ConfigMap in the cainjector deployment.

fixes #7046

### Kind

/kind bug

### Release Note

```release-note
Helm BUGFIX: the cainjector ConfigMap was not mounted in the cainjector deployment.
```
