### PR TITLE
[release-1.12] Update cmd/cmctl's go.mod to v1.12.13

### DIFF
--- a/cmd/ctl/go.mod
+++ b/cmd/ctl/go.mod
@@ -12,7 +12,7 @@ go 1.21
 // or a branch name (master).
 
 require (
-	github.com/cert-manager/cert-manager v1.12.12
+	github.com/cert-manager/cert-manager v1.12.13
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/cmd/ctl/go.sum
+++ b/cmd/ctl/go.sum
@@ -50,8 +50,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.12.12 h1:upG8EhS1bLdX1VlZkmKD2QBjld/aXtjVKvTsZkbWEQ4=
-github.com/cert-manager/cert-manager v1.12.12/go.mod h1:HyVU+Ar7qwPoBJVART8rCoDgjLQZOvnOqw35v9Z8vPI=
+github.com/cert-manager/cert-manager v1.12.13 h1:eDXRneq8ksiJdm3mDiIDGmAGK6VNYBD9LeFelbWOZK0=
+github.com/cert-manager/cert-manager v1.12.13/go.mod h1:p6GGox+cdH+9oelFw1eNdC8AoRHmwUMKrIrA69hZCG8=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -9,7 +9,7 @@ replace github.com/cert-manager/cert-manager/cmd/ctl => ../../cmd/ctl/
 replace github.com/cert-manager/cert-manager/webhook-binary => ../../cmd/webhook/
 
 require (
-	github.com/cert-manager/cert-manager v1.12.12
+	github.com/cert-manager/cert-manager v1.12.13
 	github.com/cert-manager/cert-manager/cmd/ctl v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.3.0
 	github.com/miekg/dns v1.1.50


### PR DESCRIPTION
This PR cmd/cmctl's go.mod to v1.12.13 as part of the release process.

**To the reviewer:** the version changes in `go.mod` must be reviewed.

```release-note
NONE
```
