### PR TITLE
Optional AWS Route53 region

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -529,7 +529,32 @@ spec:
                               description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
                               type: string
                             region:
-                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              description: |-
+                                Override the AWS region.
+
+                                Route53 is a global service and does not have regional endpoints but the
+                                region specified here (or via environment variables) is used as a hint to
+                                help compute the correct AWS credential scope and partition when it
+                                connects to Route53. See:
+                                - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+
+                                Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+
+                                Region is not used for computing STS regional endpoints.
+                                If you configure the `role` field, cert-manager will always use the
+                                global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
+                                requests.
+
+                                Region is used unconditionally if ambient credentials mode is disabled, by
+                                `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
+                                controller flags.
                               type: string
                             role:
                               description: |-

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -458,8 +458,6 @@ spec:
                         route53:
                           description: Use the AWS Route53 API to manage DNS01 challenge records.
                           type: object
-                          required:
-                            - region
                           properties:
                             accessKeyID:
                               description: |-

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -565,8 +565,6 @@ spec:
                               route53:
                                 description: Use the AWS Route53 API to manage DNS01 challenge records.
                                 type: object
-                                required:
-                                  - region
                                 properties:
                                   accessKeyID:
                                     description: |-

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -636,7 +636,32 @@ spec:
                                     description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
                                     type: string
                                   region:
-                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+
+                                      Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+
+                                      Region is not used for computing STS regional endpoints.
+                                      If you configure the `role` field, cert-manager will always use the
+                                      global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
+                                      requests.
+
+                                      Region is used unconditionally if ambient credentials mode is disabled, by
+                                      `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
+                                      controller flags.
                                     type: string
                                   role:
                                     description: |-

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -565,8 +565,6 @@ spec:
                               route53:
                                 description: Use the AWS Route53 API to manage DNS01 challenge records.
                                 type: object
-                                required:
-                                  - region
                                 properties:
                                   accessKeyID:
                                     description: |-

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -636,7 +636,32 @@ spec:
                                     description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
                                     type: string
                                   region:
-                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+
+                                      Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+
+                                      Region is not used for computing STS regional endpoints.
+                                      If you configure the `role` field, cert-manager will always use the
+                                      global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
+                                      requests.
+
+                                      Region is used unconditionally if ambient credentials mode is disabled, by
+                                      `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
+                                      controller flags.
                                     type: string
                                   role:
                                     description: |-

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -528,10 +528,6 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			el = append(el, field.Forbidden(fldPath.Child("route53"), "may not specify more than one provider type"))
 		} else {
 			numProviders++
-			// region is the only required field for route53 as ambient credentials can be used instead
-			if len(p.Route53.Region) == 0 {
-				el = append(el, field.Required(fldPath.Child("route53", "region"), ""))
-			}
 			// We don't include a validation here asserting that either the
 			// AccessKeyID or SecretAccessKeyID must be specified, because it is
 			// valid to use neither when using ambient credentials.

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1039,19 +1039,9 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(fldPath.Child("cloudflare", "email"), ""),
 			},
 		},
-		"missing route53 region": {
+		"empty route53 field should be valid because ambient credentials and region may be used instead": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("route53", "region"), ""),
-			},
-		},
-		"missing route53 accessKeyID and accessKeyIDSecretRef should be valid because ambient credentials may be used instead": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-					Region: "valid",
-				},
 			},
 			errs: []*field.Error{},
 		},

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -600,7 +600,7 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 	HostedZoneID string `json:"hostedZoneID,omitempty"`
 
 	// Always set the region when using AccessKeyID and SecretAccessKey
-	Region string `json:"region"`
+	Region string `json:"region,omitempty"`
 }
 
 // Route53Auth is configuration used to authenticate with a Route53.

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -599,7 +599,33 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 	// +optional
 	HostedZoneID string `json:"hostedZoneID,omitempty"`
 
-	// Always set the region when using AccessKeyID and SecretAccessKey
+	// Override the AWS region.
+	//
+	// Route53 is a global service and does not have regional endpoints but the
+	// region specified here (or via environment variables) is used as a hint to
+	// help compute the correct AWS credential scope and partition when it
+	// connects to Route53. See:
+	// - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+	// - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+	//
+	// Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+	// Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+	// [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+	//
+	// Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+	// Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+	// [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+	//
+	// Region is not used for computing STS regional endpoints.
+	// If you configure the `role` field, cert-manager will always use the
+	// global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
+	// requests.
+	//
+	// Region is used unconditionally if ambient credentials mode is disabled, by
+	// `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
+	// controller flags.
+	//
+	// +optional
 	Region string `json:"region,omitempty"`
 }
 

--- a/test/integration/validation/files/issuers.valid.yaml
+++ b/test/integration/validation/files/issuers.valid.yaml
@@ -1,0 +1,20 @@
+# The AWS Route53 solver uses AWS SDK for Go V2, which can get
+# credentials and region information from environment variables. So
+# configuration is not **required**.
+# This integration test demonstrates that the OpenAPI validation
+# **and** webhook validation permit such an empty Route53 stanza.
+# YAML and unstructured are used, instead of cert-manager API types to
+# avoid confusion around zero values for strings such as region.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: test
+  namespace: default
+spec:
+  acme:
+    server: https://acme.example.com
+    privateKeySecretRef:
+      name: testing-acme-private-key
+    solvers:
+    - dns01:
+        route53: {}

--- a/test/integration/validation/issuer_test.go
+++ b/test/integration/validation/issuer_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/cert-manager/integration-tests/framework"
+	"github.com/cert-manager/cert-manager/pkg/api"
+)
+
+var issuerGVK = schema.GroupVersionKind{
+	Group:   "cert-manager.io",
+	Version: "v1",
+	Kind:    "Issuer",
+}
+
+// Regression tests to check Issuer configurations which are expected to pass
+// the OpenAPI and webhook validation but which have been accidentally forbidden
+// in the past by inconsistent use of validation annotations in the Go types or
+// by incorrect logic in the validating webhook functions.
+func TestValidationIssuer(t *testing.T) {
+	yamlFile := "files/issuers.valid.yaml"
+	yamlBytes, err := os.Open(yamlFile)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stop := framework.RunControlPlane(t, ctx)
+	defer stop()
+
+	framework.WaitForOpenAPIResourcesToBeLoaded(t, ctx, config, issuerGVK)
+
+	cl, err := client.New(config, client.Options{Scheme: api.Scheme})
+	require.NoError(t, err)
+
+	dec := yaml.NewYAMLOrJSONDecoder(yamlBytes, 4096)
+	documentIndex := 0
+	for {
+		obj := &unstructured.Unstructured{}
+		err := dec.Decode(obj)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		name := fmt.Sprintf("%s:%d:%s/%s", yamlFile, documentIndex, obj.GetNamespace(), obj.GetName())
+		t.Run(name, func(t *testing.T) {
+			err = cl.Create(ctx, obj)
+			assert.NoError(t, err)
+		})
+		documentIndex++
+	}
+}


### PR DESCRIPTION
When you install cert-manager on EKS and use IAM Roles for Service Accounts or Pod Identity,
an AWS mutating webhook will add `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables to the controller Pod. There's no need to specify the region in the Issuer config so it should not be a required field.
> 📖 Read [Grant Kubernetes workloads access to AWS using Kubernetes Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html) to learn more about these two mechanisms.

AWS Route53 is a [global service](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html) and does not have regional endpoints.
The AWS SDK for Go V2 uses the region (whether supplied or detected from environment variables) as a hint,
with which to compute the AWS partition domain name (i.e. route53.amazonaws.com / amazonaws.com.cn  / route53.us-gov.amazonaws.com) and the [credential scope](https://docs.aws.amazon.com/general/latest/gr/r53.html#r53_region) (us-east-1 / cn-northwest-1 / us-gov-west-1). 
Here is the [metadata that the SDK uses for Route53](https://github.com/aws/aws-sdk-go-v2/blob/98ae6886ccefe00db38a3088e273e524abf3b196/service/route53/internal/endpoints/endpoints.go).

* Updated the webhook validation tests, to demonstrate that all the Route53 fields are now optional. 
* Removed the webhook validation for region, which was being used if the user supplied an empty string for region.
* OpenAPI validation was also being used, if the region field was omitted from the supplied JSON.
* So I marked annotated the  field with `omitempty` and `+optional` and regenerated the CRDS.

Fixes:  https://github.com/cert-manager/cert-manager/issues/6175
Fixes: https://github.com/cert-manager/website/issues/56

/kind bug

```release-note
The Route53 DNS01 solver of the ACME Issuer can now detect the AWS region from the AWS_REGION and AWS_DEFAULT_REGION environment variables, which is set by the IAM for Service Accounts (IRSA) webhook and by the Pod Identity webhook. 
The `issuer.spec.acme.solvers.dns01.route53.region` field is now optional.
The API documentation of the `region` field has been updated to explain when and how the region value is used.
```

## Testing

### API Documentation

```
$ kubectl explain issuer.spec.acme.solvers.dns01.route53.region
GROUP:      cert-manager.io
KIND:       Issuer
VERSION:    v1

FIELD: region <string>

DESCRIPTION:
    Override the AWS region.

    Route53 is a global service and does not have regional endpoints but the
    region specified here (or via environment variables) is used as a hint to
    help compute the correct AWS credential scope and partition when it
    connects to Route53. See:
    - [Amazon Route 53 endpoints and
    quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
    - [Global
    services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)

    Region is not needed if you use [IAM Roles for Service Accounts
    (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
    Instead an AWS_REGION environment variable is added to the cert-manager
    controller Pod by:
    [Amazon EKS Pod Identity
    Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),

    Region is not needed if you use [EKS Pod
    Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
    Instead an AWS_REGION environment variable is added to the cert-manager
    controller Pod by:
    [Amazon EKS Pod Identity
    Agent](https://github.com/aws/eks-pod-identity-agent),

    Region is not used for computing STS regional endpoints.
    If you configure the `role` field, cert-manager will always use the
    global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
    requests.

    Region is ignored if ambient credentials mode is disabled, by
    `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
    controller flags.
```
