### PR TITLE
add flag to enable Gateway api support in helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -67,8 +67,8 @@ spec:
       {{- if or .Values.volumes .Values.config}}
       volumes:
         {{- if .Values.config }}
-        - name: config 
-          configMap: 
+        - name: config
+          configMap:
             name: {{ include "cert-manager.fullname" . }}
         {{- end }}
         {{ with .Values.volumes }}
@@ -140,6 +140,9 @@ spec:
           {{- if .Values.disableAutoApproval }}
           - --controllers=-certificaterequests-approver
           {{- end }}
+          {{- if .Values.enableGatewayApi }}
+          - --enable-gateway-api=true
+          {{- end }}
           ports:
           - containerPort: 9402
             name: http-metrics
@@ -154,7 +157,7 @@ spec:
           {{- if or .Values.config .Values.volumeMounts }}
           volumeMounts:
             {{- if .Values.config }}
-            - name: config 
+            - name: config
               mountPath: /var/cert-manager/config
             {{- end }}
             {{- with .Values.volumeMounts }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -227,7 +227,6 @@ enableCertificateOwnerRef: false
 #      AdditionalCertificateOutputFormats: true
 #      DisallowInsecureCSRUsageDefinition: true
 #      ExperimentalCertificateSigningRequestControllers: true
-#      ExperimentalGatewayAPISupport: true
 #      LiteralCertificateSubject: true
 #      SecretsFilteredCaching: true
 #      ServerSideApply: true
@@ -259,6 +258,12 @@ dns01RecursiveNameserversOnly: false
 # option. This 'disableAutoApproval' option is useful when you want to make all approval decisions
 # using a different approver (like approver-policy - https://github.com/cert-manager/approver-policy).
 disableAutoApproval: false
+
+
+# Option to enable the Gateway API support. Gateway API support is still in beta,
+# and only tested with v1 Gateway API.
+# This replaces the ExperimentalGatewayAPISupport featureGate
+enableGatewayApi: false
 
 # List of signer names that cert-manager will approve by default. CertificateRequests
 # referencing these signer names will be auto-approved by cert-manager. Defaults to just


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

-->

### Pull Request Motivation

Release 1.15.0 promoted Gateway API to a beta feature in #6961

The Helm Chart still references the featureGate and provides no easy way to enable the Gateway API support.

This pull request adds a new Helm value `enableGatewayApi: false` which toggles the `--enable-gateway-api` arg on the deployment.

### Kind

feature

### Release Note

```release-note
Added `enableGatewayApi` helm chart option
```
