### PR TITLE
Reduce load on the Kubernetes API server and reduce the peak memory use of the cert-manager components by enabling the use of the WatchList (Streaming Lists) feature

### DIFF
--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -21,7 +21,9 @@ limitations under the License.
 package feature
 
 import (
+	"k8s.io/apimachinery/pkg/util/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/component-base/featuregate"
 
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -50,6 +52,16 @@ const (
 
 func init() {
 	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(cainjectorFeatureGates))
+
+	// Register all client-go features with cert-manager's feature gate instance
+	// and make all client-go feature checks use cert-manager's instance. The
+	// effect is that client-go features are wired to the existing
+	// --feature-gates flag just as all other features are. Further, client-go
+	// features automatically support the existing mechanisms for feature
+	// enablement metrics and test overrides.
+	ca := utilfeature.NewClientGoAdapter(utilfeature.DefaultMutableFeatureGate)
+	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
+	clientfeatures.ReplaceFeatureGates(ca)
 }
 
 // cainjectorFeatureGates defines all feature gates for the cainjector component.

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -22,6 +22,7 @@ package feature
 
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/component-base/featuregate"
 
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -149,6 +150,16 @@ const (
 
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultCertManagerFeatureGates))
+
+	// Register all client-go features with cert-manager's feature gate instance
+	// and make all client-go feature checks use cert-manager's instance. The
+	// effect is that client-go features are wired to the existing
+	// --feature-gates flag just as all other features are. Further, client-go
+	// features automatically support the existing mechanisms for feature
+	// enablement metrics and test overrides.
+	ca := utilfeature.NewClientGoAdapter(utilfeature.DefaultMutableFeatureGate)
+	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
+	clientfeatures.ReplaceFeatureGates(ca)
 }
 
 // defaultCertManagerFeatureGates consists of all known cert-manager feature keys.

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -21,7 +21,9 @@ limitations under the License.
 package feature
 
 import (
+	"k8s.io/apimachinery/pkg/util/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/component-base/featuregate"
 
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -84,6 +86,16 @@ const (
 
 func init() {
 	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(webhookFeatureGates))
+
+	// Register all client-go features with cert-manager's feature gate instance
+	// and make all client-go feature checks use cert-manager's instance. The
+	// effect is that client-go features are wired to the existing
+	// --feature-gates flag just as all other features are. Further, client-go
+	// features automatically support the existing mechanisms for feature
+	// enablement metrics and test overrides.
+	ca := utilfeature.NewClientGoAdapter(utilfeature.DefaultMutableFeatureGate)
+	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
+	clientfeatures.ReplaceFeatureGates(ca)
 }
 
 // webhookFeatureGates defines all feature gates for the webhook component.

--- a/make/config/kind/cluster.yaml
+++ b/make/config/kind/cluster.yaml
@@ -18,6 +18,13 @@
 
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+featureGates:
+  # Enable the WatchList / Streaming Lists feature on the API server.
+  #
+  # - https://kind.sigs.k8s.io/docs/user/configuration/#feature-gates
+  # - https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
+  WatchList: true
+
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/util/feature/client_adapter.go
+++ b/pkg/util/feature/client_adapter.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copied from https://github.com/kubernetes/kubernetes/blob/31062790a17634c2e728e44d444361800caa5b97/pkg/features/client_adapter.go
+// See https://github.com/kubernetes/kubernetes/pull/122738
+
+package feature
+
+import (
+	"fmt"
+
+	clientfeatures "k8s.io/client-go/features"
+	"k8s.io/component-base/featuregate"
+)
+
+// clientAdapter adapts a k8s.io/component-base/featuregate.MutableFeatureGate to client-go's
+// feature Gate and Registry interfaces. The component-base types Feature, FeatureSpec, and
+// prerelease, and the component-base prerelease constants, are duplicated by parallel types and
+// constants in client-go. The parallel types exist to allow the feature gate mechanism to be used
+// for client-go features without introducing a circular dependency between component-base and
+// client-go.
+type clientAdapter struct {
+	mfg featuregate.MutableFeatureGate
+}
+
+var _ clientfeatures.Gates = &clientAdapter{}
+
+func NewClientGoAdapter(mfg featuregate.MutableFeatureGate) *clientAdapter {
+	return &clientAdapter{
+		mfg: mfg,
+	}
+}
+
+func (a *clientAdapter) Enabled(name clientfeatures.Feature) bool {
+	return a.mfg.Enabled(featuregate.Feature(name))
+}
+
+var _ clientfeatures.Registry = &clientAdapter{}
+
+func (a *clientAdapter) Add(in map[clientfeatures.Feature]clientfeatures.FeatureSpec) error {
+	out := map[featuregate.Feature]featuregate.FeatureSpec{}
+	for name, spec := range in {
+		converted := featuregate.FeatureSpec{
+			Default:       spec.Default,
+			LockToDefault: spec.LockToDefault,
+		}
+		switch spec.PreRelease {
+		case clientfeatures.Alpha:
+			converted.PreRelease = featuregate.Alpha
+		case clientfeatures.Beta:
+			converted.PreRelease = featuregate.Beta
+		case clientfeatures.GA:
+			converted.PreRelease = featuregate.GA
+		case clientfeatures.Deprecated:
+			converted.PreRelease = featuregate.Deprecated
+		default:
+			// The default case implies programmer error.  The same set of prerelease
+			// constants must exist in both component-base and client-go, and each one
+			// must have a case here.
+			panic(fmt.Sprintf("unrecognized prerelease %q of feature %q", spec.PreRelease, name))
+		}
+		out[featuregate.Feature(name)] = converted
+	}
+	return a.mfg.Add(out)
+}


### PR DESCRIPTION
Allow cert-manager users to enable the `ClientWatchList` feature in client-go, so that they can experiment with the feature and evaluate its effect on the memory usage of the components.
They will also have to enable the `WatchList` feature of their Kubernetes API server.

- This PR merges the Client-Go Feature Flags into the feature flags of each of the cert-manager components. 
  Copying the technique and copying some of the code used by the kube-controller-manager. See:
  - https://github.com/kubernetes/kubernetes/pull/122738
- When the client-go ClientWatchList feature is eventually promoted to GA, the feature flag will be hidden, but the flag will continue to work if enabled, but will error if disabled, because when GA, the it will no longer be possible to turn the  implementation off.
- I expect that new client-go feature flags will be introduced in future, which may or may not be applicable to cert-manager, but these will be disabled by default and should not affect cert-manager users. 
-  We will need to be aware that the client-go features are being enabled in our E2E tests.
-  And we should update the documentation to explain which of the features are client-go features and link to the documentation for those features.
- The ALPHA [WatchList feature](https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists) of the kube-apiserver is available since v1.27. 
- The ALPHA ClientWatchList feature of client-go was introduced in [v0.28.0](https://github.com/kubernetes/client-go/blob/v0.28.0/tools/cache/reflector.go#L240-L242), enabled with a non-standard [ENABLE_CLIENT_GO_WATCH_LIST_ALPHA environment variable](https://github.com/kubernetes/kubernetes/pull/118235).
- The BETA ClientWatchList feature was promoted in v0.31.0, with a new [ClientWatchList feature flag](https://github.com/kubernetes/kubernetes/pull/122791).
- It is not clear when the WatchList and ClientWatchList features will become GA (enabled by default). 
  The following [comment from a K8S contributor](https://github.com/kubernetes/kubernetes/pull/125947#discussion_r1679514088) says: 
  > ...but only after this feature graduates to GA, which most likely be not sooner than 1.33, although looking at 3157 it's still TBD.
- I've measured a significant memory reduction in both the controller and in the kube-apiserver when the WatchList feature is enabled. (see testing section below).
- There is no memory reduction in cainjector, because it only caches the metadata of Secrets.
- There is no memory reduction in webhook, because it doesn't cache any resources.
- I did not find any examples of other projects that have enabled this feature: 
  - https://github.com/search?q=%22ClientWatchList%22+language%3AGo&type=code&l=Go

Fixes: #3748 

## Background
* https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/3157-watch-list/README.md
* https://github.com/kubernetes/enhancements/issues/3157

## Release Note
```release-note
Feature: Add a new `ClientWatchList` feature flag to cert-manager controller, cainjector and webhook, which allows the components to use of the ALPHA WatchList / Streaming list feature of the Kubernetes API server. This reduces the load on  the Kubernetes API server when cert-manager starts up and reduces the peak memory usage in the cert-manager components.
```

## Testing

## Memory reduction in a Kind cluster

I deployed cert-manager from master and from this branch in a Kind cluster with 100MiB Secret resources.
Measured the peak memory usage of all controller, cainjector, webhook using the `VmHWM` file in `/proc/*/status`.

| component      | before | after |
|----------------|--------|-------|
| controller     | 362    | 229   |
| cainjector     | 46     | 44    |
| webhook        | 48     | 49    |
| etcd           | 366    | 358   |
| kube-apiserver | 1134   | 824   |


See https://gist.github.com/wallrj/f15ad450f1b3effb107db5e6a01bf03f

### Log messages
With `--feature-gates=ClientWatchList=true` and `--v 6` you'll see the WATCH requests with the following query string parameters:
- `resourceVersionMatch=NotOlderThan`
- `sendInitialEvents=true`


```sh
kubectl logs -n cert-manager deploy/cert-manager | fgrep -v -e "starting worker" -e "leaderelection"
```

> I0712 16:40:35.025446       1 round_trippers.go:553] GET https://10.0.0.1:443/api/v1/secrets?allowWatchBookmarks=true&labelSelector=controller.cert-manager.io%2Ffao%3Dtrue&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&timeout=7m37s&timeoutSeconds=457&watch=true 200 OK in 2502 milliseconds
I0712 16:40:35.025528       1 round_trippers.go:553] GET https://10.0.0.1:443/api/v1/secrets?allowWatchBookmarks=true&labelSelector=%21controller.cert-manager.io%2Ffao&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&timeout=8m7s&timeoutSeconds=487&watch=true 200 OK in 2501 milliseconds
> I0712 16:40:35.655423       1 reflector.go:798] exiting k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232 Watch because received the bookmark that marks the end of initial events stream, total 6 items received in 3.13200872s
I0712 16:40:35.655514       1 reflector.go:359] Caches populated for *v1.PartialObjectMetadata from k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232
I0712 16:40:35.655697       1 reflector.go:798] exiting k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232 Watch because received 

### Command Line Flags

You'll see the following new features among the feature flags help output.

```console
$ go run ./cmd/controller --help | fgrep -A 20 -- --feature-gates
      --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                             AdditionalCertificateOutputFormats=true|false (BETA - default=true)
                                                             AllAlpha=true|false (ALPHA - default=false)
                                                             AllBeta=true|false (BETA - default=false)
                                                             ExperimentalCertificateSigningRequestControllers=true|false (ALPHA - default=false)
                                                             ExperimentalGatewayAPISupport=true|false (BETA - default=true)
                                                             InformerResourceVersion=true|false (ALPHA - default=false)
                                                             LiteralCertificateSubject=true|false (BETA - default=true)
                                                             NameConstraints=true|false (ALPHA - default=false)
                                                             OtherNames=true|false (ALPHA - default=false)
                                                             SecretsFilteredCaching=true|false (BETA - default=true)
                                                             ServerSideApply=true|false (ALPHA - default=false)
                                                             StableCertificateRequestName=true|false (BETA - default=true)
                                                             UseCertificateRequestBasicConstraints=true|false (ALPHA - default=false)
                                                             UseDomainQualifiedFinalizer=true|false (ALPHA - default=false)
                                                             ValidateCAA=true|false (ALPHA - default=false)
                                                             WatchListClient=true|false (BETA - default=false)
...
```

```console
$ go run ./cmd/cainjector --help

      --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                             AllAlpha=true|false (ALPHA - default=false)
                                                             AllBeta=true|false (BETA - default=false)
                                                             InformerResourceVersion=true|false (ALPHA - default=false)
                                                             ServerSideApply=true|false (ALPHA - default=false)
                                                             WatchListClient=true|false (BETA - default=false)

```

```console
$ go run ./cmd/webhook --help | fgrep -A 20 -- --feature-gates
      --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                             AdditionalCertificateOutputFormats=true|false (BETA - default=true)
                                                             AllAlpha=true|false (ALPHA - default=false)
                                                             AllBeta=true|false (BETA - default=false)
                                                             InformerResourceVersion=true|false (ALPHA - default=false)
                                                             LiteralCertificateSubject=true|false (BETA - default=true)
                                                             NameConstraints=true|false (ALPHA - default=false)
                                                             OtherNames=true|false (ALPHA - default=false)
                                                             WatchListClient=true|false (BETA - default=false)
```

### Testing cert-manager 1.15

I took the 1.15 binaries and enabled the client watch list feature using the old `ENABLE_CLIENT_GO_WATCH_LIST_ALPHA` environment variable. 
With 100MiB of Secrets
- controller peak memory (VmHWM) dropped from 436 to 212 MB.
- kube-apiserver peak memory dropped from 1134 to 772 MB. 

 * https://gist.github.com/wallrj/c4933057037967d634708548e8aa7390