### PR TITLE
Tests: add bind resource request to improve availability during tests

### DIFF
--- a/make/config/bind/configmap.yaml
+++ b/make/config/bind/configmap.yaml
@@ -10,6 +10,7 @@ data:
     	dnssec-validation auto;
     	auth-nxdomain no;    # conform to RFC1035
     	listen-on { any; };
+    	max-cache-size 192m;
     };
 
     zone "http01.example.com" {

--- a/make/config/bind/deployment.yaml
+++ b/make/config/bind/deployment.yaml
@@ -41,6 +41,12 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: data
+        resources:
+          requests:
+            cpu: 10m
+            memory: 256Mi
+          limits:
+            memory: 256Mi
       volumes:
       - name: data
         configMap:


### PR DESCRIPTION
Following the best practices described here: https://home.robusta.dev/blog/stop-using-cpu-limits

Sets a CPU request and a MEM request and limit.

Experimentally found that 256Mi works as memory limit.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
