### PR TITLE
Add further text explaining why we use an old license year

### DIFF
--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -15,7 +15,8 @@
 # LICENSE_YEAR is the value which will be substituted into licenses when they're generated
 # It would be possible to make this more dynamic, but there's seemingly no need:
 # https://stackoverflow.com/a/2391555/1615417
-# As such, this is hardcoded to avoid needless complexity
+# As such, this is hardcoded to avoid needless complexity. There's generally no need to update
+# this and create regular diffs which do nothing but update the license year.
 LICENSE_YEAR=2022
 
 # Creates the boilerplate header for YAML files from the template in hack/


### PR DESCRIPTION
As suggested by @jsoref  on slack: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1726175654671509

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
