### PR TITLE
Helm: Remove empty apiGroup from 'subjects.ServiceAccount' refs

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -39,8 +39,7 @@ roleRef:
   kind: Role
   name: {{ template "cert-manager.fullname" . }}:leaderelection
 subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
+  - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
 
@@ -83,8 +82,7 @@ roleRef:
   kind: Role
   name: {{ template "cert-manager.serviceAccountName" . }}-tokenrequest
 subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
+  - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -47,8 +47,7 @@ roleRef:
   kind: Role
   name: {{ template "webhook.fullname" . }}:dynamic-serving
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ include "cert-manager.namespace" . }}
 
@@ -85,8 +84,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "webhook.fullname" . }}:subjectaccessreviews
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ include "cert-manager.namespace" . }}
 {{- end }}


### PR DESCRIPTION
### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes #6851

Currently, there are four resources in the Helm chart that use an empty `apiGroup` in their `subjects.ServiceAccount` references. This PR aims to remove these redundant lines.

### Kind

/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
