### PR TITLE
feat: Use OAuth endpoint for Venafi Issuer when user/pass provided

### DIFF
--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -97,9 +97,9 @@ func New(namespace string, secretsLister internalinformers.SecretLister, issuer 
 	}
 
 	// Using `false` here ensures we do not immediately authenticate to the
-	// Venafi backend. Doing so invokes a call which force the API Key usage
+	// Venafi backend. Doing so invokes a call which forces the use of APIKey 
 	// on the TPP side. This auth method has been removed since 22.4 of TPP.
-	// This reults results in an APIKey usage error.
+	// This results in an APIKey usage error.
 	// Reference code from vcert library which still refers to the APIKey.
 	// ref: https://github.com/Venafi/vcert/blob/master/pkg/venafi/tpp/connector.go#L137-L146
 	//

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -29,13 +29,14 @@ import (
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/Venafi/vcert/v5/pkg/venafi/cloud"
 	"github.com/Venafi/vcert/v5/pkg/venafi/tpp"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util"
-	"github.com/go-logr/logr"
-	"k8s.io/utils/ptr"
 )
 
 const (

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -372,7 +372,9 @@ func (v *Venafi) VerifyCredentials() error {
 			}
 
 			return nil
-		} else if v.config.Credentials.User != "" && v.config.Credentials.Password != "" {
+		}
+
+		if v.config.Credentials.User != "" && v.config.Credentials.Password != "" {
 			// Use vcert libray GetRefreshToken which brings back a token pair.
 			// This includes the access_token which we set against the tppClient.
 			// Replaces usage of v.tppClient.Authenticate function which would

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -375,7 +375,7 @@ func (v *Venafi) VerifyCredentials() error {
 		}
 
 		if v.config.Credentials.User != "" && v.config.Credentials.Password != "" {
-			// Use vcert libray GetRefreshToken which brings back a token pair.
+			// Use vcert library GetRefreshToken which brings back a token pair.
 			// This includes the access_token which we set against the tppClient.
 			// Replaces usage of v.tppClient.Authenticate function which would
 			// have called the APIKey endpoint resulting in error.

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -29,14 +29,13 @@ import (
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/Venafi/vcert/v5/pkg/venafi/cloud"
 	"github.com/Venafi/vcert/v5/pkg/venafi/tpp"
-	"github.com/go-logr/logr"
-	"k8s.io/utils/ptr"
-
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -97,7 +96,7 @@ func New(namespace string, secretsLister internalinformers.SecretLister, issuer 
 	}
 
 	// Using `false` here ensures we do not immediately authenticate to the
-	// Venafi backend. Doing so invokes a call which forces the use of APIKey 
+	// Venafi backend. Doing so invokes a call which forces the use of APIKey
 	// on the TPP side. This auth method has been removed since 22.4 of TPP.
 	// This results in an APIKey usage error.
 	// Reference code from vcert library which still refers to the APIKey.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

- API Keys are deprecated, so providing a user/pass will result in an error
- Previously cert-manager would use these to return an API Key
- Do the same here except instead use the OAuth endpoint to get access_token
- Change Authentication to happen when VerifyCredentials called, not at client creation

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

feature

### Release Note

TBC - "breaking" in some ways so needs to be clearly documented. Will come back to this.

Potentially resolves: #4653

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Venafi TPP issuer can now be used with a username & password combination with OAuth. Fixes #4653.
Breaking: cert-manager will no longer use the API Key authentication method which was deprecated in 20.2 and since removed in 24.1 of TPP.
```

### Testing

To test, I both ran locally against the kind cluster, and build the image and ran it in my cluster.
Here are my test files:

```yaml
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test-2
  namespace: cert-manager
spec:
  commonName: peter-fiddes-gcp.jetstacker.net
  dnsNames:
    - peter-fiddes-gcp.jetstacker.net
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: tlspdc-demo-1
  privateKey:
    rotationPolicy: Always
  secretName: test-2-cert
  usages:
  - digital signature
  - server auth
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test
  namespace: cert-manager
spec:
  commonName: test-cluster-1.example.peter-fiddes-gcp.jetstacker.net
  dnsNames:
    - test-cluster-1.example.peter-fiddes-gcp.jetstacker.net
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: tlspdc-demo-1
  privateKey:
    rotationPolicy: Always
  secretName: test-cert
  usages:
  - digital signature
  - server auth
---
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: tlspdc-demo-1
spec:
  venafi:
    tpp:
      credentialsRef:
        name: tlspdc-demo-1-tlspk8s-creds
      url: https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net/
    zone: \VED\Policy\Certificates\Teams\cluster-1-platform
```

And my secret created previously:

```shell
export VENAFI_USER=$(cat <TEMP_FILE>| jq -r '.username') VENAFI_PASS=$(cat <TEMP_FILE> | jq -r '.password') VENAFI_URL="https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net/"
k create secret generic tlspdc-demo-1-tlspk8s-creds --from-literal username=$VENAFI_USER --from-literal password=$VENAFI_PASS -n cert-manager
```

Testing the issuer was still working after the expiry I changed the `cert-manager.io` token settings to be much shorter:
![Screenshot 2024-06-10 at 17 05 19](https://github.com/cert-manager/cert-manager/assets/11051419/9e0f365b-41d9-413b-9cb9-0a9d6d5b4668)

I can confirm that after the hour access it worked again, and new tokens were issued as you can see from the number of active grants:

![Screenshot 2024-06-10 at 17 06 14](https://github.com/cert-manager/cert-manager/assets/11051419/3525538d-a391-4e19-932d-0c6ad4427b26)

I then checked through and though that these setting might be more optimal for this use case using username / password: 

![Screenshot 2024-06-10 at 17 12 42](https://github.com/cert-manager/cert-manager/assets/11051419/0556f216-cb19-4b58-af87-1e477e8dcf62)

10 minutes seemed ok to ensure a cert was actually retrieved, which could depend on the CA and customer  workflows in TPP. Perhaps 1 minute would be fine for most cases?

I have checked this morning and it still seems I have 133 active grants. Not sure how / when TPP would clean up these grants considering they are only 10 minutes.
