### PR TITLE
Refactor Certificate conformance to tabular tests

### DIFF
--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 
@@ -400,6 +401,16 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 
 		defineTest := func(test testCase) {
 			s.it(f, test.name, func(issuerRef cmmeta.ObjectReference) {
+				requiredFeatures := sets.New(test.requiredFeatures...)
+
+				if requiredFeatures.Has(featureset.OtherNamesFeature) {
+					framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.OtherNames)
+				}
+
+				if requiredFeatures.Has(featureset.LiteralSubjectFeature) {
+					framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
+				}
+
 				randomTestID := rand.String(10)
 				certificate := &cmapi.Certificate{
 					ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -48,6 +48,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 
 	. "github.com/cert-manager/cert-manager/e2e-tests/framework/matcher"
 	. "github.com/onsi/ginkgo/v2"
@@ -87,669 +88,354 @@ func (s *Suite) Define() {
 			}
 		})
 
-		s.it(f, "should issue a basic, defaulted certificate for a single distinct DNS Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
+		type testCase struct {
+			certModifiers []gen.CertificateModifier
+			// Extra validations which may be needed for testing, on a test case by
+			// case basis. All default validations will be run on every test.
+			extraValidations []certificates.ValidationFunc
+		}
+
+		runTest := func(f *framework.Framework, test testCase, issuerRef cmmeta.ObjectReference) {
+			randomTestID := rand.String(10)
+			certificate := &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
+					Name:      "e2e-conformance-" + randomTestID,
 					Namespace: f.Namespace.Name,
 				},
 				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
+					SecretName: "e2e-conformance-tls-" + randomTestID,
 					IssuerRef:  issuerRef,
-					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
 				},
 			}
+
+			certificate = gen.CertificateFrom(
+				certificate,
+				test.certModifiers...,
+			)
+
 			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
+			err := f.CRClient.Create(ctx, certificate)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
+			certificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, certificate, time.Minute*8)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
+			validations := append(test.extraValidations, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
+			err = f.Helper().ValidateCertificate(certificate, validations...)
 			Expect(err).NotTo(HaveOccurred())
+		}
+
+		s.it(f, "should issue a basic, defaulted certificate for a single distinct DNS Name", func(issuerRef cmmeta.ObjectReference) {
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+				},
+			}, issuerRef)
 		}, featureset.OnlySAN)
 
 		s.it(f, "should issue a CA certificate with the CA basicConstraint set", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateIsCA(true),
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					IsCA:       true,
-					IssuerRef:  issuerRef,
-					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.IssueCAFeature)
 
 		s.it(f, "should issue an ECDSA, defaulted certificate for a single distinct DNS Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					PrivateKey: &cmapi.CertificatePrivateKey{
-						Algorithm: cmapi.ECDSAKeyAlgorithm,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					func(c *cmapi.Certificate) {
+						c.Spec.PrivateKey = &cmapi.CertificatePrivateKey{
+							Algorithm: cmapi.ECDSAKeyAlgorithm,
+						}
 					},
-					DNSNames:  []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-					IssuerRef: issuerRef,
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.ECDSAFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue an Ed25519, defaulted certificate for a single distinct DNS Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					PrivateKey: &cmapi.CertificatePrivateKey{
-						Algorithm: cmapi.Ed25519KeyAlgorithm,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					func(c *cmapi.Certificate) {
+						c.Spec.PrivateKey = &cmapi.CertificatePrivateKey{
+							Algorithm: cmapi.Ed25519KeyAlgorithm,
+						}
 					},
-					DNSNames:  []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-					IssuerRef: issuerRef,
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.OnlySAN, featureset.Ed25519FeatureSet)
 
 		s.it(f, "should issue a basic, defaulted certificate for a single Common Name", func(issuerRef cmmeta.ObjectReference) {
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			cn := "test-common-name-" + rand.String(10)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					// Some issuers use the CN to define the cert's "ID"
+					// if one cert manages to be in an error state in the issuer it might throw an error
+					// this makes the CN more unique
+					gen.SetCertificateCommonName("test-common-name-" + rand.String(10)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					IssuerRef:  issuerRef,
-					CommonName: cn,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate with a couple valid otherName SAN values set as well as an emailAddress", func(issuerRef cmmeta.ObjectReference) {
 			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.OtherNames)
-			emailAddresses := []string{"email@domain.test"}
-			otherNames := []cmapi.OtherName{
-				{
-					OID:       "1.3.6.1.4.1.311.20.2.3",
-					UTF8Value: "upn@domain.test",
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateOtherNames(
+						cmapi.OtherName{
+							OID:       "1.3.6.1.4.1.311.20.2.3",
+							UTF8Value: "upn@domain.test",
+						},
+						cmapi.OtherName{
+							OID:       "1.3.6.1.4.1.311.20.2.3",
+							UTF8Value: "upn@domain2.test",
+						},
+					),
+					gen.SetCertificateEmails("email@domain.test"),
+					gen.SetCertificateCommonName("someCN"),
 				},
-				{
-					OID:       "1.3.6.1.4.1.311.20.2.3",
-					UTF8Value: "upn@domain2.test",
+				extraValidations: []certificates.ValidationFunc{
+					func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+						certBytes, ok := secret.Data[corev1.TLSCertKey]
+						if !ok {
+							return fmt.Errorf("no certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
+						}
+
+						pemBlock, _ := pem.Decode(certBytes)
+						cert, err := x509.ParseCertificate(pemBlock.Bytes)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Including the appropriate GeneralNames ( RFC822 email Address and OtherName) in generated Certificate")
+						/* openssl req -nodes -newkey rsa:2048 -subj "/CN=someCN" \
+						-addext 'subjectAltName=email:email@domain.test,otherName:msUPN;utf8:upn@domain2.test,otherName:msUPN;UTF8:upn@domain.test' -x509 -out server.crt
+						*/
+						Expect(cert.Extensions).Should(HaveSameSANsAs(`-----BEGIN CERTIFICATE-----
+		MIIDZjCCAk6gAwIBAgIUWmJ+z4OCWZg4V3XjSfEN+hItXjUwDQYJKoZIhvcNAQEL
+		BQAwETEPMA0GA1UEAwwGc29tZUNOMB4XDTI0MDEwMzA4NTU1NloXDTI0MDIwMjA4
+		NTU1NlowETEPMA0GA1UEAwwGc29tZUNOMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+		MIIBCgKCAQEAr5xmoX7/vp+wid+gOvbigYXLP/OvILyRpyj/e6IqJqj83+ImMtHt
+		QtOHN/E1bYQ8juVXqhhwy5BDXV6qHCfEjAKJF/oHpdVGk4GoMV/noAjbyAdqxFb+
+		Cr/62sZWFHcuBuh/msJj6MWWAYZkb6HPiyDaV4HdRrrefifQnBGmsO0DE2guy7Yr
+		CMnE25H0yZ6z1e2tecsXSEkHyPNpil39oJ+1dT3UG8coU32rMOMKs7Za/xF0yMtU
+		TrCzZ/ylFL4vJi/s0i9zgjBQloJud+s3J+MnbYFgv0MIaosZXuk7/FR0HNIM19Zw
+		VLH6dgVCcF02bnnVpOAd6KPEzdqjYdDv/QIDAQABo4G1MIGyMB0GA1UdDgQWBBRF
+		KVGbYoD2H1NE47wJL6xFQ83Q+DAfBgNVHSMEGDAWgBRFKVGbYoD2H1NE47wJL6xF
+		Q83Q+DAPBgNVHRMBAf8EBTADAQH/MF8GA1UdEQRYMFaBEWVtYWlsQGRvbWFpbi50
+		ZXN0oCAGCisGAQQBgjcUAgOgEgwQdXBuQGRvbWFpbjIudGVzdKAfBgorBgEEAYI3
+		FAIDoBEMD3VwbkBkb21haW4udGVzdDANBgkqhkiG9w0BAQsFAAOCAQEAmrouGUth
+		yyL3jJTe2XZCqbjNgwXrT5N8SwF8JrPNzTyuh4Qiug3N/3djmq4N4V60UAJU8Xpr
+		Uf8TZBQwF6VD/TSvvJKB3qjSW0T46cF++10ueEgT7mT/icyPeiMw1syWpQlciIvv
+		WZ/PIvHm2sTB+v8v9rhiFDyQxlnvbtG0D0TV/dEZmyrqfrBpWOP8TFgexRMQU2/4
+		Gb9fYHRK+LBKRTFudEXNWcDYxK3umfht/ZUsMeWUP70XaNsTd9tQWRsctxGpU10s
+		cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
+		/XMa5c3nWcbXcA==
+		-----END CERTIFICATE-----
+		`))
+						return nil
+					},
 				},
-			}
-
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:     "testcert-tls",
-					IssuerRef:      issuerRef,
-					OtherNames:     otherNames,
-					EmailAddresses: emailAddresses,
-					CommonName:     "someCN",
-				}}
-
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*5)
-			Expect(err).NotTo(HaveOccurred())
-
-			valFunc := func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
-				certBytes, ok := secret.Data[corev1.TLSCertKey]
-				if !ok {
-					return fmt.Errorf("no certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
-				}
-
-				pemBlock, _ := pem.Decode(certBytes)
-				cert, err := x509.ParseCertificate(pemBlock.Bytes)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Including the appropriate GeneralNames ( RFC822 email Address and OtherName) in generated Certificate")
-				/* openssl req -nodes -newkey rsa:2048 -subj "/CN=someCN" \
-				-addext 'subjectAltName=email:email@domain.test,otherName:msUPN;utf8:upn@domain2.test,otherName:msUPN;UTF8:upn@domain.test' -x509 -out server.crt
-				*/
-				Expect(cert.Extensions).Should(HaveSameSANsAs(`-----BEGIN CERTIFICATE-----
-MIIDZjCCAk6gAwIBAgIUWmJ+z4OCWZg4V3XjSfEN+hItXjUwDQYJKoZIhvcNAQEL
-BQAwETEPMA0GA1UEAwwGc29tZUNOMB4XDTI0MDEwMzA4NTU1NloXDTI0MDIwMjA4
-NTU1NlowETEPMA0GA1UEAwwGc29tZUNOMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAr5xmoX7/vp+wid+gOvbigYXLP/OvILyRpyj/e6IqJqj83+ImMtHt
-QtOHN/E1bYQ8juVXqhhwy5BDXV6qHCfEjAKJF/oHpdVGk4GoMV/noAjbyAdqxFb+
-Cr/62sZWFHcuBuh/msJj6MWWAYZkb6HPiyDaV4HdRrrefifQnBGmsO0DE2guy7Yr
-CMnE25H0yZ6z1e2tecsXSEkHyPNpil39oJ+1dT3UG8coU32rMOMKs7Za/xF0yMtU
-TrCzZ/ylFL4vJi/s0i9zgjBQloJud+s3J+MnbYFgv0MIaosZXuk7/FR0HNIM19Zw
-VLH6dgVCcF02bnnVpOAd6KPEzdqjYdDv/QIDAQABo4G1MIGyMB0GA1UdDgQWBBRF
-KVGbYoD2H1NE47wJL6xFQ83Q+DAfBgNVHSMEGDAWgBRFKVGbYoD2H1NE47wJL6xF
-Q83Q+DAPBgNVHRMBAf8EBTADAQH/MF8GA1UdEQRYMFaBEWVtYWlsQGRvbWFpbi50
-ZXN0oCAGCisGAQQBgjcUAgOgEgwQdXBuQGRvbWFpbjIudGVzdKAfBgorBgEEAYI3
-FAIDoBEMD3VwbkBkb21haW4udGVzdDANBgkqhkiG9w0BAQsFAAOCAQEAmrouGUth
-yyL3jJTe2XZCqbjNgwXrT5N8SwF8JrPNzTyuh4Qiug3N/3djmq4N4V60UAJU8Xpr
-Uf8TZBQwF6VD/TSvvJKB3qjSW0T46cF++10ueEgT7mT/icyPeiMw1syWpQlciIvv
-WZ/PIvHm2sTB+v8v9rhiFDyQxlnvbtG0D0TV/dEZmyrqfrBpWOP8TFgexRMQU2/4
-Gb9fYHRK+LBKRTFudEXNWcDYxK3umfht/ZUsMeWUP70XaNsTd9tQWRsctxGpU10s
-cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
-/XMa5c3nWcbXcA==
------END CERTIFICATE-----
-`))
-				return nil
-			}
-
-			By("Validating the issued Certificate...")
-
-			err = f.Helper().ValidateCertificate(testCertificate, valFunc)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.OtherNamesFeature)
 
 		s.it(f, "should issue a basic, defaulted certificate for a single distinct DNS Name with a literal subject", func(issuerRef cmmeta.ObjectReference) {
 			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			host := fmt.Sprintf("*.%s.foo-long.bar.com", rand.String(10))
-			literalSubject := fmt.Sprintf("CN=%s,OU=FooLong,OU=Bar,OU=Baz,OU=Dept.,O=Corp.", host)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: func() []gen.CertificateModifier {
+					host := fmt.Sprintf("*.%s.foo-long.bar.com", rand.String(10))
+					literalSubject := fmt.Sprintf("CN=%s,OU=FooLong,OU=Bar,OU=Baz,OU=Dept.,O=Corp.", host)
+
+					return []gen.CertificateModifier{
+						func(c *cmapi.Certificate) {
+							c.Spec.LiteralSubject = literalSubject
+						},
+						gen.SetCertificateDNSNames(host),
+					}
+				}(),
+				extraValidations: []certificates.ValidationFunc{
+					func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+						certBytes, ok := secret.Data[corev1.TLSCertKey]
+						if !ok {
+							return fmt.Errorf("no certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
+						}
+
+						createdCert, err := pki.DecodeX509CertificateBytes(certBytes)
+						if err != nil {
+							return err
+						}
+
+						var dns pkix.RDNSequence
+						rest, err := asn1.Unmarshal(createdCert.RawSubject, &dns)
+
+						if err != nil {
+							return err
+						}
+
+						rdnSeq, err2 := pki.UnmarshalSubjectStringToRDNSequence(certificate.Spec.LiteralSubject)
+
+						if err2 != nil {
+							return err2
+						}
+
+						fmt.Fprintln(GinkgoWriter, "cert", base64.StdEncoding.EncodeToString(createdCert.RawSubject), dns, err, rest)
+						if !reflect.DeepEqual(rdnSeq, dns) {
+							return fmt.Errorf("generated certificate's subject [%s] does not match expected subject [%s]", dns.String(), certificate.Spec.LiteralSubject)
+						}
+						return nil
+					},
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:     "testcert-tls",
-					IssuerRef:      issuerRef,
-					LiteralSubject: literalSubject,
-					DNSNames:       []string{host},
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*5)
-			Expect(err).NotTo(HaveOccurred())
-
-			valFunc := func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
-				certBytes, ok := secret.Data[corev1.TLSCertKey]
-				if !ok {
-					return fmt.Errorf("no certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
-				}
-
-				createdCert, err := pki.DecodeX509CertificateBytes(certBytes)
-				if err != nil {
-					return err
-				}
-
-				var dns pkix.RDNSequence
-				rest, err := asn1.Unmarshal(createdCert.RawSubject, &dns)
-
-				if err != nil {
-					return err
-				}
-
-				rdnSeq, err2 := pki.UnmarshalSubjectStringToRDNSequence(literalSubject)
-
-				if err2 != nil {
-					return err2
-				}
-
-				fmt.Fprintln(GinkgoWriter, "cert", base64.StdEncoding.EncodeToString(createdCert.RawSubject), dns, err, rest)
-				if !reflect.DeepEqual(rdnSeq, dns) {
-					return fmt.Errorf("generated certificate's subject [%s] does not match expected subject [%s]", dns.String(), literalSubject)
-				}
-				return nil
-			}
-
-			By("Validating the issued Certificate...")
-
-			err = f.Helper().ValidateCertificate(testCertificate, valFunc)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.LiteralSubjectFeature)
 
 		s.it(f, "should issue an ECDSA, defaulted certificate for a single Common Name", func(issuerRef cmmeta.ObjectReference) {
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			cn := "test-common-name-" + rand.String(10)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					PrivateKey: &cmapi.CertificatePrivateKey{
-						Algorithm: cmapi.ECDSAKeyAlgorithm,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					func(c *cmapi.Certificate) {
+						c.Spec.PrivateKey = &cmapi.CertificatePrivateKey{
+							Algorithm: cmapi.ECDSAKeyAlgorithm,
+						}
 					},
-					CommonName: cn,
-					IssuerRef:  issuerRef,
+					// Some issuers use the CN to define the cert's "ID"
+					// if one cert manages to be in an error state in the issuer it might throw an error
+					// this makes the CN more unique
+					gen.SetCertificateCommonName("test-common-name-" + rand.String(10)),
 				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.ECDSAFeature, featureset.CommonNameFeature)
 
 		s.it(f, "should issue an Ed25519, defaulted certificate for a single Common Name", func(issuerRef cmmeta.ObjectReference) {
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			cn := "test-common-name-" + rand.String(10)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					PrivateKey: &cmapi.CertificatePrivateKey{
-						Algorithm: cmapi.Ed25519KeyAlgorithm,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					func(c *cmapi.Certificate) {
+						c.Spec.PrivateKey = &cmapi.CertificatePrivateKey{
+							Algorithm: cmapi.Ed25519KeyAlgorithm,
+						}
 					},
-					CommonName: cn,
-					IssuerRef:  issuerRef,
+					// Some issuers use the CN to define the cert's "ID"
+					// if one cert manages to be in an error state in the issuer it might throw an error
+					// this makes the CN more unique
+					gen.SetCertificateCommonName("test-common-name-" + rand.String(10)),
 				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.Ed25519FeatureSet, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate that defines an IP Address", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateIPs(sharedIPAddress),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:  "testcert-tls",
-					IPAddresses: []string{sharedIPAddress},
-					IssuerRef:   issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.IPAddressFeature)
 
 		s.it(f, "should issue a certificate that defines a DNS Name and IP Address", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateIPs(sharedIPAddress),
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:  "testcert-tls",
-					IPAddresses: []string{sharedIPAddress},
-					DNSNames:    []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-					IssuerRef:   issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.OnlySAN, featureset.IPAddressFeature)
 
 		s.it(f, "should issue a certificate that defines a Common Name and IP Address", func(issuerRef cmmeta.ObjectReference) {
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			cn := "test-common-name-" + rand.String(10)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateIPs(sharedIPAddress),
+					// Some issuers use the CN to define the cert's "ID"
+					// if one cert manages to be in an error state in the issuer it might throw an error
+					// this makes the CN more unique
+					gen.SetCertificateCommonName("test-common-name-" + rand.String(10)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:  "testcert-tls",
-					CommonName:  cn,
-					IPAddresses: []string{sharedIPAddress},
-					IssuerRef:   issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.CommonNameFeature, featureset.IPAddressFeature)
 
 		s.it(f, "should issue a certificate that defines an Email Address", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateEmails("alice@example.com"),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName:     "testcert-tls",
-					EmailAddresses: []string{"alice@example.com"},
-					IssuerRef:      issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.EmailSANsFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue a certificate that defines a Common Name and URI SAN", func(issuerRef cmmeta.ObjectReference) {
-			// Some issuers use the CN to define the cert's "ID"
-			// if one cert manages to be in an error state in the issuer it might throw an error
-			// this makes the CN more unique
-			cn := "test-common-name-" + rand.String(10)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateURIs("spiffe://cluster.local/ns/sandbox/sa/foo"),
+					// Some issuers use the CN to define the cert's "ID"
+					// if one cert manages to be in an error state in the issuer it might throw an error
+					// this makes the CN more unique
+					gen.SetCertificateCommonName("test-common-name-" + rand.String(10)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					CommonName: cn,
-					URIs:       []string{"spiffe://cluster.local/ns/sandbox/sa/foo"},
-					IssuerRef:  issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.URISANsFeature, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate that defines a 2 distinct DNS Names with one copied to the Common Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					CommonName: e2eutil.RandomSubdomain(s.DomainSuffix),
-					IssuerRef:  issuerRef,
-				},
-			}
-			testCertificate.Spec.DNSNames = []string{
-				testCertificate.Spec.CommonName, e2eutil.RandomSubdomain(s.DomainSuffix),
-			}
+			runTest(f, testCase{
+				certModifiers: func() []gen.CertificateModifier {
+					commonName := e2eutil.RandomSubdomain(s.DomainSuffix)
 
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+					return []gen.CertificateModifier{
+						gen.SetCertificateCommonName(commonName),
+						gen.SetCertificateDNSNames(commonName, e2eutil.RandomSubdomain(s.DomainSuffix)),
+					}
+				}(),
+			}, issuerRef)
 		}, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate that defines a distinct DNS Name and another distinct Common Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateCommonName(e2eutil.RandomSubdomain(s.DomainSuffix)),
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					CommonName: e2eutil.RandomSubdomain(s.DomainSuffix),
-					IssuerRef:  issuerRef,
-					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-				},
-			}
-
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate that defines a DNS Name and sets a duration", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+					gen.SetCertificateDuration(&metav1.Duration{Duration: time.Hour * 896}),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					IssuerRef:  issuerRef,
-					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-					Duration: &metav1.Duration{
-						Duration: time.Hour * 896,
-					},
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
-
-			// We set a weird time here as the duration with should never be used as
-			// a default by an issuer. This lets us test issuers are using our given
-			// duration.
-			// We set a 30 second buffer time here since Vault issues certificates
-			// with an extra 30 seconds on its duration.
-			f.CertificateDurationValid(ctx, testCertificate, time.Hour*896, 30*time.Second)
+			}, issuerRef)
 		}, featureset.DurationFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue a certificate that defines a wildcard DNS Name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateDNSNames("*." + e2eutil.RandomSubdomain(s.DomainSuffix)),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					IssuerRef:  issuerRef,
-					DNSNames:   []string{"*." + e2eutil.RandomSubdomain(s.DomainSuffix)},
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.WildcardsFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue a certificate that includes only a URISANs name", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateURIs("spiffe://cluster.local/ns/sandbox/sa/foo"),
 				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					URIs: []string{
-						"spiffe://cluster.local/ns/sandbox/sa/foo",
-					},
-					IssuerRef: issuerRef,
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+			}, issuerRef)
 		}, featureset.URISANsFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue a certificate that includes arbitrary key usages", func(issuerRef cmmeta.ObjectReference) {
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
-					IssuerRef:  issuerRef,
-					Usages: []cmapi.KeyUsage{
+			runTest(f, testCase{
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+					gen.SetCertificateKeyUsages(
 						cmapi.UsageSigning,
 						cmapi.UsageDataEncipherment,
 						cmapi.UsageServerAuth,
 						cmapi.UsageClientAuth,
-					},
+					),
 				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-
-			validations := []certificates.ValidationFunc{
-				certificates.ExpectKeyUsageExtKeyUsageClientAuth,
-				certificates.ExpectKeyUsageExtKeyUsageServerAuth,
-				certificates.ExpectKeyUsageUsageDigitalSignature,
-				certificates.ExpectKeyUsageUsageDataEncipherment,
-			}
-			validations = append(validations, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-
-			err = f.Helper().ValidateCertificate(testCertificate, validations...)
-			Expect(err).NotTo(HaveOccurred())
+				extraValidations: []certificates.ValidationFunc{
+					certificates.ExpectKeyUsageExtKeyUsageClientAuth,
+					certificates.ExpectKeyUsageExtKeyUsageServerAuth,
+					certificates.ExpectKeyUsageUsageDigitalSignature,
+					certificates.ExpectKeyUsageUsageDataEncipherment,
+				},
+			}, issuerRef)
 		}, featureset.KeyUsagesFeature, featureset.OnlySAN)
 
 		s.it(f, "should issue another certificate with the same private key if the existing certificate and CertificateRequest are deleted", func(issuerRef cmmeta.ObjectReference) {
@@ -1007,33 +693,14 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 		})
 
 		s.it(f, "should issue a certificate that defines a long domain", func(issuerRef cmmeta.ObjectReference) {
-			// the maximum length of a single segment of the domain being requested
-			const maxLengthOfDomainSegment = 63
-
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					DNSNames:   []string{e2eutil.RandomSubdomainLength(s.DomainSuffix, maxLengthOfDomainSegment)},
-					IssuerRef:  issuerRef,
-				},
-			}
-			validations := validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)
-
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*8)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Sanity-check the issued Certificate")
-			err = f.Helper().ValidateCertificate(testCertificate, validations...)
-			Expect(err).NotTo(HaveOccurred())
+			runTest(f, testCase{
+				certModifiers: func() []gen.CertificateModifier {
+					const maxLengthOfDomainSegment = 63
+					return []gen.CertificateModifier{
+						gen.SetCertificateDNSNames(e2eutil.RandomSubdomainLength(s.DomainSuffix, maxLengthOfDomainSegment)),
+					}
+				}(),
+			}, issuerRef)
 		}, featureset.OnlySAN, featureset.LongDomainFeatureSet)
 
 		s.it(f, "should allow updating an existing certificate with a new DNS Name", func(issuerRef cmmeta.ObjectReference) {
@@ -1064,8 +731,8 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 
 			By("Updating the Certificate after having added an additional dnsName")
 			newDNSName := e2eutil.RandomSubdomain(s.DomainSuffix)
-			retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				err = f.CRClient.Get(ctx, types.NamespacedName{Name: testCertificate.Name, Namespace: testCertificate.Namespace}, testCertificate)
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err := f.CRClient.Get(ctx, types.NamespacedName{Name: testCertificate.Name, Namespace: testCertificate.Namespace}, testCertificate)
 				if err != nil {
 					return err
 				}
@@ -1077,7 +744,6 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 				}
 				return nil
 			})
-
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate Ready condition to be updated")
@@ -1090,30 +756,15 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 		}, featureset.OnlySAN)
 
 		s.it(f, "should issue a certificate that defines a wildcard DNS Name and its apex DNS Name", func(issuerRef cmmeta.ObjectReference) {
-			dnsDomain := e2eutil.RandomSubdomain(s.DomainSuffix)
-			testCertificate := &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testcert",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: cmapi.CertificateSpec{
-					SecretName: "testcert-tls",
-					IssuerRef:  issuerRef,
-					DNSNames:   []string{"*." + dnsDomain, dnsDomain},
-				},
-			}
-			By("Creating a Certificate")
-			err := f.CRClient.Create(ctx, testCertificate)
-			Expect(err).NotTo(HaveOccurred())
+			runTest(f, testCase{
+				certModifiers: func() []gen.CertificateModifier {
+					dnsDomain := e2eutil.RandomSubdomain(s.DomainSuffix)
 
-			// use a longer timeout for this, as it requires performing 2 dns validations in serial
-			By("Waiting for the Certificate to be issued...")
-			testCertificate, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, testCertificate, time.Minute*10)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(testCertificate, validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
-			Expect(err).NotTo(HaveOccurred())
+					return []gen.CertificateModifier{
+						gen.SetCertificateDNSNames("*."+dnsDomain, dnsDomain),
+					}
+				}(),
+			}, issuerRef)
 		}, featureset.WildcardsFeature, featureset.OnlySAN)
 	})
 }

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -72,6 +72,12 @@ func SetCertificateIPs(ips ...string) CertificateModifier {
 	}
 }
 
+func SetCertificateOtherNames(otherNames ...v1.OtherName) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.OtherNames = otherNames
+	}
+}
+
 func SetCertificateEmails(emails ...string) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		crt.Spec.EmailAddresses = emails


### PR DESCRIPTION
This PR migrates the Certificate conformance tests to use a similar tabular definition style.

NOTE FOR REVIEWER: I split the PR in separate commits, so each individual test can be followed. I advise to review the PR commit-by-commit.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
