### PR TITLE
6898: Add validity duration to Venafi certificates

### DIFF
--- a/pkg/controller/certificaterequests/venafi/venafi.go
+++ b/pkg/controller/certificaterequests/venafi/venafi.go
@@ -115,11 +115,12 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 		}
 	}
 
+	duration := apiutil.DefaultCertDuration(cr.Spec.Duration)
 	pickupID := cr.ObjectMeta.Annotations[cmapi.VenafiPickupIDAnnotationKey]
 
 	// check if the pickup ID annotation is there, if not set it up.
 	if pickupID == "" {
-		pickupID, err = client.RequestCertificate(cr.Spec.Request, customFields)
+		pickupID, err = client.RequestCertificate(cr.Spec.Request, duration, customFields)
 		// Check some known error types
 		if err != nil {
 			switch err.(type) {
@@ -147,7 +148,7 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 		return nil, nil
 	}
 
-	certPem, err := client.RetrieveCertificate(pickupID, cr.Spec.Request, customFields)
+	certPem, err := client.RetrieveCertificate(pickupID, cr.Spec.Request, duration, customFields)
 	if err != nil {
 		switch err.(type) {
 		case endpoint.ErrCertificatePending, endpoint.ErrRetrieveCertificateTimeout:

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -222,10 +222,10 @@ func TestSign(t *testing.T) {
 	}
 
 	clientReturnsPending := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
 			return "test", nil
 		},
-		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
 			return nil, endpoint.ErrCertificatePending{
 				CertificateID: "test-cert-id",
 				Status:        "test-status-pending",
@@ -233,33 +233,33 @@ func TestSign(t *testing.T) {
 		},
 	}
 	clientReturnsGenericError := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
 			return "", errors.New("this is an error")
 		},
 	}
 	clientReturnsCert := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, customFields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
 			return "test", nil
 		},
-		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
 			return append(certPEM, rootPEM...), nil
 		},
 	}
 
 	clientReturnsCertIfCustomField := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, fields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, fields []api.CustomField) (string, error) {
 			if len(fields) > 0 && fields[0].Name == "cert-manager-test" && fields[0].Value == "test ok" {
 				return "test", nil
 			}
 			return "", errors.New("Custom field not set")
 		},
-		RetrieveCertificateFn: func(string, []byte, []api.CustomField) ([]byte, error) {
+		RetrieveCertificateFn: func(string, []byte, time.Duration, []api.CustomField) ([]byte, error) {
 			return append(certPEM, rootPEM...), nil
 		},
 	}
 
 	clientReturnsInvalidCustomFieldType := &internalvenafifake.Venafi{
-		RequestCertificateFn: func(csrPEM []byte, fields []api.CustomField) (string, error) {
+		RequestCertificateFn: func(csrPEM []byte, duration time.Duration, fields []api.CustomField) (string, error) {
 			return "", client.ErrCustomFieldsType{Type: fields[0].Type}
 		},
 	}

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -390,7 +390,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", venaficlient.ErrCustomFieldsType{Type: "test-type"}
 					},
 				}, nil
@@ -461,7 +461,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "", errors.New("generic error")
 					},
 				}, nil
@@ -532,7 +532,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RequestCertificateFn: func(_ []byte, _ []venafiapi.CustomField) (string, error) {
+					RequestCertificateFn: func(_ []byte, _ time.Duration, _ []venafiapi.CustomField) (string, error) {
 						return "test-pickup-id", nil
 					},
 				}, nil
@@ -594,7 +594,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrCertificatePending{}
 					},
 				}, nil
@@ -645,7 +645,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, endpoint.ErrRetrieveCertificateTimeout{}
 					},
 				}, nil
@@ -696,7 +696,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return nil, errors.New("generic error")
 					},
 				}, nil
@@ -747,7 +747,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte("garbage"), nil
 					},
 				}, nil
@@ -820,7 +820,7 @@ func TestProcessItem(t *testing.T) {
 			),
 			clientBuilder: func(_ string, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ *metrics.Metrics, _ logr.Logger, _ string) (venaficlient.Interface, error) {
 				return &fakevenaficlient.Venafi{
-					RetrieveCertificateFn: func(_ string, _ []byte, _ []venafiapi.CustomField) ([]byte, error) {
+					RetrieveCertificateFn: func(_ string, _ []byte, _ time.Duration, _ []venafiapi.CustomField) ([]byte, error) {
 						return []byte(fmt.Sprintf("%s%s", certBundle.ChainPEM, certBundle.CAPEM)), nil
 					},
 				}, nil

--- a/pkg/issuer/venafi/client/fake/venafi.go
+++ b/pkg/issuer/venafi/client/fake/venafi.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"time"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
@@ -24,8 +25,8 @@ import (
 
 type Venafi struct {
 	PingFn                  func() error
-	RequestCertificateFn    func(csrPEM []byte, customFields []api.CustomField) (string, error)
-	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error)
+	RequestCertificateFn    func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
+	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
 	ReadZoneConfigurationFn func() (*endpoint.ZoneConfiguration, error)
 	VerifyCredentialsFn     func() error
 }
@@ -34,12 +35,12 @@ func (v *Venafi) Ping() error {
 	return v.PingFn()
 }
 
-func (v *Venafi) RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error) {
-	return v.RequestCertificateFn(csrPEM, customFields)
+func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
+	return v.RequestCertificateFn(csrPEM, duration, customFields)
 }
 
-func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error) {
-	return v.RetrieveCertificateFn(pickupID, csrPEM, customFields)
+func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error) {
+	return v.RetrieveCertificateFn(pickupID, csrPEM, duration, customFields)
 }
 
 func (v *Venafi) ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error) {

--- a/pkg/issuer/venafi/client/fake/venafi.go
+++ b/pkg/issuer/venafi/client/fake/venafi.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	"time"
+
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -45,8 +45,8 @@ var ErrorMissingSubject = errors.New("Certificate requests submitted to Venafi i
 // The CSR will be decoded to be validated against the zone configuration policy.
 // Upon the template being successfully defaulted and validated, the CSR will be sent, as is.
 // It will return a pickup ID which can be used with RetrieveCertificate to get the certificate
-func (v *Venafi) RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error) {
-	vreq, err := v.buildVReq(csrPEM, customFields)
+func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {
+	vreq, err := v.buildVReq(csrPEM, duration, customFields)
 	if err != nil {
 		return "", err
 	}
@@ -81,8 +81,8 @@ func (v *Venafi) RequestCertificate(csrPEM []byte, customFields []api.CustomFiel
 	return v.vcertClient.RequestCertificate(vreq)
 }
 
-func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error) {
-	vreq, err := v.buildVReq(csrPEM, customFields)
+func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error) {
+	vreq, err := v.buildVReq(csrPEM, duration, customFields)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (v *Venafi) RetrieveCertificate(pickupID string, csrPEM []byte, customField
 	return []byte(chain), nil
 }
 
-func (v *Venafi) buildVReq(csrPEM []byte, customFields []api.CustomField) (*certificate.Request, error) {
+func (v *Venafi) buildVReq(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (*certificate.Request, error) {
 	// Retrieve a copy of the Venafi zone.
 	// This contains default values and policy control info that we can apply
 	// and check against locally.
@@ -185,7 +185,7 @@ func convertCustomFieldsToVcert(customFields []api.CustomField) ([]certificate.C
 func newVRequest(cert *x509.Certificate, duration time.Duration) *certificate.Request {
 	req := certificate.NewRequest(cert)
 
-	req.ValidityDurationm = &duration
+	req.ValidityDuration = &duration
 	req.ChainOption = certificate.ChainOptionRootLast
 
 	// overwrite entire Subject block

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
+	"github.com/Venafi/vcert/v5/pkg/util"
 	"github.com/Venafi/vcert/v5/pkg/venafi/tpp"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
@@ -186,6 +187,7 @@ func newVRequest(cert *x509.Certificate, duration time.Duration) *certificate.Re
 	req := certificate.NewRequest(cert)
 
 	req.ValidityDuration = &duration
+	req.IssuerHint = util.IssuerHintAllIssuers
 	req.ChainOption = certificate.ChainOptionRootLast
 
 	// overwrite entire Subject block

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -122,7 +122,7 @@ func (v *Venafi) buildVReq(csrPEM []byte, customFields []api.CustomField) (*cert
 	}
 
 	// Create a vcert Request structure
-	vreq := newVRequest(tmpl)
+	vreq := newVRequest(tmpl, duration)
 
 	// Convert over custom fields from our struct type to venafi's
 	vfields, err := convertCustomFieldsToVcert(customFields)
@@ -182,8 +182,10 @@ func convertCustomFieldsToVcert(customFields []api.CustomField) ([]certificate.C
 	return out, nil
 }
 
-func newVRequest(cert *x509.Certificate) *certificate.Request {
+func newVRequest(cert *x509.Certificate, duration time.Duration) *certificate.Request {
 	req := certificate.NewRequest(cert)
+
+	req.ValidityDurationm = &duration
 	req.ChainOption = certificate.ChainOptionRootLast
 
 	// overwrite entire Subject block

--- a/pkg/issuer/venafi/client/request_test.go
+++ b/pkg/issuer/venafi/client/request_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
@@ -214,7 +215,7 @@ func TestVenafi_RequestCertificate(t *testing.T) {
 					"foo.example.com", "bar.example.com"})
 			}
 
-			got, err := v.RequestCertificate(tt.args.csrPEM, tt.args.customFields)
+			got, err := v.RequestCertificate(tt.args.csrPEM, time.Minute, tt.args.customFields)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RequestCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -235,6 +236,7 @@ func TestVenafi_RetrieveCertificate(t *testing.T) {
 
 	type args struct {
 		csrPEM       []byte
+		duration     time.Duration
 		customFields []api.CustomField
 	}
 	tests := []struct {
@@ -278,11 +280,11 @@ func TestVenafi_RetrieveCertificate(t *testing.T) {
 			// this is needed to provide the fake venafi client with a "valid" pickup id
 			// testing errors in this should be done in TestVenafi_RequestCertificate
 			// any error returned in these tests is a hard fail
-			pickupID, err := v.RequestCertificate(tt.args.csrPEM, tt.args.customFields)
+			pickupID, err := v.RequestCertificate(tt.args.csrPEM, tt.args.duration, tt.args.customFields)
 			if err != nil {
 				t.Errorf("RequestCertificate() should but error but got error = %v", err)
 			}
-			got, err := v.RetrieveCertificate(pickupID, tt.args.csrPEM, tt.args.customFields)
+			got, err := v.RetrieveCertificate(pickupID, tt.args.csrPEM, tt.args.duration, tt.args.customFields)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RetrieveCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -52,8 +52,8 @@ type VenafiClientBuilder func(namespace string, secretsLister internalinformers.
 
 // Interface implements a Venafi client
 type Interface interface {
-	RequestCertificate(csrPEM []byte, customFields []api.CustomField) (string, error)
-	RetrieveCertificate(pickupID string, csrPEM []byte, customFields []api.CustomField) ([]byte, error)
+	RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
+	RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
 	Ping() error
 	ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error)
 	SetClient(endpoint.Connector)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

When using Venafi as issuer the specified Duration on the certificate resource does not get passed to Venafi. Therefor only the CA default expire time will be used and it's not possible to override it.

### Kind

feature

solves https://github.com/cert-manager/cert-manager/issues/6898

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Now passes down specified duration to venafi client instead of using the CA default only.
```
