### PR TITLE
Prevent aggressive Route53 retries caused by STS authentication failures by removing the Amazon Request ID from STS errors

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -112,7 +112,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			RoleSessionName: aws.String("cert-manager"),
 		})
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role: %s", err)
+			return aws.Config{}, fmt.Errorf("unable to assume role: %s", removeReqID(err))
 		}
 
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(
@@ -132,7 +132,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			WebIdentityToken: aws.String(d.WebIdentityToken),
 		})
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %s", err)
+			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %s", removeReqID(err))
 		}
 
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(


### PR DESCRIPTION
The problem we are trying to fix is described in #5486 by @pquerna, as follows:

> When using the Route53 Solver for ACME, I am attempting to use an IRSA (IAM Role for Service Accounts). However, I have a permissions error, causing sts:AssumeRoleWithWebIdentity to fail.
> When this happens, cert-manager goes into an aggressive loop, retrying to delete the challenge.

The reason for the aggressive retry loop is that the errors returned by the AWS SDK contain a unique "request ID",
which cert-manager saves to the `Challenge.Status`, triggering a re-reconcile, and so on:

> error instantiating route53 challenge solver: unable to assume role: WebIdentityErr: failed to retrieve credentials\ncaused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity\n\tstatus code: 403, 
> request id: eb150160-1a0a-4f2a-8b7f-32afa59f863f" 
>
> error instantiating route53 challenge solver: unable to assume role: WebIdentityErr: failed to retrieve credentials\ncaused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity\n\tstatus code: 403, 
> request id: 79f7c88a-c0d4-4654-8b81-ae3353e3cd2e" 
>
> error instantiating route53 challenge solver: unable to assume role: WebIdentityErr: failed to retrieve credentials\ncaused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity\n\tstatus code: 403, 
> request id: f4a66d72-d3c9-4bf7-b2a6-578e214df9d1" 

The solution in this PR is to remove the unique request ID from the errors returned by the STS client, just as we do to the errors returned by the Route53 client.

Fixes: #5486 
Fixes: #6308
Fixes: #4061

/kind bug

```release-note
Bugfix: Prevent aggressive Route53 retries caused by STS authentication failures by removing the Amazon Request ID from STS errors.
```

## Testing

I created a script to demonstrate the problem and to demonstrate the fix in this branch:
 * https://gist.github.com/wallrj/6f6cb31281f21c8a63513bfba5aeb092

The logs and the log message count are printed using:
```sh
kubectl logs -n cert-manager deploy/cert-manager | grep "error instantiating route53 challenge solver" | tee /dev/stderr | uniq | wc -l
```

### Before

> `E0906 16:12:10.319958       1 controller.go:158] "re-queuing item due to error processing" err="error instantiating route53 challenge solver: unable to assume role with web identity: operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 400, RequestID: bfc826c9-7b53-4738-90a3-b937a8b39723, InvalidIdentityToken: No OpenIDConnect provider found in your account for https://kubernetes.default.svc.cluster.local" logger="cert-manager.controller"`
>
> 8

### After

> `E0906 16:14:19.434185       1 controller.go:158] "re-queuing item due to error processing" err="error instantiating route53 challenge solver: unable to assume role with web identity: operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 400, RequestID: <REDACTED>, InvalidIdentityToken: No OpenIDConnect provider found in your account for https://kubernetes.default.svc.cluster.local" logger="cert-manager.controller"`
> 
> 3

