### PR TITLE
Update the Google CloudBuild job image

### DIFF
--- a/gcb/build_cert_manager.yaml
+++ b/gcb/build_cert_manager.yaml
@@ -15,7 +15,7 @@ steps:
   args: ['fetch', '--unshallow']
 
 ## Build release artifacts and push to a bucket
-- name: 'eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye'
+- name: 'europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm'
   entrypoint: bash
   args:
   - -c


### PR DESCRIPTION
While trying to [release cert-manager v1.15.2-alpha.0](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1721810574344189), the [cloudbuild failed](https://console.cloud.google.com/cloud-build/builds;region=global/fd32d59d-8757-4a16-87c5-9d2061ebcf7f;step=1?project=cert-manager-release) after I [pushed the tag](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.2-alpha.0):
> Pulling image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
Error response from daemon: pull access denied for eu.gcr.io/jetstack-build-infra-images/make-dind, repository does not exist or may require 'docker login': denied: Permission denied for "20230406-0ef4440-bullseye" from request "/v2/jetstack-build-infra-images/make-dind/manifests/20230406-0ef4440-bullseye".

/kind bug

```release-note
None
```
