### PR TITLE
Reduce memory usage by only caching the metadata of Secret resources

### DIFF
--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/cert-manager/cert-manager v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
+	k8s.io/api v0.30.2
 	k8s.io/apiextensions-apiserver v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
@@ -76,7 +77,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.2 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect

--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,7 +48,7 @@ const (
 func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config setup) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []ctrl.Request {
 		secretName := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-		certName := owningCertForSecret(obj.(*corev1.Secret))
+		certName := owningCertForSecret(obj.(*metav1.PartialObjectMetadata))
 		if certName == nil {
 			return nil
 		}

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,16 +162,25 @@ func dropNotFound(err error) error {
 	return err
 }
 
-// owningCertForSecret gets the name of the owning certificate for a
-// given secret, returning nil if no such object exists.
-func owningCertForSecret(secret *corev1.Secret) *types.NamespacedName {
-	val, ok := secret.Annotations[certmanager.CertificateNameKey]
+// owningCertForSecret gets the name of the owning certificate for a given
+// secret, returning nil if the supplied secret does not have a
+// `cert-manager.io/certificate-name` annotation.
+// The secret may be a v1.Secret or a v1.PartialObjectMetadata.
+//
+// NOTE: "owning" here does not mean [ownerReference][1], because
+// cert-manager does not set the ownerReference of the Secret,
+// unless the [`--enable-certificate-owner-ref` flag is true][2].
+//
+// [1]: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
+// [2]: https://cert-manager.io/docs/cli/controller/
+func owningCertForSecret(secret client.Object) *types.NamespacedName {
+	val, ok := secret.GetAnnotations()[certmanager.CertificateNameKey]
 	if !ok {
 		return nil
 	}
 	return &types.NamespacedName{
 		Name:      val,
-		Namespace: secret.Namespace,
+		Namespace: secret.GetNamespace(),
 	}
 }
 

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -117,6 +117,13 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 		// don't requeue if we're just not found, we'll get called when the secret gets created
 		return nil, dropNotFound(err)
 	}
+	// Only use Secrets that have been created by this Certificate.
+	// The Secret must have a `cert-manager.io/certificate-name` annotation
+	// value matching the name of this Certificate..
+	// NOTE: "owner" is not the `ownerReference`, because cert-manager does not
+	// usually set the ownerReference of the Secret.
+	// TODO: The logged warning below is misleading because it contains the
+	// ownerReference, which is not the reason for ignoring the Secret.
 	owner := owningCertForSecret(&secret)
 	if owner == nil || *owner != certName {
 		log.V(logf.WarnLevel).Info("refusing to target secret not owned by certificate", "owner", metav1.GetControllerOf(&secret))


### PR DESCRIPTION
Update cainjector to use metadata-only caching for Secret resources:
1. To reduce memory use of cainjector, by only caching metadata of Secret resources in-memory.
2. To reduce the load on the K8S API server when cainjector starts up, caused by the initial listing of full Secret resources in the cluster.

With 100M of Secrets in the cluster, this reduces the maximum memory usage from ~290M to ~46M:
- Before:   "rss_max_kilobytes": 289268
- After: "rss_max_kilobytes": 45652

Behind the scenes the reflector is asking the server for a `PartialObjectMetadataList` projection instead of the full data `SecretList`.
You can see the reduction in the response size using curl as follows:

```sh
# Create 1Mi file. The maximum size of a Secret
dd if=/dev/zero bs=1048576 count=1 of=f1

# Create 100M of secrets
echo -n {0..99} | xargs -d ' ' -P5 -I{} kubectl create secret generic s-$RANDOM-{} --from-file=f1

# Get API server connection parameters
kubectl get cm -n kube-public kube-root-ca.crt  -o jsonpath='{ .data.ca\.crt }' > ca.crt
export URL="$(kubectl cluster-info | grep 'Kubernetes control plane' | egrep -o 'https://[a-z0-9.]+:[0-9]+')"
export TOKEN="$(kubectl create token -n cert-manager cert-manager-cainjector)"
```
```sh
curl "${URL}/api/v1/secrets" \
     -fsSL \
     --cacert ca.crt \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Accept: application/json" \
    | dd of=/dev/null
...
274790+1 records in
274790+1 records out
140692829 bytes (141 MB, 134 MiB) copied, 1.76449 s, 79.7 MB/s
```
```sh
curl "${URL}/api/v1/secrets" \
     -fsSL \
     --cacert ca.crt \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Accept: application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1" \
    | dd of=/dev/null
...
167+1 records in
167+1 records out
85806 bytes (86 kB, 84 KiB) copied, 0.404721 s, 212 kB/s
```
> 📖 Read about [Alternate representations of resources](https://kubernetes.io/docs/reference/using-api/api-concepts/#alternate-representations-of-resources)
> and [Graduate Server-side Get and Partial Objects to GA
](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2334-graduate-server-side-get-and-partial-objects-to-GA#summary)

## Background
* A user reports cainjector crashing on startup because the initial List secrets results in an internal server error from the EKS API server
  *  #7147 
* Users report that cert-manager (not cainjector specifically) causes their K8S API servers to crash, probably because at the time, both cert-manager controller and cainjector were attempting to list all Secrets (including data) when they startup.
  * #3748 
* @irbe wrote about the advantages of using metadata-only caching in the memory-management design document:
   * https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#partial-object-metadata

Fixes: #7147, #3748

/kind feature

```release-note
Reduce the memory usage of `cainjector`, by only caching the metadata of Secret resources.
Reduce the load on the K8S API server when `cainjector` starts up, by only listing the metadata of Secret resources.
```

## Testing

### Measuring peak memory use at startup

I used `time` to measure the maximum resident set size of cainjector when it starts up with a cluster containing 100M of Secrets.
I create a cluster, load it with 100M of Secrets and then run `time cainjector` on my laptop to measure its resource usage for a few seconds, as it starts up. 
Leader election is disabled, so that cainjector can immediately begin listing and watching resources.

```sh
# Create cluster
kind create cluster

# Install cert-manager CRDs only (cainjector watches Certificate resources)
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.crds.yaml

# Create 1Mi file. The maximum size of a Secret
dd if=/dev/zero bs=1048576 count=1 of=f1

# Create ~100Mi of Secrets, 5 at a time
echo -n {0..99} | xargs -d ' ' -P5 -I{} kubectl create secret generic s-$RANDOM-{} --from-file=f1

# Configure `time` to record the maximum resident set size and a bunch of other measurements
# https://www.man7.org/linux/man-pages/man1/time.1.html#GNU_VERSION
export TIME='{
    "cpu_seconds_user": %U,
    "cpu_seconds_system": %S,
    "time_elapsed": "%E",
    "cpu_percent": "%P",
    "text_kilobytes": %X,
    "data_kilobytes": %D,
    "rss_max_kilobytes": %M,
    "fs_inputs": %I,
    "fs_outputs": %O,
    "page_faults_major": %F,
    "page_faults_minor": %R,
    "swaps": %W
}'

function measure() {
    gitref=$1
    outfile=$2

    # Checkout the git reference
    # https://stackoverflow.com/a/45967995
    git fetch origin "$gitref" && git checkout FETCH_HEAD
    # Build the cainjector
    make _bin/server/cainjector-linux-amd64

    # Run it locally for 3 seconds and measure resource usage using time.
    /usr/bin/time -o "$outfile" -- \
                  _bin/server/cainjector-linux-amd64 --kubeconfig ~/.kube/config -v1 --leader-elect=false &
    sleep 3
    killall cainjector-linux-amd64
    wait
}

measure master master.json
measure pull/7161/head branch.json

diff -u master.json branch.json
```

```diff
--- master.json 2024-07-10 12:14:07.863996263 +0100
+++ branch.json 2024-07-10 12:14:13.354828683 +0100
@@ -1,14 +1,14 @@
 {
-    "cpu_seconds_user": 0.30,
-    "cpu_seconds_system": 0.09,
+    "cpu_seconds_user": 0.05,
+    "cpu_seconds_system": 0.02,
     "time_elapsed": "0:03.00",
-    "cpu_percent": "13%",
+    "cpu_percent": "2%",
     "text_kilobytes": 0,
     "data_kilobytes": 0,
-    "rss_max_kilobytes": 289268,
+    "rss_max_kilobytes": 45652,
     "fs_inputs": 0,
     "fs_outputs": 0,
     "page_faults_major": 0,
-    "page_faults_minor": 3486,
+    "page_faults_minor": 2008,
     "swaps": 0
 }
```

### Benchmarks

I ran `tlspk-bench` to create 1000 RSA 2048 Certificates to compare the memory usage of cert-manager from master and this branch.
1000 RSA 2048 Secrets amounts to ~6MB of data so the difference in memory usage is not dramatic. 
```sh
$ kubectl get secret -l controller.cert-manager.io/fao -A -o json | dd bs=1M of=/dev/null
0+95 records in
0+95 records out
6200133 bytes (6.2 MB, 5.9 MiB) copied, 0.621156 s, 10.0 MB/s
```
But it is visible in the graphs below.

* master
![image](https://github.com/cert-manager/cert-manager/assets/978965/eb7b72ba-440e-45f6-9719-50a4871a28a5)

* branch
![image](https://github.com/cert-manager/cert-manager/assets/978965/1c5136bc-ea13-4c6a-b6a8-7d7cc22da579)


