### PR TITLE
Adds certificate name key annotation validation in secret as part of post issuance policy chain

### DIFF
--- a/internal/controller/certificates/policies/policies.go
+++ b/internal/controller/certificates/policies/policies.go
@@ -104,6 +104,7 @@ func NewReadinessPolicyChain(c clock.Clock) Chain {
 // correctness of metadata and output formats of Certificate's Secrets.
 func NewSecretPostIssuancePolicyChain(ownerRefEnabled bool, fieldManager string) Chain {
 	return Chain{
+		SecretCertificateNameAnnotationsMismatch,                             // Make sure the Secret's CertificateName annotation matches the Certificate's name
 		SecretBaseLabelsMismatch,                                             // Make sure the managed labels have the correct values
 		SecretCertificateDetailsAnnotationsMismatch,                          // Make sure the managed certificate details annotations have the correct values
 		SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(fieldManager), // Make sure the only the expected managed labels and annotations exist

--- a/pkg/controller/certificates/issuing/secret_manager.go
+++ b/pkg/controller/certificates/issuing/secret_manager.go
@@ -84,6 +84,12 @@ func (c *controller) ensureSecretData(ctx context.Context, log logr.Logger, crt 
 
 	if isViolation {
 		switch reason {
+		case policies.IncorrectCertificate:
+			// An error here indicates that the certificate is the not the owner of
+			// the created secret. This maybe the case of secret being referenced
+			// in multiple certificates.
+			log.Error(errors.New(message), "certificate name does not match the secret annotation")
+			return nil
 		case policies.InvalidCertificate, policies.ManagedFieldsParseError:
 			// An error here indicates that the managed fields are malformed and the
 			// decoder doesn't understand the managed fields on the Secret, or the


### PR DESCRIPTION
### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes #7063 

NOTE(@inteon): fixes duplicate Secret Reference runaway for the PostIssuance chain (updating a Secret without re-issuing), see https://github.com/cert-manager/cert-manager/pull/6406 for a similar fix for the TriggerPolicy chain (re-issuing a certificate).

### Kind

/kind bug 

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
