### PR TITLE
BUGFIX: adhere to RFC 5280 - Section 4.2.1.3 and don't include empty KeyUsages extensions

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -260,11 +260,13 @@ func GenerateCSR(crt *v1.Certificate, optFuncs ...GenerateCSROption) (*x509.Cert
 			return nil, fmt.Errorf("failed to build key usages: %w", err)
 		}
 
-		usage, err := MarshalKeyUsage(ku)
-		if err != nil {
-			return nil, fmt.Errorf("failed to asn1 encode usages: %w", err)
+		if ku != 0 {
+			usage, err := MarshalKeyUsage(ku)
+			if err != nil {
+				return nil, fmt.Errorf("failed to asn1 encode usages: %w", err)
+			}
+			extraExtensions = append(extraExtensions, usage)
 		}
-		extraExtensions = append(extraExtensions, usage)
 
 		// Only add extended usages if they are specified.
 		if len(ekus) > 0 {


### PR DESCRIPTION
fixes https://github.com/cert-manager/cert-manager/issues/6541

### Kind

/kind bug

### Release Note

```release-note
We no longer add the KeyUsages x509 extension when there are no key usages set in accordance to RFC 5280 - Section 4.2.1.3.
```
