### PR TITLE
fix: update shasum for docker.io/ubuntu/bind9

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -30,7 +30,7 @@ IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.10.1@sha
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:127def0e41f49fea6e260abf7b1662fe7bdfb9f33e8f9047fb74d0162a5697bb
 IMAGE_kyvernopre_amd64 := ghcr.io/kyverno/kyvernopre:v1.12.3@sha256:d388cd67b38fb4f55eb5e38107dbbce9e06208b8e3839f0b63f8631f286181be
 IMAGE_vault_amd64 := docker.io/hashicorp/vault:1.14.1@sha256:436d056e8e2a96c7356720069c29229970466f4f686886289dcc94dfa21d3155
-IMAGE_bind_amd64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:d4e3d143d0619eff7b34f7f3c19160bceb94615ba376f6f78b8b67abb84754e2
+IMAGE_bind_amd64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:0cf4cbf9d4ff65613e8c8574b65dadc6ec83785fc44779bcb9fa480b2c0b0914
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:964b378fe0dda7fc38ce3f211c3b24c780e44cef13c39d3206de985bad67f294
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:bb7af851ac5832c315e0863d12ed583cee54c495d58a206f1d0897647505ed70
 
@@ -38,7 +38,7 @@ IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.10.1@sha
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:c076a1ba9e0fb33d8eca3e7499caddfa3bb4f5e52e9dee589d8476ae1688cd34
 IMAGE_kyvernopre_arm64 := ghcr.io/kyverno/kyvernopre:v1.12.3@sha256:d8d750012ed4bb46fd41d8892e92af6fb9fd212317bc23e68a2a47199646b04a
 IMAGE_vault_arm64 := docker.io/hashicorp/vault:1.14.1@sha256:27dd264f3813c71a66792191db5382f0cf9eeaf1ae91770634911facfcfe4837
-IMAGE_bind_arm64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:b2405abacaee3e3e65f5dc8a0c28c7f05788307d32c2d23dab0c06f33aaa7c64
+IMAGE_bind_arm64 := docker.io/ubuntu/bind9:9.18-22.04_beta@sha256:8dd697024f794e20ab44b805144ce27e0a14bbddd6cce2c14aeeaf45140a2e33
 IMAGE_sampleexternalissuer_arm64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:bdff00089ec7581c0d12414ce5ad1c6ccf5b6cacbfb0b0804fefe5043a1cb849
 IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:dbfec77951e123bf383a09412a51df218b716aaf3fe7b2778bb2f208ac495dc5
 


### PR DESCRIPTION
### Pull Request Motivation

E2E setup is currently broken because the bind9 image we are using got pushed over, changing its shasum

### Kind

/kind bug

### Release Note

```release-note
NONE
```
