### PR TITLE
Fix staticcheck linter: use types.NamespacedName in workqueue

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 issues:
   exclude-rules:
     - linters:
-        - staticcheck
         - govet
         - usestdlibvars
         - misspell

--- a/pkg/acme/webhook/apiserver/apiserver.go
+++ b/pkg/acme/webhook/apiserver/apiserver.go
@@ -162,7 +162,7 @@ func (c completedConfig) New() (*ChallengeServer, error) {
 		}
 		s.GenericAPIServer.AddPostStartHookOrDie(postStartName,
 			func(context genericapiserver.PostStartHookContext) error {
-				return solver.Initialize(c.restConfig, context.StopCh)
+				return solver.Initialize(c.restConfig, context.Done())
 			},
 		)
 	}

--- a/pkg/acme/webhook/cmd/server/start.go
+++ b/pkg/acme/webhook/cmd/server/start.go
@@ -142,5 +142,5 @@ func (o WebhookServerOptions) RunWebhookServer(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
+	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -68,7 +69,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -82,12 +83,17 @@ type controller struct {
 	objectUpdater
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*5, time.Minute*30), ControllerName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultACMERateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	challengeInformer := ctx.SharedInformerFactory.Acme().V1().Challenges()
@@ -196,13 +202,9 @@ func (c *controller) runScheduler(ctx context.Context) {
 	}
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	ch, err := c.challengeLister.Challenges(namespace).Get(name)
 

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -68,7 +68,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -82,12 +82,12 @@ type controller struct {
 	objectUpdater
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*5, time.Minute*30), ControllerName)
+	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*5, time.Minute*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	challengeInformer := ctx.SharedInformerFactory.Acme().V1().Challenges()

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
 
@@ -29,7 +30,7 @@ import (
 )
 
 func handleGenericIssuerFunc(
-	queue workqueue.TypedRateLimitingInterface[any],
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	orderLister cmacmelisters.OrderLister,
 ) func(interface{}) {
 	return func(obj interface{}) {
@@ -45,12 +46,10 @@ func handleGenericIssuerFunc(
 			return
 		}
 		for _, crt := range certs {
-			key, err := keyFunc(crt)
-			if err != nil {
-				runtime.HandleError(err)
-				continue
-			}
-			queue.Add(key)
+			queue.Add(types.NamespacedName{
+				Namespace: crt.Namespace,
+				Name:      crt.Name,
+			})
 		}
 	}
 }

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -29,7 +29,7 @@ import (
 )
 
 func handleGenericIssuerFunc(
-	queue workqueue.RateLimitingInterface,
+	queue workqueue.TypedRateLimitingInterface[any],
 	orderLister cmacmelisters.OrderLister,
 ) func(interface{}) {
 	return func(obj interface{}) {

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -19,10 +19,10 @@ package acmeorders
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -30,6 +30,7 @@ import (
 
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
@@ -38,8 +39,6 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/scheduler"
 )
-
-var keyFunc = controllerpkg.KeyFunc
 
 type controller struct {
 	// issuer helper is used to obtain references to issuers, used by Sync()
@@ -67,10 +66,10 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// scheduledWorkQueue holds items to be re-queued after a period of time.
-	scheduledWorkQueue scheduler.ScheduledWorkQueue
+	scheduledWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
 }
 
 // NewController constructs an orders controller using the provided options.
@@ -78,12 +77,12 @@ func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
 	isNamespaced bool,
-) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 
 	// Create a queue used to queue up Orders to be processed.
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*5, time.Minute*30),
-		workqueue.TypedRateLimitingQueueConfig[any]{
+		controllerpkg.DefaultACMERateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
 			Name: ControllerName,
 		},
 	)
@@ -162,13 +161,9 @@ func NewController(
 
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	order, err := c.orderLister.Orders(namespace).Get(name)
 	if err != nil {
@@ -185,8 +180,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 }
 
 // Returns a function that finds a named Order in a particular namespace.
-func orderGetterFunc(orderLister cmacmelisters.OrderLister) func(string, string) (interface{}, error) {
-	return func(namespace, name string) (interface{}, error) {
+func orderGetterFunc(orderLister cmacmelisters.OrderLister) func(string, string) (*cmacme.Order, error) {
+	return func(namespace, name string) (*cmacme.Order, error) {
 		return orderLister.Orders(namespace).Get(name)
 	}
 }
@@ -206,7 +201,7 @@ type controllerWrapper struct {
 // Register registers a controller, created using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// Construct a new named logger to be reused throughout the controller.
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -27,6 +27,7 @@ import (
 	acmeapi "golang.org/x/crypto/acme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
@@ -933,7 +934,7 @@ func runTest(t *testing.T, test testT) {
 	}
 	gotScheduled := false
 	fakeScheduler := schedulertest.FakeScheduler{
-		AddFunc: func(obj interface{}, duration time.Duration) {
+		AddFunc: func(obj types.NamespacedName, duration time.Duration) {
 			gotScheduled = true
 		},
 	}

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -42,10 +42,10 @@ type controller struct {
 	sync          shimhelper.SyncFn
 
 	// For testing purposes.
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	c.gatewayLister = ctx.GWShared.Gateway().V1().Gateways().Lister()
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 	c.sync = shimhelper.SyncFnFor(ctx.Recorder, log, ctx.CMClient, ctx.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), ctx.IngressShimOptions, ctx.FieldManager)
@@ -119,7 +119,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 //	    name: gateway-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.RateLimitingInterface) func(obj interface{}) {
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(obj interface{}) {
 	return func(obj interface{}) {
 		crt, ok := obj.(*cmapi.Certificate)
 		if !ok {

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -22,6 +22,7 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -42,10 +43,10 @@ type controller struct {
 	sync          shimhelper.SyncFn
 
 	// For testing purposes.
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	c.gatewayLister = ctx.GWShared.Gateway().V1().Gateways().Lister()
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 	c.sync = shimhelper.SyncFnFor(ctx.Recorder, log, ctx.CMClient, ctx.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), ctx.IngressShimOptions, ctx.FieldManager)
@@ -83,12 +84,8 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	return c.queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
-		return nil
-	}
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
+	namespace, name := key.Namespace, key.Name
 
 	gateway, err := c.gatewayLister.Gateways(namespace).Get(name)
 
@@ -119,7 +116,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 //	    name: gateway-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(obj interface{}) {
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
 	return func(obj interface{}) {
 		crt, ok := obj.(*cmapi.Certificate)
 		if !ok {
@@ -141,14 +138,22 @@ func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(ob
 			return
 		}
 
-		queue.Add(crt.Namespace + "/" + ref.Name)
+		queue.Add(types.NamespacedName{
+			Namespace: crt.Namespace,
+			Name:      ref.Name,
+		})
 	}
 }
 
 func init() {
 	controllerpkg.Register(ControllerName, func(ctx *controllerpkg.ContextFactory) (controllerpkg.Interface, error) {
 		return controllerpkg.NewBuilder(ctx, ControllerName).
-			For(&controller{queue: workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)}).
+			For(&controller{queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+				controllerpkg.DefaultItemBasedRateLimiter(),
+				workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+					Name: ControllerName,
+				},
+			)}).
 			Complete()
 	})
 }

--- a/pkg/controller/certificate-shim/gateways/controller_test.go
+++ b/pkg/controller/certificate-shim/gateways/controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -41,7 +42,7 @@ func Test_controller_Register(t *testing.T) {
 		name           string
 		existingCert   *cmapi.Certificate
 		givenCall      func(*testing.T, cmclient.Interface, gwclient.Interface)
-		expectAddCalls []interface{}
+		expectAddCalls []types.NamespacedName
 	}{
 		{
 			name: "gateway is re-queued when an 'Added' event is received for this gateway",
@@ -51,7 +52,12 @@ func Test_controller_Register(t *testing.T) {
 				}}, metav1.CreateOptions{})
 				require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-1"},
+			expectAddCalls: []types.NamespacedName{
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-1",
+				},
+			},
 		},
 		{
 			name: "gateway is re-queued when an 'Updated' event is received for this gateway",
@@ -69,8 +75,18 @@ func Test_controller_Register(t *testing.T) {
 				}}, metav1.UpdateOptions{})
 				require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-1", "namespace-1/gateway-1"},
-			//                                <----- Create ------>    <------ Update ----->
+			expectAddCalls: []types.NamespacedName{
+				// Create
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-1",
+				},
+				// Update
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-1",
+				},
+			},
 		},
 		{
 			name: "gateway is re-queued when a 'Deleted' event is received for this gateway",
@@ -83,8 +99,18 @@ func Test_controller_Register(t *testing.T) {
 				err = c.GatewayV1().Gateways("namespace-1").Delete(context.Background(), "gateway-1", metav1.DeleteOptions{})
 				require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-1", "namespace-1/gateway-1"},
-			//                                <----- Create ------>    <------ Delete ----->
+			expectAddCalls: []types.NamespacedName{
+				// Create
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-1",
+				},
+				// Delete
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-1",
+				},
+			},
 		},
 		{
 			name: "gateway is re-queued when an 'Added' event is received for its child Certificate",
@@ -97,7 +123,12 @@ func Test_controller_Register(t *testing.T) {
 				}}, metav1.CreateOptions{})
 				require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-2"},
+			expectAddCalls: []types.NamespacedName{
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-2",
+				},
+			},
 		},
 		{
 			name: "gateway is re-queued when an 'Updated' event is received for its child Certificate",
@@ -116,7 +147,12 @@ func Test_controller_Register(t *testing.T) {
 				}}, metav1.UpdateOptions{})
 				require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-2"},
+			expectAddCalls: []types.NamespacedName{
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-2",
+				},
+			},
 		},
 		{
 			name: "gateway is re-queued when a 'Deleted' event is received for its child Certificate",
@@ -130,7 +166,12 @@ func Test_controller_Register(t *testing.T) {
 				// err := c.CertmanagerV1().Certificates("namespace-1").Delete(context.Background(), "cert-1", metav1.DeleteOptions{})
 				// require.NoError(t, err)
 			},
-			expectAddCalls: []interface{}{"namespace-1/gateway-2"},
+			expectAddCalls: []types.NamespacedName{
+				{
+					Namespace: "namespace-1",
+					Name:      "gateway-2",
+				},
+			},
 		},
 	}
 
@@ -181,34 +222,34 @@ func Test_controller_Register(t *testing.T) {
 
 type mockWorkqueue struct {
 	t          *testing.T
-	callsToAdd []interface{}
+	callsToAdd []types.NamespacedName
 }
 
-var _ workqueue.TypedInterface[any] = &mockWorkqueue{}
+var _ workqueue.TypedInterface[types.NamespacedName] = &mockWorkqueue{}
 
-func (m *mockWorkqueue) Add(arg0 interface{}) {
+func (m *mockWorkqueue) Add(arg0 types.NamespacedName) {
 	m.callsToAdd = append(m.callsToAdd, arg0)
 }
 
-func (m *mockWorkqueue) AddAfter(arg0 interface{}, arg1 time.Duration) {
+func (m *mockWorkqueue) AddAfter(arg0 types.NamespacedName, arg1 time.Duration) {
 	m.t.Error("workqueue.AddAfter was called but was not expected to be called")
 }
 
-func (m *mockWorkqueue) AddRateLimited(arg0 interface{}) {
+func (m *mockWorkqueue) AddRateLimited(arg0 types.NamespacedName) {
 	m.t.Error("workqueue.AddRateLimited was called but was not expected to be called")
 }
 
-func (m *mockWorkqueue) Done(arg0 interface{}) {
+func (m *mockWorkqueue) Done(arg0 types.NamespacedName) {
 	m.t.Error("workqueue.Done was called but was not expected to be called")
 }
 
-func (m *mockWorkqueue) Forget(arg0 interface{}) {
+func (m *mockWorkqueue) Forget(arg0 types.NamespacedName) {
 	m.t.Error("workqueue.Forget was called but was not expected to be called")
 }
 
-func (m *mockWorkqueue) Get() (interface{}, bool) {
+func (m *mockWorkqueue) Get() (types.NamespacedName, bool) {
 	m.t.Error("workqueue.Get was called but was not expected to be called")
-	return nil, false
+	return types.NamespacedName{}, false
 }
 
 func (m *mockWorkqueue) Len() int {
@@ -216,7 +257,7 @@ func (m *mockWorkqueue) Len() int {
 	return 0
 }
 
-func (m *mockWorkqueue) NumRequeues(arg0 interface{}) int {
+func (m *mockWorkqueue) NumRequeues(arg0 types.NamespacedName) int {
 	m.t.Error("workqueue.NumRequeues was called but was not expected to be called")
 	return 0
 }

--- a/pkg/controller/certificate-shim/gateways/controller_test.go
+++ b/pkg/controller/certificate-shim/gateways/controller_test.go
@@ -184,7 +184,7 @@ type mockWorkqueue struct {
 	callsToAdd []interface{}
 }
 
-var _ workqueue.Interface = &mockWorkqueue{}
+var _ workqueue.TypedInterface[any] = &mockWorkqueue{}
 
 func (m *mockWorkqueue) Add(arg0 interface{}) {
 	m.callsToAdd = append(m.callsToAdd, arg0)

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -42,7 +42,7 @@ type controller struct {
 	sync          shimhelper.SyncFn
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	cmShared := ctx.SharedInformerFactory
 
 	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
@@ -124,7 +124,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 //	    name: ingress-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.RateLimitingInterface) func(obj interface{}) {
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(obj interface{}) {
 	return func(obj interface{}) {
 		cert, ok := obj.(*cmapi.Certificate)
 		if !ok {

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -22,6 +22,7 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,7 +43,7 @@ type controller struct {
 	sync          shimhelper.SyncFn
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	cmShared := ctx.SharedInformerFactory
 
 	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
@@ -51,7 +52,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 	c.sync = shimhelper.SyncFnFor(ctx.Recorder, log, ctx.CMClient, cmShared.Certmanager().V1().Certificates().Lister(), ctx.IngressShimOptions, ctx.FieldManager)
 
-	queue := workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	mustSync := []cache.InformerSynced{
 		ingressInformer.Informer().HasSynced,
@@ -88,12 +94,8 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	return queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
-		return nil
-	}
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
+	namespace, name := key.Namespace, key.Name
 
 	ingress, err := c.ingressLister.Ingresses(namespace).Get(name)
 
@@ -124,7 +126,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 //	    name: ingress-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(obj interface{}) {
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
 	return func(obj interface{}) {
 		cert, ok := obj.(*cmapi.Certificate)
 		if !ok {
@@ -143,7 +145,10 @@ func certificateHandler(queue workqueue.TypedRateLimitingInterface[any]) func(ob
 			return
 		}
 
-		queue.Add(cert.Namespace + "/" + ingress.Name)
+		queue.Add(types.NamespacedName{
+			Namespace: cert.Namespace,
+			Name:      ingress.Name,
+		})
 	}
 }
 

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -74,7 +75,7 @@ func init() {
 			For(certificaterequests.New(
 				apiutil.IssuerACME,
 				NewACME,
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error) {
 					orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
 					certificateRequestLister := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister()
 
@@ -82,7 +83,7 @@ func init() {
 						WorkFunc: controllerpkg.HandleOwnedResourceNamespacedFunc(
 							log, queue,
 							cmapi.SchemeGroupVersion.WithKind(cmapi.CertificateRequestKind),
-							func(namespace, name string) (interface{}, error) {
+							func(namespace, name string) (*cmapi.CertificateRequest, error) {
 								return certificateRequestLister.CertificateRequests(namespace).Get(name)
 							},
 						),

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -74,7 +74,7 @@ func init() {
 			For(certificaterequests.New(
 				apiutil.IssuerACME,
 				NewACME,
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.RateLimitingInterface) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
 					orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
 					certificateRequestLister := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister()
 

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -51,7 +52,7 @@ type Controller struct {
 
 	recorder record.EventRecorder
 
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
 func init() {
@@ -65,9 +66,14 @@ func init() {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
-	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
 	mustSync := []cache.InformerSynced{certificateRequestInformer.Informer().HasSynced}
@@ -85,15 +91,11 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	return c.queue, mustSync, nil
 }
 
-func (c *Controller) ProcessItem(ctx context.Context, key string) error {
+func (c *Controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	cr, err := c.certificateRequestLister.CertificateRequests(namespace).Get(name)
 	if apierrors.IsNotFound(err) {

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -51,7 +51,7 @@ type Controller struct {
 
 	recorder record.EventRecorder
 
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 }
 
 func init() {
@@ -65,7 +65,7 @@ func init() {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
 

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -41,13 +42,10 @@ func (c *Controller) handleGenericIssuer(obj interface{}) {
 		return
 	}
 	for _, cr := range crs {
-		log := logf.WithRelatedResource(log, cr)
-		key, err := keyFunc(cr)
-		if err != nil {
-			log.Error(err, "error computing key for resource")
-			continue
-		}
-		c.queue.Add(key)
+		c.queue.Add(types.NamespacedName{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		})
 	}
 }
 

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -54,7 +54,7 @@ type IssuerConstructor func(*controllerpkg.Context) Issuer
 // covered in the main shared controller implementation.
 // The returned set of InformerSyncs will be waited on when the controller
 // starts.
-type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.RateLimitingInterface) ([]cache.InformerSynced, error)
+type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error)
 
 // Controller is an implementation of the queueingController for
 // certificate requests.
@@ -74,7 +74,7 @@ type Controller struct {
 	// more details at https://github.com/cert-manager/cert-manager/issues/5216
 	secretLister internalinformers.SecretLister
 
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -123,7 +123,7 @@ func New(issuerType string, issuerConstructor IssuerConstructor, registerExtraIn
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	componentName := "certificaterequests-issuer-" + c.issuerType
 
 	// construct a new named logger to be reused throughout the controller

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -36,8 +37,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
-
-var keyFunc = controllerpkg.KeyFunc
 
 // Issuer implements the functionality to sign a certificate request for a
 // particular issuer type.
@@ -54,7 +53,7 @@ type IssuerConstructor func(*controllerpkg.Context) Issuer
 // covered in the main shared controller implementation.
 // The returned set of InformerSyncs will be waited on when the controller
 // starts.
-type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error)
+type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error)
 
 // Controller is an implementation of the queueingController for
 // certificate requests.
@@ -74,7 +73,7 @@ type Controller struct {
 	// more details at https://github.com/cert-manager/cert-manager/issues/5216
 	secretLister internalinformers.SecretLister
 
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -123,14 +122,19 @@ func New(issuerType string, issuerConstructor IssuerConstructor, registerExtraIn
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	componentName := "certificaterequests-issuer-" + c.issuerType
 
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, componentName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), componentName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: componentName,
+		},
+	)
 
 	secretsInformer := ctx.KubeSharedInformerFactory.Secrets()
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
@@ -202,15 +206,11 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 
 // ProcessItem is the worker function that will be called with a new key from
 // the workqueue. A key corresponds to a certificate request object.
-func (c *Controller) ProcessItem(ctx context.Context, key string) error {
+func (c *Controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	cr, err := c.certificateRequestLister.CertificateRequests(namespace).Get(name)
 	if err != nil {

--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -41,7 +41,7 @@ import (
 func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateRequestLister,
 	helper issuer.Helper,
-	queue workqueue.RateLimitingInterface,
+	queue workqueue.TypedRateLimitingInterface[any],
 ) func(obj any) {
 	return func(obj any) {
 		log := log.WithName("handleSecretReference")

--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -41,7 +42,7 @@ import (
 func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateRequestLister,
 	helper issuer.Helper,
-	queue workqueue.TypedRateLimitingInterface[any],
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 ) func(obj any) {
 	return func(obj any) {
 		log := log.WithName("handleSecretReference")
@@ -57,13 +58,10 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 			return
 		}
 		for _, request := range requests {
-			log := logf.WithRelatedResource(log, request)
-			key, err := controllerpkg.KeyFunc(request)
-			if err != nil {
-				log.Error(err, "error computing key for resource")
-				continue
-			}
-			queue.Add(key)
+			queue.Add(types.NamespacedName{
+				Name:      request.Name,
+				Namespace: request.Namespace,
+			})
 		}
 	}
 }

--- a/pkg/controller/certificaterequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2/ktesting"
 
@@ -37,7 +38,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 		secret          runtime.Object
 		existingCRs     []runtime.Object
 		existingIssuers []runtime.Object
-		expectedQueue   []string
+		expectedQueue   []types.NamespacedName
 	}{
 		"if given object is not secret, expect empty queue": {
 			secret: gen.Certificate("not-a-secret"),
@@ -68,7 +69,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{},
+			expectedQueue: []types.NamespacedName{},
 		},
 		"if no requests then expect empty queue": {
 			secret:      gen.Secret("test-secret", gen.SetSecretNamespace("test-namespace")),
@@ -82,7 +83,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{},
+			expectedQueue: []types.NamespacedName{},
 		},
 		"referenced requests should be added to the queue": {
 			secret: gen.Secret("test-secret", gen.SetSecretNamespace("test-namespace")),
@@ -113,7 +114,16 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{"test-namespace/a", "test-namespace/b"},
+			expectedQueue: []types.NamespacedName{
+				{
+					Namespace: "test-namespace",
+					Name:      "a",
+				},
+				{
+					Namespace: "test-namespace",
+					Name:      "b",
+				},
+			},
 		},
 	}
 
@@ -134,13 +144,13 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 
 			builder.Start()
 
-			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName]())
 			handleSecretReferenceWorkFunc(ktesting.NewLogger(t, ktesting.NewConfig()), lister, helper, queue)(test.secret)
 			require.Equal(t, len(test.expectedQueue), queue.Len())
-			var actualQueue []string
+			var actualQueue []types.NamespacedName
 			for range test.expectedQueue {
 				i, _ := queue.Get()
-				actualQueue = append(actualQueue, i.(string))
+				actualQueue = append(actualQueue, i)
 			}
 			assert.ElementsMatch(t, test.expectedQueue, actualQueue)
 		})

--- a/pkg/controller/certificaterequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks_test.go
@@ -134,7 +134,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 
 			builder.Start()
 
-			queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
 			handleSecretReferenceWorkFunc(ktesting.NewLogger(t, ktesting.NewConfig()), lister, helper, queue)(test.secret)
 			require.Equal(t, len(test.expectedQueue), queue.Len())
 			var actualQueue []string

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -71,7 +71,7 @@ func init() {
 
 				// Handle informed Secrets which may be referenced by the
 				// "cert-manager.io/private-key-secret-name" annotation.
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.RateLimitingInterface) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
 					secretInformer := ctx.KubeSharedInformerFactory.Secrets().Informer()
 					certificateRequestLister := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister()
 					helper := issuer.NewHelper(

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -71,7 +72,7 @@ func init() {
 
 				// Handle informed Secrets which may be referenced by the
 				// "cert-manager.io/private-key-secret-name" annotation.
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error) {
 					secretInformer := ctx.KubeSharedInformerFactory.Secrets().Informer()
 					certificateRequestLister := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests().Lister()
 					helper := issuer.NewHelper(

--- a/pkg/controller/certificates/informers.go
+++ b/pkg/controller/certificates/informers.go
@@ -21,10 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
-	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
 )
@@ -37,7 +37,7 @@ import (
 // call when enqueuing Certificate resources.
 // If no predicate constructors are given, all Certificate resources will be
 // enqueued on every invocation.
-func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[any], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
+func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[types.NamespacedName], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
 	return func(obj interface{}) {
 		s, ok := obj.(metav1.Object)
 		if !ok {
@@ -58,12 +58,10 @@ func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqu
 		}
 
 		for _, cert := range certs {
-			key, err := controllerpkg.KeyFunc(cert)
-			if err != nil {
-				log.Error(err, "Error determining 'key' for resource")
-				continue
-			}
-			queue.Add(key)
+			queue.Add(types.NamespacedName{
+				Name:      cert.Name,
+				Namespace: cert.Namespace,
+			})
 		}
 	}
 }

--- a/pkg/controller/certificates/informers.go
+++ b/pkg/controller/certificates/informers.go
@@ -37,7 +37,7 @@ import (
 // call when enqueuing Certificate resources.
 // If no predicate constructors are given, all Certificate resources will be
 // enqueued on every invocation.
-func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.Interface, lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
+func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[any], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
 	return func(obj interface{}) {
 		s, ok := obj.(metav1.Object)
 		if !ok {

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -91,10 +91,10 @@ type controller struct {
 func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -475,7 +475,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -91,10 +92,15 @@ type controller struct {
 func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
-) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -155,7 +161,7 @@ func NewController(
 	}, queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	// TODO: Change to globals.DefaultControllerContextTimeout as part of a wider effort to ensure we have
 	// failsafe timeouts in every controller
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
@@ -163,10 +169,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	log := logf.FromContext(ctx).WithValues("key", key)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -475,7 +478,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -27,8 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/cache"
 	fakeclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -1397,13 +1397,10 @@ func TestIssuingController(t *testing.T) {
 
 			test.builder.Start()
 
-			key, err := cache.MetaNamespaceKeyFunc(test.certificate)
-			if err != nil {
-				t.Errorf("failed to build meta namespace key from certificate: %s", err)
-				t.FailNow()
-			}
-
-			err = w.controller.ProcessItem(context.Background(), key)
+			err = w.controller.ProcessItem(context.Background(), types.NamespacedName{
+				Namespace: test.certificate.Namespace,
+				Name:      test.certificate.Name,
+			})
 			if err != nil && !test.expectedErr {
 				t.Errorf("expected to not get an error, but got: %v", err)
 			}

--- a/pkg/controller/certificates/issuing/secret_manager_test.go
+++ b/pkg/controller/certificates/issuing/secret_manager_test.go
@@ -48,7 +48,7 @@ func Test_ensureSecretData(t *testing.T) {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be "".
-		key string
+		key types.NamespacedName
 
 		// cert is the optional cert to be loaded to fake clientset.
 		cert *cmapi.Certificate
@@ -67,15 +67,20 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if 'key' is an invalid value, should do nothing and not error": {
-			key:            "abc/def/ghi",
+			key: types.NamespacedName{
+				Namespace: "abc",
+				Name:      "def/ghi",
+			},
 			expectedAction: false,
 		},
 		"if 'key' references a Certificate that doesn't exist, should do nothing and not error": {
-			key:            "random-namespace/random-certificate",
+			key: types.NamespacedName{
+				Namespace: "random-namespace",
+				Name:      "random-certificate",
+			},
 			expectedAction: false,
 		},
 		"if Certificate and Secret exists, but the Secret contains no certificate or private key data, do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -90,7 +95,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate and Secret exists, but the Secret contains no certificate data, do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -107,7 +111,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate and Secret exists, but the Secret contains no private key data, do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -124,7 +127,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate and Secret exists, but the Certificate has a True Issuing condition, do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -145,7 +147,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate exists without a Issuing condition, but Secret does not exist, do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -158,7 +159,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists and matches the SecretTemplate but no managed fields, should reconcile Secret": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -182,7 +182,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists and matches the SecretTemplate but the managed fields contains more than what is in the SecretTemplate, should reconcile Secret": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -226,7 +225,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists and matches the SecretTemplate but the managed fields are managed by another manager, should reconcile Secret": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -268,7 +266,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists and matches the SecretTemplate with the correct managed fields and base labels, should do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -312,7 +309,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists but does not match SecretTemplate, should apply the Labels and Annotations": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -337,7 +333,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists but is missing the required label, apply the label": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -362,7 +357,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate exists in a false Issuing condition, Secret exists with some labels, but is missing the required label, apply the label": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -386,7 +380,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate with combined pem and Secret exists, but the Secret doesn't have combined pem, should apply the combined pem": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -407,7 +400,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate with der and Secret exists, but the Secret doesn't have der, should apply the der": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -428,7 +420,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate with combined pem and der, and Secret exists, but the Secret doesn't have combined pem or der, should apply the combined pem and der": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -450,7 +441,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"if Certificate with combined pem and der, and Secret exists with combined pem and der with managed fields, should do nothing": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -501,7 +491,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"if Certificate with no combined pem or der, and Secret exists with combined pem and der managed by field manager, should apply to remove them": {
-			key: "test-namespace/test-name",
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name"},
 				Spec: cmapi.CertificateSpec{
@@ -550,7 +539,6 @@ func Test_ensureSecretData(t *testing.T) {
 		},
 
 		"enabledOwnerRef=false if Secret has owner reference to Certificate owned by field manager, expect action": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: false,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -584,7 +572,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"enabledOwnerRef=true if Secret has owner reference to Certificate owned by field manager, expect no action": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -621,7 +608,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"refresh secrets when keystore is not defined and the secret has keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-234")},
@@ -676,7 +662,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"refresh secrets when JKS keystore is defined and the secret does not have keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -735,7 +720,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"refresh secrets when JKS keystore is defined, create is disabled and the secret has keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -795,7 +779,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"refresh secrets when JKS keystore is null and the secret has keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -853,7 +836,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"do nothing when JKS keystore is defined and create field is set to false": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -912,7 +894,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: false,
 		},
 		"refresh secret when PKCS12 keystore is defined and the secret does not have keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -971,7 +952,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"refresh secret when PKCS12 keystore is defined, create is disabled and the secret has keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -1031,7 +1011,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"refresh secret when PKCS12 keystore is null and the secret has keystore/truststore fields": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -1089,7 +1068,6 @@ func Test_ensureSecretData(t *testing.T) {
 			expectedAction: true,
 		},
 		"do nothing when PKCS12 keystore is defined and the create is set to false": {
-			key:            "test-namespace/test-name",
 			enableOwnerRef: true,
 			cert: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-name", UID: types.UID("uid-123")},
@@ -1185,6 +1163,12 @@ func Test_ensureSecretData(t *testing.T) {
 			defer builder.Stop()
 
 			key := test.key
+			if key == (types.NamespacedName{}) && test.cert != nil {
+				key = types.NamespacedName{
+					Name:      test.cert.Name,
+					Namespace: test.cert.Namespace,
+				}
+			}
 
 			// Call ProcessItem
 			err = w.controller.ProcessItem(context.Background(), key)

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -75,9 +75,9 @@ type controller struct {
 
 func NewController(
 	log logr.Logger, ctx *controllerpkg.Context,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -366,7 +366,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -75,9 +75,14 @@ type controller struct {
 
 func NewController(
 	log logr.Logger, ctx *controllerpkg.Context,
-) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -133,15 +138,11 @@ func init() {
 	isNextPrivateKeyLabelSelector = labels.NewSelector().Add(*r)
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 	ctx = logf.NewContext(ctx, log)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key passed to ProcessItem")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -366,7 +367,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -32,7 +32,6 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
@@ -98,7 +97,7 @@ func TestProcessItem(t *testing.T) {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be ""
-		key string
+		key types.NamespacedName
 
 		// Certificate to be synced for the test.
 		// if not set, the 'key' will be passed to ProcessItem instead.
@@ -118,10 +117,16 @@ func TestProcessItem(t *testing.T) {
 	}{
 		"do nothing if an empty 'key' is used": {},
 		"do nothing if an invalid 'key' is used": {
-			key: "abc/def/ghi",
+			key: types.NamespacedName{
+				Namespace: "abc",
+				Name:      "def/ghi",
+			},
 		},
 		"do nothing if a key references a Certificate that does not exist": {
-			key: "namespace/name",
+			key: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      "name",
+			},
 		},
 		"do nothing if Certificate has 'Issuing' condition set to 'false'": {
 			certificate: &cmapi.Certificate{
@@ -494,10 +499,10 @@ func TestProcessItem(t *testing.T) {
 			defer builder.Stop()
 
 			key := test.key
-			if key == "" && test.certificate != nil {
-				key, err = controllerpkg.KeyFunc(test.certificate)
-				if err != nil {
-					t.Fatal(err)
+			if key == (types.NamespacedName{}) && test.certificate != nil {
+				key = types.NamespacedName{
+					Name:      test.certificate.Name,
+					Namespace: test.certificate.Namespace,
 				}
 			}
 

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -50,9 +50,9 @@ type controller struct {
 	metrics *metrics.Metrics
 }
 
-func NewController(ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func NewController(ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -99,7 +99,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	ctrl, queue, mustSync, err := NewController(ctx)
 	c.controller = ctrl
 	return queue, mustSync, err

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -19,9 +19,9 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -50,9 +50,14 @@ type controller struct {
 	metrics *metrics.Metrics
 }
 
-func NewController(ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func NewController(ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -77,11 +82,8 @@ func NewController(ctx *controllerpkg.Context) (*controller, workqueue.TypedRate
 	}, queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return nil
-	}
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -99,7 +101,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	ctrl, queue, mustSync, err := NewController(ctx)
 	c.controller = ctrl
 	return queue, mustSync, err

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -19,7 +19,6 @@ package readiness
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -83,9 +83,14 @@ func NewController(
 	chain policies.Chain,
 	renewalTimeCalculator pki.RenewalTimeFunc,
 	policyEvaluator policyEvaluatorFunc,
-) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -138,15 +143,11 @@ func NewController(
 // ProcessItem is a worker function that will be called when a new key
 // corresponding to a Certificate to be re-synced is pulled from the workqueue.
 // ProcessItem will update the Ready condition of a Certificate.
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 
 	ctx = logf.NewContext(ctx, log)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key passed to ProcessItem")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -251,7 +252,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -83,9 +83,9 @@ func NewController(
 	chain policies.Chain,
 	renewalTimeCalculator pki.RenewalTimeFunc,
 	policyEvaluator policyEvaluatorFunc,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -251,7 +251,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -23,13 +23,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
@@ -74,7 +74,7 @@ func TestProcessItem(t *testing.T) {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be "".
-		key string
+		key types.NamespacedName
 
 		// cert to be loaded to fake clientset
 		cert *cmapi.Certificate
@@ -105,10 +105,16 @@ func TestProcessItem(t *testing.T) {
 	}{
 		"do nothing if an empty 'key' is used": {},
 		"do nothing if an invalid 'key' is used": {
-			key: "abc/def/ghi",
+			key: types.NamespacedName{
+				Namespace: "abc",
+				Name:      "def/ghi",
+			},
 		},
 		"do nothing if a key references a Certificate that does not exist": {
-			key: "namespace/name",
+			key: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      "name",
+			},
 		},
 		"update status for a Certificate that is evaluated as Ready and whose spec.secretName secret contains a valid X509 cert": {
 			condition: cmapi.CertificateCondition{
@@ -303,10 +309,10 @@ func TestProcessItem(t *testing.T) {
 			defer builder.Stop()
 
 			key := test.key
-			if key == "" && cert != nil {
-				key, err = controllerpkg.KeyFunc(cert)
-				if err != nil {
-					t.Fatal(err)
+			if key == (types.NamespacedName{}) && cert != nil {
+				key = types.NamespacedName{
+					Name:      cert.Name,
+					Namespace: cert.Namespace,
 				}
 			}
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -77,9 +78,14 @@ type controller struct {
 }
 
 func NewController(
-	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -126,15 +132,11 @@ func NewController(
 	}, queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 
 	ctx = logf.NewContext(ctx, log)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key passed to ProcessItem")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -461,7 +463,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -77,9 +77,9 @@ type controller struct {
 }
 
 func NewController(
-	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+	log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -461,7 +461,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -36,7 +37,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -117,7 +117,7 @@ func TestProcessItem(t *testing.T) {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be ""
-		key string
+		key types.NamespacedName
 
 		// Featuregates to set for a particular test.
 		featuresFlags map[featuregate.Feature]bool
@@ -140,10 +140,16 @@ func TestProcessItem(t *testing.T) {
 	}{
 		"do nothing if an empty 'key' is used": {},
 		"do nothing if an invalid 'key' is used": {
-			key: "abc/def/ghi",
+			key: types.NamespacedName{
+				Namespace: "abc",
+				Name:      "def/ghi",
+			},
 		},
 		"do nothing if a key references a Certificate that does not exist": {
-			key: "namespace/name",
+			key: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      "name",
+			},
 		},
 		"do nothing if Certificate has 'Issuing' condition set to 'false'": {
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -751,10 +757,10 @@ func TestProcessItem(t *testing.T) {
 			defer builder.Stop()
 
 			key := test.key
-			if key == "" && test.certificate != nil {
-				key, err = controllerpkg.KeyFunc(test.certificate)
-				if err != nil {
-					t.Fatal(err)
+			if key == (types.NamespacedName{}) && test.certificate != nil {
+				key = types.NamespacedName{
+					Name:      test.certificate.Name,
+					Namespace: test.certificate.Namespace,
 				}
 			}
 

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,9 +57,14 @@ type revision struct {
 	types.NamespacedName
 }
 
-func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -95,15 +99,11 @@ func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, wo
 // ProcessItem will attempt to garbage collect old CertificateRequests based
 // upon `spec.revisionHistoryLimit`. This controller will only act on
 // Certificates which are in a Ready state and this value is set.
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 
 	ctx = logf.NewContext(ctx, log)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key passed to ProcessItem")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -205,7 +205,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -58,9 +58,9 @@ type revision struct {
 	types.NamespacedName
 }
 
-func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func NewController(log logr.Logger, ctx *controllerpkg.Context) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -205,7 +205,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -29,7 +29,6 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -52,7 +51,7 @@ func TestProcessItem(t *testing.T) {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
 		// if neither is set, the key will be ""
-		key string
+		key types.NamespacedName
 
 		// Certificate to be synced for the test.
 		// if not set, the 'key' will be passed to ProcessItem instead.
@@ -68,10 +67,16 @@ func TestProcessItem(t *testing.T) {
 	}{
 		"do nothing if an empty 'key' is used": {},
 		"do nothing if an invalid 'key' is used": {
-			key: "abc/def/ghi",
+			key: types.NamespacedName{
+				Namespace: "abc",
+				Name:      "def/ghi",
+			},
 		},
 		"do nothing if a key references a Certificate that does not exist": {
-			key: "namespace/name",
+			key: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      "name",
+			},
 		},
 		"do nothing if Certificate is not in a Ready=True state": {
 			certificate: gen.CertificateFrom(baseCrt,
@@ -239,10 +244,10 @@ func TestProcessItem(t *testing.T) {
 			defer builder.Stop()
 
 			key := test.key
-			if key == "" && test.certificate != nil {
-				key, err = controllerpkg.KeyFunc(test.certificate)
-				if err != nil {
-					t.Fatal(err)
+			if key == (types.NamespacedName{}) && test.certificate != nil {
+				key = types.NamespacedName{
+					Name:      test.certificate.Name,
+					Namespace: test.certificate.Namespace,
 				}
 			}
 

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -86,9 +86,9 @@ func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
 	shouldReissue policies.Func,
-) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -355,7 +355,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -69,7 +70,7 @@ type controller struct {
 	secretLister             internalinformers.SecretLister
 	client                   cmclient.Interface
 	recorder                 record.EventRecorder
-	scheduledWorkQueue       scheduler.ScheduledWorkQueue
+	scheduledWorkQueue       scheduler.ScheduledWorkQueue[types.NamespacedName]
 
 	// fieldManager is the string which will be used as the Field Manager on
 	// fields created or edited by the cert-manager Kubernetes client during
@@ -86,9 +87,14 @@ func NewController(
 	log logr.Logger,
 	ctx *controllerpkg.Context,
 	shouldReissue policies.Func,
-) (*controller, workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+) (*controller, workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// create a queue used to queue up items to be processed
-	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*1, time.Second*30), ControllerName)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultCertificateRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1().Certificates()
@@ -141,14 +147,10 @@ func NewController(
 	}, queue, mustSync, nil
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 	ctx = logf.NewContext(ctx, log)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key passed to ProcessItem")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -333,7 +335,7 @@ func shouldBackoffReissuingOnFailure(log logr.Logger, c clock.Clock, crt *cmapi.
 // has elapsed.
 // If the 'durationUntilRenewalTime' is less than zero, it will not be
 // queued again.
-func (c *controller) scheduleRecheckOfCertificateIfRequired(log logr.Logger, key string, durationUntilRenewalTime time.Duration) {
+func (c *controller) scheduleRecheckOfCertificateIfRequired(log logr.Logger, key types.NamespacedName, durationUntilRenewalTime time.Duration) {
 	// don't schedule a re-queue if the time is in the past.
 	// if it is in the past, the resource will be triggered during the
 	// current call to the ProcessItem method. If we added the item to the
@@ -355,7 +357,7 @@ type controllerWrapper struct {
 	*controller
 }
 
-func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -80,7 +81,7 @@ func init() {
 
 func controllerBuilder() *certificatesigningrequests.Controller {
 	return certificatesigningrequests.New(apiutil.IssuerACME, NewACME,
-		func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
+		func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error) {
 			orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
 			csrLister := ctx.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 
@@ -88,7 +89,7 @@ func controllerBuilder() *certificatesigningrequests.Controller {
 				WorkFunc: controllerpkg.HandleOwnedResourceNamespacedFunc(
 					log, queue,
 					certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"),
-					func(_, name string) (interface{}, error) {
+					func(_, name string) (*certificatesv1.CertificateSigningRequest, error) {
 						return csrLister.Get(name)
 					},
 				),

--- a/pkg/controller/certificatesigningrequests/acme/acme.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme.go
@@ -80,7 +80,7 @@ func init() {
 
 func controllerBuilder() *certificatesigningrequests.Controller {
 	return certificatesigningrequests.New(apiutil.IssuerACME, NewACME,
-		func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.RateLimitingInterface) ([]cache.InformerSynced, error) {
+		func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
 			orderInformer := ctx.SharedInformerFactory.Acme().V1().Orders().Informer()
 			csrLister := ctx.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 

--- a/pkg/controller/certificatesigningrequests/acme/acme_test.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
@@ -66,19 +67,19 @@ func Test_controllerBuilder(t *testing.T) {
 		existingCSR       runtime.Object
 		existingCMObjects []runtime.Object
 		givenCall         func(*testing.T, cmclient.Interface, kubernetes.Interface)
-		expectRequeueKey  string
+		expectRequeueKey  types.NamespacedName
 	}{
 		"if no request then no request should sync": {
 			existingCSR:       nil,
 			existingCMObjects: []runtime.Object{baseOrder},
 			givenCall:         func(t *testing.T, _ cmclient.Interface, _ kubernetes.Interface) {},
-			expectRequeueKey:  "",
+			expectRequeueKey:  types.NamespacedName{},
 		},
 		"if no changes to request or order, then no request should sync": {
 			existingCSR:       baseCSR,
 			existingCMObjects: []runtime.Object{baseOrder},
 			givenCall:         func(t *testing.T, _ cmclient.Interface, _ kubernetes.Interface) {},
-			expectRequeueKey:  "",
+			expectRequeueKey:  types.NamespacedName{},
 		},
 		"request should be synced if an owned order is updated": {
 			existingCSR: baseCSR,
@@ -95,7 +96,9 @@ func Test_controllerBuilder(t *testing.T) {
 				_, err := cmclient.AcmeV1().Orders("test-namespace").Update(context.TODO(), order, metav1.UpdateOptions{})
 				require.NoError(t, err)
 			},
-			expectRequeueKey: "test-csr",
+			expectRequeueKey: types.NamespacedName{
+				Name: "test-csr",
+			},
 		},
 		"request should not be synced if updated order is not owned": {
 			existingCSR: baseCSR,
@@ -109,7 +112,7 @@ func Test_controllerBuilder(t *testing.T) {
 				_, err := cmclient.AcmeV1().Orders("test-namespace").Update(context.TODO(), order, metav1.UpdateOptions{})
 				require.NoError(t, err)
 			},
-			expectRequeueKey: "",
+			expectRequeueKey: types.NamespacedName{},
 		},
 		"request should be synced if request is updated": {
 			existingCSR:       baseCSR,
@@ -121,7 +124,9 @@ func Test_controllerBuilder(t *testing.T) {
 				_, err := kubeclient.CertificatesV1().CertificateSigningRequests().UpdateStatus(context.TODO(), csr, metav1.UpdateOptions{})
 				require.NoError(t, err)
 			},
-			expectRequeueKey: "test-csr",
+			expectRequeueKey: types.NamespacedName{
+				Name: "test-csr",
+			},
 		},
 	}
 
@@ -158,7 +163,7 @@ func Test_controllerBuilder(t *testing.T) {
 			// to be nil.
 			time.AfterFunc(50*time.Millisecond, queue.ShutDown)
 
-			var gotKeys []string
+			var gotKeys []types.NamespacedName
 			for {
 				// Get blocks until either (1) a key is returned, or (2) the
 				// queue is shut down.
@@ -166,13 +171,13 @@ func Test_controllerBuilder(t *testing.T) {
 				if done {
 					break
 				}
-				gotKeys = append(gotKeys, gotKey.(string))
+				gotKeys = append(gotKeys, gotKey)
 			}
 			assert.Equal(t, 0, queue.Len(), "queue should be empty")
 
 			// We only expect 0 or 1 keys received in the queue.
-			if test.expectRequeueKey != "" {
-				assert.Equal(t, []string{test.expectRequeueKey}, gotKeys)
+			if test.expectRequeueKey != (types.NamespacedName{}) {
+				assert.Equal(t, []types.NamespacedName{test.expectRequeueKey}, gotKeys)
 			} else {
 				assert.Nil(t, gotKeys)
 			}
@@ -922,7 +927,9 @@ func Test_ProcessItem(t *testing.T) {
 
 			test.builder.Start()
 
-			err := controller.ProcessItem(context.Background(), test.csr.Name)
+			err := controller.ProcessItem(context.Background(), types.NamespacedName{
+				Name: test.csr.Name,
+			})
 			if (err != nil) != test.expectedErr {
 				t.Errorf("unexpected error, exp=%t got=%v", test.expectedErr, err)
 			}

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -36,6 +36,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientcorev1 "k8s.io/client-go/listers/core/v1"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
@@ -578,7 +579,9 @@ func runTest(t *testing.T, test testT) {
 	}
 	test.builder.Start()
 
-	err := controller.ProcessItem(context.Background(), test.csr.Name)
+	err := controller.ProcessItem(context.Background(), types.NamespacedName{
+		Name: test.csr.Name,
+	})
 	if err != nil && !test.expectedErr {
 		t.Errorf("expected to not get an error, but got: %v", err)
 	}

--- a/pkg/controller/certificatesigningrequests/checks.go
+++ b/pkg/controller/certificatesigningrequests/checks.go
@@ -21,6 +21,7 @@ import (
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -44,13 +45,10 @@ func (c *Controller) handleGenericIssuer(obj interface{}) {
 		return
 	}
 	for _, cr := range crs {
-		log := logf.WithRelatedResource(log, cr)
-		key, err := keyFunc(cr)
-		if err != nil {
-			log.Error(err, "error computing key for resource")
-			continue
-		}
-		c.queue.Add(key)
+		c.queue.Add(types.NamespacedName{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		})
 	}
 }
 

--- a/pkg/controller/certificatesigningrequests/controller.go
+++ b/pkg/controller/certificatesigningrequests/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	authzclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	certificateslisters "k8s.io/client-go/listers/certificates/v1"
@@ -36,8 +37,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
-
-var keyFunc = controllerpkg.KeyFunc
 
 // Signer is an implementation of a Kubernetes CertificateSigningRequest
 // signer, backed by a cert-manager Issuer.
@@ -54,7 +53,7 @@ type SignerConstructor func(*controllerpkg.Context) Signer
 // informers not covered in the main shared controller implementation.
 // The returned set of InformerSyncs will be waited on when the controller
 // starts.
-type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error)
+type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error)
 
 // Controller is a base Kubernetes CertificateSigningRequest controller. It is
 // responsible for orchestrating and performing shared operations that all
@@ -72,7 +71,7 @@ type Controller struct {
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
 
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -113,14 +112,19 @@ func New(signerType string, signerConstructor SignerConstructor, registerExtraIn
 	}
 }
 
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	componentName := "certificatesigningrequests-" + c.signerType
 
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, componentName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), componentName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: componentName,
+		},
+	)
 
 	kubeClient := ctx.Client
 	c.sarClient = kubeClient.AuthorizationV1().SubjectAccessReviews()
@@ -188,15 +192,11 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	return c.queue, mustSync, nil
 }
 
-func (c *Controller) ProcessItem(ctx context.Context, key string) error {
+func (c *Controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
 
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	name := key.Name
 
 	csr, err := c.csrLister.Get(name)
 	if apierrors.IsNotFound(err) {

--- a/pkg/controller/certificatesigningrequests/controller.go
+++ b/pkg/controller/certificatesigningrequests/controller.go
@@ -54,7 +54,7 @@ type SignerConstructor func(*controllerpkg.Context) Signer
 // informers not covered in the main shared controller implementation.
 // The returned set of InformerSyncs will be waited on when the controller
 // starts.
-type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.RateLimitingInterface) ([]cache.InformerSynced, error)
+type RegisterExtraInformerFn func(*controllerpkg.Context, logr.Logger, workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error)
 
 // Controller is a base Kubernetes CertificateSigningRequest controller. It is
 // responsible for orchestrating and performing shared operations that all
@@ -72,7 +72,7 @@ type Controller struct {
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
 
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -113,7 +113,7 @@ func New(signerType string, signerConstructor SignerConstructor, registerExtraIn
 	}
 }
 
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	componentName := "certificatesigningrequests-" + c.signerType
 
 	// construct a new named logger to be reused throughout the controller

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	clientv1 "k8s.io/client-go/listers/certificates/v1"
 	"k8s.io/client-go/util/workqueue"
 
@@ -43,7 +44,7 @@ import (
 func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateSigningRequestLister,
 	helper issuer.Helper,
-	queue workqueue.TypedRateLimitingInterface[any],
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	issuerOptions controllerpkg.IssuerOptions,
 ) func(obj any) {
 	return func(obj any) {
@@ -60,13 +61,10 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 			return
 		}
 		for _, request := range requests {
-			log := logf.WithRelatedResource(log, request)
-			key, err := controllerpkg.KeyFunc(request)
-			if err != nil {
-				log.Error(err, "error computing key for resource")
-				continue
-			}
-			queue.Add(key)
+			queue.Add(types.NamespacedName{
+				Name:      request.Name,
+				Namespace: request.Namespace,
+			})
 		}
 	}
 }

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks.go
@@ -43,7 +43,7 @@ import (
 func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateSigningRequestLister,
 	helper issuer.Helper,
-	queue workqueue.RateLimitingInterface,
+	queue workqueue.TypedRateLimitingInterface[any],
 	issuerOptions controllerpkg.IssuerOptions,
 ) func(obj any) {
 	return func(obj any) {

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2/ktesting"
 
@@ -38,7 +39,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 		secret          runtime.Object
 		existingCSRs    []runtime.Object
 		existingIssuers []runtime.Object
-		expectedQueue   []string
+		expectedQueue   []types.NamespacedName
 	}{
 		"if given object is not secret, expect empty queue": {
 			secret: gen.Certificate("not-a-secret"),
@@ -65,7 +66,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{},
+			expectedQueue: []types.NamespacedName{},
 		},
 		"if no requests then expect empty queue": {
 			secret:       gen.Secret("test-secret", gen.SetSecretNamespace("test-namespace")),
@@ -79,7 +80,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{},
+			expectedQueue: []types.NamespacedName{},
 		},
 		"referenced requests should be added to the queue": {
 			secret: gen.Secret("test-secret", gen.SetSecretNamespace("test-namespace")),
@@ -106,7 +107,10 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 					gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 				),
 			},
-			expectedQueue: []string{"a", "b"},
+			expectedQueue: []types.NamespacedName{
+				{Name: "a"},
+				{Name: "b"},
+			},
 		},
 	}
 
@@ -128,15 +132,15 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 
 			builder.Start()
 
-			queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[any](), workqueue.TypedRateLimitingQueueConfig[any]{})
+			queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName](), workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{})
 			handleSecretReferenceWorkFunc(ktesting.NewLogger(t, ktesting.NewConfig()), lister, helper, queue,
 				controllerpkg.IssuerOptions{ClusterResourceNamespace: "test-namespace"},
 			)(test.secret)
 			require.Equal(t, len(test.expectedQueue), queue.Len())
-			var actualQueue []string
+			var actualQueue []types.NamespacedName
 			for range test.expectedQueue {
 				i, _ := queue.Get()
-				actualQueue = append(actualQueue, i.(string))
+				actualQueue = append(actualQueue, i)
 			}
 			assert.ElementsMatch(t, test.expectedQueue, actualQueue)
 		})

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
@@ -128,7 +128,7 @@ func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 
 			builder.Start()
 
-			queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[any](), workqueue.TypedRateLimitingQueueConfig[any]{})
 			handleSecretReferenceWorkFunc(ktesting.NewLogger(t, ktesting.NewConfig()), lister, helper, queue,
 				controllerpkg.IssuerOptions{ClusterResourceNamespace: "test-namespace"},
 			)(test.secret)

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -79,7 +79,7 @@ func init() {
 
 				// Handle informed Secrets which may be referenced by the
 				// "experimental.cert-manager.io/private-key-secret-name" annotation.
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.RateLimitingInterface) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
 					secretInformer := ctx.KubeSharedInformerFactory.Secrets().Informer()
 					certificateSigningRequestLister := ctx.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 					helper := issuer.NewHelper(

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -27,6 +27,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -79,7 +80,7 @@ func init() {
 
 				// Handle informed Secrets which may be referenced by the
 				// "experimental.cert-manager.io/private-key-secret-name" annotation.
-				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[any]) ([]cache.InformerSynced, error) {
+				func(ctx *controllerpkg.Context, log logr.Logger, queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) ([]cache.InformerSynced, error) {
 					secretInformer := ctx.KubeSharedInformerFactory.Secrets().Informer()
 					certificateSigningRequestLister := ctx.KubeSharedInformerFactory.CertificateSigningRequests().Lister()
 					helper := issuer.NewHelper(

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
@@ -621,7 +622,9 @@ func TestProcessItem(t *testing.T) {
 			}
 			test.builder.Start()
 
-			err := controller.ProcessItem(context.Background(), test.csr.Name)
+			err := controller.ProcessItem(context.Background(), types.NamespacedName{
+				Name: test.csr.Name,
+			})
 			if err != nil && !test.expectedErr {
 				t.Errorf("expected to not get an error, but got: %v", err)
 			}

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
@@ -444,7 +445,9 @@ func TestProcessItem(t *testing.T) {
 			}
 			test.builder.Start()
 
-			err := controller.ProcessItem(context.Background(), test.csr.Name)
+			err := controller.ProcessItem(context.Background(), types.NamespacedName{
+				Name: test.csr.Name,
+			})
 			if err != nil && !test.expectedErr {
 				t.Errorf("expected to not get an error, but got: %v", err)
 			}

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
@@ -912,7 +913,9 @@ func TestProcessItem(t *testing.T) {
 			}
 			test.builder.Start()
 
-			err := controller.ProcessItem(context.Background(), test.csr.Name)
+			err := controller.ProcessItem(context.Background(), types.NamespacedName{
+				Name: test.csr.Name,
+			})
 			if err != nil && !test.expectedErr {
 				t.Errorf("expected to not get an error, but got: %v", err)
 			}

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -40,7 +41,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -66,12 +67,17 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
@@ -122,24 +128,17 @@ func (c *controller) secretDeleted(obj interface{}) {
 		return
 	}
 	for _, iss := range issuers {
-		log := logf.WithRelatedResource(log, iss)
-		key, err := keyFunc(iss)
-		if err != nil {
-			log.Error(err, "error computing key for resource")
-			continue
-		}
-		c.queue.AddRateLimited(key)
+		c.queue.AddRateLimited(types.NamespacedName{
+			Name:      iss.Name,
+			Namespace: iss.Namespace,
+		})
 	}
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
 
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(nil, "invalid resource key")
-		return nil
-	}
+	name := key.Name
 
 	issuer, err := c.clusterIssuerLister.Get(name)
 	if err != nil {
@@ -154,8 +153,6 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
 	return c.Sync(ctx, issuer)
 }
-
-var keyFunc = controllerpkg.KeyFunc
 
 const (
 	// ControllerName is the name of the ClusterIssuers controller.

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -40,7 +40,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -66,7 +66,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/client-go/tools/cache"
@@ -40,17 +41,17 @@ type runDurationFunc struct {
 }
 
 type queueingController interface {
-	Register(*Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error)
-	ProcessItem(ctx context.Context, key string) error
+	Register(*Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error)
+	ProcessItem(ctx context.Context, key types.NamespacedName) error
 }
 
 func NewController(
 	name string,
 	metrics *metrics.Metrics,
-	syncFunc func(ctx context.Context, key string) error,
+	syncFunc func(ctx context.Context, key types.NamespacedName) error,
 	mustSync []cache.InformerSynced,
 	runDurationFuncs []runDurationFunc,
-	queue workqueue.TypedRateLimitingInterface[any],
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 ) Interface {
 	return &controller{
 		name:             name,
@@ -68,7 +69,7 @@ type controller struct {
 
 	// the function that should be called when an item is popped
 	// off the workqueue
-	syncHandler func(ctx context.Context, key string) error
+	syncHandler func(ctx context.Context, key types.NamespacedName) error
 
 	// mustSync is a slice of informers that must have synced before
 	// this controller can start
@@ -82,7 +83,7 @@ type controller struct {
 
 	// queue is a reference to the queue used to enqueue resources
 	// to be processed
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// metrics is used to expose Prometheus, shared by all controllers
 	metrics *metrics.Metrics
@@ -137,21 +138,16 @@ func (c *controller) worker(ctx context.Context) {
 			break
 		}
 
-		var key string
 		// use an inlined function so we can use defer
 		func() {
 			defer c.queue.Done(obj)
-			var ok bool
-			if key, ok = obj.(string); !ok {
-				return
-			}
-			log := log.WithValues("key", key)
+
 			log.V(logf.DebugLevel).Info("syncing item")
 
 			// Increase sync count for this controller
 			c.metrics.IncrementSyncCallCount(c.name)
 
-			err := c.syncHandler(ctx, key)
+			err := c.syncHandler(ctx, obj)
 			if err != nil {
 				if strings.Contains(err.Error(), genericregistry.OptimisticLockErrorMsg) {
 					log.Info("re-queuing item due to optimistic locking on resource", "error", err.Error())

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,7 +40,7 @@ type runDurationFunc struct {
 }
 
 type queueingController interface {
-	Register(*Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error)
+	Register(*Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error)
 	ProcessItem(ctx context.Context, key string) error
 }
 
@@ -50,7 +50,7 @@ func NewController(
 	syncFunc func(ctx context.Context, key string) error,
 	mustSync []cache.InformerSynced,
 	runDurationFuncs []runDurationFunc,
-	queue workqueue.RateLimitingInterface,
+	queue workqueue.TypedRateLimitingInterface[any],
 ) Interface {
 	return &controller{
 		name:             name,
@@ -82,7 +82,7 @@ type controller struct {
 
 	// queue is a reference to the queue used to enqueue resources
 	// to be processed
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// metrics is used to expose Prometheus, shared by all controllers
 	metrics *metrics.Metrics

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -40,7 +41,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.TypedRateLimitingInterface[any]
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -62,12 +63,17 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[types.NamespacedName], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
 	// create a queue used to queue up items to be processed
-	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
+	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		controllerpkg.DefaultItemBasedRateLimiter(),
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: ControllerName,
+		},
+	)
 
 	// obtain references to all the informers used by this controller
 	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
@@ -116,22 +122,16 @@ func (c *controller) secretDeleted(obj interface{}) {
 		return
 	}
 	for _, iss := range issuers {
-		key, err := keyFunc(iss)
-		if err != nil {
-			log.Error(err, "error computing key for resource")
-			continue
-		}
-		c.queue.AddRateLimited(key)
+		c.queue.AddRateLimited(types.NamespacedName{
+			Name:      iss.Name,
+			Namespace: iss.Namespace,
+		})
 	}
 }
 
-func (c *controller) ProcessItem(ctx context.Context, key string) error {
+func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		log.Error(err, "invalid resource key")
-		return nil
-	}
+	namespace, name := key.Namespace, key.Name
 
 	issuer, err := c.issuerLister.Issuers(namespace).Get(name)
 	if err != nil {
@@ -146,8 +146,6 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
 	return c.Sync(ctx, issuer)
 }
-
-var keyFunc = controllerpkg.KeyFunc
 
 const (
 	ControllerName = "issuers"

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -40,7 +40,7 @@ type controller struct {
 
 	// maintain a reference to the workqueue for this controller
 	// so the handleOwnedResource method can enqueue resources
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[any]
 
 	// logger to be used by this controller
 	log logr.Logger
@@ -62,7 +62,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLimitingInterface[any], []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -33,21 +34,33 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-// KeyFunc creates a key for an API object. The key can be passed to a
-// worker function that processes an object from a queue such as
-// ProcessItem.
-var KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
-
 // DefaultItemBasedRateLimiter returns a new rate limiter with base delay of 5
 // seconds, max delay of 5 minutes.
-func DefaultItemBasedRateLimiter() workqueue.TypedRateLimiter[any] {
-	return workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*5, time.Minute*5)
+func DefaultItemBasedRateLimiter() workqueue.TypedRateLimiter[types.NamespacedName] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](time.Second*5, time.Minute*5)
+}
+
+// DefaultCertificateRateLimiter returns a new rate limiter with base delay of 1
+// seconds, max delay of 30 seconds.
+func DefaultCertificateRateLimiter() workqueue.TypedRateLimiter[types.NamespacedName] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](time.Second*1, time.Second*30)
+}
+
+// DefaultCertificateRateLimiter returns a new rate limiter with base delay of 5
+// seconds, max delay of 30 minutes.
+func DefaultACMERateLimiter() workqueue.TypedRateLimiter[types.NamespacedName] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](time.Second*5, time.Minute*30)
 }
 
 // HandleOwnedResourceNamespacedFunc returns a function thataccepts a
 // Kubernetes object and adds its owner references to the workqueue.
 // https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
-func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.TypedRateLimitingInterface[any], ownerGVK schema.GroupVersionKind, get func(namespace, name string) (interface{}, error)) func(obj interface{}) {
+func HandleOwnedResourceNamespacedFunc[T metav1.Object](
+	log logr.Logger,
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
+	ownerGVK schema.GroupVersionKind,
+	get func(namespace, name string) (T, error),
+) func(obj interface{}) {
 	return func(obj interface{}) {
 		log := log.WithName("handleOwnedResource")
 
@@ -87,12 +100,10 @@ func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.TypedRat
 					log.Error(err, "error getting referenced owning resource from cache")
 					continue
 				}
-				objKey, err := KeyFunc(obj)
-				if err != nil {
-					log.Error(err, "error computing key for resource")
-					continue
-				}
-				queue.Add(objKey)
+				queue.Add(types.NamespacedName{
+					Name:      obj.GetName(),
+					Namespace: obj.GetNamespace(),
+				})
 			}
 		}
 	}
@@ -101,17 +112,20 @@ func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.TypedRat
 // QueuingEventHandler is an implementation of cache.ResourceEventHandler that
 // simply queues objects that are added/updated/deleted.
 type QueuingEventHandler struct {
-	Queue workqueue.TypedRateLimitingInterface[any]
+	Queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
 // Enqueue adds a key for an object to the workqueue.
 func (q *QueuingEventHandler) Enqueue(obj interface{}) {
-	key, err := KeyFunc(obj)
+	objectName, err := cache.DeletionHandlingObjectToName(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	q.Queue.Add(key)
+	q.Queue.Add(types.NamespacedName{
+		Name:      objectName.Name,
+		Namespace: objectName.Namespace,
+	})
 }
 
 // OnAdd adds a newly created object to the workqueue.

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -40,14 +40,14 @@ var KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
 // DefaultItemBasedRateLimiter returns a new rate limiter with base delay of 5
 // seconds, max delay of 5 minutes.
-func DefaultItemBasedRateLimiter() workqueue.RateLimiter {
-	return workqueue.NewItemExponentialFailureRateLimiter(time.Second*5, time.Minute*5)
+func DefaultItemBasedRateLimiter() workqueue.TypedRateLimiter[any] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[any](time.Second*5, time.Minute*5)
 }
 
 // HandleOwnedResourceNamespacedFunc returns a function thataccepts a
 // Kubernetes object and adds its owner references to the workqueue.
 // https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
-func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.RateLimitingInterface, ownerGVK schema.GroupVersionKind, get func(namespace, name string) (interface{}, error)) func(obj interface{}) {
+func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.TypedRateLimitingInterface[any], ownerGVK schema.GroupVersionKind, get func(namespace, name string) (interface{}, error)) func(obj interface{}) {
 	return func(obj interface{}) {
 		log := log.WithName("handleOwnedResource")
 
@@ -101,7 +101,7 @@ func HandleOwnedResourceNamespacedFunc(log logr.Logger, queue workqueue.RateLimi
 // QueuingEventHandler is an implementation of cache.ResourceEventHandler that
 // simply queues objects that are added/updated/deleted.
 type QueuingEventHandler struct {
-	Queue workqueue.RateLimitingInterface
+	Queue workqueue.TypedRateLimitingInterface[any]
 }
 
 // Enqueue adds a key for an object to the workqueue.

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -18,7 +18,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/types"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -99,12 +99,8 @@ func (m *Metrics) updateCertificateReadyStatus(crt *cmapi.Certificate, current c
 
 // RemoveCertificate will delete the Certificate metrics from continuing to be
 // exposed.
-func (m *Metrics) RemoveCertificate(key string) {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		m.log.Error(err, "failed to get namespace and name from key")
-		return
-	}
+func (m *Metrics) RemoveCertificate(key types.NamespacedName) {
+	namespace, name := key.Namespace, key.Name
 
 	m.certificateExpiryTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
 	m.certificateRenewalTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -24,6 +24,7 @@ import (
 	logtesting "github.com/go-logr/logr/testing"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -322,7 +323,10 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove second certificate and check not exists
-	m.RemoveCertificate("default-unit-test-ns/crt2")
+	m.RemoveCertificate(types.NamespacedName{
+		Namespace: "default-unit-test-ns",
+		Name:      "crt2",
+	})
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata+`
         certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 0
@@ -347,9 +351,18 @@ func TestCertificateCache(t *testing.T) {
 	}
 
 	// Remove all Certificates (even is already removed) and observe no Certificates
-	m.RemoveCertificate("default-unit-test-ns/crt1")
-	m.RemoveCertificate("default-unit-test-ns/crt2")
-	m.RemoveCertificate("default-unit-test-ns/crt3")
+	m.RemoveCertificate(types.NamespacedName{
+		Namespace: "default-unit-test-ns",
+		Name:      "crt1",
+	})
+	m.RemoveCertificate(types.NamespacedName{
+		Namespace: "default-unit-test-ns",
+		Name:      "crt2",
+	})
+	m.RemoveCertificate(types.NamespacedName{
+		Namespace: "default-unit-test-ns",
+		Name:      "crt3",
+	})
 	if err := testutil.CollectAndCompare(m.certificateReadyStatus,
 		strings.NewReader(readyMetadata),
 		"certmanager_certificate_ready_status",

--- a/pkg/scheduler/test/fake.go
+++ b/pkg/scheduler/test/fake.go
@@ -19,21 +19,23 @@ package test
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/cert-manager/cert-manager/pkg/scheduler"
 )
 
-var _ scheduler.ScheduledWorkQueue = &FakeScheduler{}
+var _ scheduler.ScheduledWorkQueue[types.NamespacedName] = &FakeScheduler{}
 
 // FakeScheduler allows stubbing the methods of scheduler.ScheduledWorkQueue in tests.
 type FakeScheduler struct {
-	AddFunc    func(interface{}, time.Duration)
-	ForgetFunc func(interface{})
+	AddFunc    func(types.NamespacedName, time.Duration)
+	ForgetFunc func(types.NamespacedName)
 }
 
-func (f *FakeScheduler) Add(obj interface{}, duration time.Duration) {
+func (f *FakeScheduler) Add(obj types.NamespacedName, duration time.Duration) {
 	f.AddFunc(obj, duration)
 }
 
-func (f *FakeScheduler) Forget(obj interface{}) {
+func (f *FakeScheduler) Forget(obj types.NamespacedName) {
 	f.ForgetFunc(obj)
 }


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/7237, we upgraded our go dependencies and had to disable the staticcheck linter to keep using the deprecated function calls. This PR replaces all deprecated function calls so we can re-enable the staticcheck linter.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
