### PR TITLE
WIP: Issues/7234: Remove failed challenges after timeout

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -270,7 +270,8 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 	if !ch.Status.Processing {
 		if ch.Status.State == "expired" {
 			// When a challenge is "expired", no more work can be done and it should be cleaned up and deleted
-			ch.DeletionTimestamp = &metav1.Time{}
+			expiredDeleteTimestamp := metav1.Now()
+			ch.SetDeletionTimestamp(&expiredDeleteTimestamp)
 		} else {
 			return nil
 		}


### PR DESCRIPTION

### Pull Request Motivation

Sometimes Challenges fail or get stuck, but even after resolving the underlying issue the Challenge retains reference to previous state information and is unable to complete. This PR is intended to allow expired Challenges to be automatically deleted so that new Challenge resources will be created with updated state information

### Kind
feature

### Release Note

```release-note
Expired Challenges will have DeletionTimestamp set to allow those challenges to be deleted and then recreated by the CertificateRequest controller
```
