### PR TITLE
Fix errcheck linter by adding error checks everywhere

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,6 @@ issues:
   exclude-rules:
     - linters:
         - dogsled
-        - errcheck
         - promlinter
         - errname
         - exhaustive

--- a/cmd/cainjector/app/cainjector_test.go
+++ b/cmd/cainjector/app/cainjector_test.go
@@ -50,7 +50,9 @@ func testCmdCommand(t *testing.T, tempDir string, yaml string, args func(string)
 
 	var finalConfig *config.CAInjectorConfiguration
 
-	logsapi.ResetForTest(nil)
+	if err := logsapi.ResetForTest(nil); err != nil {
+		t.Error(err)
+	}
 
 	cmd := newCAInjectorCommand(context.TODO(), func(ctx context.Context, cc *config.CAInjectorConfiguration) error {
 		finalConfig = cc

--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -83,18 +84,10 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 	}
 
 	scheme := runtime.NewScheme()
-	if err := kscheme.AddToScheme(scheme); err != nil {
-		return err
-	}
-	if err := cmscheme.AddToScheme(scheme); err != nil {
-		return err
-	}
-	if err := apiext.AddToScheme(scheme); err != nil {
-		return err
-	}
-	if err := apireg.AddToScheme(scheme); err != nil {
-		return err
-	}
+	utilruntime.Must(kscheme.AddToScheme(scheme))
+	utilruntime.Must(cmscheme.AddToScheme(scheme))
+	utilruntime.Must(apiext.AddToScheme(scheme))
+	utilruntime.Must(apireg.AddToScheme(scheme))
 
 	mgr, err := ctrl.NewManager(
 		restConfig,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cliflag "k8s.io/component-base/cli/flag"
 
@@ -219,11 +220,11 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.StringVar(&c.HealthzListenAddress, "internal-healthz-listen-address", c.HealthzListenAddress, ""+
 		"The host and port that the healthz server should listen on. "+
 		"The healthz server serves the /livez endpoint, which is called by the LivenessProbe.")
-	fs.MarkHidden("internal-healthz-listen-address")
+	utilruntime.Must(fs.MarkHidden("internal-healthz-listen-address"))
 
 	fs.DurationVar(&c.LeaderElectionConfig.HealthzTimeout, "internal-healthz-leader-election-timeout", c.LeaderElectionConfig.HealthzTimeout, ""+
 		"Leader election healthz checks within this timeout period after the lease expires will still return healthy")
-	fs.MarkHidden("internal-healthz-leader-election-timeout")
+	utilruntime.Must(fs.MarkHidden("internal-healthz-leader-election-timeout"))
 
 	logf.AddFlags(&c.Logging, fs)
 }

--- a/cmd/controller/app/start_test.go
+++ b/cmd/controller/app/start_test.go
@@ -50,7 +50,9 @@ func testCmdCommand(t *testing.T, tempDir string, yaml string, args func(string)
 
 	var finalConfig *config.ControllerConfiguration
 
-	logsapi.ResetForTest(nil)
+	if err := logsapi.ResetForTest(nil); err != nil {
+		t.Error(err)
+	}
 	cmd := newServerCommand(context.TODO(), func(ctx context.Context, cc *config.ControllerConfiguration) error {
 		finalConfig = cc
 		return nil

--- a/cmd/webhook/app/webhook_test.go
+++ b/cmd/webhook/app/webhook_test.go
@@ -50,7 +50,10 @@ func testCmdCommand(t *testing.T, tempDir string, yaml string, args func(string)
 
 	var finalConfig *config.WebhookConfiguration
 
-	logsapi.ResetForTest(nil)
+	if err := logsapi.ResetForTest(nil); err != nil {
+		t.Error(err)
+	}
+
 	cmd := newServerCommand(context.TODO(), func(ctx context.Context, cc *config.WebhookConfiguration) error {
 		finalConfig = cc
 		return nil

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -21,6 +21,7 @@ limitations under the License.
 package feature
 
 import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
 
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -48,7 +49,7 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultMutableFeatureGate.Add(cainjectorFeatureGates)
+	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(cainjectorFeatureGates))
 }
 
 // cainjectorFeatureGates defines all feature gates for the cainjector component.

--- a/internal/controller/certificates/policies/gatherer_test.go
+++ b/internal/controller/certificates/policies/gatherer_test.go
@@ -163,8 +163,12 @@ func TestDataForCertificate(t *testing.T) {
 			// tests, we "force" the creation of the indexer for the CR
 			// type by registering a fake handler.
 			noop := cache.ResourceEventHandlerFuncs{AddFunc: func(obj interface{}) {}}
-			test.builder.SharedInformerFactory.Certmanager().V1().CertificateRequests().Informer().AddEventHandler(noop)
-			test.builder.KubeSharedInformerFactory.Secrets().Informer().AddEventHandler(noop)
+			if _, err := test.builder.SharedInformerFactory.Certmanager().V1().CertificateRequests().Informer().AddEventHandler(noop); err != nil {
+				t.Fatalf("failed to add event handler to CertificateRequest informer: %v", err)
+			}
+			if _, err := test.builder.KubeSharedInformerFactory.Secrets().Informer().AddEventHandler(noop); err != nil {
+				t.Fatalf("failed to add event handler to Secret informer: %v", err)
+			}
 
 			// Even though we are only relying on listers in this unit test
 			// and do not use the informer event handlers, we still need to

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -21,6 +21,7 @@ limitations under the License.
 package feature
 
 import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
 
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -82,7 +83,7 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultMutableFeatureGate.Add(webhookFeatureGates)
+	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(webhookFeatureGates))
 }
 
 // webhookFeatureGates defines all feature gates for the webhook component.

--- a/pkg/acme/webhook/apiserver/apiserver.go
+++ b/pkg/acme/webhook/apiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -42,7 +43,7 @@ var (
 )
 
 func init() {
-	whapi.AddToScheme(Scheme)
+	utilruntime.Must(whapi.AddToScheme(Scheme))
 
 	// we need to add the options to empty v1
 	// TODO fix the server code to avoid this

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -18,6 +18,7 @@ package acmechallenges
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -128,7 +129,9 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	}
 
 	// register handler functions
-	challengeInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
+	if _, err := challengeInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue}); err != nil {
+		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 	c.scheduler = scheduler.New(logf.NewContext(ctx.RootContext, c.log), c.challengeLister, ctx.SchedulerOptions.MaxConcurrentChallenges)

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -584,7 +584,9 @@ func runTest(t *testing.T, test testT) {
 	defer test.builder.Stop()
 
 	c := &controller{}
-	c.Register(test.builder.Context)
+	if _, _, err := c.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 	c.helper = issuer.NewHelper(
 		test.builder.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 		test.builder.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -78,7 +78,7 @@ func init() {
 					orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
 					certificateRequestLister := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister()
 
-					orderInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
+					if _, err := orderInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
 						WorkFunc: controllerpkg.HandleOwnedResourceNamespacedFunc(
 							log, queue,
 							cmapi.SchemeGroupVersion.WithKind(cmapi.CertificateRequestKind),
@@ -86,7 +86,9 @@ func init() {
 								return certificateRequestLister.CertificateRequests(namespace).Get(name)
 							},
 						),
-					})
+					}); err != nil {
+						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
 					return []cache.InformerSynced{orderInformer.HasSynced}, nil
 				},
 			)).

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -71,7 +71,9 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 	mustSync := []cache.InformerSynced{certificateRequestInformer.Informer().HasSynced}
-	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
+	if _, err := certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue}); err != nil {
+		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	c.certificateRequestLister = certificateRequestInformer.Lister()
 	c.cmClient = ctx.CMClient

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -440,7 +440,9 @@ func runTest(t *testing.T, test testT) {
 		apiutil.IssuerCA,
 		func(*controller.Context) certificaterequests.Issuer { return ca },
 	)
-	controller.Register(test.builder.Context)
+	if _, _, err := controller.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 	test.builder.Start()
 
 	err := controller.Sync(context.Background(), test.certificateRequest)

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -78,9 +78,11 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
 					)
-					secretInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
+					if _, err := secretInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
 						WorkFunc: handleSecretReferenceWorkFunc(log, certificateRequestLister, helper, queue),
-					})
+					}); err != nil {
+						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
 					return []cache.InformerSynced{
 						secretInformer.HasSynced,
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Informer().HasSynced,

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -630,7 +630,9 @@ func runTest(t *testing.T, test testT) {
 		apiutil.IssuerSelfSigned,
 		func(*controller.Context) certificaterequests.Issuer { return self },
 	)
-	controller.Register(test.builder.Context)
+	if _, _, err := controller.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 	test.builder.Start()
 
 	err := controller.Sync(context.Background(), test.certificateRequest)

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -773,7 +773,9 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	c := New(util.IssuerSelfSigned, func(*controller.Context) Issuer { return test.issuerImpl })
-	c.Register(test.builder.Context)
+	if _, _, err := c.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 
 	if test.helper != nil {
 		c.helper = test.helper

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -833,7 +833,9 @@ func runTest(t *testing.T, test testT) {
 		apiutil.IssuerVenafi,
 		func(*controllerpkg.Context) certificaterequests.Issuer { return v },
 	)
-	controller.Register(test.builder.Context)
+	if _, _, err := controller.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 	test.builder.Start()
 
 	// Deep copy the certificate request to prevent pulling condition state across tests

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -91,7 +91,7 @@ type controller struct {
 func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
@@ -101,21 +101,29 @@ func NewController(
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 
-	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
-	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	if _, err := certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(), predicate.ResourceOwnerOf),
-	})
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Issuer reconciles on changes to the Secret named `spec.nextPrivateKeySecretName`
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
 			predicate.ResourceOwnerOf,
 			predicate.ExtractResourceName(predicate.CertificateNextPrivateKeySecretName)),
-	})
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Issuer reconciles on changes to the Secret named `spec.secretName`
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
 			predicate.ExtractResourceName(predicate.CertificateSecretName)),
-	})
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.
@@ -144,7 +152,7 @@ func NewController(
 		),
 		fieldManager:         ctx.FieldManager,
 		localTemporarySigner: pki.GenerateLocallySignedTemporaryCertificate,
-	}, queue, mustSync
+	}, queue, mustSync, nil
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
@@ -471,10 +479,10 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
-	ctrl, queue, mustSync := NewController(log, ctx)
+	ctrl, queue, mustSync, err := NewController(log, ctx)
 	c.controller = ctrl
 
-	return queue, mustSync, nil
+	return queue, mustSync, err
 }
 
 func init() {

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -18,6 +18,7 @@ package readiness
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -82,7 +83,7 @@ func NewController(
 	chain policies.Chain,
 	renewalTimeCalculator pki.RenewalTimeFunc,
 	policyEvaluator policyEvaluatorFunc,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
 
@@ -91,18 +92,24 @@ func NewController(
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 
-	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
+	if _, err := certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	// When a CertificateRequest resource changes, enqueue the Certificate resource that owns it.
-	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	if _, err := certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(), predicate.ResourceOwnerOf),
-	})
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 	// When a Secret resource changes, enqueue any Certificate resources that name it as spec.secretName.
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	if _, err := secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Trigger reconciles on changes to the Secret named `spec.secretName`
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
 			predicate.ExtractResourceName(predicate.CertificateSecretName)),
-	})
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.
@@ -125,7 +132,7 @@ func NewController(
 		policyEvaluator:       policyEvaluator,
 		renewalTimeCalculator: renewalTimeCalculator,
 		fieldManager:          ctx.FieldManager,
-	}, queue, mustSync
+	}, queue, mustSync, nil
 }
 
 // ProcessItem is a worker function that will be called when a new key
@@ -248,7 +255,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
-	ctrl, queue, mustSync := NewController(log,
+	ctrl, queue, mustSync, err := NewController(log,
 		ctx,
 		policies.NewReadinessPolicyChain(ctx.Clock),
 		pki.RenewalTime,
@@ -256,7 +263,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	)
 	c.controller = ctrl
 
-	return queue, mustSync, nil
+	return queue, mustSync, err
 }
 
 func init() {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -77,7 +77,7 @@ type controller struct {
 }
 
 func NewController(
-	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
 
@@ -86,19 +86,25 @@ func NewController(
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 
-	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
-	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	if _, err := certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Trigger reconciles on changes to any 'owned' CertificateRequest resources
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
 			predicate.ResourceOwnerOf,
 		),
-	})
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Trigger reconciles on changes to any 'owned' secret resources
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
 			predicate.ResourceOwnerOf,
 		),
-	})
+	}); err != nil {
+		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	// build a list of InformerSynced functions that will be returned by the Register method.
 	// the controller will only begin processing items once all of these informers have synced.
@@ -117,7 +123,7 @@ func NewController(
 		clock:                    ctx.Clock,
 		copiedAnnotationPrefixes: ctx.CertificateOptions.CopiedAnnotationPrefixes,
 		fieldManager:             ctx.FieldManager,
-	}, queue, mustSync
+	}, queue, mustSync, nil
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
@@ -459,10 +465,10 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
-	ctrl, queue, mustSync := NewController(log, ctx)
+	ctrl, queue, mustSync, err := NewController(log, ctx)
 	c.controller = ctrl
 
-	return queue, mustSync, nil
+	return queue, mustSync, err
 }
 
 func init() {

--- a/pkg/controller/certificatesigningrequests/acme/acme_test.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme_test.go
@@ -916,7 +916,9 @@ func Test_ProcessItem(t *testing.T) {
 			defer test.builder.Stop()
 
 			controller := controllerBuilder()
-			controller.Register(test.builder.Context)
+			if _, _, err := controller.Register(test.builder.Context); err != nil {
+				t.Fatal(err)
+			}
 
 			test.builder.Start()
 

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -573,7 +573,9 @@ func runTest(t *testing.T, test testT) {
 		apiutil.IssuerCA,
 		func(*controller.Context) certificatesigningrequests.Signer { return ca },
 	)
-	controller.Register(test.builder.Context)
+	if _, _, err := controller.Register(test.builder.Context); err != nil {
+		t.Fatal(err)
+	}
 	test.builder.Start()
 
 	err := controller.ProcessItem(context.Background(), test.csr.Name)

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -86,9 +86,11 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
 					)
-					secretInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
+					if _, err := secretInformer.AddEventHandler(&controllerpkg.BlockingEventHandler{
 						WorkFunc: handleSecretReferenceWorkFunc(log, certificateSigningRequestLister, helper, queue, ctx.IssuerOptions),
-					})
+					}); err != nil {
+						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
 					return []cache.InformerSynced{
 						secretInformer.HasSynced,
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Informer().HasSynced,

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -616,7 +616,9 @@ func TestProcessItem(t *testing.T) {
 				apiutil.IssuerSelfSigned,
 				func(*controller.Context) certificatesigningrequests.Signer { return selfsigned },
 			)
-			controller.Register(test.builder.Context)
+			if _, _, err := controller.Register(test.builder.Context); err != nil {
+				t.Fatal(err)
+			}
 			test.builder.Start()
 
 			err := controller.ProcessItem(context.Background(), test.csr.Name)

--- a/pkg/controller/certificatesigningrequests/sync_test.go
+++ b/pkg/controller/certificatesigningrequests/sync_test.go
@@ -330,7 +330,9 @@ func TestController_Sync(t *testing.T) {
 			}
 
 			c := New(util.IssuerSelfSigned, func(*controller.Context) Signer { return scenario.signerImpl })
-			c.Register(scenario.builder.Context)
+			if _, _, err := c.Register(scenario.builder.Context); err != nil {
+				t.Fatal(err)
+			}
 
 			scenario.builder.Start()
 

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -439,7 +439,9 @@ func TestProcessItem(t *testing.T) {
 				apiutil.IssuerVault,
 				func(*controllerpkg.Context) certificatesigningrequests.Signer { return vault },
 			)
-			controller.Register(test.builder.Context)
+			if _, _, err := controller.Register(test.builder.Context); err != nil {
+				t.Fatal(err)
+			}
 			test.builder.Start()
 
 			err := controller.ProcessItem(context.Background(), test.csr.Name)

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -907,7 +907,9 @@ func TestProcessItem(t *testing.T) {
 				apiutil.IssuerVenafi,
 				func(*controllerpkg.Context) certificatesigningrequests.Signer { return venafi },
 			)
-			controller.Register(test.builder.Context)
+			if _, _, err := controller.Register(test.builder.Context); err != nil {
+				t.Fatal(err)
+			}
 			test.builder.Start()
 
 			err := controller.ProcessItem(context.Background(), test.csr.Name)

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -328,9 +328,15 @@ func (c *ContextFactory) Build(component ...string) (*Context, error) {
 	restConfig := util.RestConfigWithUserAgent(c.baseRestConfig, component...)
 
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	cmscheme.AddToScheme(scheme)
-	gwscheme.AddToScheme(scheme)
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := cmscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := gwscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	clients, err := buildClients(restConfig, c.ctx.ContextOptions)
 	if err != nil {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -328,15 +329,9 @@ func (c *ContextFactory) Build(component ...string) (*Context, error) {
 	restConfig := util.RestConfigWithUserAgent(c.baseRestConfig, component...)
 
 	scheme := runtime.NewScheme()
-	if err := kscheme.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := cmscheme.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := gwscheme.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
+	utilruntime.Must(kscheme.AddToScheme(scheme))
+	utilruntime.Must(cmscheme.AddToScheme(scheme))
+	utilruntime.Must(gwscheme.AddToScheme(scheme))
 
 	clients, err := buildClients(restConfig, c.ctx.ContextOptions)
 	if err != nil {

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -18,6 +18,7 @@ package issuers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,8 +84,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.secretLister = secretInformer.Lister()
 
 	// register handler functions
-	issuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
-	secretInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: c.secretDeleted})
+	if _, err := issuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue}); err != nil {
+		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: c.secretDeleted}); err != nil {
+		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	// instantiate additional helpers used by this controller
 	c.issuerFactory = issuer.NewFactory(ctx)

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -121,7 +121,9 @@ func (b *Builder) Init() {
 		b.StringGenerator = rand.String
 	}
 	scheme := metadatafake.NewTestScheme()
-	metav1.AddMetaToScheme(scheme)
+	if err := metav1.AddMetaToScheme(scheme); err != nil {
+		b.T.Fatalf("error adding meta to scheme: %v", err)
+	}
 	b.ACMEOptions.ACMEHTTP01SolverRunAsNonRoot = true // default from cmd/controller/app/options/options.go
 	b.Client = kubefake.NewSimpleClientset(b.KubeObjects...)
 	b.CMClient = cmfake.NewSimpleClientset(b.CertManagerObjects...)

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -111,7 +111,11 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 	dnsServerCalled := int32(0)
 
 	server := &dns.Server{Addr: "127.0.0.1:15353", Net: "udp", NotifyStartedFunc: func() { close(dnsServerStarted) }}
-	defer server.Shutdown()
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	mux := &dns.ServeMux{}
 	server.Handler = mux

--- a/pkg/issuer/vault/setup_test.go
+++ b/pkg/issuer/vault/setup_test.go
@@ -47,7 +47,9 @@ func TestVault_Setup(t *testing.T) {
 	vaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/auth/approle/login" || r.URL.Path == "/v1/auth/kubernetes/login" || r.URL.Path == "/v1/auth/cert/login" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"auth":{"client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"}}`))
+			if _, err := w.Write([]byte(`{"auth":{"client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"}}`)); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}))
 	defer vaultServer.Close()

--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -120,11 +120,13 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 		}),
 	)
 	informer := factory.Core().V1().Secrets().Informer()
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    d.handleAdd,
 		UpdateFunc: d.handleUpdate,
 		DeleteFunc: d.handleDelete,
-	})
+	}); err != nil {
+		return fmt.Errorf("error setting up event handler: %v", err)
+	}
 
 	d.lister = factory.Core().V1().Secrets().Lister().Secrets(d.SecretNamespace)
 	d.client = cl.CoreV1().Secrets(d.SecretNamespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -99,7 +99,9 @@ func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
 func JoinWithEscapeCSV(in []string) (string, error) {
 	b := new(bytes.Buffer)
 	writer := csv.NewWriter(b)
-	writer.Write(in)
+	if err := writer.Write(in); err != nil {
+		return "", fmt.Errorf("failed to write %q as CSV: %w", in, err)
+	}
 	writer.Flush()
 
 	if err := writer.Error(); err != nil {

--- a/test/acme/fixture.go
+++ b/test/acme/fixture.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -34,8 +35,8 @@ import (
 func init() {
 	vFlag := flag.Lookup("v")
 	if vFlag != nil {
-		flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
-		vFlag.Value.Set("12")
+		utilruntime.Must(flag.Set("alsologtostderr", fmt.Sprintf("%t", true)))
+		utilruntime.Must(vFlag.Value.Set("12"))
 	}
 }
 
@@ -138,7 +139,9 @@ func (f *fixture) setup(t *testing.T) func() {
 
 	stopCh := make(chan struct{})
 
-	f.testSolver.Initialize(env.Config, stopCh)
+	if err := f.testSolver.Initialize(env.Config, stopCh); err != nil {
+		t.Fatalf("error initializing solver: %v", err)
+	}
 
 	return func() {
 		close(stopCh)

--- a/test/acme/server/rfc2136.go
+++ b/test/acme/server/rfc2136.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -28,6 +29,7 @@ import (
 )
 
 type rfc2136Handler struct {
+	t   *testing.T
 	log logr.Logger
 
 	txtRecords map[string][]string
@@ -44,7 +46,11 @@ func (b *rfc2136Handler) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 
 	m := new(dns.Msg)
 	m.SetReply(req)
-	defer w.WriteMsg(m)
+	defer func() {
+		if err := w.WriteMsg(m); err != nil {
+			b.t.Errorf("failed to write response: %v", err)
+		}
+	}()
 
 	var zone string
 	if len(req.Question) > 0 {

--- a/test/acme/util.go
+++ b/test/acme/util.go
@@ -82,11 +82,13 @@ func (f *fixture) setupNamespace(t *testing.T, name string) (string, func()) {
 	}
 
 	return name, func() {
-		f.clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if err := f.clientset.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("error deleting test namespace %q: %v", name, err)
+		}
 	}
 }
 
-func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.ChallengeRequest {
+func (f *fixture) buildChallengeRequest(ns string) *whapi.ChallengeRequest {
 	return &whapi.ChallengeRequest{
 		ResourceNamespace:       ns,
 		ResolvedFQDN:            f.resolvedFQDN,

--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -799,10 +799,6 @@ func CleanKubernetesRoleForServiceAccountRefAuth(ctx context.Context, client kub
 		return err
 	}
 
-	if err := client.CoreV1().ServiceAccounts(saNS).Delete(ctx, saName, metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -95,10 +95,10 @@ func NewDefaultFramework(baseName string) *Framework {
 // It uses the config provided to it for the duration of the tests.
 func NewFramework(baseName string, cfg *config.Config) *Framework {
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	certmgrscheme.AddToScheme(scheme)
-	apiext.AddToScheme(scheme)
-	apireg.AddToScheme(scheme)
+	Expect(kscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(certmgrscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(apiext.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(apireg.AddToScheme(scheme)).NotTo(HaveOccurred())
 
 	f := &Framework{
 		Config:   cfg,

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
@@ -213,17 +214,21 @@ func (h *Helper) WaitCertificateRequestIssuedValidTLS(ctx context.Context, ns, n
 	cr, err := h.WaitForCertificateRequestReady(ctx, ns, name, timeout)
 	if err != nil {
 		log.Logf("Error waiting for CertificateRequest to become Ready: %v", err)
-		err = combineError(err, h.Kubectl(ns).DescribeResource("certificaterequest", name))
-		err = combineError(err, h.Kubectl(ns).Describe("order", "challenge"))
-		return err
+		return kerrors.NewAggregate([]error{
+			err,
+			h.Kubectl(ns).DescribeResource("certificaterequest", name),
+			h.Kubectl(ns).Describe("order", "challenge"),
+		})
 	}
 
 	_, err = h.ValidateIssuedCertificateRequest(ctx, cr, key, rootCAPEM)
 	if err != nil {
 		log.Logf("Error validating issued certificate: %v", err)
-		err = combineError(err, h.Kubectl(ns).DescribeResource("certificaterequest", name))
-		err = combineError(err, h.Kubectl(ns).Describe("order", "challenge"))
-		return err
+		return kerrors.NewAggregate([]error{
+			err,
+			h.Kubectl(ns).DescribeResource("certificaterequest", name),
+			h.Kubectl(ns).Describe("order", "challenge"),
+		})
 	}
 
 	return nil

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -213,16 +213,16 @@ func (h *Helper) WaitCertificateRequestIssuedValidTLS(ctx context.Context, ns, n
 	cr, err := h.WaitForCertificateRequestReady(ctx, ns, name, timeout)
 	if err != nil {
 		log.Logf("Error waiting for CertificateRequest to become Ready: %v", err)
-		h.Kubectl(ns).DescribeResource("certificaterequest", name)
-		h.Kubectl(ns).Describe("order", "challenge")
+		err = combineError(err, h.Kubectl(ns).DescribeResource("certificaterequest", name))
+		err = combineError(err, h.Kubectl(ns).Describe("order", "challenge"))
 		return err
 	}
 
 	_, err = h.ValidateIssuedCertificateRequest(ctx, cr, key, rootCAPEM)
 	if err != nil {
 		log.Logf("Error validating issued certificate: %v", err)
-		h.Kubectl(ns).DescribeResource("certificaterequest", name)
-		h.Kubectl(ns).Describe("order", "challenge")
+		err = combineError(err, h.Kubectl(ns).DescribeResource("certificaterequest", name))
+		err = combineError(err, h.Kubectl(ns).Describe("order", "challenge"))
 		return err
 	}
 

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -75,17 +75,17 @@ func (h *Helper) waitForCertificateCondition(ctx context.Context, client clients
 		log.Logf("Failed waiting for certificate %v: %v\n", name, pollErr.Error())
 
 		log.Logf("Certificate:\n")
-		h.describeCMObject(certificate)
+		pollErr = combineError(pollErr, h.describeCMObject(certificate))
 
 		log.Logf("Order and challenge descriptions:\n")
-		h.Kubectl(certificate.Namespace).Describe("order", "challenge")
+		pollErr = combineError(pollErr, h.Kubectl(certificate.Namespace).Describe("order", "challenge"))
 
 		log.Logf("CertificateRequest description:\n")
 		crName, err := apiutil.ComputeName(certificate.Name, certificate.Spec)
 		if err != nil {
-			log.Logf("Failed to compute CertificateRequest name from certificate: %s", err)
+			pollErr = combineError(pollErr, fmt.Errorf("failed to compute CertificateRequest name from certificate: %w", err))
 		} else {
-			h.Kubectl(certificate.Namespace).DescribeResource("certificaterequest", crName)
+			pollErr = combineError(pollErr, h.Kubectl(certificate.Namespace).DescribeResource("certificaterequest", crName))
 		}
 	}
 	return certificate, pollErr
@@ -189,7 +189,7 @@ func (h *Helper) waitForIssuerCondition(ctx context.Context, client clientset.Is
 		log.Logf("Failed waiting for issuer %v :%v\n", name, pollErr.Error())
 
 		log.Logf("Issuer:\n")
-		h.describeCMObject(issuer)
+		pollErr = combineError(pollErr, h.describeCMObject(issuer))
 	}
 
 	return issuer, pollErr
@@ -236,7 +236,7 @@ func (h *Helper) waitForClusterIssuerCondition(ctx context.Context, client clien
 		log.Logf("Failed waiting for issuer %v :%v\n", name, pollErr.Error())
 
 		log.Logf("Issuer:\n")
-		h.describeCMObject(issuer)
+		pollErr = combineError(pollErr, h.describeCMObject(issuer))
 	}
 
 	return issuer, pollErr

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -25,6 +25,7 @@ import (
 
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
@@ -74,19 +75,23 @@ func (h *Helper) waitForCertificateCondition(ctx context.Context, client clients
 	if pollErr != nil && certificate != nil {
 		log.Logf("Failed waiting for certificate %v: %v\n", name, pollErr.Error())
 
+		errs := []error{pollErr}
+
 		log.Logf("Certificate:\n")
-		pollErr = combineError(pollErr, h.describeCMObject(certificate))
+		errs = append(errs, h.describeCMObject(certificate))
 
 		log.Logf("Order and challenge descriptions:\n")
-		pollErr = combineError(pollErr, h.Kubectl(certificate.Namespace).Describe("order", "challenge"))
+		errs = append(errs, h.Kubectl(certificate.Namespace).Describe("order", "challenge"))
 
 		log.Logf("CertificateRequest description:\n")
 		crName, err := apiutil.ComputeName(certificate.Name, certificate.Spec)
 		if err != nil {
-			pollErr = combineError(pollErr, fmt.Errorf("failed to compute CertificateRequest name from certificate: %w", err))
+			errs = append(errs, fmt.Errorf("failed to compute CertificateRequest name from certificate: %w", err))
 		} else {
-			pollErr = combineError(pollErr, h.Kubectl(certificate.Namespace).DescribeResource("certificaterequest", crName))
+			errs = append(errs, h.Kubectl(certificate.Namespace).DescribeResource("certificaterequest", crName))
 		}
+
+		pollErr = kerrors.NewAggregate(errs)
 	}
 	return certificate, pollErr
 }
@@ -189,7 +194,7 @@ func (h *Helper) waitForIssuerCondition(ctx context.Context, client clientset.Is
 		log.Logf("Failed waiting for issuer %v :%v\n", name, pollErr.Error())
 
 		log.Logf("Issuer:\n")
-		pollErr = combineError(pollErr, h.describeCMObject(issuer))
+		pollErr = kerrors.NewAggregate([]error{pollErr, h.describeCMObject(issuer)})
 	}
 
 	return issuer, pollErr
@@ -236,7 +241,7 @@ func (h *Helper) waitForClusterIssuerCondition(ctx context.Context, client clien
 		log.Logf("Failed waiting for issuer %v :%v\n", name, pollErr.Error())
 
 		log.Logf("Issuer:\n")
-		pollErr = combineError(pollErr, h.describeCMObject(issuer))
+		pollErr = kerrors.NewAggregate([]error{pollErr, h.describeCMObject(issuer)})
 	}
 
 	return issuer, pollErr

--- a/test/e2e/framework/helper/describe.go
+++ b/test/e2e/framework/helper/describe.go
@@ -17,12 +17,11 @@ limitations under the License.
 package helper
 
 import (
-	"os"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
 	cmscheme "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/scheme"
 )
 
@@ -32,7 +31,7 @@ func (h *Helper) describeKubeObject(object runtime.Object) error {
 		Pretty: true,
 	})
 	encoder := kscheme.Codecs.WithoutConversion().EncoderForVersion(serializer, nil)
-	return encoder.Encode(object, os.Stdout)
+	return encoder.Encode(object, log.Writer)
 }
 
 func (h *Helper) describeCMObject(object runtime.Object) error {
@@ -41,5 +40,5 @@ func (h *Helper) describeCMObject(object runtime.Object) error {
 		Pretty: true,
 	})
 	encoder := cmscheme.Codecs.WithoutConversion().EncoderForVersion(serializer, nil)
-	return encoder.Encode(object, os.Stdout)
+	return encoder.Encode(object, log.Writer)
 }

--- a/test/e2e/framework/helper/kubectl.go
+++ b/test/e2e/framework/helper/kubectl.go
@@ -20,6 +20,8 @@ import (
 	"os/exec"
 	"strings"
 
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
 )
 
@@ -60,4 +62,18 @@ func (k *Kubectl) Run(args ...string) error {
 	cmd.Stdout = log.Writer
 	cmd.Stderr = log.Writer
 	return cmd.Run()
+}
+
+func combineError(err1 error, err2 error) error {
+	if err1 == nil && err2 == nil {
+		return nil
+	}
+	if err1 == nil {
+		return err2
+	}
+	if err2 == nil {
+		return err1
+	}
+
+	return kerrors.NewAggregate([]error{err1, err2})
 }

--- a/test/e2e/framework/helper/kubectl.go
+++ b/test/e2e/framework/helper/kubectl.go
@@ -20,8 +20,6 @@ import (
 	"os/exec"
 	"strings"
 
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
 )
 
@@ -62,18 +60,4 @@ func (k *Kubectl) Run(args ...string) error {
 	cmd.Stdout = log.Writer
 	cmd.Stderr = log.Writer
 	return cmd.Run()
-}
-
-func combineError(err1 error, err2 error) error {
-	if err1 == nil && err2 == nil {
-		return nil
-	}
-	if err1 == nil {
-		return err2
-	}
-	if err2 == nil {
-		return err1
-	}
-
-	return kerrors.NewAggregate([]error{err1, err2})
 }

--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -44,10 +44,10 @@ func (h *Helper) ValidateCertificate(certificate *cmapi.Certificate, validations
 		err := fn(certificate, secret)
 		if err != nil {
 			log.Logf("Certificate:\n")
-			h.describeCMObject(certificate)
+			err = combineError(err, h.describeCMObject(certificate))
 
 			log.Logf("Secret:\n")
-			h.describeKubeObject(secret)
+			err = combineError(err, h.describeKubeObject(secret))
 
 			return err
 		}

--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
@@ -43,13 +44,14 @@ func (h *Helper) ValidateCertificate(certificate *cmapi.Certificate, validations
 	for _, fn := range validations {
 		err := fn(certificate, secret)
 		if err != nil {
+			errs := []error{err}
 			log.Logf("Certificate:\n")
-			err = combineError(err, h.describeCMObject(certificate))
+			errs = append(errs, h.describeCMObject(certificate))
 
 			log.Logf("Secret:\n")
-			err = combineError(err, h.describeKubeObject(secret))
+			errs = append(errs, h.describeKubeObject(secret))
 
-			return err
+			return kerrors.NewAggregate(errs)
 		}
 	}
 

--- a/test/e2e/suite/conformance/certificatesigningrequests/tests.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/tests.go
@@ -462,7 +462,8 @@ func (s *Suite) Define() {
 				defer func() {
 					cleanupCtx := context.Background()
 
-					f.CRClient.Delete(cleanupCtx, kubeCSR)
+					err := f.CRClient.Delete(cleanupCtx, kubeCSR)
+					Expect(err).NotTo(HaveOccurred())
 				}()
 
 				// Approve the request for testing, so that cert-manager may sign the

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
@@ -69,6 +69,8 @@ type kubernetes struct {
 	testWithRootCA bool
 	// saTokenSecretName is the name of the Secret containing the service account token
 	saTokenSecretName string
+	// saBoundSA is the name of the service account which is used in the test, will be cleaned up after the test
+	saBoundSA string
 
 	setup *vault.VaultInitializer
 }
@@ -120,7 +122,13 @@ func (k *kubernetes) delete(ctx context.Context, f *framework.Framework, signerN
 		err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, ref.Name, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = k.setup.CleanKubernetesRole(ctx, f.KubeClientSet, f.Config.Addons.CertManager.ClusterResourceNamespace, k.setup.Role())
+		err = k.setup.CleanKubernetesRole(ctx, f.KubeClientSet, f.Config.Addons.CertManager.ClusterResourceNamespace, k.saBoundSA)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, ref.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k.setup.CleanKubernetesRole(ctx, f.KubeClientSet, f.Namespace.Name, k.saBoundSA)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -142,12 +150,12 @@ func (k *kubernetes) initVault(ctx context.Context, f *framework.Framework, boun
 	By("Creating a ServiceAccount for Vault authentication")
 
 	// boundNS is name of the service account for which a Secret containing the service account token will be created
-	boundSA := "vault-issuer-" + rand.String(5)
-	err := k.setup.CreateKubernetesRole(ctx, f.KubeClientSet, boundNS, boundSA)
+	k.saBoundSA = "vault-issuer-" + rand.String(5)
+	err := k.setup.CreateKubernetesRole(ctx, f.KubeClientSet, boundNS, k.saBoundSA)
 	Expect(err).NotTo(HaveOccurred())
 
 	k.saTokenSecretName = "vault-sa-secret-" + rand.String(5)
-	_, err = f.KubeClientSet.CoreV1().Secrets(boundNS).Create(ctx, vault.NewVaultKubernetesSecret(k.saTokenSecretName, boundSA), metav1.CreateOptions{})
+	_, err = f.KubeClientSet.CoreV1().Secrets(boundNS).Create(ctx, vault.NewVaultKubernetesSecret(k.saTokenSecretName, k.saBoundSA), metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/vault/kubernetes.go
@@ -120,7 +120,8 @@ func (k *kubernetes) delete(ctx context.Context, f *framework.Framework, signerN
 		err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, ref.Name, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		k.setup.CleanKubernetesRole(ctx, f.KubeClientSet, f.Config.Addons.CertManager.ClusterResourceNamespace, k.setup.Role())
+		err = k.setup.CleanKubernetesRole(ctx, f.KubeClientSet, f.Config.Addons.CertManager.ClusterResourceNamespace, k.setup.Role())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	Expect(k.setup.Clean(ctx)).NotTo(HaveOccurred(), "failed to deprovision vault initializer")

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -131,8 +131,10 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should allow updating an existing failing certificate that had a blocked dns name", func() {

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -123,8 +123,10 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should obtain a signed certificate with a single CN from the ACME server with 1 hour validity", func() {

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -106,9 +106,12 @@ var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 
 		AfterEach(func() {
 			By("Cleaning up")
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
-			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, certificateSecretName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, certificateSecretName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should call the dummy webhook provider and mark the challenges as presented=true", func() {

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -110,8 +110,6 @@ var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, certificateSecretName, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should call the dummy webhook provider and mark the challenges as presented=true", func() {

--- a/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
@@ -107,8 +107,10 @@ func testRFC2136DNSProvider() bool {
 
 		AfterEach(func() {
 			By("Cleaning up")
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, testingACMEPrivateKey, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, testingACMEPrivateKey, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should obtain a signed certificate for a regular domain", func() {

--- a/test/e2e/suite/issuers/acme/certificaterequest/http01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/http01.go
@@ -117,8 +117,10 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, testingACMEPrivateKey, metav1.DeleteOptions{})
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, testingACMEPrivateKey, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should obtain a signed certificate with a single CN from the ACME server", func() {

--- a/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
+++ b/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
@@ -103,8 +103,7 @@ func (b *Cloudflare) Provision() error {
 }
 
 func (b *Cloudflare) Deprovision() error {
-	b.Base.Details().KubeClient.CoreV1().Secrets(b.createdSecret.Namespace).Delete(context.TODO(), b.createdSecret.Name, metav1.DeleteOptions{})
-	return nil
+	return b.Base.Details().KubeClient.CoreV1().Secrets(b.createdSecret.Namespace).Delete(context.TODO(), b.createdSecret.Name, metav1.DeleteOptions{})
 }
 
 func (b *Cloudflare) Details() *Details {

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -46,8 +46,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should register ACME account", func() {

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -62,8 +62,10 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, issuerSecretName, metav1.DeleteOptions{})
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, issuerSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("when the CA is the root", func() {

--- a/test/e2e/suite/issuers/ca/certificaterequest.go
+++ b/test/e2e/suite/issuers/ca/certificaterequest.go
@@ -77,8 +77,10 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, issuerSecretName, metav1.DeleteOptions{})
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, issuerSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("when the CA is the root", func() {

--- a/test/e2e/suite/issuers/ca/clusterissuer.go
+++ b/test/e2e/suite/issuers/ca/clusterissuer.go
@@ -47,8 +47,10 @@ var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.KubeClientSet.CoreV1().Secrets(f.Config.Addons.CertManager.ClusterResourceNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-		f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, issuerName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(f.Config.Addons.CertManager.ClusterResourceNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should validate a signing keypair", func() {

--- a/test/e2e/suite/issuers/ca/issuer.go
+++ b/test/e2e/suite/issuers/ca/issuer.go
@@ -46,7 +46,8 @@ var _ = framework.CertManagerDescribe("CA Issuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, secretName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, secretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should generate a signing keypair", func() {

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -76,8 +76,10 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, certificateRequestSecretName, metav1.DeleteOptions{})
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, certificateRequestSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("Self Signed and private key", func() {

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -98,12 +98,15 @@ func runVaultAppRoleTests(issuerKind string, testWithRoot bool, unsupportedFeatu
 		Expect(setup.Clean(ctx)).NotTo(HaveOccurred())
 
 		if issuerKind == cmapi.IssuerKind {
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		} else {
-			f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}
 
-		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should generate a new valid certificate", func() {

--- a/test/e2e/suite/issuers/vault/certificate/cert_auth.go
+++ b/test/e2e/suite/issuers/vault/certificate/cert_auth.go
@@ -104,12 +104,15 @@ func runVaultClientCertAuthTest(issuerKind string, testWithRoot bool, unsupporte
 		Expect(setup.Clean(ctx)).NotTo(HaveOccurred())
 
 		if issuerKind == cmapi.IssuerKind {
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		} else {
-			f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}
 
-		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should generate a new valid certificate", func() {

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -96,12 +96,15 @@ func runVaultAppRoleTests(issuerKind string) {
 		Expect(setup.Clean(ctx)).NotTo(HaveOccurred())
 
 		if issuerKind == cmapi.IssuerKind {
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		} else {
-			f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Delete(ctx, vaultIssuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}
 
-		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		err := f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should generate a new valid certificate", func() {

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -39,7 +39,8 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	f := framework.NewDefaultFramework("create-vault-issuer")
 	ctx := context.TODO()
 
-	issuerName := "test-vault-issuer"
+	issuerGeneratorName := "test-vault-issuer-"
+	var issuerName string
 	vaultSecretServiceAccount := "vault-serviceaccount"
 	var roleId, secretId, vaultSecretName string
 
@@ -62,6 +63,8 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		roleId, secretId, err = setup.CreateAppRole(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
+		vaultSecretName = ""
+
 		By("creating a service account for Vault authentication")
 		err = setup.CreateKubernetesRole(ctx, f.KubeClientSet, f.Namespace.Name, vaultSecretServiceAccount)
 		Expect(err).NotTo(HaveOccurred())
@@ -69,11 +72,15 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	JustAfterEach(func() {
 		By("Cleaning up AppRole")
-		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), vaultSecretName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		err = setup.CleanAppRole(ctx)
+		if issuerName != "" { // When we test validation errors, the issuer won't be created
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		if vaultSecretName != "" {
+			err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), vaultSecretName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		err := setup.CleanAppRole(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Cleaning up Kubernetes")
@@ -90,18 +97,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 		vaultSecretName = sec.Name
 
-		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -111,18 +120,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Vault AppRole", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", roleId, setup.Role(), setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -132,18 +143,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Vault Token", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultTokenAuth("secretkey", "vault-token"))
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -156,18 +169,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -180,17 +195,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		// we test without creating the secret
 
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
+
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -200,7 +218,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init when both caBundle and caBundleSecretRef are set", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -208,6 +226,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"))
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).To(HaveOccurred())
+
 		Expect(err.Error()).To(ContainSubstring(
 			"spec.vault.caBundle: Invalid value: \"<snip>\": specified caBundle and caBundleSecretRef cannot be used together",
 		))
@@ -230,18 +249,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -254,18 +275,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Validate that the Issuer is not ready yet")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -285,7 +308,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -309,18 +332,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -342,7 +367,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 		By("Validate that the issuer isn't ready anymore due to Vault still using the old certificate")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -361,18 +386,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		}()
 
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(addon.Vault.Details().URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(addon.Vault.Details().VaultCA),
 			gen.SetIssuerVaultKubernetesAuthServiceAccount(vaultSecretServiceAccount, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,

--- a/test/e2e/suite/issuers/vault/mtls.go
+++ b/test/e2e/suite/issuers/vault/mtls.go
@@ -39,7 +39,8 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 	f := framework.NewDefaultFramework("create-vault-issuer")
 	ctx := context.TODO()
 
-	issuerName := "test-vault-issuer"
+	issuerGeneratorName := "test-vault-issuer-"
+	var issuerName string
 	vaultSecretServiceAccount := "vault-serviceaccount"
 	vaultClientCertificateSecretName := "vault-client-cert-secret-" + rand.String(5)
 	var roleId, secretId, vaultSecretName string
@@ -79,13 +80,15 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 	JustAfterEach(func() {
 		By("Cleaning up AppRole")
-		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		if vaultSecretName != "" {
-			err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+		if issuerName != "" { // When we test validation errors, the issuer won't be created
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}
-		err = setup.CleanAppRole(ctx)
+		if vaultSecretName != "" {
+			err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, vaultSecretName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		err := setup.CleanAppRole(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Cleaning up Kubernetes")
@@ -102,7 +105,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 		vaultSecretName = sec.Name
 
-		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -110,12 +113,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -130,18 +135,20 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		vaultSecretName = sec.Name
 
 		By("Creating an Issuer")
-		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
 			gen.SetIssuerVaultCABundle(details.VaultCA),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -151,7 +158,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 	It("should fail to init with missing Vault AppRole", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -159,12 +166,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", roleId, setup.Role(), setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -174,7 +183,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 	It("should fail to init with missing Vault Token", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -182,12 +191,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultTokenAuth("secretkey", "vault-token"))
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -200,7 +211,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -208,12 +219,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -226,7 +239,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		// we test without creating the secret
 
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -234,11 +247,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
+
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -248,7 +264,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 	It("should fail to init when both caBundle and caBundleSecretRef are set", func() {
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -258,6 +274,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultCABundleSecretRef("ca-bundle", f.Namespace.Name, "ca.crt"))
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).To(HaveOccurred())
+
 		Expect(err.Error()).To(ContainSubstring(
 			"spec.vault.caBundle: Invalid value: \"<snip>\": specified caBundle and caBundleSecretRef cannot be used together",
 		))
@@ -280,7 +297,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -288,12 +305,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -306,7 +325,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, vaultaddon.NewVaultKubernetesSecret(saTokenSecretName, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -314,12 +333,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Validate that the Issuer is not ready yet")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -339,7 +360,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -354,7 +375,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		vaultSecretName = sec.Name
 		customVaultClientCertificateSecretName := "vault-client-cert-secret-custom-" + rand.String(5)
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -362,12 +383,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(customVaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(customVaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, setup.AppRoleAuthPath()))
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Validate that the Issuer is not ready yet")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -381,7 +404,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			iss.Name,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -405,7 +428,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -413,12 +436,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthSecret("token", saTokenSecretName, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -440,7 +465,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 
 		By("Validate that the issuer isn't ready anymore due to Vault still using the old certificate")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,
@@ -459,7 +484,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 		}()
 
 		By("Creating an Issuer")
-		vaultIssuer := gen.Issuer(issuerName,
+		vaultIssuer := gen.IssuerWithRandomName(issuerGeneratorName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
 			gen.SetIssuerVaultURL(details.URL),
 			gen.SetIssuerVaultPath(setup.IntermediateSignPath()),
@@ -467,12 +492,14 @@ var _ = framework.CertManagerDescribe("Vault Issuer [mtls]", func() {
 			gen.SetIssuerVaultClientCertSecretRef(vaultClientCertificateSecretName, corev1.TLSCertKey),
 			gen.SetIssuerVaultClientKeySecretRef(vaultClientCertificateSecretName, corev1.TLSPrivateKeyKey),
 			gen.SetIssuerVaultKubernetesAuthServiceAccount(vaultSecretServiceAccount, setup.Role(), setup.KubernetesAuthPath()))
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
+		vaultIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		issuerName = vaultIssuer.Name
 
 		By("Waiting for Issuer to become Ready")
 		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
-			issuerName,
+			vaultIssuer.Name,
 			v1.IssuerCondition{
 				Type:   v1.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,

--- a/test/e2e/suite/issuers/venafi/cloud/setup.go
+++ b/test/e2e/suite/issuers/venafi/cloud/setup.go
@@ -52,7 +52,8 @@ var _ = CloudDescribe("properly configured Venafi Cloud Issuer", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
-		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set Ready=True accordingly", func() {

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -73,7 +73,8 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 	AfterEach(func() {
 		By("Cleaning up")
 		if issuer != nil {
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuer.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 

--- a/test/e2e/suite/issuers/venafi/tpp/setup.go
+++ b/test/e2e/suite/issuers/venafi/tpp/setup.go
@@ -49,7 +49,8 @@ var _ = TPPDescribe("properly configured Venafi TPP Issuer", func() {
 	AfterEach(func() {
 		By("Cleaning up")
 		if issuer != nil {
-			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuer.Name, metav1.DeleteOptions{})
+			err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuer.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -162,7 +162,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				injectable, cert := generalSetup(test.makeInjectable("changed"))
 
 				By("changing the name of the corresponding secret in the cert")
-				retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, cert)
 					if err != nil {
 						return err
@@ -176,8 +176,9 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 					}
 					return nil
 				})
+				Expect(err).NotTo(HaveOccurred())
 
-				cert, err := f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, cert, time.Minute*2)
+				cert, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, cert, time.Minute*2)
 				Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become updated")
 
 				By("grabbing the new secret")

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -136,11 +136,14 @@ func TestAcmeOrdersController(t *testing.T) {
 	}
 
 	// Create a new orders controller.
-	ctrl, queue, mustSync := acmeorders.NewController(
+	ctrl, queue, mustSync, err := acmeorders.NewController(
 		logf.Log,
 		&controllerContext,
 		false,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := controllerpkg.NewController(
 		"orders_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -161,8 +164,7 @@ func TestAcmeOrdersController(t *testing.T) {
 
 	// Create a Namespace.
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testName}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -340,22 +340,40 @@ func runAllControllers(t *testing.T, config *rest.Config) framework.StopFunc {
 	}
 
 	// TODO: set field mananager before calling each of those- is that what we do in actual code?
-	revCtrl, revQueue, revMustSync := revisionmanager.NewController(log, &controllerContext)
+	revCtrl, revQueue, revMustSync, err := revisionmanager.NewController(log, &controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 	revisionManager := controllerpkg.NewController("revisionmanager_controller", metrics, revCtrl.ProcessItem, revMustSync, nil, revQueue)
 
-	readyCtrl, readyQueue, readyMustSync := readiness.NewController(log, &controllerContext, policies.NewReadinessPolicyChain(clock), pki.RenewalTime, readiness.BuildReadyConditionFromChain)
+	readyCtrl, readyQueue, readyMustSync, err := readiness.NewController(log, &controllerContext, policies.NewReadinessPolicyChain(clock), pki.RenewalTime, readiness.BuildReadyConditionFromChain)
+	if err != nil {
+		t.Fatal(err)
+	}
 	readinessManager := controllerpkg.NewController("readiness_controller", metrics, readyCtrl.ProcessItem, readyMustSync, nil, readyQueue)
 
-	issueCtrl, issueQueue, issueMustSync := issuing.NewController(log, &controllerContext)
+	issueCtrl, issueQueue, issueMustSync, err := issuing.NewController(log, &controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 	issueManager := controllerpkg.NewController("issuing_controller", metrics, issueCtrl.ProcessItem, issueMustSync, nil, issueQueue)
 
-	reqCtrl, reqQueue, reqMustSync := requestmanager.NewController(log, &controllerContext)
+	reqCtrl, reqQueue, reqMustSync, err := requestmanager.NewController(log, &controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 	requestManager := controllerpkg.NewController("requestmanager_controller", metrics, reqCtrl.ProcessItem, reqMustSync, nil, reqQueue)
 
-	keyCtrl, keyQueue, keyMustSync := keymanager.NewController(log, &controllerContext)
+	keyCtrl, keyQueue, keyMustSync, err := keymanager.NewController(log, &controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 	keyManager := controllerpkg.NewController("keymanager_controller", metrics, keyCtrl.ProcessItem, keyMustSync, nil, keyQueue)
 
-	triggerCtrl, triggerQueue, triggerMustSync := trigger.NewController(log, &controllerContext, policies.NewTriggerPolicyChain(clock).Evaluate)
+	triggerCtrl, triggerQueue, triggerMustSync, err := trigger.NewController(log, &controllerContext, policies.NewTriggerPolicyChain(clock).Evaluate)
+	if err != nil {
+		t.Fatal(err)
+	}
 	triggerManager := controllerpkg.NewController("trigger_controller", metrics, triggerCtrl.ProcessItem, triggerMustSync, nil, triggerQueue)
 
 	return framework.StartInformersAndControllers(t, factory, cmFactory, revisionManager, requestManager, keyManager, triggerManager, readinessManager, issueManager)

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -80,7 +80,8 @@ func TestIssuingController(t *testing.T) {
 		FieldManager: "cert-manager-certificates-issuing-test",
 	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c := controllerpkg.NewController(
 		"issuing_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -102,8 +103,7 @@ func TestIssuingController(t *testing.T) {
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -285,7 +285,8 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		FieldManager: "cert-manager-certificates-issuing-test",
 	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c := controllerpkg.NewController(
 		"issuing_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -307,8 +308,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -499,7 +499,8 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 		FieldManager: "cert-manager-certificates-issuing-test",
 	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c := controllerpkg.NewController(
 		"issuing_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -521,8 +522,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -735,7 +735,8 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		FieldManager: "cert-manager-certificates-issuing-test",
 	}
 
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c := controllerpkg.NewController(
 		"issuing_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -757,8 +758,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -962,7 +962,8 @@ func Test_IssuingController_OwnerRefernece(t *testing.T) {
 		Recorder:     framework.NewEventRecorder(t, scheme),
 		FieldManager: fieldManager,
 	}
-	ctrl, queue, mustSync := issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c := controllerpkg.NewController(fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
 	stopControllerNoOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
 	defer func() {
@@ -1059,7 +1060,8 @@ func Test_IssuingController_OwnerRefernece(t *testing.T) {
 		Recorder:     framework.NewEventRecorder(t, scheme),
 		FieldManager: fieldManager,
 	}
-	ctrl, queue, mustSync = issuing.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err = issuing.NewController(logf.Log, &controllerContext)
+	require.NoError(t, err)
 	c = controllerpkg.NewController(fieldManager, metrics.New(logf.Log, clock.RealClock{}), ctrl.ProcessItem, mustSync, nil, queue)
 	stopControllerOwnerRef := framework.StartInformersAndController(t, factory, cmFactory, c)
 	defer stopControllerOwnerRef()

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -102,7 +102,10 @@ func TestMetricsController(t *testing.T) {
 			Metrics: metricsHandler,
 		},
 	}
-	ctrl, queue, mustSync := controllermetrics.NewController(&controllerContext)
+	ctrl, queue, mustSync, err := controllermetrics.NewController(&controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := controllerpkg.NewController(
 		"metrics_test",
 		metricsHandler,

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -57,7 +57,10 @@ func TestRevisionManagerController(t *testing.T) {
 		SharedInformerFactory: cmFactory,
 	}
 
-	ctrl, queue, mustSync := revisionmanager.NewController(logf.Log, &controllerContext)
+	ctrl, queue, mustSync, err := revisionmanager.NewController(logf.Log, &controllerContext)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	c := controllerpkg.NewController(
 		"revisionmanager_controller_test",
@@ -78,8 +81,7 @@ func TestRevisionManagerController(t *testing.T) {
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -81,7 +81,10 @@ func TestTriggerController(t *testing.T) {
 		Recorder:     framework.NewEventRecorder(t, scheme),
 		FieldManager: "cert-manager-certificates-trigger-test",
 	}
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shouldReissue)
+	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shouldReissue)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := controllerpkg.NewController(
 		"trigger_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -187,7 +190,10 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 		FieldManager: "cert-manager-certificates-trigger-test",
 	}
 	// Start the trigger controller
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shoudReissue)
+	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shoudReissue)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := controllerpkg.NewController(
 		"trigger_test",
 		metrics.New(logf.Log, clock.RealClock{}),
@@ -283,7 +289,10 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 	}
 
 	// Start the trigger controller
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, controllerContext, shoudReissue)
+	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shoudReissue)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := controllerpkg.NewController(
 		"trigger_test",
 		metrics.New(logf.Log, clock.RealClock{}),

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -68,11 +68,21 @@ func NewClients(t *testing.T, config *rest.Config) (kubernetes.Interface, intern
 	cmFactory := cminformers.NewSharedInformerFactory(cmCl, 0)
 
 	scheme := runtime.NewScheme()
-	kscheme.AddToScheme(scheme)
-	certmgrscheme.AddToScheme(scheme)
-	apiext.AddToScheme(scheme)
-	apireg.AddToScheme(scheme)
-	gwapi.Install(scheme)
+	if err := kscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := certmgrscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := apiext.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := apireg.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gwapi.Install(scheme); err != nil {
+		t.Fatal(err)
+	}
 
 	return cl, factory, cmCl, cmFactory, scheme
 }

--- a/test/integration/framework/helpers.go
+++ b/test/integration/framework/helpers.go
@@ -26,6 +26,7 @@ import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -68,21 +69,11 @@ func NewClients(t *testing.T, config *rest.Config) (kubernetes.Interface, intern
 	cmFactory := cminformers.NewSharedInformerFactory(cmCl, 0)
 
 	scheme := runtime.NewScheme()
-	if err := kscheme.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := certmgrscheme.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := apiext.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := apireg.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := gwapi.Install(scheme); err != nil {
-		t.Fatal(err)
-	}
+	utilruntime.Must(kscheme.AddToScheme(scheme))
+	utilruntime.Must(certmgrscheme.AddToScheme(scheme))
+	utilruntime.Must(apiext.AddToScheme(scheme))
+	utilruntime.Must(apireg.AddToScheme(scheme))
+	utilruntime.Must(gwapi.Install(scheme))
 
 	return cl, factory, cmCl, cmFactory, scheme
 }

--- a/test/integration/rfc2136_dns01/provider_test.go
+++ b/test/integration/rfc2136_dns01/provider_test.go
@@ -33,6 +33,7 @@ import (
 func TestRunSuiteWithTSIG(t *testing.T) {
 	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
 	server := &testserver.BasicServer{
+		T:             t,
 		Zones:         []string{rfc2136TestZone},
 		EnableTSIG:    true,
 		TSIGZone:      rfc2136TestZone,
@@ -76,6 +77,7 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 func TestRunSuiteNoTSIG(t *testing.T) {
 	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
 	server := &testserver.BasicServer{
+		T:     t,
 		Zones: []string{rfc2136TestZone},
 	}
 	if err := server.Run(ctx); err != nil {

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -67,7 +67,9 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string, argume
 	webhookFlags.AddFlags(fs)
 	options.AddConfigFlags(fs, webhookConfig)
 	// Parse the arguments passed in into the WebhookOptions struct
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("Failed parsing arguments: %v", err)
+	}
 
 	var caPEM []byte
 	tempDir, err := os.MkdirTemp("", "webhook-tls-")


### PR DESCRIPTION
All these changes, just to enable the errcheck linter: https://github.com/cert-manager/cert-manager/compare/master...inteon:fix_errcheck?expand=1#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L5

Note for reviewer:
Generally, this PR should not contain anything unexpected (lots of additional err checks).
I had to update some of the test cleanup code to fix issues with delete operations that were incorrect.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
