### PR TITLE
Draft: Add support for FullChain additional output format

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -109,6 +109,7 @@ spec:
                         enum:
                           - DER
                           - CombinedPEM
+                          - FullChain
                 commonName:
                   description: |-
                     Requested common name X509 certificate subject attribute.

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -346,12 +346,16 @@ var (
 
 // CertificateOutputFormatType specifies which additional output formats should
 // be written to the Certificate's target Secret.
-// Allowed values are `DER` or `CombinedPEM`.
+// Allowed values are `DER`, `CombinedPEM`, or `FullChain`.
 // When Type is set to `DER` an additional entry `key.der` will be written to
 // the Secret, containing the binary format of the private key.
 // When Type is set to `CombinedPEM` an additional entry `tls-combined.pem`
 // will be written to the Secret, containing the PEM formatted private key and
 // signed certificate chain (tls.key + tls.crt concatenated).
+// When Type is set to `FullChain` an additional entry `tls-full-chain.pem`
+// will be written to the Secret, containing the PEM formatted signed
+// certificate chain, including the root certificate if present.
+// +kubebuilder:validation:Enum=DER;CombinedPEM;FullChain
 type CertificateOutputFormatType string
 
 const (
@@ -366,6 +370,11 @@ const (
 	// character, followed by the chain of signed certificate PEM documents
 	// (`<private key> + \n + <signed certificate chain>`).
 	CertificateOutputFormatCombinedPEM CertificateOutputFormatType = "CombinedPEM"
+
+	// CertificateOutputFormatFullChain  writes the Certificate's complete certificate chain,
+	// including root certificates if present, in PEM format, to the `tls-full-chain.pem`
+	// target Secret Data key.
+	CertificateOutputFormatFullChain CertificateOutputFormatType = "FullChain"
 )
 
 // CertificateAdditionalOutputFormat defines an additional output format of a

--- a/internal/controller/certificates/secrets.go
+++ b/internal/controller/certificates/secrets.go
@@ -96,3 +96,14 @@ func OutputFormatDER(privateKey []byte) []byte {
 func OutputFormatCombinedPEM(privateKey, certificate []byte) []byte {
 	return bytes.Join([][]byte{privateKey, certificate}, []byte("\n"))
 }
+
+// OutputFormatFullChain returns the byte slice of the PEM encoded full certificate
+// chain, including the root. To be used for Additional Output Format FullChain.
+func OutputFormatFullChain(certificate, ca []byte) []byte {
+	if ca == nil {
+		return certificate
+	}
+	chainWithCA := bytes.Join([][]byte{certificate, ca}, []byte("\n"))
+	bundle, _ := utilpki.ParseSingleCertificateRootChainPEM(chainWithCA)
+	return bundle.ChainPEM
+}

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -376,13 +376,16 @@ var (
 
 // CertificateOutputFormatType specifies which additional output formats should
 // be written to the Certificate's target Secret.
-// Allowed values are `DER` or `CombinedPEM`.
+// Allowed values are `DER`, `CombinedPEM`, or `FullChain`.
 // When Type is set to `DER` an additional entry `key.der` will be written to
 // the Secret, containing the binary format of the private key.
 // When Type is set to `CombinedPEM` an additional entry `tls-combined.pem`
 // will be written to the Secret, containing the PEM formatted private key and
 // signed certificate chain (tls.key + tls.crt concatenated).
-// +kubebuilder:validation:Enum=DER;CombinedPEM
+// When Type is set to `FullChain` an additional entry `tls-full-chain.pem`
+// will be written to the Secret, containing the PEM formatted signed
+// certificate chain, including the root certificate if present.
+// +kubebuilder:validation:Enum=DER;CombinedPEM;FullChain
 type CertificateOutputFormatType string
 
 const (
@@ -405,6 +408,15 @@ const (
 	// character, followed by the chain of signed certificate PEM documents
 	// (`<private key> + \n + <signed certificate chain>`).
 	CertificateOutputFormatCombinedPEM CertificateOutputFormatType = "CombinedPEM"
+
+	// CertificateOutputFormatFullChainKey is the name of the data entry in the Secret
+	// resource used to store the full chain PEM
+	CertificateOutputFormatFullChainKey string = "tls-full-chain.pem"
+
+	// CertificateOutputFormatFullChain  writes the Certificate's complete certificate chain,
+	// including root certificates if present, in PEM format, to the `tls-full-chain.pem`
+	// target Secret Data key.
+	CertificateOutputFormatFullChain CertificateOutputFormatType = "FullChain"
 )
 
 // CertificateAdditionalOutputFormat defines an additional output format of a

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -322,6 +322,9 @@ func setAdditionalOutputFormats(crt *cmapi.Certificate, secret *corev1.Secret, d
 		case cmapi.CertificateOutputFormatCombinedPEM:
 			// Combine tls.key and tls.crt
 			secret.Data[cmapi.CertificateOutputFormatCombinedPEMKey] = certificates.OutputFormatCombinedPEM(data.PrivateKey, data.Certificate)
+		case cmapi.CertificateOutputFormatFullChain:
+			// Store full chain
+			secret.Data[cmapi.CertificateOutputFormatFullChainKey] = certificates.OutputFormatFullChain(data.Certificate, data.CA)
 		default:
 			return fmt.Errorf("unknown additional output format %s", format.Type)
 		}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Allow exporting a complete certificate chain, including the root. See #6876.

### Kind
feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add support for FullChain additional output format
```

### Bikeshedding

- Output format name : `FullChain`
- Output secret key : `tls-full-chain.pem`

### Alternatives

An alternative could be a flag on the Certificate for requesting a full chain in `tls.crt`. In the case of long chains, this could save data usage on the Secret, if you consider the user is unlikely to use both chains separately.

### Further work

I'd like to put this out there to get the ball rolling before continuing working on the tests.