### PR TITLE
Add unit tests for tls authority logic

### DIFF
--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -86,6 +86,8 @@ type DynamicAuthority struct {
 	// watchMutex gates access to the slice of watch channels
 	watchMutex sync.Mutex
 	watches    []chan<- struct{}
+
+	newClient func() (kubernetes.Interface, error) // for testing
 }
 
 type SignFunc func(template *x509.Certificate) (*x509.Certificate, error)
@@ -107,9 +109,19 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 		d.LeafDuration = time.Hour * 24 * 7 // 7d
 	}
 
-	cl, err := kubernetes.NewForConfig(d.RESTConfig)
-	if err != nil {
-		return err
+	var cl kubernetes.Interface
+	if d.newClient == nil {
+		var err error
+		cl, err = kubernetes.NewForConfig(d.RESTConfig)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		cl, err = d.newClient()
+		if err != nil {
+			return err
+		}
 	}
 
 	escapedName := fields.EscapeValue(d.SecretName)
@@ -133,7 +145,13 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 
 	// start the informers and wait for the cache to sync
 	factory.Start(ctx.Done())
+	defer factory.Shutdown()
+
 	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		if ctx.Err() != nil { // context was cancelled, we are shutting down; so, don't return an error because the informer caches were not yet synced
+			return nil
+		}
+
 		return fmt.Errorf("failed waiting for informer caches to sync")
 	}
 
@@ -157,8 +175,6 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 		return err
 	}
 
-	factory.Shutdown()
-
 	return nil
 }
 
@@ -168,6 +184,10 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 func (d *DynamicAuthority) Sign(template *x509.Certificate) (*x509.Certificate, error) {
 	d.signMutex.Lock()
 	defer d.signMutex.Unlock()
+
+	if d.currentCertData == nil || d.currentPrivateKeyData == nil {
+		return nil, fmt.Errorf("no tls.Certificate available yet, try again later")
+	}
 
 	// tls.X509KeyPair performs a number of verification checks against the
 	// keypair, so we run it to verify the certificate and private key are
@@ -244,12 +264,14 @@ func (d *DynamicAuthority) ensureCA(ctx context.Context) error {
 
 	s, err := d.lister.Get(d.SecretName)
 	if apierrors.IsNotFound(err) {
+		d.log.V(logf.DebugLevel).Info("Will regenerate CA", "reason", "CA secret not found")
 		return d.regenerateCA(ctx, nil)
 	}
 	if err != nil {
 		return err
 	}
-	if d.caRequiresRegeneration(s) {
+	if required, reason := caRequiresRegeneration(s); required {
+		d.log.V(logf.DebugLevel).Info("Will regenerate CA", "reason", reason)
 		return d.regenerateCA(ctx, s.DeepCopy())
 	}
 	d.notifyWatches(s.Data[corev1.TLSCertKey], s.Data[corev1.TLSPrivateKeyKey])
@@ -262,7 +284,14 @@ func (d *DynamicAuthority) notifyWatches(newCertData, newPrivateKeyData []byte) 
 		return
 	}
 
-	d.log.V(logf.DebugLevel).Info("Detected change in CA secret data, notifying watchers...")
+	d.log.V(logf.InfoLevel).Info("Detected change in CA secret data, update current CA data and notify watches")
+
+	func() {
+		d.signMutex.Lock()
+		defer d.signMutex.Unlock()
+		d.currentCertData = newCertData
+		d.currentPrivateKeyData = newPrivateKeyData
+	}()
 
 	func() {
 		d.watchMutex.Lock()
@@ -276,53 +305,42 @@ func (d *DynamicAuthority) notifyWatches(newCertData, newPrivateKeyData []byte) 
 			}
 		}
 	}()
-
-	func() {
-		d.signMutex.Lock()
-		defer d.signMutex.Unlock()
-		d.currentCertData = newCertData
-		d.currentPrivateKeyData = newPrivateKeyData
-	}()
 }
 
 // caRequiresRegeneration will check data in a Secret resource and return true
 // if the CA needs to be regenerated for any reason.
-func (d *DynamicAuthority) caRequiresRegeneration(s *corev1.Secret) bool {
+func caRequiresRegeneration(s *corev1.Secret) (bool, string) {
 	if s.Data == nil {
-		return true
+		return true, "Missing data in CA secret."
 	}
 	caData := s.Data[cmmeta.TLSCAKey]
 	pkData := s.Data[corev1.TLSPrivateKeyKey]
 	certData := s.Data[corev1.TLSCertKey]
 	if len(caData) == 0 || len(pkData) == 0 || len(certData) == 0 {
-		d.log.V(logf.InfoLevel).Info("Missing data in CA secret. Regenerating")
-		return true
+		return true, "Missing data in CA secret."
 	}
 	// ensure that the ca.crt and tls.crt keys are equal
 	if !bytes.Equal(caData, certData) {
-		return true
+		return true, "Different data in ca.crt and tls.crt."
 	}
 	cert, err := tls.X509KeyPair(certData, pkData)
 	if err != nil {
-		d.log.Error(err, "Failed to parse data in CA secret. Regenerating")
-		return true
+		return true, "Failed to parse data in CA secret."
 	}
 
 	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		d.log.Error(err, "internal error parsing x509 certificate")
-		return true
+		return true, "Internal error parsing x509 certificate."
 	}
 	if !x509Cert.IsCA {
-		d.log.V(logf.InfoLevel).Info("Stored certificate is not marked as a CA. Regenerating...")
-		return true
+		return true, "Stored certificate is not marked as a CA."
 	}
 	// renew the root CA when the current one is 2/3 of the way through its life
 	if time.Until(x509Cert.NotAfter) < (x509Cert.NotAfter.Sub(x509Cert.NotBefore) / 3) {
-		d.log.V(logf.InfoLevel).Info("Root CA certificate is nearing expiry. Regenerating...")
-		return true
+		return true, "Root CA certificate is nearing expiry."
 	}
-	return false
+
+	return false, ""
 }
 
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
@@ -331,7 +349,6 @@ var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 // If the provided Secret is nil, a new secret resource will be Created.
 // Otherwise, the provided resource will be modified and Updated.
 func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) error {
-	d.log.V(logf.DebugLevel).Info("Generating new root CA")
 	pk, err := pki.GenerateECPrivateKey(384)
 	if err != nil {
 		return err
@@ -383,6 +400,13 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 				cmmeta.TLSCAKey:         certBytes,
 			},
 		}, metav1.CreateOptions{})
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			// another controller has created the secret, we expect a watch event
+			// to trigger another call to ensureCA
+			d.log.V(logf.DebugLevel).Info("Failed to create new root CA Secret, another controller has created it, waiting for watch event")
+			return nil
+		}
+		d.log.V(logf.InfoLevel).Info("Created new root CA Secret")
 		return err
 	}
 
@@ -392,11 +416,9 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 	s.Data[corev1.TLSCertKey] = certBytes
 	s.Data[corev1.TLSPrivateKeyKey] = pkBytes
 	s.Data[cmmeta.TLSCAKey] = certBytes
-	if _, err := d.client.Update(ctx, s, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-	d.log.V(logf.DebugLevel).Info("Generated new root CA")
-	return nil
+	_, err = d.client.Update(ctx, s, metav1.UpdateOptions{})
+	d.log.V(logf.InfoLevel).Info("Updated existing root CA Secret")
+	return err
 }
 
 func (d *DynamicAuthority) handleAdd(obj interface{}) {

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -17,20 +17,170 @@ limitations under the License.
 package authority
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"testing"
 	"time"
 
+	testlogr "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
 // Integration tests for the authority can be found in `test/integration/webhook/dynamic_authority_test.go`.
+
+func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAuthority {
+	logger := testlogr.NewTestLoggerWithOptions(t, testlogr.Options{
+		Verbosity: 3,
+	})
+	logger = logger.WithName(name)
+
+	da := &DynamicAuthority{
+		SecretNamespace: "test-namespace",
+		SecretName:      "test-secret",
+		CADuration:      365 * 24 * time.Hour,
+		LeafDuration:    7 * 24 * time.Hour,
+
+		newClient: func() (kubernetes.Interface, error) {
+			return cs, nil
+		},
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := da.Run(logf.NewContext(runCtx, logger)); err != nil {
+			t.Error(err)
+		}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	return da
+}
+
+func TestDynamicAuthority(t *testing.T) {
+	fake := kubefake.NewSimpleClientset()
+
+	da := testAuthority(t, "authority", fake)
+
+	// Test WatchRotation function
+	output := make(chan struct{}, 1)
+	da.WatchRotation(output)
+	defer da.StopWatchingRotation(output)
+
+	waitForRotationAndSign := func(testInitial bool) {
+		privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template := &x509.Certificate{
+			PublicKey: privateKey.Public(),
+		}
+
+		if testInitial {
+			// If Sign works, we don't need to wait for rotation
+			cert, err := da.Sign(template)
+			if err == nil {
+				assert.NotNil(t, cert)
+				return
+			}
+		}
+
+		select {
+		case <-output:
+			// Rotation detected
+			cert, err := da.Sign(template)
+			assert.NoError(t, err)
+			assert.NotNil(t, cert)
+		case <-time.After(5 * time.Second):
+			t.Error("Timeout waiting for rotation")
+
+			t.Log("Queue length:", len(output))
+		}
+	}
+
+	waitForRotationAndSign(true)
+
+	err := fake.CoreV1().Secrets(da.SecretNamespace).Delete(context.TODO(), da.SecretName, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	waitForRotationAndSign(false)
+
+	secret, err := fake.CoreV1().Secrets(da.SecretNamespace).Get(context.TODO(), da.SecretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	secret.Data = map[string][]byte{
+		"tls.crt": []byte("test"),
+		"tls.key": []byte("test"),
+	}
+	_, err = fake.CoreV1().Secrets(da.SecretNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	waitForRotationAndSign(false)
+}
+
+func TestDynamicAuthorityMulti(t *testing.T) {
+	fake := kubefake.NewSimpleClientset()
+
+	authorities := make([]*DynamicAuthority, 0)
+	for i := 0; i < 200; i++ {
+		da := testAuthority(t, fmt.Sprintf("authority-%d", i), fake)
+		authorities = append(authorities, da)
+	}
+
+	da := authorities[0]
+
+	output := make(chan struct{}, 1)
+	da.WatchRotation(output)
+	defer da.StopWatchingRotation(output)
+
+	waitForRotationAndSign := func() {
+		privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template := &x509.Certificate{
+			PublicKey: privateKey.Public(),
+		}
+
+		// If Sign works, we don't need to wait for rotation
+		cert, err := da.Sign(template)
+		if err == nil {
+			assert.NotNil(t, cert)
+			return
+		}
+
+		select {
+		case <-output:
+			// Rotation detected
+			cert, err := da.Sign(template)
+			assert.NoError(t, err)
+			assert.NotNil(t, cert)
+		case <-time.After(5 * time.Second):
+			t.Error("Timeout waiting for rotation")
+
+			t.Log("Queue length:", len(output))
+		}
+	}
+
+	waitForRotationAndSign()
+}
 
 func Test__caRequiresRegeneration(t *testing.T) {
 	generateSecretData := func(mod func(*x509.Certificate)) map[string][]byte {
@@ -70,16 +220,18 @@ func Test__caRequiresRegeneration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		secret *corev1.Secret
-		expect bool
+		name         string
+		secret       *corev1.Secret
+		expect       bool
+		expectReason string
 	}{
 		{
 			name: "Missing data in CA secret (nil data)",
 			secret: &corev1.Secret{
 				Data: nil,
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Missing data in CA secret.",
 		},
 		{
 			name: "Missing data in CA secret (missing ca.crt)",
@@ -88,7 +240,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					"tls.key": []byte("private key"),
 				},
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Missing data in CA secret.",
 		},
 		{
 			name: "Different data in ca.crt and tls.crt",
@@ -99,7 +252,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					"tls.key": []byte("secret"),
 				},
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Different data in ca.crt and tls.crt.",
 		},
 		{
 			name: "Failed to parse data in CA secret",
@@ -110,7 +264,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					"tls.key": []byte("secret"),
 				},
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Failed to parse data in CA secret.",
 		},
 		{
 			name: "Stored certificate is not marked as a CA",
@@ -121,7 +276,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					},
 				),
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Stored certificate is not marked as a CA.",
 		},
 		{
 			name: "Root CA certificate is JUST nearing expiry",
@@ -133,7 +289,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					},
 				),
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Root CA certificate is nearing expiry.",
 		},
 		{
 			name: "Root CA certificate is ALMOST nearing expiry",
@@ -157,22 +314,27 @@ func Test__caRequiresRegeneration(t *testing.T) {
 					},
 				),
 			},
-			expect: true,
+			expect:       true,
+			expectReason: "Root CA certificate is nearing expiry.",
 		},
 		{
 			name: "Ok",
 			secret: &corev1.Secret{
 				Data: generateSecretData(nil),
 			},
-			expect: false,
+			expect:       false,
+			expectReason: "",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			required := (&DynamicAuthority{}).caRequiresRegeneration(test.secret)
+			required, reason := caRequiresRegeneration(test.secret)
 			if required != test.expect {
 				t.Errorf("Expected %v, but got %v", test.expect, required)
+			}
+			if reason != test.expectReason {
+				t.Errorf("Expected %q, but got %q", test.expectReason, reason)
 			}
 		})
 	}

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -53,7 +54,7 @@ func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAu
 		CADuration:      365 * 24 * time.Hour,
 		LeafDuration:    7 * 24 * time.Hour,
 
-		newClient: func() (kubernetes.Interface, error) {
+		newClient: func(_ *rest.Config) (kubernetes.Interface, error) {
 			return cs, nil
 		},
 	}
@@ -290,7 +291,7 @@ func Test__caRequiresRegeneration(t *testing.T) {
 				),
 			},
 			expect:       true,
-			expectReason: "Root CA certificate is nearing expiry.",
+			expectReason: "CA certificate is nearing expiry.",
 		},
 		{
 			name: "Root CA certificate is ALMOST nearing expiry",
@@ -315,7 +316,7 @@ func Test__caRequiresRegeneration(t *testing.T) {
 				),
 			},
 			expect:       true,
-			expectReason: "Root CA certificate is nearing expiry.",
+			expectReason: "CA certificate is nearing expiry.",
 		},
 		{
 			name: "Ok",

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
+// Integration tests for the DynamicSource can be found in `test/integration/webhook/dynamic_source_test.go`.
+
 func signUsingTempCA(t *testing.T, template *x509.Certificate) *x509.Certificate {
 	// generate random ca private key
 	caPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)


### PR DESCRIPTION
Adds unit tests and intruces a few minor changes to improve logging and make the test work as expected. Should make the logs a lot more insightful.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
