### PR TITLE
fix: set Challenges with not permitted zones in the domain as invalid

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-  "slices"
+  	"slices"
 	"strings"
 	"time"
 


### PR DESCRIPTION
resolve https://github.com/cert-manager/cert-manager/issues/7239

### Pull Request Motivation

As described in #7239, there are cases where the issuer configuration selected to expend a Certificate, and consequentially a Challenge is invalid.

The error is in the `Present` method, where we would see the following message:

```
Error presenting challenge: failed to change Route 53 record set: InvalidChangeBatch: [RRSet with DNS name subdomains.example.io. is not permitted in zone another-zone.io.]
```

This is basically from a zone mismatch between the Issuer and the domain selected in the object.

The problem with the current logic is that Challenges that get this error raised will still be considered as processing in the Challenges queue, which may affect the expedition of other Challenges. In our specific case, this has a larger blast radius since we host multi tenant clusters and one misconfiguration can lead to impeding other expeditions.

The fix proposed in this pull request is to identify these kind of errors, and update the challenges' State and Processing bool, so it's reflected accordingly. Also, it will provide a clearer interface towards users, since `Pending` in this case does not seem to be the best fit state, due to the fact that this has been processed already and it's actually invalid.
### Kind

bug - fix


### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
fixes Challenges with not permitted zones in the domain are considered as processing
```
