### PR TITLE
Fix incorrect indentation of the PodMonitor template in the Helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -45,6 +45,6 @@ spec:
       scrapeTimeout: {{ .Values.prometheus.podmonitor.scrapeTimeout }}
       honorLabels: {{ .Values.prometheus.podmonitor.honorLabels }}
       {{- with .Values.prometheus.podmonitor.endpointAdditionalProperties }}
-      {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6459 @shlomitubul introduced a PodMonitor resource. 
There was a bug in the PodMonitor template where the servicemonitor.endpointAdditionalProperties were being added instead of podmonitor.endpointAdditionalProperties and that bug has been recently fixed by @inteon in https://github.com/cert-manager/cert-manager/pull/7069#pullrequestreview-2099180596

But there is an additional mistake in the indentation of those values which is only now apparent.

Here's how to recreate the issue:

```yaml
#value.yaml
prometheus:
  enabled: true
  podmonitor:
    enabled: true
    endpointAdditionalProperties:
      scheme: https
      tlsConfig:
        serverName: cert-manager-metrics
        ca:
          secret:
            name: cert-manager-metrics-ca
            key: "tls.crt"
```

```sh
git fetch origin master
git checkout FETCH_HEAD
make helm-chart
CHART=$(ls -1t _bin/cert-manager-*.tgz | head -n1)
helm template $CHART --values values.yaml --debug
```

```console
...
Error: YAML parse error on cert-manager/templates/podmonitor.yaml: error converting YAML to JSON: yaml: line 27: did not find expected '-' indicator
helm.go:84: [debug] error converting YAML to JSON: yaml: line 27: did not find expected '-' indicator
YAML parse error on cert-manager/templates/podmonitor.yaml
```

/kind bug

```release-note
Fix incorrect indentation of `endpointAdditionalProperties` in the `PodMonitor` template of the Helm chart
```

## Testing

```sh
git fetch origin pull/7190/head
git checkout FETCH_HEAD
make helm-chart
CHART=$(ls -1t _bin/cert-manager-*.tgz | head -n1)
helm template $CHART --values values.yaml --debug | grep -A 30 PodMonitor
```

```yaml
kind: PodMonitor
metadata:
  name: release-name-cert-manager
  namespace: default
  labels:
    app: cert-manager
    app.kubernetes.io/name: cert-manager
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: "controller"
    app.kubernetes.io/version: "v1.15.0-beta.1-103-gc5e95aac633b68"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: cert-manager-v1.15.0-beta.1-103-gc5e95aac633b68
    prometheus: default
spec:
  jobLabel: release-name-cert-manager
  selector:
    matchLabels:
      app.kubernetes.io/name: cert-manager
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: "controller"
  podMetricsEndpoints:
    - port: http-metrics
      path: /metrics
      interval: 60s
      scrapeTimeout: 30s
      honorLabels: false
      scheme: https
      tlsConfig:
        ca:
          secret:
            key: tls.crt
            name: cert-manager-metrics-ca
        serverName: cert-manager-metrics
---
```