### PR TITLE
Remove issuer argument from CleanUp function

### DIFF
--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -55,14 +55,14 @@ func (f *fakeSolver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cma
 // CleanUp will remove challenge records for a given solver.
 // This may involve deleting resources in the Kubernetes API Server, or
 // communicating with other external components (e.g. DNS providers).
-func (f *fakeSolver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
-	return f.fakeCleanUp(ctx, issuer, ch)
+func (f *fakeSolver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
+	return f.fakeCleanUp(ctx, ch)
 }
 
 type fakeSolver struct {
 	fakePresent func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
 	fakeCheck   func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
-	fakeCleanUp func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
+	fakeCleanUp func(ctx context.Context, ch *cmacme.Challenge) error
 }
 
 type testT struct {
@@ -102,7 +102,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(ctx context.Context, ch *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -134,7 +134,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return simulatedCleanupError
 				},
 			},
@@ -347,7 +347,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -402,7 +402,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -461,7 +461,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -521,7 +521,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengePresented(true),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -556,7 +556,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengePresented(true),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
 // ResourceNamespace returns the Kubernetes namespace where resources
@@ -30,6 +31,13 @@ func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
 	return ns
 }
 
+func (o IssuerOptions) ResourceNamespaceFromRef(ref cmmeta.ObjectReference, ns string) string {
+	if ns != "" {
+		return ns
+	}
+	return o.ClusterResourceNamespace
+}
+
 // CanUseAmbientCredentials returns whether `iss` will attempt to configure itself
 // from ambient credentials (e.g. from a cloud metadata service).
 func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
@@ -37,6 +45,16 @@ func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
 	case *cmapi.ClusterIssuer:
 		return o.ClusterIssuerAmbientCredentials
 	case *cmapi.Issuer:
+		return o.IssuerAmbientCredentials
+	}
+	return false
+}
+
+func (o IssuerOptions) CanUseAmbientCredentialsFromRef(ref cmmeta.ObjectReference) bool {
+	switch ref.Kind {
+	case cmapi.ClusterIssuerKind:
+		return o.ClusterIssuerAmbientCredentials
+	case "", cmapi.IssuerKind:
 		return o.IssuerAmbientCredentials
 	}
 	return false

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -31,13 +31,6 @@ func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
 	return ns
 }
 
-func (o IssuerOptions) ResourceNamespaceFromRef(ref cmmeta.ObjectReference, ns string) string {
-	if ns != "" {
-		return ns
-	}
-	return o.ClusterResourceNamespace
-}
-
 // CanUseAmbientCredentials returns whether `iss` will attempt to configure itself
 // from ambient credentials (e.g. from a cloud metadata service).
 func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
@@ -50,6 +43,11 @@ func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
 	return false
 }
 
+// CanUseAmbientCredentialsFromRef returns whether the referenced issuer will attempt
+// to configure itself from ambient credentials (e.g. from a cloud metadata service).
+// This function is identical to CanUseAmbientCredentials, but takes a reference to
+// the issuer instead of the issuer itself (which means we don't need to fetch the
+// issuer from the API server).
 func (o IssuerOptions) CanUseAmbientCredentialsFromRef(ref cmmeta.ObjectReference) bool {
 	switch ref.Kind {
 	case cmapi.ClusterIssuerKind:

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -181,7 +181,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 	log := logf.FromContext(ctx, "solverForChallenge")
 	dbg := log.V(logf.DebugLevel)
 
-	resourceNamespace := s.ResourceNamespaceFromRef(ch.Spec.IssuerRef, ch.Namespace)
+	resourceNamespace := ch.Namespace
 	canUseAmbientCredentials := s.CanUseAmbientCredentialsFromRef(ch.Spec.IssuerRef)
 
 	providerConfig, err := extractChallengeSolverConfig(ch)
@@ -460,7 +460,7 @@ func (s *Solver) prepareChallengeRequest(ctx context.Context, ch *cmacme.Challen
 		return nil, nil, err
 	}
 
-	resourceNamespace := s.ResourceNamespaceFromRef(ch.Spec.IssuerRef, ch.Namespace)
+	resourceNamespace := ch.Namespace
 	canUseAmbientCredentials := s.CanUseAmbientCredentialsFromRef(ch.Spec.IssuerRef)
 
 	// construct a ChallengeRequest which can be passed to DNS solvers.

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -284,7 +284,7 @@ func TestSolverFor(t *testing.T) {
 			test.Setup(t)
 			defer test.Finish(t)
 			s := test.Solver
-			dnsSolver, _, err := s.solverForChallenge(context.Background(), test.Issuer, test.Challenge)
+			dnsSolver, _, err := s.solverForChallenge(context.Background(), test.Challenge)
 			if err != nil && !test.expectErr {
 				t.Errorf("expected solverFor to not error, but got: %s", err.Error())
 				return
@@ -334,7 +334,7 @@ func TestSolveForDigitalOcean(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -387,7 +387,7 @@ func TestRoute53TrimCreds(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -445,7 +445,7 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -545,7 +545,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 		if tt.out.expectedErr != err {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}
@@ -643,7 +643,7 @@ func TestRoute53AssumeRole(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 		if tt.out.expectedErr != err {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -35,20 +34,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/cloudflare"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 )
-
-func newIssuer() *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				ACME: &cmacme.ACMEIssuer{},
-			},
-		},
-	}
-}
 
 func newSecret(name string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
@@ -76,8 +61,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -107,8 +94,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -131,9 +120,11 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider with a missing secret": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -156,9 +147,11 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider when key and token are provided": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -194,8 +187,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -225,8 +220,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -256,8 +253,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -310,8 +309,10 @@ func TestSolveForDigitalOcean(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -361,8 +362,10 @@ func TestRoute53TrimCreds(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -414,8 +417,10 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -484,9 +489,11 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -517,9 +524,11 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -580,9 +589,11 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -614,9 +625,11 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns"
@@ -31,11 +30,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/digitalocean"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/route53"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
-	"github.com/cert-manager/cert-manager/test/unit/gen"
-)
-
-const (
-	defaultTestIssuerName = "test-issuer"
 )
 
 type solverFixture struct {
@@ -43,8 +37,6 @@ type solverFixture struct {
 	Solver *Solver
 	*test.Builder
 
-	// Issuer to be passed to functions on the Solver (a default will be used if nil)
-	Issuer v1.GenericIssuer
 	// Challenge resource to use during tests
 	Challenge *cmacme.Challenge
 
@@ -67,9 +59,6 @@ type solverFixture struct {
 }
 
 func (s *solverFixture) Setup(t *testing.T) {
-	if s.Issuer == nil {
-		s.Issuer = gen.Issuer(defaultTestIssuerName, gen.SetIssuerACME(cmacme.ACMEIssuer{}))
-	}
 	if s.testResources == nil {
 		s.testResources = map[string]interface{}{}
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -188,7 +188,7 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 
 // CleanUp will ensure the created service, ingress and pod are clean/deleted of any
 // cert-manager created data.
-func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+func (s *Solver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
 	var errs []error
 	errs = append(errs, s.cleanupPods(ctx, ch))
 	errs = append(errs, s.cleanupServices(ctx, ch))


### PR DESCRIPTION
At the time of deleting the Challenge resource, the issuer might no longer exist.
We actually do not depend on the configuration of the issuer, we only use the issuer reference that is in the Challenge object.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
