### PR TITLE
Support a domain qualified finalizer instead of one that triggers a warning from kubernetes

### DIFF
--- a/internal/apis/config/controller/v1alpha1/defaults_test.go
+++ b/internal/apis/config/controller/v1alpha1/defaults_test.go
@@ -52,7 +52,7 @@ func TestControllerConfigurationDefaults(t *testing.T) {
 			if err := os.WriteFile(tt.jsonFilePath, defaultData, 0644); err != nil {
 				t.Fatal(err)
 			}
-			t.Log("cainjector config api defaults updated")
+			t.Log("controller config api defaults updated")
 		}
 
 		expectedData, err := os.ReadFile(tt.jsonFilePath)

--- a/internal/apis/config/webhook/v1alpha1/defaults_test.go
+++ b/internal/apis/config/webhook/v1alpha1/defaults_test.go
@@ -51,7 +51,7 @@ func TestWebhookConfigurationDefaults(t *testing.T) {
 				if err := os.WriteFile(tt.jsonFilePath, defaultData, 0644); err != nil {
 					t.Fatal(err)
 				}
-				t.Log("cainjector config api defaults updated")
+				t.Log("webhook config api defaults updated")
 			}
 
 			expectedData, err := os.ReadFile(tt.jsonFilePath)

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // feature contains cainjector feature gate setup code. Do not import this
 // package into any code that's shared with other components to prevent
-// overwriting other component's featue gates, see i.e
+// overwriting other component's feature gates, see i.e
 // https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -137,6 +137,14 @@ const (
 	// Certificate resources.
 	// Github Issue: https://github.com/cert-manager/cert-manager/issues/6393
 	OtherNames featuregate.Feature = "OtherNames"
+
+	// Owner: @jsoref
+	// Alpha: v1.16
+	//
+	// UseDomainQualifiedFinalizer changes the finalizer added to cert-manager created
+	// resources to acme.cert-manager.io/finalizer instead of finalizer.acme.cert-manager.io.
+	// GitHub Issue: https://github.com/cert-manager/cert-manager/issues/7266
+	UseDomainQualifiedFinalizer featuregate.Feature = "UseDomainQualifiedFinalizer"
 )
 
 func init() {
@@ -160,4 +168,5 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
 	NameConstraints:                                  {Default: false, PreRelease: featuregate.Alpha},
 	OtherNames:                                       {Default: false, PreRelease: featuregate.Alpha},
+	UseDomainQualifiedFinalizer:                      {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // feature contains controller's feature gate setup functionality. Do not import
 // this package into any code that's shared with other components to prevent
-// overwriting other component's featue gates, see i.e
+// overwriting other component's feature gates, see i.e
 // https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // feature contains webhook's feature gate setup functionality. Do not import
 // this package into any code that's shared with other components to prevent
-// overwriting other component's featue gates, see i.e
+// overwriting other component's feature gates, see i.e
 // https://github.com/cert-manager/cert-manager/issues/6011
 package feature
 

--- a/pkg/apis/acme/v1/const.go
+++ b/pkg/apis/acme/v1/const.go
@@ -17,5 +17,6 @@ limitations under the License.
 package v1
 
 const (
-	ACMEFinalizer = "finalizer.acme.cert-manager.io"
+	ACMELegacyFinalizer          = "finalizer.acme.cert-manager.io"
+	ACMEDomainQualifiedFinalizer = "acme.cert-manager.io/finalizer"
 )

--- a/pkg/controller/acmechallenges/finalizer.go
+++ b/pkg/controller/acmechallenges/finalizer.go
@@ -30,6 +30,18 @@ import (
 // allowing the garbage collector to remove the challenge.
 
 // finalizerRequired returns true if the finalizer is not found on the challenge.
+//
+// API transition
+// We currently only add cmacme.ACMELegacyFinalizer, but a future version will add
+// cmacme.ACMEDomainQualifiedFinalizer.
+// A finalizer only needs to be added if neither is present.
 func finalizerRequired(ch *cmacme.Challenge) bool {
-	return !sets.NewString(ch.Finalizers...).Has(cmacme.ACMEFinalizer)
+	finalizers := sets.NewString(ch.Finalizers...)
+	return !finalizers.Has(cmacme.ACMELegacyFinalizer) &&
+		!finalizers.Has(cmacme.ACMEDomainQualifiedFinalizer)
+}
+
+func otherFinalizerPresent(ch *cmacme.Challenge) bool {
+	return ch.Finalizers[0] != cmacme.ACMELegacyFinalizer &&
+		ch.Finalizers[0] != cmacme.ACMEDomainQualifiedFinalizer
 }

--- a/pkg/controller/acmechallenges/finalizer_test.go
+++ b/pkg/controller/acmechallenges/finalizer_test.go
@@ -37,13 +37,33 @@ func Test_finalizerRequired(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "only-native-finalizer",
-			finalizers: []string{cmacme.ACMEFinalizer},
+			name:       "only-native-legacy-finalizer",
+			finalizers: []string{cmacme.ACMELegacyFinalizer},
 			want:       false,
 		},
 		{
-			name:       "some-foreign-finalizers",
-			finalizers: []string{"f1", "f2", cmacme.ACMEFinalizer, "f3"},
+			name:       "only-native-domain-qualified-finalizer",
+			finalizers: []string{cmacme.ACMEDomainQualifiedFinalizer},
+			want:       false,
+		},
+		{
+			name:       "both-native-finalizers",
+			finalizers: []string{cmacme.ACMELegacyFinalizer, cmacme.ACMEDomainQualifiedFinalizer},
+			want:       false,
+		},
+		{
+			name:       "some-foreign-and-legacy-finalizer",
+			finalizers: []string{"f1", "f2", cmacme.ACMELegacyFinalizer, "f3"},
+			want:       false,
+		},
+		{
+			name:       "some-foreign-and-domain-qualified-finalizer",
+			finalizers: []string{"f1", "f2", cmacme.ACMEDomainQualifiedFinalizer, "f3"},
+			want:       false,
+		},
+		{
+			name:       "some-foreign-and-legacy-finalizer-and-domain-qualified-finalizer",
+			finalizers: []string{"f1", "f2", cmacme.ACMELegacyFinalizer, cmacme.ACMEDomainQualifiedFinalizer, "f3"},
 			want:       false,
 		},
 		{

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -71,7 +71,7 @@ type testT struct {
 	acmeClient *acmecl.FakeACME
 }
 
-func TestSyncHappyPath(t *testing.T) {
+func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string) {
 	testIssuerHTTP01Enabled := gen.Issuer("testissuer", gen.SetIssuerACME(cmacme.ACMEIssuer{
 		Solvers: []cmacme.ACMEChallengeSolver{
 			{
@@ -85,7 +85,7 @@ func TestSyncHappyPath(t *testing.T) {
 		gen.SetChallengeIssuer(cmmeta.ObjectReference{
 			Name: "testissuer",
 		}),
-		gen.SetChallengeFinalizers([]string{cmacme.ACMEFinalizer}),
+		gen.SetChallengeFinalizers([]string{finalizer}),
 	)
 	deletedChallenge := gen.ChallengeFrom(baseChallenge,
 		gen.SetChallengeDeletionTimestamp(metav1.Now()))
@@ -188,7 +188,7 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.DefaultTestNamespace,
 							gen.ChallengeFrom(baseChallenge,
 								gen.SetChallengeProcessing(true),
-								gen.SetChallengeFinalizers([]string{cmacme.ACMEFinalizer})))),
+								gen.SetChallengeFinalizers([]string{cmacme.ACMELegacyFinalizer})))),
 				},
 			},
 			expectErr: false,
@@ -586,6 +586,14 @@ func TestSyncHappyPath(t *testing.T) {
 			runTest(t, test)
 		})
 	}
+}
+
+func TestSyncHappyPathFinalizer1(t *testing.T) {
+	testSyncHappyPathWithFinalizer(t, cmacme.ACMELegacyFinalizer)
+}
+
+func TestSyncHappyPathFinalizer2(t *testing.T) {
+	testSyncHappyPathWithFinalizer(t, cmacme.ACMEDomainQualifiedFinalizer)
 }
 
 func runTest(t *testing.T, test testT) {


### PR DESCRIPTION
### Pull Request Motivation

#7266

### Kind

/kind bug

### Release Note

```release-note
Adds support (behind a flag) to use a domain qualified finalizer. If the feature is enabled (which is not by default), it should prevent Kubernetes from reporting:
> metadata.finalizers: "finalizer.acme.cert-manager.io": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers
```
