### PR TITLE
Fix API fields description for Venafi TPP credentialsRef

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -2365,9 +2365,9 @@ spec:
                               type: string
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the username and
-                            password for the TPP server.
-                            The secret must contain two keys, 'username' and 'password'.
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
                           type: object
                           required:
                             - name

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -2365,9 +2365,9 @@ spec:
                               type: string
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the username and
-                            password for the TPP server.
-                            The secret must contain two keys, 'username' and 'password'.
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
                           type: object
                           required:
                             - name

--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -132,9 +132,9 @@ type VenafiTPP struct {
 	// for example: "https://tpp.example.com/vedsdk".
 	URL string
 
-	// CredentialsRef is a reference to a Secret containing the username and
-	// password for the TPP server.
-	// The secret must contain two keys, 'username' and 'password'.
+	// CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+	// The secret must contain the key 'access-token' for the Access Token Authentication,
+	// or two keys, 'username' and 'password' for the API Keys Authentication.
 	CredentialsRef cmmeta.LocalObjectReference
 
 	// Base64-encoded bundle of PEM CAs which will be used to validate the certificate

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -149,9 +149,9 @@ type VenafiTPP struct {
 	// for example: "https://tpp.example.com/vedsdk".
 	URL string `json:"url"`
 
-	// CredentialsRef is a reference to a Secret containing the username and
-	// password for the TPP server.
-	// The secret must contain two keys, 'username' and 'password'.
+	// CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+	// The secret must contain the key 'access-token' for the Access Token Authentication,
+	// or two keys, 'username' and 'password' for the API Keys Authentication.
 	CredentialsRef cmmeta.LocalObjectReference `json:"credentialsRef"`
 
 	// Base64-encoded bundle of PEM CAs which will be used to validate the certificate


### PR DESCRIPTION
### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/7145

Trying to rephrase the outdated description according to the doc https://cert-manager.io/docs/configuration/venafi/#creating-a-venafi-trust-protection-platform-issuer

I have executed `make generate-crds` `generate-codegen` `ci-presubmit`.

### Kind

/kind documentation
/kind bug

### Release Note

```release-note
NONE
```
