### PR TITLE
[release-1.15] BUGFIX: retry signing when encountering transient error (Vault issuer)

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -38,6 +38,7 @@ import (
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -220,7 +221,7 @@ func (v *Vault) setToken(ctx context.Context, client Client) error {
 		return nil
 	}
 
-	return fmt.Errorf("error initializing Vault client: tokenSecretRef, appRoleSecretRef, or Kubernetes auth role not set")
+	return cmerrors.NewInvalidData("error initializing Vault client: tokenSecretRef, appRoleSecretRef, or Kubernetes auth role not set")
 }
 
 func (v *Vault) newConfig() (*vault.Config, error) {

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -92,7 +92,7 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 		message := "Failed to initialise vault client for signing"
 		v.reporter.Pending(cr, err, "VaultInitError", message)
 		log.Error(err, message)
-		return nil, nil
+		return nil, err // Return error to requeue and retry
 	}
 
 	certDuration := apiutil.DefaultCertDuration(cr.Spec.Duration)

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -30,6 +30,7 @@ import (
 	crutil "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/util"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
 )
 
 const (
@@ -87,11 +88,15 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 		return nil, nil
 	}
 
-	// TODO: distinguish between network errors and other which might warrant a failure.
 	if err != nil {
 		message := "Failed to initialise vault client for signing"
 		v.reporter.Pending(cr, err, "VaultInitError", message)
 		log.Error(err, message)
+
+		if cmerrors.IsInvalidData(err) {
+			return nil, nil // Don't retry, wait for the issuer to be updated
+		}
+
 		return nil, err // Return error to requeue and retry
 	}
 


### PR DESCRIPTION
Manual backport of https://github.com/cert-manager/cert-manager/pull/7105

### Kind

/kind bug

### Release Note

```release-note
BUGFIX: fix issue that caused Vault issuer to not retry signing when an error was encountered.
```
