### PR TITLE
Tests: use supported bind9 image and run as non-root

### DIFF
--- a/make/config/bind/configmap.yaml
+++ b/make/config/bind/configmap.yaml
@@ -9,9 +9,11 @@ data:
     	directory "/var/cache/bind";
     	dnssec-validation auto;
     	auth-nxdomain no;    # conform to RFC1035
-    	listen-on { any; };
+    	listen-on port 8053 { any; };
     	max-cache-size 192m;
     };
+    
+    controls { };
 
     zone "http01.example.com" {
       type master;

--- a/make/config/bind/deployment.yaml
+++ b/make/config/bind/deployment.yaml
@@ -14,33 +14,30 @@ spec:
       labels:
         app: bind
     spec:
+      securityContext:
+        # 101 is the userid of the bind user
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
       containers:
       - name: bind
         image: "{IMAGE}"
         imagePullPolicy: Never
-        # TODO(wallrj): I couldn't figure out how to run Bind as a non-root user, using this Docker image.
-        # I think bind expects to start as root and then chown to a non-root BIND user.
-        # securityContext:
-        #   runAsNonRoot: true
         command:
         - /bin/bash
         - -c
         - |
-          rm -rf /etc/bind
-          mkdir -p /etc/bind
-          ls -lah /config/
           cp -Lr /config/* /etc/bind/
-          chown -R "${BIND_USER}:${BIND_USER}" /etc/bind
-          exec $(which named) -u ${BIND_USER} -g
-        env:
-        - name: WEBMIN_ENABLED
-          value: "false"
+          exec $(which named) -u bind -g -4
         ports:
-        - containerPort: 53
+        - containerPort: 8053
           protocol: UDP
         volumeMounts:
         - mountPath: /config
-          name: data
+          name: config
+          readOnly: true
+        - name: tmpfs-volume
+          mountPath: /etc/bind/
         resources:
           requests:
             cpu: 10m
@@ -48,9 +45,11 @@ spec:
           limits:
             memory: 256Mi
       volumes:
-      - name: data
+      - name: config
         configMap:
           name: bind
+      - name: tmpfs-volume
+        emptyDir: {}
       dnsConfig:
         options:
         - name: ndots

--- a/make/config/bind/service.yaml
+++ b/make/config/bind/service.yaml
@@ -11,7 +11,7 @@ spec:
   clusterIP: {SERVICE_IP_PREFIX}.16
   ports:
   - port: 53
-    targetPort: 53
+    targetPort: 8053
     protocol: UDP
   selector:
     app: bind

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -30,7 +30,7 @@ IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.10.1@sha
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:127def0e41f49fea6e260abf7b1662fe7bdfb9f33e8f9047fb74d0162a5697bb
 IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.12.3@sha256:d388cd67b38fb4f55eb5e38107dbbce9e06208b8e3839f0b63f8631f286181be
 IMAGE_vault_amd64 := docker.io/hashicorp/vault:1.14.1@sha256:436d056e8e2a96c7356720069c29229970466f4f686886289dcc94dfa21d3155
-IMAGE_bind_amd64 := docker.io/eafxx/bind:latest-ccf145d3@sha256:b6ea4da6cb689985a6729f20a1a2775b9211bdaebd2c956f22871624d4925db2
+IMAGE_bind_amd64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:d4e3d143d0619eff7b34f7f3c19160bceb94615ba376f6f78b8b67abb84754e2
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:964b378fe0dda7fc38ce3f211c3b24c780e44cef13c39d3206de985bad67f294
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:bb7af851ac5832c315e0863d12ed583cee54c495d58a206f1d0897647505ed70
 
@@ -38,7 +38,7 @@ IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.10.1@sha
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:c076a1ba9e0fb33d8eca3e7499caddfa3bb4f5e52e9dee589d8476ae1688cd34
 IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.12.3@sha256:d8d750012ed4bb46fd41d8892e92af6fb9fd212317bc23e68a2a47199646b04a
 IMAGE_vault_arm64 := docker.io/hashicorp/vault:1.14.1@sha256:27dd264f3813c71a66792191db5382f0cf9eeaf1ae91770634911facfcfe4837
-IMAGE_bind_arm64 := docker.io/eafxx/bind:latest-ccf145d3@sha256:a302cff9f7ecfac0c3cfde1b53a614a81d16f93a247c838d3dac43384fefd9b4
+IMAGE_bind_arm64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:b2405abacaee3e3e65f5dc8a0c28c7f05788307d32c2d23dab0c06f33aaa7c64
 IMAGE_sampleexternalissuer_arm64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:bdff00089ec7581c0d12414ce5ad1c6ccf5b6cacbfb0b0804fefe5043a1cb849
 IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:dbfec77951e123bf383a09412a51df218b716aaf3fe7b2778bb2f208ac495dc5
 


### PR DESCRIPTION
Use the supported docker.io/ubuntu/bind9 image and run it as non-root.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
