### PR TITLE
Only remove the cleanup finalizer if the cleanup succeeds

### DIFF
--- a/pkg/controller/acmechallenges/finalizer.go
+++ b/pkg/controller/acmechallenges/finalizer.go
@@ -29,19 +29,12 @@ import (
 // deployed ("presented") resources and if successful, removes this finalizer
 // allowing the garbage collector to remove the challenge.
 
-// finalizerRequired returns true if the finalizer is not found on the challenge.
+// hasFinalizer returns true if the finalizer is found on the challenge.
 //
 // API transition
 // We currently only add cmacme.ACMELegacyFinalizer, but a future version will add
 // cmacme.ACMEDomainQualifiedFinalizer.
-// A finalizer only needs to be added if neither is present.
-func finalizerRequired(ch *cmacme.Challenge) bool {
+func hasFinalizer(ch *cmacme.Challenge) bool {
 	finalizers := sets.NewString(ch.Finalizers...)
-	return !finalizers.Has(cmacme.ACMELegacyFinalizer) &&
-		!finalizers.Has(cmacme.ACMEDomainQualifiedFinalizer)
-}
-
-func otherFinalizerPresent(ch *cmacme.Challenge) bool {
-	return ch.Finalizers[0] != cmacme.ACMELegacyFinalizer &&
-		ch.Finalizers[0] != cmacme.ACMEDomainQualifiedFinalizer
+	return finalizers.Has(cmacme.ACMELegacyFinalizer) || finalizers.Has(cmacme.ACMEDomainQualifiedFinalizer)
 }

--- a/pkg/controller/acmechallenges/finalizer_test.go
+++ b/pkg/controller/acmechallenges/finalizer_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func Test_finalizerRequired(t *testing.T) {
+func Test_not_hasFinalizer(t *testing.T) {
 	tests := []struct {
 		name       string
 		finalizers []string
-		want       bool
+		want       bool // what we expect !hasFinalizer to return
 	}{
 		{
 			name:       "no-finalizers",
@@ -77,7 +77,7 @@ func Test_finalizerRequired(t *testing.T) {
 			assert.Equal(
 				t,
 				tt.want,
-				finalizerRequired(
+				!hasFinalizer(
 					gen.Challenge("example", gen.SetChallengeFinalizers(tt.finalizers)),
 				),
 			)

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	acmeapi "golang.org/x/crypto/acme"
@@ -38,6 +39,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
+	"github.com/stretchr/testify/assert"
 )
 
 // Present the challenge value with the given solver.
@@ -119,15 +121,25 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 					testpkg.NewAction(coretesting.NewUpdateAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
 						gen.DefaultTestNamespace,
 						gen.ChallengeFrom(deletedChallenge,
-							gen.SetChallengeProcessing(true),
+							gen.SetChallengeProcessing(false),
 							gen.SetChallengeURL("testurl"),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengeFinalizers([]string{}),
 						))),
+					testpkg.NewAction(
+						coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
+							"status",
+							gen.DefaultTestNamespace,
+							gen.ChallengeFrom(deletedChallenge,
+								gen.SetChallengeProcessing(false),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+								gen.SetChallengeFinalizers([]string{}),
+								gen.SetChallengeURL("testurl"),
+							))),
 				},
 			},
 		},
-		"if the challenge is deleted and the cleanup fails, set the reason (and remove the finalizer, which is a bug)": {
+		"if the challenge is deleted and the cleanup fails, set the reason": {
 			challenge: gen.ChallengeFrom(deletedChallenge,
 				gen.SetChallengeProcessing(true),
 				gen.SetChallengeURL("testurl"),
@@ -148,15 +160,6 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 					testIssuerHTTP01Enabled,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
-						gen.DefaultTestNamespace,
-						gen.ChallengeFrom(deletedChallenge,
-							gen.SetChallengeProcessing(true),
-							gen.SetChallengeURL("testurl"),
-							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
-							gen.SetChallengeFinalizers([]string{}),
-							gen.SetChallengeReason(simulatedCleanupError.Error()),
-						))),
 					testpkg.NewAction(
 						coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
 							"status",
@@ -165,23 +168,25 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 								gen.SetChallengeProcessing(true),
 								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeURL("testurl"),
-								gen.SetChallengeFinalizers([]string{}),
-								gen.SetChallengeReason(simulatedCleanupError.Error()),
+								gen.SetChallengeReason(fmt.Sprintf("Error cleaning up challenge: %s", simulatedCleanupError)),
 							))),
 				},
 				ExpectedEvents: []string{
 					fmt.Sprintf("Warning CleanUpError Error cleaning up challenge: %s", simulatedCleanupError),
 				},
 			},
+			expectErr: true,
 		},
 		"if finalizer is missing, add it": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 				gen.SetChallengeFinalizers(nil),
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
 					gen.SetChallengeProcessing(true),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 					gen.SetChallengeFinalizers(nil),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
@@ -191,6 +196,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.DefaultTestNamespace,
 							gen.ChallengeFrom(baseChallenge,
 								gen.SetChallengeProcessing(true),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeFinalizers([]string{activeFinalizer})))),
 				},
 			},
@@ -199,11 +205,13 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 		"if GetAuthorization doesn't return challenge, error": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 				gen.SetChallengeURL("testurl"),
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
 					gen.SetChallengeProcessing(true),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 					gen.SetChallengeURL("testurl"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
@@ -214,6 +222,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.ChallengeFrom(baseChallenge,
 								gen.SetChallengeURL("testurl"),
 								gen.SetChallengeProcessing(true),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeReason("unexpected non-ACME API error: challenge was not present in authorization"),
 								gen.SetChallengeState(cmacme.Errored)))),
 				},
@@ -232,11 +241,13 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 		"if GetAuthorization returns challenge ready, update ready": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 				gen.SetChallengeURL("testurl"),
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
 					gen.SetChallengeProcessing(true),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 					gen.SetChallengeURL("testurl"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
@@ -246,6 +257,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.DefaultTestNamespace,
 							gen.ChallengeFrom(baseChallenge,
 								gen.SetChallengeProcessing(true),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeURL("testurl"),
 								gen.SetChallengeState(cmacme.Ready),
 							))),
@@ -264,11 +276,13 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 		"update status if state is unknown": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 				gen.SetChallengeURL("testurl"),
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
 					gen.SetChallengeProcessing(true),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 					gen.SetChallengeURL("testurl"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
@@ -278,6 +292,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.DefaultTestNamespace,
 							gen.ChallengeFrom(baseChallenge,
 								gen.SetChallengeProcessing(true),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeURL("testurl"),
 								gen.SetChallengeState(cmacme.Pending),
 							))),
@@ -512,7 +527,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				},
 			},
 		},
-		"mark the challenge as not processing if it is already valid": {
+		"cleanup and mark the challenge as not processing if it is already valid": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
 				gen.SetChallengeURL("testurl"),
@@ -534,6 +549,17 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(
+						coretesting.NewUpdateAction(
+							cmacme.SchemeGroupVersion.WithResource("challenges"),
+							gen.DefaultTestNamespace,
+							gen.ChallengeFrom(baseChallenge,
+								gen.SetChallengeProcessing(false),
+								gen.SetChallengeURL("testurl"),
+								gen.SetChallengeState(cmacme.Valid),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+								gen.SetChallengePresented(false),
+								gen.SetChallengeFinalizers([]string{})))),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
 						"status",
 						gen.DefaultTestNamespace,
@@ -543,11 +569,12 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.SetChallengeState(cmacme.Valid),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengePresented(false),
+							gen.SetChallengeFinalizers([]string{}),
 						))),
 				},
 			},
 		},
-		"mark the challenge as not processing if it is already failed": {
+		"cleanup and mark the challenge as not processing if it is already failed": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
 				gen.SetChallengeURL("testurl"),
@@ -569,6 +596,17 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(
+						coretesting.NewUpdateAction(
+							cmacme.SchemeGroupVersion.WithResource("challenges"),
+							gen.DefaultTestNamespace,
+							gen.ChallengeFrom(baseChallenge,
+								gen.SetChallengeProcessing(false),
+								gen.SetChallengeURL("testurl"),
+								gen.SetChallengeState(cmacme.Invalid),
+								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+								gen.SetChallengePresented(false),
+								gen.SetChallengeFinalizers([]string{})))),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
 						"status",
 						gen.DefaultTestNamespace,
@@ -578,6 +616,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 							gen.SetChallengeState(cmacme.Invalid),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengePresented(false),
+							gen.SetChallengeFinalizers([]string{}),
 						))),
 				},
 			},
@@ -642,4 +681,67 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	test.builder.CheckAndFinish(err)
+}
+
+func TestHandleCleanup(t *testing.T) {
+	simulatedCleanupError := errors.New("simulated-cleanup-error")
+	tests := []struct {
+		name         string
+		mods         []gen.ChallengeModifier
+		cleanupError error
+		errorMessage string
+	}{
+		// Invoke solver.Cleanup if the finalizer is present and remove the
+		// finalizer and reset the status fields if it succeeds
+		{
+			name: "success-with-cleanup",
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{cmacme.ACMELegacyFinalizer}),
+			},
+		},
+		// Skip the solver.Cleanup when the finalizer absent, but reset the
+		// status fields if it succeeds
+		{
+			name:         "success-skip-cleanup",
+			cleanupError: simulatedCleanupError,
+		},
+		// Return the solver.Cleanup error if it fails and do not remove the
+		// finalizer nor update he status fields.
+		{
+			name: "cleanup-error",
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{cmacme.ACMELegacyFinalizer}),
+			},
+			cleanupError: simulatedCleanupError,
+			errorMessage: "Error cleaning up challenge: simulated-cleanup-error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			ctrl := controller{
+				dnsSolver: &fakeSolver{
+					fakeCleanUp: func(ctx context.Context, ch *cmacme.Challenge) error {
+						return tt.cleanupError
+					},
+				},
+				recorder: new(testpkg.FakeRecorder),
+			}
+			ch := gen.Challenge("challenge1", append(
+				slices.Clone(tt.mods),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengePresented(true),
+			)...)
+			err := ctrl.handleFinalizer(ctx, ch)
+			if tt.errorMessage == "" {
+				assert.NoError(t, err)
+				assert.NotContains(t, ch.Finalizers, cmacme.ACMELegacyFinalizer, "The finalizer should be removed if cleanup succeeded")
+			} else {
+				assert.EqualError(t, err, tt.errorMessage)
+				assert.Contains(t, ch.Finalizers, cmacme.ACMELegacyFinalizer, "The finalizer should not be removed if cleanup failed")
+				assert.Equal(t, tt.errorMessage, ch.Status.Reason, "The status reason should be set to the cleanup error")
+			}
+		})
+	}
 }

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -55,14 +55,14 @@ func (f *fakeSolver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cma
 // CleanUp will remove challenge records for a given solver.
 // This may involve deleting resources in the Kubernetes API Server, or
 // communicating with other external components (e.g. DNS providers).
-func (f *fakeSolver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
-	return f.fakeCleanUp(ctx, issuer, ch)
+func (f *fakeSolver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
+	return f.fakeCleanUp(ctx, ch)
 }
 
 type fakeSolver struct {
 	fakePresent func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
 	fakeCheck   func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
-	fakeCleanUp func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error
+	fakeCleanUp func(ctx context.Context, ch *cmacme.Challenge) error
 }
 
 type testT struct {
@@ -102,7 +102,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(ctx context.Context, ch *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -134,7 +134,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return simulatedCleanupError
 				},
 			},
@@ -347,7 +347,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -402,7 +402,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -461,7 +461,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
 					return nil
 				},
-				fakeCleanUp: func(context.Context, v1.GenericIssuer, *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -521,7 +521,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengePresented(true),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},
@@ -556,7 +556,7 @@ func testSyncHappyPathWithFinalizer(t *testing.T, finalizer string, activeFinali
 				gen.SetChallengePresented(true),
 			),
 			httpSolver: &fakeSolver{
-				fakeCleanUp: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+				fakeCleanUp: func(context.Context, *cmacme.Challenge) error {
 					return nil
 				},
 			},

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
 // ResourceNamespace returns the Kubernetes namespace where resources
@@ -30,6 +31,13 @@ func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
 	return ns
 }
 
+func (o IssuerOptions) ResourceNamespaceFromRef(ref cmmeta.ObjectReference, ns string) string {
+	if ns != "" {
+		return ns
+	}
+	return o.ClusterResourceNamespace
+}
+
 // CanUseAmbientCredentials returns whether `iss` will attempt to configure itself
 // from ambient credentials (e.g. from a cloud metadata service).
 func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
@@ -37,6 +45,16 @@ func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {
 	case *cmapi.ClusterIssuer:
 		return o.ClusterIssuerAmbientCredentials
 	case *cmapi.Issuer:
+		return o.IssuerAmbientCredentials
+	}
+	return false
+}
+
+func (o IssuerOptions) CanUseAmbientCredentialsFromRef(ref cmmeta.ObjectReference) bool {
+	switch ref.Kind {
+	case cmapi.ClusterIssuerKind:
+		return o.ClusterIssuerAmbientCredentials
+	case cmapi.IssuerKind:
 		return o.IssuerAmbientCredentials
 	}
 	return false

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -284,7 +284,7 @@ func TestSolverFor(t *testing.T) {
 			test.Setup(t)
 			defer test.Finish(t)
 			s := test.Solver
-			dnsSolver, _, err := s.solverForChallenge(context.Background(), test.Issuer, test.Challenge)
+			dnsSolver, _, err := s.solverForChallenge(context.Background(), test.Challenge)
 			if err != nil && !test.expectErr {
 				t.Errorf("expected solverFor to not error, but got: %s", err.Error())
 				return
@@ -334,7 +334,7 @@ func TestSolveForDigitalOcean(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -387,7 +387,7 @@ func TestRoute53TrimCreds(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -445,7 +445,7 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -545,7 +545,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 		if tt.out.expectedErr != err {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}
@@ -643,7 +643,7 @@ func TestRoute53AssumeRole(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(context.Background(), f.Challenge)
 		if tt.out.expectedErr != err {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -35,20 +34,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/cloudflare"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 )
-
-func newIssuer() *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				ACME: &cmacme.ACMEIssuer{},
-			},
-		},
-	}
-}
 
 func newSecret(name string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
@@ -76,8 +61,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -107,8 +94,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -131,9 +120,11 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider with a missing secret": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -156,9 +147,11 @@ func TestSolverFor(t *testing.T) {
 		},
 		"fails to load a cloudflare provider when key and token are provided": {
 			solverFixture: &solverFixture{
-				Issuer: newIssuer(),
 				// don't include any secrets in the lister
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -194,8 +187,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -225,8 +220,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -256,8 +253,10 @@ func TestSolverFor(t *testing.T) {
 						}),
 					},
 				},
-				Issuer: newIssuer(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -310,8 +309,10 @@ func TestSolveForDigitalOcean(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -361,8 +362,10 @@ func TestRoute53TrimCreds(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -414,8 +417,10 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 				}),
 			},
 		},
-		Issuer: newIssuer(),
 		Challenge: &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
 			Spec: cmacme.ChallengeSpec{
 				Solver: cmacme.ACMEChallengeSolver{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -484,9 +489,11 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -517,9 +524,11 @@ func TestRoute53AmbientCreds(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -580,9 +589,11 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -614,9 +625,11 @@ func TestRoute53AssumeRole(t *testing.T) {
 						},
 					},
 				},
-				Issuer:       newIssuer(),
 				dnsProviders: newFakeDNSProviders(),
 				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Spec: cmacme.ChallengeSpec{
 						Solver: cmacme.ACMEChallengeSolver{
 							DNS01: &cmacme.ACMEChallengeSolverDNS01{

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/azuredns"
@@ -31,11 +30,6 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/digitalocean"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/route53"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
-	"github.com/cert-manager/cert-manager/test/unit/gen"
-)
-
-const (
-	defaultTestIssuerName = "test-issuer"
 )
 
 type solverFixture struct {
@@ -44,7 +38,7 @@ type solverFixture struct {
 	*test.Builder
 
 	// Issuer to be passed to functions on the Solver (a default will be used if nil)
-	Issuer v1.GenericIssuer
+	// Issuer v1.GenericIssuer
 	// Challenge resource to use during tests
 	Challenge *cmacme.Challenge
 
@@ -67,9 +61,6 @@ type solverFixture struct {
 }
 
 func (s *solverFixture) Setup(t *testing.T) {
-	if s.Issuer == nil {
-		s.Issuer = gen.Issuer(defaultTestIssuerName, gen.SetIssuerACME(cmacme.ACMEIssuer{}))
-	}
 	if s.testResources == nil {
 		s.testResources = map[string]interface{}{}
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -188,7 +188,7 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 
 // CleanUp will ensure the created service, ingress and pod are clean/deleted of any
 // cert-manager created data.
-func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+func (s *Solver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
 	var errs []error
 	errs = append(errs, s.cleanupPods(ctx, ch))
 	errs = append(errs, s.cleanupServices(ctx, ch))


### PR DESCRIPTION
depends on #7285

supersedes https://github.com/cert-manager/cert-manager/pull/5126

This addresses two problems:
 * The finalizer was being removed unconditionally, regardless of whether solver.Cleanup succeeds
 * The finalizer was assumed to be the first in the list of finalizers, potentially resulting in the removal of foreign finalizers and resulting in the cleanup finalizer never being removed.
 * solver.Cleanup was invoked inconsistently from two different places, in handleFinalizer and in an `acme.IsFinalState` block, but in the former, the Status.Processing and Status.Presented fields were not being reset and in the latter case, the finalizer wasn't being removed if the cleanup succeeded.

Part of:
 * #3640

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
