### PR TITLE
ingress-shim: optionally copy specific annotation

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -357,6 +357,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DefaultIssuerKind:                 opts.IngressShimConfig.DefaultIssuerKind,
 			DefaultIssuerGroup:                opts.IngressShimConfig.DefaultIssuerGroup,
 			DefaultAutoCertificateAnnotations: opts.IngressShimConfig.DefaultAutoCertificateAnnotations,
+			ExtraCertificateAnnotations:       opts.IngressShimConfig.ExtraCertificateAnnotations,
 		},
 
 		CertificateOptions: controller.CertificateOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -143,6 +143,8 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 
 	fs.StringSliceVar(&c.IngressShimConfig.DefaultAutoCertificateAnnotations, "auto-certificate-annotations", c.IngressShimConfig.DefaultAutoCertificateAnnotations, ""+
 		"The annotation consumed by the ingress-shim controller to indicate an ingress is requesting a certificate")
+	fs.StringSliceVar(&c.IngressShimConfig.ExtraCertificateAnnotations, "extra-certificate-annotations", []string{}, ""+
+		"Extra annotation to be added by the ingress-shim controller to certificate object")
 	fs.StringVar(&c.IngressShimConfig.DefaultIssuerName, "default-issuer-name", c.IngressShimConfig.DefaultIssuerName, ""+
 		"Name of the Issuer to use when the tls is requested but issuer name is not specified on the ingress resource.")
 	fs.StringVar(&c.IngressShimConfig.DefaultIssuerKind, "default-issuer-kind", c.IngressShimConfig.DefaultIssuerKind, ""+

--- a/cmd/controller/app/start_test.go
+++ b/cmd/controller/app/start_test.go
@@ -176,6 +176,19 @@ logging:
 				cc.Logging.Format = "text"
 			}),
 		},
+		{
+			yaml: `
+apiVersion: controller.config.cert-manager.io/v1alpha1
+kind: ControllerConfiguration
+ingressShimConfig: {}
+`,
+			args: func(tempFilePath string) []string {
+				return []string{"--config=" + tempFilePath, "--extra-certificate-annotations", "venafi.cert-manager.io/custom-fields"}
+			},
+			expConfig: configFromDefaults(func(tempDir string, cc *config.ControllerConfiguration) {
+				cc.IngressShimConfig.ExtraCertificateAnnotations = []string{"venafi.cert-manager.io/custom-fields"}
+			}),
+		},
 	}
 
 	for i, tc := range tests {

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -160,6 +160,10 @@ type IngressShimConfig struct {
 	// The annotation consumed by the ingress-shim controller to indicate an ingress
 	// is requesting a certificate
 	DefaultAutoCertificateAnnotations []string
+
+	// ExtraCertificateAnnotations is a list of annotations which should be copied from
+	// and ingress-like object to a Certificate.
+	ExtraCertificateAnnotations []string
 }
 
 type ACMEHTTP01Config struct {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -98,7 +98,8 @@ var (
 	defaultACMEHTTP01SolverRunAsNonRoot          = true
 	defaultACMEHTTP01SolverNameservers           = []string{}
 
-	defaultAutoCertificateAnnotations = []string{"kubernetes.io/tls-acme"}
+	defaultAutoCertificateAnnotations  = []string{"kubernetes.io/tls-acme"}
+	defaultExtraCertificateAnnotations = []string{}
 
 	AllControllers = []string{
 		issuerscontroller.ControllerName,
@@ -264,6 +265,10 @@ func SetDefaults_IngressShimConfig(obj *v1alpha1.IngressShimConfig) {
 
 	if len(obj.DefaultAutoCertificateAnnotations) == 0 {
 		obj.DefaultAutoCertificateAnnotations = defaultAutoCertificateAnnotations
+	}
+
+	if len(obj.ExtraCertificateAnnotations) == 0 {
+		obj.ExtraCertificateAnnotations = defaultExtraCertificateAnnotations
 	}
 }
 

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -289,6 +289,7 @@ func autoConvert_v1alpha1_IngressShimConfig_To_controller_IngressShimConfig(in *
 	out.DefaultIssuerKind = in.DefaultIssuerKind
 	out.DefaultIssuerGroup = in.DefaultIssuerGroup
 	out.DefaultAutoCertificateAnnotations = *(*[]string)(unsafe.Pointer(&in.DefaultAutoCertificateAnnotations))
+	out.ExtraCertificateAnnotations = *(*[]string)(unsafe.Pointer(&in.ExtraCertificateAnnotations))
 	return nil
 }
 
@@ -302,6 +303,7 @@ func autoConvert_controller_IngressShimConfig_To_v1alpha1_IngressShimConfig(in *
 	out.DefaultIssuerKind = in.DefaultIssuerKind
 	out.DefaultIssuerGroup = in.DefaultIssuerGroup
 	out.DefaultAutoCertificateAnnotations = *(*[]string)(unsafe.Pointer(&in.DefaultAutoCertificateAnnotations))
+	out.ExtraCertificateAnnotations = *(*[]string)(unsafe.Pointer(&in.ExtraCertificateAnnotations))
 	return nil
 }
 

--- a/internal/apis/config/controller/zz_generated.deepcopy.go
+++ b/internal/apis/config/controller/zz_generated.deepcopy.go
@@ -123,6 +123,11 @@ func (in *IngressShimConfig) DeepCopyInto(out *IngressShimConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraCertificateAnnotations != nil {
+		in, out := &in.ExtraCertificateAnnotations, &out.ExtraCertificateAnnotations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -162,6 +162,10 @@ type IngressShimConfig struct {
 	// The annotation consumed by the ingress-shim controller to indicate an ingress
 	// is requesting a certificate
 	DefaultAutoCertificateAnnotations []string `json:"defaultAutoCertificateAnnotations,omitempty"`
+
+	// ExtraCertificateAnnotations is a list of annotations which should be copied from
+	// and ingress-like object to a Certificate.
+	ExtraCertificateAnnotations []string `json:"extraCertificateAnnotations,omitempty"`
 }
 
 type ACMEHTTP01Config struct {

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -184,6 +184,11 @@ func (in *IngressShimConfig) DeepCopyInto(out *IngressShimConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraCertificateAnnotations != nil {
+		in, out := &in.ExtraCertificateAnnotations, &out.ExtraCertificateAnnotations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -3811,7 +3811,7 @@ func TestExtractAnnotations(t *testing.T) {
 		},
 		{
 			IngressLike: buildIngress("name", "namespace", nil),
-			Expected:    map[string]string{},
+			Expected:    nil,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -19,6 +19,7 @@ package shimhelper
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -1826,6 +1827,198 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:   "extra Ingress annotation is copied to Certificate object",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels:    map[string]string{},
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.CommonNameAnnotationKey:               "my-cn",
+						"venafi.cert-manager.io/custom-fields":      "foo",
+						"venafi.cert-manager.io/do-not-copy":        "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-com-tls",
+						Namespace: gen.DefaultTestNamespace,
+						Labels:    map[string]string{},
+						Annotations: map[string]string{
+							"venafi.cert-manager.io/custom-fields": "foo",
+						},
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com", "www.example.com"},
+						CommonName: "my-cn",
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should update a Certificate annotations if custom annotation is needed",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:   "issuer-name",
+						cmapi.IssuerKindAnnotationKey:          "Issuer",
+						cmapi.IssuerGroupAnnotationKey:         "cert-manager.io",
+						"venafi.cert-manager.io/custom-fields": "foo",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						CommonName: "example-common-name",
+						IssuerRef: cmmeta.ObjectReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							"venafi.cert-manager.io/custom-fields": "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should append a Certificate annotations if annotation is set",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:   "issuer-name",
+						cmapi.IssuerKindAnnotationKey:          "Issuer",
+						cmapi.IssuerGroupAnnotationKey:         "cert-manager.io",
+						"venafi.cert-manager.io/custom-fields": "foo",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							"venafi.cert-manager.io/custom-fields": "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						CommonName: "example-common-name",
+						IssuerRef: cmmeta.ObjectReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							"venafi.cert-manager.io/custom-fields": "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
 	}
 
 	testGatewayShim := []testT{
@@ -3361,6 +3554,69 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:   "extra Gateway annotation is copied to Certificate object",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels:    map[string]string{},
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.CommonNameAnnotationKey:               "my-cn",
+						"venafi.cert-manager.io/custom-fields":      "foo",
+						"venafi.cert-manager.io/do-not-copy":        "bar",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.GatewayTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-com-tls",
+						Namespace: gen.DefaultTestNamespace,
+						Labels:    map[string]string{},
+						Annotations: map[string]string{
+							"venafi.cert-manager.io/custom-fields": "foo",
+						},
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						CommonName: "my-cn",
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
 	}
 
 	testFn := func(test testT) func(t *testing.T) {
@@ -3418,6 +3674,7 @@ func TestSync(t *testing.T) {
 				DefaultIssuerKind:                 test.DefaultIssuerKind,
 				DefaultIssuerGroup:                test.DefaultIssuerGroup,
 				DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
+				ExtraCertificateAnnotations:       []string{"venafi.cert-manager.io/custom-fields"},
 			}, "cert-manager-test")
 			b.Start()
 
@@ -3447,7 +3704,6 @@ func TestSync(t *testing.T) {
 			t.Run(test.Name, testFn(test))
 		}
 	})
-
 }
 
 func TestIssuerForIngress(t *testing.T) {
@@ -3534,6 +3790,34 @@ func TestIssuerForIngress(t *testing.T) {
 
 		if group != test.ExpectedGroup {
 			t.Errorf("expected group to be %q but got %q", test.ExpectedGroup, group)
+		}
+	}
+}
+
+func TestExtractAnnotations(t *testing.T) {
+	type testT struct {
+		IngressLike *networkingv1.Ingress
+		Expected    map[string]string
+	}
+	tests := []testT{
+		{
+			IngressLike: buildIngress("ing1", "namespace1", map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}),
+			Expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			IngressLike: buildIngress("name", "namespace", nil),
+			Expected:    map[string]string{},
+		},
+	}
+	for _, test := range tests {
+		annotations := extractExtraAnnotations(test.IngressLike, []string{"key1"})
+		if !reflect.DeepEqual(annotations, test.Expected) {
+			t.Errorf("expected annotations to be %v but got %v", test.Expected, annotations)
 		}
 	}
 }
@@ -3974,4 +4258,82 @@ func Test_isDeletedInForeground(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestMergeAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]string
+		update   map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "No conflicts, simple merge",
+			existing: map[string]string{
+				"env":  "prod",
+				"team": "alpha",
+			},
+			update: map[string]string{
+				"version": "1.0.0",
+			},
+			expected: map[string]string{
+				"env":     "prod",
+				"team":    "alpha",
+				"version": "1.0.0",
+			},
+		},
+		{
+			name: "Overwriting existing keys",
+			existing: map[string]string{
+				"owner": "team-a",
+			},
+			update: map[string]string{
+				"owner": "team-b",
+			},
+			expected: map[string]string{
+				"owner": "team-b",
+			},
+		},
+		{
+			name:     "Merging empty maps",
+			existing: map[string]string{},
+			update:   map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name: "One empty map",
+			existing: map[string]string{
+				"key1": "value1",
+			},
+			update: map[string]string{},
+			expected: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "Overlapping and new keys",
+			existing: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			update: map[string]string{
+				"key2": "new-value2",
+				"key3": "value3",
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "new-value2", // Overwritten
+				"key3": "value3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeAnnotations(tt.existing, tt.update)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("mergeAnnotations() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -221,6 +221,7 @@ type IngressShimOptions struct {
 	DefaultIssuerKind                 string
 	DefaultIssuerGroup                string
 	DefaultAutoCertificateAnnotations []string
+	ExtraCertificateAnnotations       []string
 }
 
 type CertificateOptions struct {


### PR DESCRIPTION
Some setups have a requirement to have custom-field annotation set on Certificate object.

This commit introduces an ingress-shim option:
 * --extra-certificate-annotations which sets list of annotation keys to be copied from Ingress-like to resulting Certificate object
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind
feautre
<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note
<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added ingress-shim option:
* --extra-certificate-annotations which sets list of annotation keys to be copied from Ingress-like to resulting Certificate object
```
