### PR TITLE
BUGFIX: Venafi issuer and clusterissuer checks were failing due to nilpointer exception

### DIFF
--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -60,11 +60,11 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 					affected = append(affected, iss)
 					continue
 				}
-			}
-			if iss.Spec.Venafi.TPP.CABundleSecretRef != nil {
-				if iss.Spec.Venafi.TPP.CABundleSecretRef.Name == secret.Name {
-					affected = append(affected, iss)
-					continue
+				if iss.Spec.Venafi.TPP.CABundleSecretRef != nil {
+					if iss.Spec.Venafi.TPP.CABundleSecretRef.Name == secret.Name {
+						affected = append(affected, iss)
+						continue
+					}
 				}
 			}
 			if iss.Spec.Venafi.Cloud != nil {

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -62,11 +62,11 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 					affected = append(affected, iss)
 					continue
 				}
-			}
-			if iss.Spec.Venafi.TPP.CABundleSecretRef != nil {
-				if iss.Spec.Venafi.TPP.CABundleSecretRef.Name == secret.Name {
-					affected = append(affected, iss)
-					continue
+				if iss.Spec.Venafi.TPP.CABundleSecretRef != nil {
+					if iss.Spec.Venafi.TPP.CABundleSecretRef.Name == secret.Name {
+						affected = append(affected, iss)
+						continue
+					}
 				}
 			}
 			if iss.Spec.Venafi.Cloud != nil {


### PR DESCRIPTION
Introduced in https://github.com/cert-manager/cert-manager/pull/7036 (did not run the Venafi tests on the last commit).

Adds a missing nilpointer check that is causing panics for Venafi issuers.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
