### PR TITLE
[release-1.12] chore: update go to 1.21.13

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -56,7 +56,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.11
+VENDORED_GO_VERSION := 1.21.13
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
### Pull Request Motivation

Updates the version of Go to 1.21.13 to resolve CVE-2024-24791

### Kind

<!--

Pick a kind which best describes your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->
/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Updates Go to 1.21.13 to resolve CVE-2024-24791
```
