### PR TITLE
Prevent aggressive Route53 retries caused by IRSA authentication failures by removing the Amazon Request ID from errors wrapped by the default credential cache

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -326,15 +326,15 @@ func newTXTRecordSet(fqdn, value string, ttl int) *route53types.ResourceRecordSe
 // avoid spurious challenge updates.
 //
 // The given error must not be nil. This function must be called everywhere
-// we have a non-nil error coming from an aws-sdk-go func. The passed error
-// is modified in place. This function does not work in case the full error
-// message is pre-generated at construction time (instead of when Error() is
-// called), which is the case for eg. fmt.Errorf("error message: %w", err).
+// we have a non-nil error coming from an aws-sdk-go func.
 func removeReqID(err error) error {
 	var responseError *awshttp.ResponseError
 	if errors.As(err, &responseError) {
+		before := responseError.Error()
 		// remove the request id from the error message
 		responseError.RequestID = "<REDACTED>"
+		after := responseError.Error()
+		return errors.New(strings.Replace(err.Error(), before, after, 1))
 	}
 	return err
 }

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -325,8 +325,8 @@ func newTXTRecordSet(fqdn, value string, ttl int) *route53types.ResourceRecordSe
 // want our error messages to be the same when the cause is the same to
 // avoid spurious challenge updates.
 //
-// The given error must not be nil. This function must be called everywhere
-// we have a non-nil error coming from an aws-sdk-go func.
+// This function must be called everywhere we have an error coming from
+// an aws-sdk-go func. The passed error is modified in place.
 func removeReqID(err error) error {
 	var responseError *awshttp.ResponseError
 	if errors.As(err, &responseError) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -402,6 +402,11 @@ func Test_removeReqID(t *testing.T) {
 			err:     errors.New("foo"),
 			wantErr: errors.New("foo"),
 		},
+		{
+			name:    "should ignore nil errors",
+			err:     nil,
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -388,6 +388,11 @@ func Test_removeReqID(t *testing.T) {
 			wantErr: &awshttp.ResponseError{RequestID: "<REDACTED>", ResponseError: newResponseError()},
 		},
 		{
+			name:    "should replace the request id even in a %w wrapped error",
+			err:     fmt.Errorf("failed to refresh cached credentials, %w", &awshttp.ResponseError{RequestID: "SOMEREQUESTID", ResponseError: newResponseError()}),
+			wantErr: fmt.Errorf("failed to refresh cached credentials, %w", &awshttp.ResponseError{RequestID: "<REDACTED>", ResponseError: newResponseError()}),
+		},
+		{
 			name:    "should do nothing if no request id is set",
 			err:     newResponseError(),
 			wantErr: newResponseError(),

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -388,7 +388,7 @@ func Test_removeReqID(t *testing.T) {
 			wantErr: &awshttp.ResponseError{RequestID: "<REDACTED>", ResponseError: newResponseError()},
 		},
 		{
-			name:    "should replace the request id even in a %w wrapped error",
+			name:    "should replace the request id in a %w wrapped error",
 			err:     fmt.Errorf("failed to refresh cached credentials, %w", &awshttp.ResponseError{RequestID: "SOMEREQUESTID", ResponseError: newResponseError()}),
 			wantErr: fmt.Errorf("failed to refresh cached credentials, %w", &awshttp.ResponseError{RequestID: "<REDACTED>", ResponseError: newResponseError()}),
 		},


### PR DESCRIPTION
The AWS errors that contain RequestID are sometimes wrapped using `%w`, in which case the error message is generated at the time the error is wrapped. The current implementation of `removeReqID` doesn't handle this case. 
There are multiple examples of such error wrapping in the aws-sdk. Here's an example from the credential cache:
 * https://github.com/aws/smithy-go/pull/484
 * Here for example: https://github.com/aws/aws-sdk-go-v2/blob/06150d96305d6b6c19db0a2e5d1c1f4fa4a95612/aws/credential_cache.go#L121-L130

Fixes: https://github.com/cert-manager/cert-manager/issues/5486
Fixes: https://github.com/cert-manager/cert-manager/issues/6308
Fixes: https://github.com/cert-manager/cert-manager/issues/4061

/kind bug

```release-note
Bugfix: Prevent aggressive Route53 retries caused by IRSA authentication failures by removing the Amazon Request ID from errors wrapped by the default credential cache.
```

## Testing

### Unit test

You can run the unit tests as follows:

```bash
make test WHAT='./pkg/issuer/acme/dns/route53/... -run Test_removeReqID'
```

Example test failure:
*  https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/7291/pull-cert-manager-master-make-test/1837123184734769152

![image](https://github.com/user-attachments/assets/490dcc6f-299b-44ec-bdc3-bdc7612e0b94)


### E2E test

* https://gist.github.com/wallrj/7db6f7682990882f89a2d8a88a673943

Before:

```json
{"ts":1726840718830.1624,"caller":"controller/controller.go:158","msg":"re-queuing item due to error processing","logger":"cert-manager.controller","err":"failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: 6c084cd6-e346-4de0-9a48-7feb9d3f5bdc, InvalidIdentityToken: No OpenIDConnect provider found in your account for https://kubernetes.default.svc.cluster.local"}
```

```
24
```

```yaml
# $ kubectl get challenges.acme.cert-manager.io www-1-2762490819-1292702510 -o yaml
status:
  presented: false
  processing: true
  reason: 'failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets,
    get identity: get credentials: failed to refresh cached credentials, failed to
    retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, exceeded
    maximum number of attempts, 3, https response error StatusCode: 400, RequestID:
    6e849068-4b98-4130-b4db-9b590d7f9983, InvalidIdentityToken: No OpenIDConnect provider
    found in your account for https://kubernetes.default.svc.cluster.local'
  state: pending
```

After:

```json
{"ts":1726840879317.0305,"caller":"logs/logs.go:197","msg":"Event(v1.ObjectReference{Kind:\"Challenge\", Namespace:\"default\", Name:\"www-1-2762490819-1292702510\", UID:\"61c76dd8-ef2a-4279-9fa9-f69ff4fd3519\", APIVersion:\"acme.cert-manager.io/v1\", ResourceVersion:\"13469\", FieldPath:\"\"}): type: 'Warning' reason: 'PresentError' Error presenting challenge: failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: <REDACTED>, InvalidIdentityToken: No OpenIDConnect provider found in your account for https://kubernetes.default.svc.cluster.local","v":4,"logger":"cert-manager.controller"}
```

```
6
```

````yaml
# $ kubectl get challenges.acme.cert-manager.io www-1-2762490819-1292702510 -o yaml
status:
  presented: false
  processing: true
  reason: 'failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets,
    get identity: get credentials: failed to refresh cached credentials, failed to
    retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, exceeded
    maximum number of attempts, 3, https response error StatusCode: 400, RequestID:
    <REDACTED>, InvalidIdentityToken: No OpenIDConnect provider found in your account
    for https://kubernetes.default.svc.cluster.local'
  state: pending
```