### PR TITLE
fix: Handle case of Azure returning auth error

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -210,7 +210,7 @@ func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater 
 	resp, err := c.recordClient.Get(ctx, c.resourceGroupName, zone, name, dns.RecordTypeTXT, nil)
 	if err != nil {
 		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr); respErr.StatusCode == http.StatusNotFound {
+		if errors.As(err, &respErr); respErr != nil && respErr.StatusCode == http.StatusNotFound {
 			set = &dns.RecordSet{
 				Properties: &dns.RecordSetProperties{
 					TTL:        to.Ptr(int64(60)),

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -128,6 +128,17 @@ func TestInvalidAzureDns(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestAuthenticationError(t *testing.T) {
+	provider, err := NewDNSProviderCredentials("", "invalid-client-id", "invalid-client-secret", "subid", "tenid", "rg", "example.com", util.RecursiveNameservers, false, &v1.AzureManagedIdentity{})
+	assert.NoError(t, err)
+
+	err = provider.Present(context.TODO(), "example.com", "_acme-challenge.example.com.", "123d==")
+	assert.Error(t, err)
+
+	err = provider.CleanUp(context.TODO(), "example.com", "_acme-challenge.example.com.", "123d==")
+	assert.Error(t, err)
+}
+
 func populateFederatedToken(t *testing.T, filename string, content string) {
 	t.Helper()
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

When checking for a HTTP status code returned by Azure client, we did not consider the case of authentication error - which happens to be a completely different type in some cases.

This PR fixes this issue by making sure the error extraction actually succeeded and we got a valid non-nil error.

Fixes #7136 

### Kind

/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fix Azure DNS causing panics whenever authentication error happens
```
