### PR TITLE
Simplify CertificateSigningRequest conformance tests and add missing tests

### DIFF
--- a/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
+++ b/test/e2e/framework/helper/validation/certificatesigningrequests/certificatesigningrequests.go
@@ -331,10 +331,9 @@ func ExpectIsCA(csr *certificatesv1.CertificateSigningRequest, _ crypto.Signer) 
 			markedIsCA, cert.IsCA)
 	}
 
-	hasCertSign := (cert.KeyUsage & x509.KeyUsageCertSign) == x509.KeyUsageCertSign
-	if hasCertSign != markedIsCA {
-		return fmt.Errorf("Expected certificate to have KeyUsageCertSign=%t, but got=%t", markedIsCA, hasCertSign)
-	}
+	// NOTE: For CertificateSigningRequests that are marked as CA, we do not automatically
+	// add the KeyUsageCertSign bit to the KeyUsage field. This behaviour is different
+	// to the behaviour of the cert-manager Certificate resource.
 
 	return nil
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -49,7 +49,7 @@ func Skipf(format string, args ...interface{}) {
 	Skip(nowStamp() + ": " + msg)
 }
 
-func RequireFeatureGate(f *Framework, featureSet featuregate.FeatureGate, gate featuregate.Feature) {
+func RequireFeatureGate(featureSet featuregate.FeatureGate, gate featuregate.Feature) {
 	if !featureSet.Enabled(gate) {
 		Skipf("feature gate %q is not enabled, skipping test", gate)
 	}

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -54,7 +54,7 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 	f := framework.NewDefaultFramework("certificates-additional-output-formats")
 
 	createCertificate := func(f *framework.Framework, aof []cmapi.CertificateAdditionalOutputFormat) (string, *cmapi.Certificate) {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
 
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
@@ -332,7 +332,7 @@ var _ = framework.CertManagerDescribe("Certificate AdditionalCertificateOutputFo
 
 	It("if a third party set additional output formats, they then get added to the Certificate, when they are removed again they should persist as they are still owned by a third party", func() {
 		// This e2e test requires that the ServerSideApply feature gate is enabled.
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ServerSideApply)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ServerSideApply)
 
 		crtName, crt := createCertificate(f, nil)
 

--- a/test/e2e/suite/certificates/literalsubjectrdns.go
+++ b/test/e2e/suite/certificates/literalsubjectrdns.go
@@ -49,7 +49,7 @@ var _ = framework.CertManagerDescribe("literalsubject rdn parsing", func() {
 	f := framework.NewDefaultFramework("certificate-literalsubject-rdns")
 
 	createCertificate := func(f *framework.Framework, literalSubject string) (*cmapi.Certificate, error) {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testName + "-",

--- a/test/e2e/suite/certificates/othernamesan.go
+++ b/test/e2e/suite/certificates/othernamesan.go
@@ -74,7 +74,7 @@ var _ = framework.CertManagerDescribe("othername san processing", func() {
 	}
 
 	BeforeEach(func() {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.OtherNames)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.OtherNames)
 
 		By("creating a self-signing issuer")
 		issuer := gen.Issuer(issuerName,

--- a/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
@@ -63,7 +63,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 	})
 
 	It("Issuer: the private key Secret is created after the request is created should still be signed", func() {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
 
 		var err error
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), &cmapi.Issuer{
@@ -125,7 +125,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 	})
 
 	It("Issuer: private key Secret is updated with a valid private key after the request is created should still be signed", func() {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
 
 		var err error
 		By("creating Secret with missing private key")
@@ -190,7 +190,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 	})
 
 	It("ClusterIssuer: the private key Secret is created after the request is created should still be signed", func() {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
 
 		var err error
 		issuer, err = f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), &cmapi.ClusterIssuer{
@@ -252,7 +252,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 	})
 
 	It("ClusterIssuer: private key Secret is updated with a valid private key after the request is created should still be signed", func() {
-		framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
+		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalCertificateSigningRequestControllers)
 
 		var err error
 		By("creating Secret with missing private key")

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -83,7 +83,7 @@ func (s *Suite) Define() {
 				sharedIPAddress = f.Config.Addons.ACMEServer.IngressIP
 			case "Gateway":
 				sharedIPAddress = f.Config.Addons.ACMEServer.GatewayIP
-				framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
+				framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
 			}
 		})
 
@@ -224,7 +224,7 @@ func (s *Suite) Define() {
 		}, featureset.CommonNameFeature)
 
 		s.it(f, "should issue a certificate with a couple valid otherName SAN values set as well as an emailAddress", func(issuerRef cmmeta.ObjectReference) {
-			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.OtherNames)
+			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.OtherNames)
 			emailAddresses := []string{"email@domain.test"}
 			otherNames := []cmapi.OtherName{
 				{
@@ -305,7 +305,7 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 		}, featureset.OtherNamesFeature)
 
 		s.it(f, "should issue a basic, defaulted certificate for a single distinct DNS Name with a literal subject", func(issuerRef cmmeta.ObjectReference) {
-			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
+			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.LiteralCertificateSubject)
 			// Some issuers use the CN to define the cert's "ID"
 			// if one cert manages to be in an error state in the issuer it might throw an error
 			// this makes the CN more unique
@@ -963,7 +963,7 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 		})
 
 		s.it(f, "Creating a Gateway with annotations for issuerRef and other Certificate fields", func(issuerRef cmmeta.ObjectReference) {
-			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
+			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
 
 			name := "testcert-gateway"
 			secretName := "testcert-gateway-tls"

--- a/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
@@ -53,6 +53,10 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.CommonNameFeature,
 		featureset.KeyUsagesFeature,
 		featureset.EmailSANsFeature,
+		featureset.SaveCAToSecret,
+		featureset.IssueCAFeature,
+		featureset.LiteralSubjectFeature,
+		featureset.OtherNamesFeature,
 	)
 
 	// unsupportedDNS01Features is a list of features that are not supported by the ACME
@@ -64,6 +68,10 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.CommonNameFeature,
 		featureset.KeyUsagesFeature,
 		featureset.EmailSANsFeature,
+		featureset.SaveCAToSecret,
+		featureset.IssueCAFeature,
+		featureset.LiteralSubjectFeature,
+		featureset.OtherNamesFeature,
 	)
 
 	http01 := &acme{

--- a/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
@@ -46,7 +46,6 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 	// unsupportedHTTP01Features is a list of features that are not supported by the ACME
 	// issuer type using HTTP01
 	var unsupportedHTTP01Features = featureset.NewFeatureSet(
-		featureset.IPAddressFeature,
 		featureset.DurationFeature,
 		featureset.WildcardsFeature,
 		featureset.URISANsFeature,
@@ -81,8 +80,8 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 	}
 
 	(&certificatesigningrequests.Suite{
-		Name:                "ACME HTTP01 Issuer",
-		DomainSuffix:        "ingress-nginx.http01.example.com",
+		Name:                "ACME HTTP01 Issuer (Ingress)",
+		HTTP01TestType:      "Ingress",
 		CreateIssuerFunc:    http01.createHTTP01Issuer,
 		DeleteIssuerFunc:    http01.delete,
 		UnsupportedFeatures: unsupportedHTTP01Features,
@@ -97,8 +96,8 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 	}).Define()
 
 	(&certificatesigningrequests.Suite{
-		Name:                "ACME HTTP01 ClusterIssuer",
-		DomainSuffix:        "ingress-nginx.http01.example.com",
+		Name:                "ACME HTTP01 ClusterIssuer (Ingress)",
+		HTTP01TestType:      "Ingress",
 		CreateIssuerFunc:    http01.createHTTP01ClusterIssuer,
 		DeleteIssuerFunc:    http01.delete,
 		UnsupportedFeatures: unsupportedHTTP01Features,

--- a/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/acme/acme.go
@@ -55,7 +55,6 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.EmailSANsFeature,
 		featureset.SaveCAToSecret,
 		featureset.IssueCAFeature,
-		featureset.LiteralSubjectFeature,
 		featureset.OtherNamesFeature,
 	)
 
@@ -70,7 +69,6 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.EmailSANsFeature,
 		featureset.SaveCAToSecret,
 		featureset.IssueCAFeature,
-		featureset.LiteralSubjectFeature,
 		featureset.OtherNamesFeature,
 	)
 

--- a/test/e2e/suite/conformance/certificatesigningrequests/suite.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/suite.go
@@ -64,6 +64,11 @@ type Suite struct {
 	// If not specified, this function will be skipped.
 	DeProvisionFunc func(context.Context, *framework.Framework, *certificatesv1.CertificateSigningRequest)
 
+	// SharedIPAddress is the IP address that will be used in all certificates
+	// that require an IP address to be set. For HTTP-01 tests, this IP address
+	// will be set to the IP address of the Ingress/ Gateway controller.
+	SharedIPAddress string
+
 	// DomainSuffix is a suffix used on all domain requests.
 	// This is useful when the issuer being tested requires special
 	// configuration for a set of domains in order for certificates to be
@@ -78,18 +83,14 @@ type Suite struct {
 	// certain features due to restrictions in their implementation.
 	UnsupportedFeatures featureset.FeatureSet
 
-	// completed is used internally to track whether Complete() has been called
-	completed bool
+	// validated is used internally to track whether Validate has been called already.
+	validated bool
 }
 
-// complete will validate configuration and set default values.
-func (s *Suite) complete(f *framework.Framework) {
-	if s.Name == "" {
-		Fail("Name must be set")
-	}
-
-	if s.CreateIssuerFunc == nil {
-		Fail("CreateIssuerFunc must be set")
+// setup will set default values for fields on the Suite struct.
+func (s *Suite) setup(f *framework.Framework) {
+	if s.SharedIPAddress == "" {
+		s.SharedIPAddress = "127.0.0.1"
 	}
 
 	if s.DomainSuffix == "" {
@@ -99,8 +100,23 @@ func (s *Suite) complete(f *framework.Framework) {
 	if s.UnsupportedFeatures == nil {
 		s.UnsupportedFeatures = make(featureset.FeatureSet)
 	}
+}
 
-	s.completed = true
+// validate will validate the Suite struct to ensure all required fields are set.
+func (s *Suite) validate() {
+	if s.validated {
+		return
+	}
+
+	if s.Name == "" {
+		Fail("Name must be set")
+	}
+
+	if s.CreateIssuerFunc == nil {
+		Fail("CreateIssuerFunc must be set")
+	}
+
+	s.validated = true
 }
 
 // it is called by the tests to in Define() to setup and run the test

--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -171,6 +171,46 @@ func (s *Suite) Define() {
 				requiredFeatures: []featureset.Feature{featureset.CommonNameFeature, featureset.IPAddressFeature},
 			},
 			{
+				name:    "should issue a certificate that defines an IP Address",
+				keyAlgo: x509.RSA,
+				csrModifiers: []gen.CSRModifier{
+					gen.SetCSRIPAddresses(net.ParseIP(s.SharedIPAddress)),
+				},
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.IPAddressFeature},
+			},
+			{
+				name:    "should issue a certificate that defines a DNS Name and IP Address",
+				keyAlgo: x509.RSA,
+				csrModifiers: []gen.CSRModifier{
+					gen.SetCSRIPAddresses(net.ParseIP(s.SharedIPAddress)),
+					gen.SetCSRDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+				},
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.OnlySAN, featureset.IPAddressFeature},
+			},
+			{
+				name:    "should issue a CA certificate with the CA basicConstraint set",
+				keyAlgo: x509.RSA,
+				csrModifiers: []gen.CSRModifier{
+					gen.SetCSRDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+				},
+				kubeCSRAnnotations: map[string]string{
+					experimentalapi.CertificateSigningRequestIsCAAnnotationKey: "true",
+				},
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.IssueCAFeature},
+			},
+			{
 				name:    "should issue a certificate that defines an Email Address",
 				keyAlgo: x509.RSA,
 				csrModifiers: []gen.CSRModifier{
@@ -291,6 +331,22 @@ func (s *Suite) Define() {
 				requiredFeatures: []featureset.Feature{featureset.WildcardsFeature, featureset.OnlySAN},
 			},
 			{
+				name:    "should issue a certificate which has a wildcard DNS Name and its apex DNS Name defined",
+				keyAlgo: x509.RSA,
+				csrModifiers: func() []gen.CSRModifier {
+					dnsDomain := e2eutil.RandomSubdomain(s.DomainSuffix)
+
+					return []gen.CSRModifier{
+						gen.SetCSRDNSNames("*."+dnsDomain, dnsDomain),
+					}
+				}(),
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.WildcardsFeature, featureset.OnlySAN},
+			},
+			{
 				name:    "should issue a certificate that includes only a URISANs name",
 				keyAlgo: x509.RSA,
 				csrModifiers: []gen.CSRModifier{
@@ -323,6 +379,26 @@ func (s *Suite) Define() {
 				requiredFeatures: []featureset.Feature{featureset.KeyUsagesFeature},
 			},
 			{
+				name:    "should issue a certificate that includes arbitrary key usages with SAN only",
+				keyAlgo: x509.RSA,
+				csrModifiers: []gen.CSRModifier{
+					gen.SetCSRDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
+				},
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageSigning,
+					certificatesv1.UsageDataEncipherment,
+					certificatesv1.UsageServerAuth,
+					certificatesv1.UsageClientAuth,
+				},
+				extraValidations: []certificatesigningrequests.ValidationFunc{
+					certificatesigningrequests.ExpectKeyUsageExtKeyUsageClientAuth,
+					certificatesigningrequests.ExpectKeyUsageExtKeyUsageServerAuth,
+					certificatesigningrequests.ExpectKeyUsageUsageDigitalSignature,
+					certificatesigningrequests.ExpectKeyUsageUsageDataEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.KeyUsagesFeature, featureset.OnlySAN},
+			},
+			{
 				name:    "should issue a signing CA certificate that has a large duration",
 				keyAlgo: x509.RSA,
 				csrModifiers: []gen.CSRModifier{
@@ -338,6 +414,21 @@ func (s *Suite) Define() {
 					experimentalapi.CertificateSigningRequestIsCAAnnotationKey:     "true",
 				},
 				requiredFeatures: []featureset.Feature{featureset.KeyUsagesFeature, featureset.DurationFeature, featureset.CommonNameFeature},
+			},
+			{
+				name:    "should issue a certificate that defines a long domain",
+				keyAlgo: x509.RSA,
+				csrModifiers: func() []gen.CSRModifier {
+					const maxLengthOfDomainSegment = 63
+					return []gen.CSRModifier{
+						gen.SetCSRDNSNames(e2eutil.RandomSubdomainLength(s.DomainSuffix, maxLengthOfDomainSegment)),
+					}
+				}(),
+				kubeCSRUsages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+				},
+				requiredFeatures: []featureset.Feature{featureset.OnlySAN, featureset.LongDomainFeatureSet},
 			},
 		}
 

--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -379,26 +379,6 @@ func (s *Suite) Define() {
 				requiredFeatures: []featureset.Feature{featureset.KeyUsagesFeature},
 			},
 			{
-				name:    "should issue a certificate that includes arbitrary key usages with SAN only",
-				keyAlgo: x509.RSA,
-				csrModifiers: []gen.CSRModifier{
-					gen.SetCSRDNSNames(e2eutil.RandomSubdomain(s.DomainSuffix)),
-				},
-				kubeCSRUsages: []certificatesv1.KeyUsage{
-					certificatesv1.UsageSigning,
-					certificatesv1.UsageDataEncipherment,
-					certificatesv1.UsageServerAuth,
-					certificatesv1.UsageClientAuth,
-				},
-				extraValidations: []certificatesigningrequests.ValidationFunc{
-					certificatesigningrequests.ExpectKeyUsageExtKeyUsageClientAuth,
-					certificatesigningrequests.ExpectKeyUsageExtKeyUsageServerAuth,
-					certificatesigningrequests.ExpectKeyUsageUsageDigitalSignature,
-					certificatesigningrequests.ExpectKeyUsageUsageDataEncipherment,
-				},
-				requiredFeatures: []featureset.Feature{featureset.KeyUsagesFeature, featureset.OnlySAN},
-			},
-			{
 				name:    "should issue a signing CA certificate that has a large duration",
 				keyAlgo: x509.RSA,
 				csrModifiers: []gen.CSRModifier{

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/approle.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/approle.go
@@ -53,56 +53,50 @@ type secrets struct {
 }
 
 var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
+	var unsupportedFeatures = featureset.NewFeatureSet(
+		featureset.KeyUsagesFeature,
+		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
+	)
+
 	issuer := &approle{
 		testWithRootCA: true,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault AppRole Issuer With Root CA",
-		CreateIssuerFunc: issuer.createIssuer,
-		DeleteIssuerFunc: issuer.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault AppRole Issuer With Root CA",
+		CreateIssuerFunc:    issuer.createIssuer,
+		DeleteIssuerFunc:    issuer.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 
 	issuerNoRoot := &approle{
 		testWithRootCA: false,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault AppRole Issuer Without Root CA",
-		CreateIssuerFunc: issuerNoRoot.createIssuer,
-		DeleteIssuerFunc: issuerNoRoot.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault AppRole Issuer Without Root CA",
+		CreateIssuerFunc:    issuerNoRoot.createIssuer,
+		DeleteIssuerFunc:    issuerNoRoot.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 
 	clusterIssuer := &approle{
 		testWithRootCA: true,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault AppRole ClusterIssuer With Root CA",
-		CreateIssuerFunc: clusterIssuer.createClusterIssuer,
-		DeleteIssuerFunc: clusterIssuer.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault AppRole ClusterIssuer With Root CA",
+		CreateIssuerFunc:    clusterIssuer.createClusterIssuer,
+		DeleteIssuerFunc:    clusterIssuer.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 
 	clusterIssuerNoRoot := &approle{
 		testWithRootCA: false,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault AppRole ClusterIssuer Without Root CA",
-		CreateIssuerFunc: clusterIssuerNoRoot.createClusterIssuer,
-		DeleteIssuerFunc: clusterIssuerNoRoot.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault AppRole ClusterIssuer Without Root CA",
+		CreateIssuerFunc:    clusterIssuerNoRoot.createClusterIssuer,
+		DeleteIssuerFunc:    clusterIssuerNoRoot.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 })
 

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
@@ -38,30 +38,30 @@ import (
 )
 
 var _ = framework.ConformanceDescribe("CertificateSigningRequests", func() {
+	var unsupportedFeatures = featureset.NewFeatureSet(
+		featureset.KeyUsagesFeature,
+		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
+	)
+
 	issuer := &kubernetes{
 		testWithRootCA: true,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault Kubernetes Auth Issuer With Root CA",
-		CreateIssuerFunc: issuer.createIssuer,
-		DeleteIssuerFunc: issuer.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault Kubernetes Auth Issuer With Root CA",
+		CreateIssuerFunc:    issuer.createIssuer,
+		DeleteIssuerFunc:    issuer.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 
 	clusterIssuer := &kubernetes{
 		testWithRootCA: true,
 	}
 	(&certificatesigningrequests.Suite{
-		Name:             "Vault Kubernetes Auth ClusterIssuer With Root CA",
-		CreateIssuerFunc: clusterIssuer.createClusterIssuer,
-		DeleteIssuerFunc: clusterIssuer.delete,
-		UnsupportedFeatures: featureset.NewFeatureSet(
-			featureset.KeyUsagesFeature,
-			featureset.Ed25519FeatureSet,
-		),
+		Name:                "Vault Kubernetes Auth ClusterIssuer With Root CA",
+		CreateIssuerFunc:    clusterIssuer.createClusterIssuer,
+		DeleteIssuerFunc:    clusterIssuer.delete,
+		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 })
 

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -157,7 +157,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		It("should be able to create a certificate with additional output formats", func() {
 			// Output formats is only enabled via this feature gate being enabled.
 			// Don't run test if the gate isn't enabled.
-			framework.RequireFeatureGate(f, utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
+			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.AdditionalCertificateOutputFormats)
 
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 


### PR DESCRIPTION
Simplifies the definitions of the CertificateSigningRequest conformance tests and adds additional tests, matching tests that exist for the Certificate resources.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
