### PR TITLE
BUGFIX: AWS route53: Set global region for sts

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -82,7 +82,6 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	switch {
 	case d.Role != "" && d.WebIdentityToken != "":
 		d.log.V(logf.DebugLevel).Info("using assume role with web identity")
-		optFns = append(optFns, config.WithRegion(d.Region))
 	case useAmbientCredentials:
 		d.log.V(logf.DebugLevel).Info("using ambient credentials")
 		// Leaving credentials unset results in a default credential chain being
@@ -98,9 +97,14 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		return aws.Config{}, fmt.Errorf("unable to create aws config: %s", err)
 	}
 
+	// Explicitly set the region to aws-global so that AssumeRole can be used
+	// with the global sts endpoint.
+	stsCfg := cfg.Copy()
+	stsCfg.Region = "aws-global"
+
 	if d.Role != "" && d.WebIdentityToken == "" {
 		d.log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
-		stsSvc := d.StsProvider(cfg)
+		stsSvc := d.StsProvider(stsCfg)
 		result, err := stsSvc.AssumeRole(ctx, &sts.AssumeRoleInput{
 			RoleArn:         aws.String(d.Role),
 			RoleSessionName: aws.String("cert-manager"),
@@ -119,7 +123,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	if d.Role != "" && d.WebIdentityToken != "" {
 		d.log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
 
-		stsSvc := d.StsProvider(cfg)
+		stsSvc := d.StsProvider(stsCfg)
 		result, err := stsSvc.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
 			RoleArn:          aws.String(d.Role),
 			RoleSessionName:  aws.String("cert-manager"),

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -253,7 +253,8 @@ func TestAssumeRole(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			provider := makeMockSessionProvider(func(aws.Config) StsClient {
+			provider := makeMockSessionProvider(func(cfg aws.Config) StsClient {
+				assert.Equal(t, "aws-global", cfg.Region) // verify that the global sts endpoint is used
 				return c.mockSTS
 			}, c.key, c.secret, c.region, c.role, c.webIdentityToken, c.ambient)
 			cfg, err := provider.GetSession(context.TODO())


### PR DESCRIPTION
fixes https://github.com/cert-manager/cert-manager/issues/7102

I think this issue was introduced in https://github.com/cert-manager/cert-manager/pull/6671, the v2 version of the aws sdk does now require a region to be provided for the sts client. We now have to explicitly provide the "aws-global" value to be used by the sts client (see https://github.com/go-acme/lego/issues/2067#issuecomment-1845666491).

@pchang388 could you verify this solves your issue?

### Kind

/kind bug

### Release Note

```release-note
BUGFIX route53: explicitly set the "aws-global" sts region which is now required by the github.com/aws/aws-sdk-go-v2 library.
```
