### PR TITLE
WIP: Allow STS token to be refreshed by the AWS client if necessary

### DIFF
--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -630,6 +630,7 @@ type ServiceAccountRef struct {
 	// and name is always included.
 	// If unset the audience defaults to `sts.amazonaws.com`.
 	// +optional
+	// +default=["sts.amazonaws.com"]
 	TokenAudiences []string `json:"audiences,omitempty"`
 }
 

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -140,8 +141,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			}
 			return nil, nil
 		},
-		route53: func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error) {
-			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, webIdentityToken, ambient, util.RecursiveNameservers)
+		route53: func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role string, webIdentityTokenRetriever stscreds.IdentityTokenRetriever, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error) {
+			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, webIdentityTokenRetriever, ambient, util.RecursiveNameservers)
 			return nil, nil
 		},
 		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error) {


### PR DESCRIPTION
I https://github.com/cert-manager/cert-manager/issues/7102#issuecomment-2276697596, @ealogar reports the folowing error when using the Route53 DNS-01 solver with the [AssumeRoleWithWebIdentity authentication method](https://cert-manager.io/docs/configuration/acme/dns01/route53/#referencing-your-own-serviceaccount-within-issuerclusterissuer-config):
> │ E0808 21:29:29.746771       1 controller.go:162] "re-queuing item due to error processing" err="failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, endpoint rule  │
│ error, Invalid Configuration: Missing Region" logger="cert-manager.controller" key="xxxxxxxxxxxxxxx"

The message "failed to refresh cached credentials" makes me wonder  whether the problem might be that there's a delay in the following sequence during which the STS token expires:
1. [re-queuing item due to error processing](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/controller/controller.go#L162)
2. [route53:NewDNSProvider](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L181)
3. [route53:provider.GetSession](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L190C14-L190C33)
4. [stsSvc.AssumeRoleWithWebIdentity](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L129)
5. [route53:Present](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L207)
6. route53:changeRecord: [failed to determine Route 53 hosted zone ID](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L221)
7. route53:getHostedZoneID: util.FindZoneByFqdn (takes longer than X seconds during which STS token has expired)
8. route53:getHostedZoneID: [operation error Route 53: ListHostedZonesByName](https://github.com/cert-manager/cert-manager/blob/release-1.15/pkg/issuer/acme/dns/route53/route53.go#L281-L284)
9. internal/auth/smithy/credentials_adapter.go#L42: [get credentials](https://github.com/aws/aws-sdk-go-v2/blob/51ca5b5729bc6a8599fe5b8d9aa193df22290db3/internal/auth/smithy/credentials_adapter.go#L42)
10. aws/credential_cache.go#L128: [failed to refresh cached credentials](https://github.com/aws/aws-sdk-go-v2/blob/51ca5b5729bc6a8599fe5b8d9aa193df22290db3/aws/credential_cache.go#L128)

Fixes: #7108
 * #7108
```release-note
NONE
```
