### PR TITLE
fix: HTTP01 challenge HTTPRoute creation for GatewayAPI

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -125,6 +125,9 @@ func (s *Solver) Present(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 			return utilerrors.NewAggregate([]error{podErr, svcErr, ingressErr})
 		}
 		if ch.Spec.Solver.HTTP01.GatewayHTTPRoute != nil {
+			if !s.GatewaySolverEnabled {
+				return fmt.Errorf("couldn't Present challenge %s/%s: gateway api is not enabled", ch.Namespace, ch.Name)
+			}
 			_, gatewayErr = s.ensureGatewayHTTPRoute(ctx, ch, svcName)
 			return utilerrors.NewAggregate([]error{podErr, svcErr, gatewayErr})
 		}

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -95,7 +95,7 @@ func (s *Solver) createGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challeng
 	}
 	httpRoute := &gwapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    "cm-acme-http-solver",
+			GenerateName:    "cm-acme-http-solver-",
 			Namespace:       ch.Namespace,
 			Labels:          labels,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -166,6 +166,7 @@ func generateHTTPRouteSpec(ch *cmacme.Challenge, svcName string) gwapi.HTTPRoute
 					{
 						BackendRef: gwapi.BackendRef{
 							BackendObjectReference: gwapi.BackendObjectReference{
+								Group:     func() *gwapi.Group { g := gwapi.Group(""); return &g }(),
 								Kind:      func() *gwapi.Kind { k := gwapi.Kind("Service"); return &k }(),
 								Name:      gwapi.ObjectName(svcName),
 								Namespace: func() *gwapi.Namespace { n := gwapi.Namespace(ch.Namespace); return &n }(),

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -132,7 +132,6 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 		newHTTPRoute := oldHTTPRoute.DeepCopy()
 		newHTTPRoute.Spec = expectedSpec
 		newHTTPRoute.Labels = expectedLabels
-		newHTTPRoute.GenerateName = ""
 		ret, err = s.GWClient.GatewayV1().HTTPRoutes(newHTTPRoute.Namespace).Update(ctx, newHTTPRoute, metav1.UpdateOptions{})
 		if err != nil {
 			return err

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -117,7 +117,7 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 	for k, v := range ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels {
 		expectedLabels[k] = v
 	}
-	actualLabels := ch.Labels
+	actualLabels := httpRoute.Labels
 	if reflect.DeepEqual(expectedSpec, actualSpec) && reflect.DeepEqual(expectedLabels, actualLabels) {
 		return httpRoute, nil
 	}
@@ -132,6 +132,7 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 		newHTTPRoute := oldHTTPRoute.DeepCopy()
 		newHTTPRoute.Spec = expectedSpec
 		newHTTPRoute.Labels = expectedLabels
+		newHTTPRoute.GenerateName = ""
 		ret, err = s.GWClient.GatewayV1().HTTPRoutes(newHTTPRoute.Namespace).Update(ctx, newHTTPRoute, metav1.UpdateOptions{})
 		if err != nil {
 			return err

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package http
 
 import (

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/diff"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -102,6 +104,62 @@ func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
 			resp, err := test.Solver.getGatewayHTTPRoute(context.TODO(), test.Challenge)
+			if err != nil && !test.Err {
+				t.Errorf("Expected function to not error, but got: %v", err)
+			}
+			if err == nil && test.Err {
+				t.Errorf("Expected function to get an error, but got: %v", err)
+			}
+			test.Finish(t, resp, err)
+		})
+	}
+}
+
+func TestEnsureGatewayHTTPRoute(t *testing.T) {
+	tests := map[string]solverFixture{
+		"should update challenge httproute if service changes": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				_, err := s.Solver.createGatewayHTTPRoute(context.TODO(), s.Challenge, "anotherfakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				httpRoutes, err := s.Solver.httpRouteLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("error listing HTTPRoutes: %v", err)
+					t.Fail()
+					return
+				}
+
+				if len(httpRoutes) != 1 {
+					t.Errorf("Expected 1 HTTPRoute, but got: %v", len(httpRoutes))
+				}
+
+				gotHTTPRouteSpec := httpRoutes[0].Spec
+				expectedHTTPRoute := generateHTTPRouteSpec(s.Challenge, "fakeservice")
+				if !reflect.DeepEqual(gotHTTPRouteSpec, expectedHTTPRoute) {
+					t.Errorf("Expected HTTPRoute specs to match, but got diff:\n%v",
+						diff.ObjectDiff(gotHTTPRouteSpec, expectedHTTPRoute))
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.ensureGatewayHTTPRoute(context.TODO(), test.Challenge, "fakeservice")
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -1,0 +1,114 @@
+package http
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	gwapi "sigs.k8s.io/gateway-api/apis/v1"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+)
+
+func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
+	const createdHTTPRouteKey = "createdHTTPRoute"
+	tests := map[string]solverFixture{
+		"should return one httproute that matches": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				httpRoute, err := s.Solver.createGatewayHTTPRoute(context.TODO(), s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.testResources[createdHTTPRouteKey] = httpRoute
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				createdHTTPRoute := s.testResources[createdHTTPRouteKey].(*gwapi.HTTPRoute)
+				gotHttpRoute := args[0].(*gwapi.HTTPRoute)
+				if !reflect.DeepEqual(gotHttpRoute, createdHTTPRoute) {
+					t.Errorf("Expected %v to equal %v", gotHttpRoute, createdHTTPRoute)
+				}
+			},
+		},
+		"should return one httproute for IP that matches": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "10.0.0.1",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				httpRoute, err := s.Solver.createGatewayHTTPRoute(context.TODO(), s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.testResources[createdHTTPRouteKey] = httpRoute
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				createdHTTPRoute := s.testResources[createdHTTPRouteKey].(*gwapi.HTTPRoute)
+				gotHttpRoute := args[0].(*gwapi.HTTPRoute)
+				if !reflect.DeepEqual(gotHttpRoute, createdHTTPRoute) {
+					t.Errorf("Expected %v to equal %v", gotHttpRoute, createdHTTPRoute)
+				}
+			},
+		},
+		"should not return an httproute for the same certificate but different domain": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				differentChallenge := s.Challenge.DeepCopy()
+				differentChallenge.Spec.DNSName = "notexample.com"
+				_, err := s.Solver.createGatewayHTTPRoute(context.TODO(), differentChallenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				gotHttpRoute := args[0].(*gwapi.HTTPRoute)
+				if gotHttpRoute != nil {
+					t.Errorf("Expected function to not return an HTTPRoute, but got: %v", gotHttpRoute)
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.getGatewayHTTPRoute(context.TODO(), test.Challenge)
+			if err != nil && !test.Err {
+				t.Errorf("Expected function to not error, but got: %v", err)
+			}
+			if err == nil && test.Err {
+				t.Errorf("Expected function to get an error, but got: %v", err)
+			}
+			test.Finish(t, resp, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes #7176 

### Kind

/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md.

-->

```release-note
Fixes ACME HTTP01 challenge behaviour when using Gateway API to prevent unbounded creation of HTTPRoute resources
```
