### PR TITLE
Fix Venafi conformance test

### DIFF
--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -208,7 +208,7 @@ func (s *Suite) Define() {
 					certificatesv1.UsageDigitalSignature,
 					certificatesv1.UsageKeyEncipherment,
 				},
-				requiredFeatures: []featureset.Feature{featureset.IssueCAFeature},
+				requiredFeatures: []featureset.Feature{featureset.OnlySAN, featureset.IssueCAFeature},
 			},
 			{
 				name:    "should issue a certificate that defines an Email Address",


### PR DESCRIPTION
Follow-up PR for https://github.com/cert-manager/cert-manager/pull/7110, adding missing required `OnlySAN` feature.
Fixes periodic CI job: https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-master-e2e-v1-30-issuers-venafi/1805033541822582784

### Kind

/kind bug

### Release Note

```release-note
NONE
```
