### PR TITLE
Route53: Allow STS token to be refreshed by the AWS client if necessary

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -23,10 +23,8 @@ import (
 	"strings"
 	"time"
 
-	authv1 "k8s.io/api/authentication/v1"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
@@ -61,7 +59,7 @@ type solver interface {
 type dnsProviderConstructors struct {
 	cloudDNS     func(ctx context.Context, project string, serviceAccount []byte, dns01Nameservers []string, ambient bool, hostedZoneName string) (*clouddns.DNSProvider, error)
 	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string) (*cloudflare.DNSProvider, error)
-	route53      func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
+	route53      func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role string, webIdentityTokenRetriever stscreds.IdentityTokenRetriever, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
 	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error)
 	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
 	digitalOcean func(token string, dns01Nameservers []string, userAgent string) (*digitalocean.DNSProvider, error)
@@ -346,7 +344,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			secretAccessKey = string(secretAccessKeyBytes)
 		}
 
-		webIdentityToken := ""
+		var webIdentityTokenRetriever stscreds.IdentityTokenRetriever
 		if providerConfig.Route53.Auth != nil && providerConfig.Route53.Auth.Kubernetes != nil && providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef != nil {
 			if providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name == "" {
 				return nil, nil, fmt.Errorf("service account name is required for Kubernetes auth")
@@ -357,12 +355,12 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 				audiences = providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.TokenAudiences
 			}
 
-			jwt, err := s.createToken(ctx, resourceNamespace, providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name, audiences)
-			if err != nil {
-				return nil, nil, fmt.Errorf("error getting service account token: %w", err)
+			webIdentityTokenRetriever = &route53.KubernetesServiceAccountTokenRetriever{
+				ServiceAccountName: providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name,
+				Audiences:          audiences,
+				Namespace:          resourceNamespace,
+				Client:             s.Client.CoreV1().ServiceAccounts(resourceNamespace),
 			}
-
-			webIdentityToken = jwt
 		}
 
 		impl, err = s.dnsProviderConstructors.route53(
@@ -372,7 +370,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			providerConfig.Route53.HostedZoneID,
 			providerConfig.Route53.Region,
 			providerConfig.Route53.Role,
-			webIdentityToken,
+			webIdentityTokenRetriever,
 			canUseAmbientCredentials,
 			s.DNS01Nameservers,
 			s.RESTConfig.UserAgent,
@@ -558,18 +556,4 @@ func (s *Solver) loadSecretData(selector *cmmeta.SecretKeySelector, ns string) (
 	}
 
 	return nil, fmt.Errorf("no key %q in secret %q", selector.Key, ns+"/"+selector.Name)
-}
-
-func (s *Solver) createToken(ctx context.Context, ns, serviceAccount string, audiences []string) (string, error) {
-	tokenrequest, err := s.Client.CoreV1().ServiceAccounts(ns).CreateToken(ctx, serviceAccount, &authv1.TokenRequest{
-		Spec: authv1.TokenRequestSpec{
-			Audiences:         audiences,
-			ExpirationSeconds: ptr.To(int64(600)),
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return "", fmt.Errorf("failed to request token for %s/%s: %w", ns, serviceAccount, err)
-	}
-
-	return tokenrequest.Status.Token, nil
 }

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -18,9 +18,11 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -398,13 +400,10 @@ func TestRoute53TrimCreds(t *testing.T) {
 	expectedR53Call := []fakeDNSProviderCall{
 		{
 			name: "route53",
-			args: []interface{}{"test_with_spaces", "AKIENDINNEWLINE", "", "us-west-2", "", "", false, util.RecursiveNameservers},
+			args: []interface{}{"test_with_spaces", "AKIENDINNEWLINE", "", "us-west-2", "", nil, false, util.RecursiveNameservers},
 		},
 	}
-
-	if !reflect.DeepEqual(expectedR53Call, f.dnsProviders.calls) {
-		t.Fatalf("expected %+v == %+v", expectedR53Call, f.dnsProviders.calls)
-	}
+	require.Equal(t, expectedR53Call, f.dnsProviders.calls)
 }
 
 func TestRoute53SecretAccessKey(t *testing.T) {
@@ -458,13 +457,10 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 	expectedR53Call := []fakeDNSProviderCall{
 		{
 			name: "route53",
-			args: []interface{}{"AWSACCESSKEYID", "AKIENDINNEWLINE", "", "us-west-2", "", "", false, util.RecursiveNameservers},
+			args: []interface{}{"AWSACCESSKEYID", "AKIENDINNEWLINE", "", "us-west-2", "", nil, false, util.RecursiveNameservers},
 		},
 	}
-
-	if !reflect.DeepEqual(expectedR53Call, f.dnsProviders.calls) {
-		t.Fatalf("expected %+v == %+v", expectedR53Call, f.dnsProviders.calls)
-	}
+	require.Equal(t, expectedR53Call, f.dnsProviders.calls)
 }
 
 func TestRoute53AmbientCreds(t *testing.T) {
@@ -508,7 +504,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 			result{
 				expectedCall: &fakeDNSProviderCall{
 					name: "route53",
-					args: []interface{}{"", "", "", "us-west-2", "", "", true, util.RecursiveNameservers},
+					args: []interface{}{"", "", "", "us-west-2", "", nil, true, util.RecursiveNameservers},
 				},
 			},
 		},
@@ -543,27 +539,27 @@ func TestRoute53AmbientCreds(t *testing.T) {
 			result{
 				expectedCall: &fakeDNSProviderCall{
 					name: "route53",
-					args: []interface{}{"", "", "", "us-west-2", "", "", false, util.RecursiveNameservers},
+					args: []interface{}{"", "", "", "us-west-2", "", nil, false, util.RecursiveNameservers},
 				},
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		f := tt.in
-		f.Setup(t)
-		defer f.Finish(t)
-		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
-		if tt.out.expectedErr != err {
-			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
-		}
-
-		if tt.out.expectedCall != nil {
-			if !reflect.DeepEqual([]fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls) {
-				t.Fatalf("expected %+v == %+v", []fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls)
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f := tt.in
+			f.Setup(t)
+			defer f.Finish(t)
+			s := f.Solver
+			_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
+			if tt.out.expectedErr != err {
+				t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 			}
-		}
+
+			if tt.out.expectedCall != nil {
+				require.Equal(t, []fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls)
+			}
+		})
 	}
 }
 
@@ -609,7 +605,7 @@ func TestRoute53AssumeRole(t *testing.T) {
 			result{
 				expectedCall: &fakeDNSProviderCall{
 					name: "route53",
-					args: []interface{}{"", "", "", "us-west-2", "my-role", "", true, util.RecursiveNameservers},
+					args: []interface{}{"", "", "", "us-west-2", "my-role", nil, true, util.RecursiveNameservers},
 				},
 			},
 		},
@@ -645,26 +641,26 @@ func TestRoute53AssumeRole(t *testing.T) {
 			result{
 				expectedCall: &fakeDNSProviderCall{
 					name: "route53",
-					args: []interface{}{"", "", "", "us-west-2", "my-other-role", "", false, util.RecursiveNameservers},
+					args: []interface{}{"", "", "", "us-west-2", "my-other-role", nil, false, util.RecursiveNameservers},
 				},
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		f := tt.in
-		f.Setup(t)
-		defer f.Finish(t)
-		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
-		if tt.out.expectedErr != err {
-			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
-		}
-
-		if tt.out.expectedCall != nil {
-			if !reflect.DeepEqual([]fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls) {
-				t.Fatalf("expected %+v == %+v", []fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls)
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f := tt.in
+			f.Setup(t)
+			defer f.Finish(t)
+			s := f.Solver
+			_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
+			if tt.out.expectedErr != err {
+				t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 			}
-		}
+
+			if tt.out.expectedCall != nil {
+				require.Equal(t, []fakeDNSProviderCall{*tt.out.expectedCall}, f.dnsProviders.calls)
+			}
+		})
 	}
 }

--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -1,4 +1,18 @@
-// +skip_license_check
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 /*
 This file contains portions of code directly taken from the 'xenolf/lego' project.
@@ -7,6 +21,83 @@ this directory.
 */
 
 package route53
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Examples
+var AssumeRoleWithWebIdentityResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
+    <Audience>client.5498841531868486423.1548@apps.example.com</Audience>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1</Arn>
+      <AssumedRoleId>AROACLKWSDQRAOEXAMPLE:app1</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <SessionToken>AQoDYXdzEE0a8ANXXXXXXXXNO1ewxE5TijQyp+IEXAMPLE</SessionToken>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+      <Expiration>2014-10-24T23:00:23Z</Expiration>
+      <AccessKeyId>ASgeIAIOSFODNN7EXAMPLE</AccessKeyId>
+    </Credentials>
+    <SourceIdentity>SourceIdentityValue</SourceIdentity>
+    <Provider>www.amazon.com</Provider>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata>
+    <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+  </ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
+var AssumeRoleWithWebIdentity400Response = `<?xml version="1.0"?>
+<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error>
+	<Type>Sender</Type>
+	<Code>ValidationError</Code>
+	<Message>Request ARN is invalid</Message>
+  </Error>
+  <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+</ErrorResponse>
+`
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_Examples
+var AssumeRoleResponse = `<?xml version="1.0"?>
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+  <SourceIdentity>Alice</SourceIdentity>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/demo/TestAR</Arn>
+      <AssumedRoleId>ARO123EXAMPLE123:TestAR</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>ASIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>
+       AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQW
+       LWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGd
+       QrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXDvp75YU
+       9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64lIZbqBAz
+       +scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2ICCR/oLxBA==
+      </SessionToken>
+      <Expiration>2019-11-09T13:34:41Z</Expiration>
+    </Credentials>
+    <PackedPolicySize>6</PackedPolicySize>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>
+`
+
+// https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
+var AssumeRole403Response = `<?xml version="1.0"?>
+<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error>
+	<Type>Sender</Type>
+	<Code>InvalidClientTokenId</Code>
+	<Message>The security token included in the request is invalid.</Message>
+  </Error>
+  <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+</ErrorResponse>
+`
 
 var ChangeResourceRecordSetsResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -1,4 +1,18 @@
-// +skip_license_check
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 /*
 This file contains portions of code directly taken from the 'xenolf/lego' project.
@@ -22,11 +36,15 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/logging"
 	"github.com/aws/smithy-go/middleware"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -45,35 +63,72 @@ type DNSProvider struct {
 }
 
 type sessionProvider struct {
-	AccessKeyID      string
-	SecretAccessKey  string
-	Ambient          bool
-	Region           string
-	Role             string
-	WebIdentityToken string
-	StsProvider      func(aws.Config) StsClient
-	userAgent        string
+	AccessKeyID               string
+	SecretAccessKey           string
+	Ambient                   bool
+	Region                    string
+	Role                      string
+	webIdentityTokenRetriever stscreds.IdentityTokenRetriever
+	userAgent                 string
 }
 
-type StsClient interface {
-	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
-	AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error)
-}
-
-func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
-	switch {
-	case d.Role == "" && d.WebIdentityToken != "":
-		return aws.Config{}, fmt.Errorf("unable to construct route53 provider: role must be set when web identity token is set")
-	case d.AccessKeyID == "" && d.SecretAccessKey == "":
-		if !d.Ambient && d.WebIdentityToken == "" {
-			return aws.Config{}, fmt.Errorf("unable to construct route53 provider: empty credentials; perhaps you meant to enable ambient credentials?")
-		}
-	case d.AccessKeyID == "" || d.SecretAccessKey == "":
-		// It's always an error to set one of those but not the other
-		return aws.Config{}, fmt.Errorf("unable to construct route53 provider: only one of access and secret key was provided")
+func NewWrappedSTSClient(ctx context.Context, optFns ...func(*config.LoadOptions) error) (*stsWrapper, error) {
+	stsCfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	if err != nil {
+		return nil, err
 	}
+	return &stsWrapper{
+		wrapped: sts.NewFromConfig(stsCfg),
+	}, nil
+}
 
-	useAmbientCredentials := d.Ambient && (d.AccessKeyID == "" && d.SecretAccessKey == "") && d.WebIdentityToken == ""
+type stsWrapper struct {
+	wrapped *sts.Client
+}
+
+func (o *stsWrapper) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	out, err := o.wrapped.AssumeRole(ctx, params, optFns...)
+	if err != nil {
+		err = removeReqID(err)
+	}
+	return out, err
+}
+
+func (o *stsWrapper) AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	out, err := o.wrapped.AssumeRoleWithWebIdentity(ctx, params, optFns...)
+	if err != nil {
+		err = removeReqID(err)
+	}
+	return out, err
+}
+
+var _ stscreds.AssumeRoleAPIClient = &stsWrapper{}
+var _ stscreds.AssumeRoleWithWebIdentityAPIClient = &stsWrapper{}
+
+// GetSession loads an AWS SDK for Go V2 configuration which is used for the
+// Route53 client.
+//
+// It uses the [standardized credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html),
+// so that cert-manager can be compatible with AWS authentication mechanisms
+// such as:
+// - [IAM for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), and
+// - [Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+//
+// To support bespoke OIDC authentication using a non-mounted ServiceAccount
+// token, we instantiate an stscreds WebIdentityTokenRetriever, if the user has
+// supplied a ServiceAccount reference. This allows AWS SDK for Go to request a
+// ServiceAccountToken when ever it needs to re-authenticate to AWS.
+// In this case, the supplied Role is used.
+//
+// We also support Assuming a different role for other credential sources,
+// such as ambient credentials or static credentials.
+// If a Role is supplied an AssumeRole credential provider is instantiated.
+//
+// Note: We deliberately do not use config.WithAssumeRoleCredentialOptions.
+// That option is misleading. See:
+// - https://github.com/aws/aws-sdk-go-v2/issues/1382
+func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
+	useAmbientCredentials := d.Ambient && (d.AccessKeyID == "" && d.SecretAccessKey == "") && d.webIdentityTokenRetriever == nil
 
 	log := logf.FromContext(ctx)
 	optFns := []func(*config.LoadOptions) error{
@@ -85,7 +140,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			}
 			log.Info(fmt.Sprintf(format, v...))
 		})),
-		config.WithClientLogMode(aws.LogDeprecatedUsage | aws.LogRequest),
+		config.WithClientLogMode(aws.LogDeprecatedUsage | aws.LogRequest | aws.LogResponseWithBody),
 		config.WithLogConfigurationWarnings(true),
 		// Append cert-manager user-agent string to all AWS API requests
 		config.WithAPIOptions(
@@ -129,59 +184,63 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	}
 
 	switch {
-	case d.Role != "" && d.WebIdentityToken != "":
-		log.V(logf.DebugLevel).Info("using assume role with web identity")
-	case useAmbientCredentials:
-		log.V(logf.DebugLevel).Info("using ambient credentials")
-		// Leaving credentials unset results in a default credential chain being
-		// used; this chain is a reasonable default for getting ambient creds.
-		// https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+	case d.AccessKeyID != "" && d.SecretAccessKey != "":
+		log.V(logf.DebugLevel).Info("Using static credentials provider. Ambient credentials will be ignored.")
+		optFns = append(
+			optFns,
+			config.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider(d.AccessKeyID, d.SecretAccessKey, ""),
+			),
+		)
+	case d.webIdentityTokenRetriever != nil:
+		log.V(logf.DebugLevel).Info("Using AssumeRoleWithWebIdentity (OIDC) credentials provider. Ambient credentials will be ignored.")
+		if d.Role == "" {
+			return aws.Config{}, errors.New("unable to construct route53 provider: role must be set when web identity token is set")
+		}
+		stsClient, err := NewWrappedSTSClient(ctx, optFns...)
+		if err != nil {
+			return aws.Config{}, err
+		}
+		optFns = append(
+			optFns,
+			config.WithCredentialsProvider(
+				aws.NewCredentialsCache(
+					stscreds.NewWebIdentityRoleProvider(
+						stsClient,
+						d.Role,
+						d.webIdentityTokenRetriever,
+					),
+				),
+			),
+		)
+	case !d.Ambient:
+		return aws.Config{}, fmt.Errorf("unable to construct route53 provider: empty credentials; perhaps you meant to enable ambient credentials?")
 	default:
-		log.V(logf.DebugLevel).Info("not using ambient credentials")
-		optFns = append(optFns, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(d.AccessKeyID, d.SecretAccessKey, "")))
+		log.V(logf.DebugLevel).Info("Using ambient credentials. All AWS SDK standardized credential providers will be tried.")
+	}
+
+	if d.Role != "" && d.webIdentityTokenRetriever == nil {
+		log.V(logf.DebugLevel).Info("Using assumed role", "role", d.Role)
+		stsClient, err := NewWrappedSTSClient(ctx, optFns...)
+		if err != nil {
+			return aws.Config{}, err
+		}
+		optFns = append(
+			optFns,
+			config.WithCredentialsProvider(
+				aws.NewCredentialsCache(
+					stscreds.NewAssumeRoleProvider(
+						stsClient,
+						d.Role,
+					),
+				),
+			),
+		)
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("unable to create aws config: %s", err)
-	}
-
-	if d.Role != "" && d.WebIdentityToken == "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
-		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRole(ctx, &sts.AssumeRoleInput{
-			RoleArn:         aws.String(d.Role),
-			RoleSessionName: aws.String("cert-manager"),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role: %s", removeReqID(err))
-		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
-	}
-
-	if d.Role != "" && d.WebIdentityToken != "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
-
-		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
-			RoleArn:          aws.String(d.Role),
-			RoleSessionName:  aws.String("cert-manager"),
-			WebIdentityToken: aws.String(d.WebIdentityToken),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %s", removeReqID(err))
-		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
 	}
 
 	// Log some key values of the loaded configuration, so that users can
@@ -203,21 +262,16 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	return cfg, nil
 }
 
-func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webIdentityToken string, ambient bool, userAgent string) *sessionProvider {
+func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webIdentityTokenRetriever stscreds.IdentityTokenRetriever, ambient bool, userAgent string) *sessionProvider {
 	return &sessionProvider{
-		AccessKeyID:      accessKeyID,
-		SecretAccessKey:  secretAccessKey,
-		Ambient:          ambient,
-		Region:           region,
-		Role:             role,
-		WebIdentityToken: webIdentityToken,
-		StsProvider:      defaultSTSProvider,
-		userAgent:        userAgent,
+		AccessKeyID:               accessKeyID,
+		SecretAccessKey:           secretAccessKey,
+		Ambient:                   ambient,
+		Region:                    region,
+		Role:                      role,
+		webIdentityTokenRetriever: webIdentityTokenRetriever,
+		userAgent:                 userAgent,
 	}
-}
-
-func defaultSTSProvider(cfg aws.Config) StsClient {
-	return sts.NewFromConfig(cfg)
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for the AWS
@@ -225,12 +279,13 @@ func defaultSTSProvider(cfg aws.Config) StsClient {
 // unset and the 'ambient' option is set, credentials from the environment.
 func NewDNSProvider(
 	ctx context.Context,
-	accessKeyID, secretAccessKey, hostedZoneID, region, role, webIdentityToken string,
+	accessKeyID, secretAccessKey, hostedZoneID, region, role string,
+	webIdentityTokenRetriever stscreds.IdentityTokenRetriever,
 	ambient bool,
 	dns01Nameservers []string,
 	userAgent string,
 ) (*DNSProvider, error) {
-	provider := newSessionProvider(accessKeyID, secretAccessKey, region, role, webIdentityToken, ambient, userAgent)
+	provider := newSessionProvider(accessKeyID, secretAccessKey, region, role, webIdentityTokenRetriever, ambient, userAgent)
 
 	cfg, err := provider.GetSession(ctx)
 	if err != nil {
@@ -382,4 +437,31 @@ func removeReqID(err error) error {
 		return errors.New(strings.Replace(err.Error(), before, after, 1))
 	}
 	return err
+}
+
+type ServiceAccountTokenCreator interface {
+	CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authv1.TokenRequest, opts metav1.CreateOptions) (*authv1.TokenRequest, error)
+}
+
+type KubernetesServiceAccountTokenRetriever struct {
+	ServiceAccountName string
+	Audiences          []string
+	Namespace          string
+	Client             ServiceAccountTokenCreator
+}
+
+var _ stscreds.IdentityTokenRetriever = &KubernetesServiceAccountTokenRetriever{}
+
+func (o *KubernetesServiceAccountTokenRetriever) GetIdentityToken() ([]byte, error) {
+	tokenrequest, err := o.Client.CreateToken(context.TODO(), o.ServiceAccountName, &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences:         o.Audiences,
+			ExpirationSeconds: ptr.To(int64(600)),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token for %s/%s: %w", o.Namespace, o.ServiceAccountName, err)
+	}
+
+	return []byte(tokenrequest.Status.Token), nil
 }

--- a/pkg/issuer/acme/dns/route53/testutil_test.go
+++ b/pkg/issuer/acme/dns/route53/testutil_test.go
@@ -1,4 +1,18 @@
-// +skip_license_check
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 /*
 This file contains portions of code directly taken from the 'xenolf/lego' project.
@@ -42,6 +56,7 @@ func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
 		_, _ = w.Write([]byte(resp.Body))
 	}))
 
+	t.Cleanup(ts.Close)
 	time.Sleep(100 * time.Millisecond)
 	return ts
 }

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
@@ -129,8 +131,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			}
 			return nil, nil
 		},
-		route53: func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error) {
-			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, webIdentityToken, ambient, util.RecursiveNameservers)
+		route53: func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role string, webIdentityTokenRetriever stscreds.IdentityTokenRetriever, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error) {
+			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, webIdentityTokenRetriever, ambient, util.RecursiveNameservers)
 			return nil, nil
 		},
 		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error) {


### PR DESCRIPTION
An alternative approach to #7235.

Instead of creating a bespoke STS client and STS credential provider, this branch just uses the AWS-SDK LoadDefaultConfig mechanisms which creates an STS client if Assume role configuration is provided.

Fixes: #7102 
Fixes: #5455 
Fixes: https://github.com/cert-manager/website/issues/56
 * #7102
 * #5455
 * https://github.com/cert-manager/website/issues/56

```release-note
Route53 ACME DNS Solver: Allow STS token to be refreshed by the AWS client if necessary, when using a non-mounted Kubernetes ServiceAccount token.
```
