### PR TITLE
error out ACME Challenges when encountering non-ACME errors

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -385,8 +385,8 @@ func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 	}
 
 	log.V(logf.DebugLevel).Info("waiting for authorization for domain")
-	// The underlying ACME implementation from golang.org/x/crypto of WaitAuthorization retries on 
-	// response parsing errors.  In the event that an ACME server is not returning expected JSON 
+	// The underlying ACME implementation from golang.org/x/crypto of WaitAuthorization retries on
+	// response parsing errors.  In the event that an ACME server is not returning expected JSON
 	// responses, the call to WaitAuthorization can and has been seen to not return and loop forever,
 	// blocking the challenge's processing. Here, we defensively add a timeout for this exchange
 	// with the ACME server and a "context deadline reached" error will be returned by WaitAuthorization

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -136,8 +136,6 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 	if ch.Status.State == "" {
 		err := c.syncChallengeStatus(ctx, cl, ch)
 		if err != nil {
-			logf.V(logf.ErrorLevel).ErrorS(err, "error synchronizing with ACME server")
-			ch.Status.Reason = fmt.Sprintf("error synchronizing with ACME server: %v", err)
 			return handleError(ch, err)
 		}
 
@@ -395,8 +393,7 @@ func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 	defer cancelAuthorization()
 	authorization, err := cl.WaitAuthorization(ctxTimeout, ch.Spec.AuthorizationURL)
 	if err != nil {
-		log.V(logf.ErrorLevel).Error(err, "error waiting for authorization")
-		ch.Status.Reason = fmt.Sprintf("Error waiting for authorization: %v", err)
+		log.Error(err, "error waiting for authorization")
 		return c.handleAuthorizationError(ch, err)
 	}
 

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -203,7 +203,17 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengeProcessing(true),
 					gen.SetChallengeURL("testurl"),
 				), testIssuerHTTP01Enabled},
-				ExpectedActions: []testpkg.Action{},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(
+						coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
+							"status",
+							gen.DefaultTestNamespace,
+							gen.ChallengeFrom(baseChallenge,
+								gen.SetChallengeURL("testurl"),
+								gen.SetChallengeProcessing(true),
+								gen.SetChallengeReason("unexpected non-ACME API error: challenge was not present in authorization"),
+								gen.SetChallengeState(cmacme.Errored)))),
+				},
 			},
 			expectErr: true,
 			acmeClient: &acmecl.FakeACME{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

I encountered several ACME challenges that were stuck in bad state, with no associated DNS01 TXT record.
Specifically, in the logs, I saw the error: "challenge was not present in authorization", from pkg/controller/acmechallenges/sync.go:syncChallengeStatus()
Since this error is not of type acmeapi.error, handleError was returning immediately:
```
	if acmeErr, ok = err.(*acmeapi.Error); !ok {
		return err
	}
```
When I tried deleting the challenge manually, the challenge was still not presented to the ACME server, and the code that `Present`'s the challenge is never reached because when `ch.status.State` is empty and `syncChallengeState` returns an error, the Sync method exits immediately. I also looked at the ACME server's console and did not see pending verifications for the domain in question.

Seems that the correct way to proceed in `handleError` is to change the state to `errored` for this condition. I tested this on a cluster and this change caused all such challenges to error out and cleanUp on the next sync run, since `errored` is a final state (line 102 in sync.go), and then present the challenge as expected on the next run.

I looked for possible side effects of this behavior change by looking at what errors are being returned in all callers to `handleError`, and each call is to a function in the `acmecl` interface, except for `syncControllerState`, which possibly returns two errors of the base error type.
Perhaps the `handleError` err parameter should change to `acmeapi.Error` if it indeed is only supposed to handle errors of that type, but the `acmecl` interface calls do return the base error type, as well, so it might not be a safe assumption to make.


### Kind

bug

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
handle errors arising from challenges missing from the ACME server
```
