### PR TITLE
Enable and fix usestdlibvars, misspell and staticcheck linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@ issues:
     - linters:
         - govet
         - usestdlibvars
-        - misspell
         - dogsled
         - promlinter
         - errname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,6 @@ issues:
   exclude-rules:
     - linters:
         - govet
-        - usestdlibvars
         - dogsled
         - promlinter
         - errname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,9 +18,6 @@ issues:
       text: "G(101|107|204|306|402)"
     - linters:
         - staticcheck
-      text: "SA(1002|1006|4000|4006)"
-    - linters:
-        - staticcheck
       text: "(NewCertManagerBasicCertificateRequest)"
 linters:
   # Explicitly define all enabled linters

--- a/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
+++ b/pkg/acme/webhook/registry/challengepayload/challenge_payload.go
@@ -33,7 +33,7 @@ type REST struct {
 	hookFn webhook.Solver
 }
 
-var _ rest.Creater = &REST{}
+var _ rest.Creater = &REST{} // nolint:misspell
 var _ rest.Scoper = &REST{}
 var _ rest.GroupVersionKindProvider = &REST{}
 var _ rest.SingularNameProvider = &REST{}

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/http"
 	"time"
 
 	acmeapi "golang.org/x/crypto/acme"
@@ -531,7 +532,7 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 	// finalized in an earlier reconcile, but the reconciler failed
 	// to update the status of the Order CR.
 	// https://datatracker.ietf.org/doc/html/rfc8555#:~:text=A%20request%20to%20finalize%20an%20order%20will%20result%20in%20error,will%20indicate%20what%20action%20the%20client%20should%20take%20(see%20below).
-	if ok && acmeErr.StatusCode == 403 {
+	if ok && acmeErr.StatusCode == http.StatusForbidden {
 
 		acmeOrder, getOrderErr := getACMEOrder(ctx, cl, o)
 		acmeGetOrderErr, ok := getOrderErr.(*acmeapi.Error)

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -3253,7 +3253,7 @@ func TestSync(t *testing.T) {
 				t.Error(err)
 			}
 			if err := b.AllActionsExecuted(); err != nil {
-				t.Errorf(err.Error())
+				t.Error(err)
 			}
 		}
 	}

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -217,10 +217,10 @@ func (b *Builder) FakeDiscoveryClient() *discoveryfake.Discovery {
 func (b *Builder) CheckAndFinish(args ...interface{}) {
 	defer b.Stop()
 	if err := b.AllActionsExecuted(); err != nil {
-		b.T.Errorf(err.Error())
+		b.T.Error(err)
 	}
 	if err := b.AllEventsCalled(); err != nil {
-		b.T.Errorf(err.Error())
+		b.T.Error(err)
 	}
 
 	// resync listers before running checks

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -115,7 +115,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 		if err != nil {
 			msg = messageAccountRegistrationFailed + err.Error()
 			reason = errorAccountRegistrationFailed
-			return fmt.Errorf(msg)
+			return fmt.Errorf("%s", msg)
 		}
 		// We clear the ACME account URI as we have generated a new private key
 		a.issuer.GetStatus().ACMEStatus().URI = ""
@@ -139,7 +139,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 	case err != nil:
 		reason = errorAccountVerificationFailed
 		msg = messageAccountVerificationFailed + err.Error()
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 	rsaPk, ok := pk.(*rsa.PrivateKey)
 	if !ok {
@@ -244,7 +244,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 		case err != nil:
 			reason = errorAccountRegistrationFailed
 			msg = messageAccountRegistrationFailed + err.Error()
-			return fmt.Errorf(msg)
+			return fmt.Errorf("%s", msg)
 		}
 
 		// set the external account binding

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -219,7 +219,7 @@ func TestGeneratePrivateKeyForCertificate(t *testing.T) {
 
 					curve, err := ecCurveForKeySize(test.keySize)
 					if err != nil {
-						t.Errorf(err.Error())
+						t.Error(err)
 						return
 					}
 

--- a/test/e2e/suite/certificaterequests/approval/userinfo.go
+++ b/test/e2e/suite/certificaterequests/approval/userinfo.go
@@ -82,7 +82,7 @@ var _ = framework.CertManagerDescribe("UserInfo CertificateRequests", func() {
 		By("Should error when attempting to update UserInfo fields")
 		cr.Spec.Username = "abc"
 		cr.Spec.UID = "123"
-		cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Update(context.TODO(), cr, metav1.UpdateOptions{})
+		_, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Update(context.TODO(), cr, metav1.UpdateOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/test/e2e/suite/certificates/secrettemplate.go
+++ b/test/e2e/suite/certificates/secrettemplate.go
@@ -268,7 +268,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		secret.Labels["abc"] = "123"
 		secret.Labels["foo"] = "bar"
 
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.UpdateOptions{})
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, secretName, metav1.GetOptions{})
@@ -278,7 +278,7 @@ var _ = framework.CertManagerDescribe("Certificate SecretTemplate", func() {
 		Expect(secret.Labels).To(HaveKeyWithValue("abc", "123"))
 		Expect(secret.Labels).To(HaveKeyWithValue("foo", "bar"))
 
-		secret, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(),
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Apply(context.Background(),
 			applycorev1.Secret(secret.Name, secret.Namespace).
 				WithAnnotations(secret.Annotations).
 				WithLabels(secret.Labels),

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -76,7 +76,7 @@ var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 					},
 				}))
 			issuer.Namespace = f.Namespace.Name
-			issuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, issuer, metav1.CreateOptions{})
+			_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, issuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for Issuer to become Ready")
 			err = util.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),


### PR DESCRIPTION
depends on #7242

Fixes remaining linter violations and enables the linters in `.golangci.yaml`.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
