### PR TITLE
Allow the Route53 solver to get the AWS region from IMDS when running on EKS or EC2

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -91,6 +91,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		})),
 		config.WithClientLogMode(aws.LogDeprecatedUsage | aws.LogRequest),
 		config.WithLogConfigurationWarnings(true),
+		config.WithEC2IMDSRegion(),
 	}
 	switch {
 	case d.Role != "" && d.WebIdentityToken != "":

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -64,6 +64,9 @@ type StsClient interface {
 	AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error)
 }
 
+// We use this to disable IMDS region lookups in unit-tests
+var enableEC2IMDSRegionLookup = true
+
 func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	switch {
 	case d.Role == "" && d.WebIdentityToken != "":
@@ -91,7 +94,9 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		})),
 		config.WithClientLogMode(aws.LogDeprecatedUsage | aws.LogRequest),
 		config.WithLogConfigurationWarnings(true),
-		config.WithEC2IMDSRegion(),
+	}
+	if enableEC2IMDSRegionLookup {
+		optFns = append(optFns, config.WithEC2IMDSRegion())
 	}
 	switch {
 	case d.Role != "" && d.WebIdentityToken != "":

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -32,6 +32,11 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
+func init() {
+	// Disable IMDS region lookups in unit-tests
+	enableEC2IMDSRegionLookup = false
+}
+
 const jwt string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzdHMuYW1hem9uYXdzLmNvbSIsImV4cCI6MTc0MTg4NzYwOCwiaWF0IjoxNzEwMzUxNjM4LCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwibmFtZSI6IkpvaG4gRG9lIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.SfuV3SW-vEdV-tLFIr2PK2DnN6QYmozygav5OeoH36Q"
 
 func makeRoute53Provider(ts *httptest.Server) (*DNSProvider, error) {


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/issues/7102 we thought we fixed one case of the "missing region" error,
for the situation where the user provides a per-issuer ServiceAccount token, for which we instantiate a dedicated STS client.

But if using ambient credentials from the IMDS service (as opposed to IRSA or Pod Identity), there will be no AWS_REGION environment variable injected by a webhook and the AWS SDK client does not query the IMDS server for the region by default.

> 📖 I've started trying to document this case in [Load credentials from EC2 Instance Metadata Service (IMDS)](https://github.com/cert-manager/website/blob/6668546c0faa047778a90c1d9609f7fce6a470f2/content/docs/configuration/acme/dns01/route53.md#load-credentials-from-ec2-instance-metadata-service-imds), in https://github.com/cert-manager/website/pull/1555.

In this PR I enable the option to use the region provided by IMDS.

Fixes: https://github.com/cert-manager/cert-manager/issues/7102

/kind bug

```release-note
Bugfix: Allow the Route53 solver to get the AWS region from IMDS when running on EKS or EC2
```

## Testing

In the **before** case, you'll see requests for: 

1. GET IMDS authentication token, 
2. GET IMDS instance Role
3. GET IMDS temporary credentials 
4. Error "missing region"

In the after case, you'll see an additional request to Route53, because the client has used the region metadata that was included in the response to the request for the instance Role.

Before:

```
[2024-09-20 15:01:13] preparing to create Route53 provider [caller=dns/dns.go:296 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present.solverForChallenge resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:01:13] using ambient credentials [caller=route53/route53.go:99 logger=cert-manager.route53-session-provider]
[2024-09-20 15:01:13] presenting DNS01 challenge for domain [caller=dns/dns.go:104 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:01:13] Request
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Content-Length: 0
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 300
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:90 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:01:13] Request
GET /latest/meta-data/iam/security-credentials/ HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token: AQAEAG6AzLw34TyIAFjspMkkUneKrUKeOpihKAfncLPjSJaQ8Sl0sw==
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:90 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:01:13] Request
GET /latest/meta-data/iam/security-credentials/eksctl-test-cluster-1-nodegroup-no-NodeInstanceRole-mWz0hOJsfEne HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token: AQAEAG6AzLw34TyIAFjspMkkUneKrUKeOpihKAfncLPjSJaQ8Sl0sw==
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:90 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:01:13] re-queuing item due to error processing [caller=controller/controller.go:158 err=failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region logger=cert-manager.controller]
[2024-09-20 15:01:13] Event(v1.ObjectReference{Kind:"Challenge", Namespace:"default", Name:"www-1-2762490819-449052295", UID:"46da37ca-5ecc-44d0-b55c-c0973787d5aa", APIVersion:"acme.cert-manager.io/v1", ResourceVersion:"3553", FieldPath:""}): type: 'Warning' reason: 'PresentError' Error presenting challenge: failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region [caller=logs/logs.go:197 logger=cert-manager.controller]
```


After:

```
[2024-09-20 15:22:44] using ambient credentials [caller=route53/route53.go:101 logger=cert-manager.route53-session-provider]
[2024-09-20 15:22:44] presenting DNS01 challenge for domain [caller=dns/dns.go:104 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:22:44] Request
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Content-Length: 0
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 300
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:92 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:22:44] Request
GET /latest/meta-data/iam/security-credentials/ HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token: AQAEAL3PhUJLWMKC7CSqPigflSIVhqtwX0ZqXR2duZ9w7aetudib2w==
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:92 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:22:44] Request
GET /latest/meta-data/iam/security-credentials/eksctl-test-cluster-1-nodegroup-no-NodeInstanceRole-mWz0hOJsfEne HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 ft/ec2-imds
Amz-Sdk-Request: attempt=1; max=3
X-Aws-Ec2-Metadata-Token: AQAEAL3PhUJLWMKC7CSqPigflSIVhqtwX0ZqXR2duZ9w7aetudib2w==
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:92 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:22:44] Request
POST /2013-04-01/hostedzone/DEADBEEF/rrset HTTP/1.1
Host: route53.amazonaws.com
User-Agent: m/E aws-sdk-go-v2/1.30.4 os/linux lang/go#1.22.3 md/GOOS#linux md/GOARCH#amd64 api/route53#1.42.4 cert-manager/cert-manager-challenges-canary--linux-amd64--cert-manager-
Content-Length: 648
Amz-Sdk-Invocation-Id: daf35e51-f7ed-47f1-9953-f5764832fc3f
Amz-Sdk-Request: attempt=1; max=3
Authorization: AWS4-HMAC-SHA256 Credential=ASIAU3SWGEVCJTGASREC/20240920/us-east-1/route53/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date;x-amz-security-token, Signature=7a3b86016405713306f866f4ccd187a199acb4b1c0449accf430103a23d20d84
Content-Type: application/xml
X-Amz-Date: 20240920T152244Z
X-Amz-Security-Token: IQoJb3JpZ2luX2VjED8aCXVzLXdlc3QtMiJIMEYCIQDATg7UAfPboTflFuevaky57BCU0ko2Em0+6RHUALyrzwIhAJgH92z57IkKnrArDIk4+VuUSC4ik4RuncIdc/gQEPi1Kr0FCHgQABoMMzM0MTE0NDY1MDkyIgwUvfbL6f4LnULe5uAqmgUzMpOe4qJmQf67819u1faIy2mnDjEmT8BVKfXWwCfnQHdVsv8YOpVGq++PliTcJYmCj93HT5ONr4IhemWmNhiUhMp1SKVlrmMIXeGkCXZDsTNo0B6vt74OYFu2izBJe4O5+J8KXu331YVJdYbtJhVgFSbYRy+9JEcz87JW8p+zmFAOX5bPwL4CAKpCaHykK0uUc24zijwtm5eq/40hBhcAJSXHtmcFglBAQppvluflxcOhxuj3oe/hyKRmxBEJsfTna/KUeA1yUVRT797GieMs2IZMX8P6KMcDtDVY4u5fP57AmdAwuIh7A1hloTUokcBccx9L6PNKT9QgdqhksBpljnJ2i5zYyLC7Lpqucl4EXpnXQc/qXihwHJB8goGxvGMYi3GCn58XVIH58gp/CKgfgKkHAMooCEHSgx6rRnY73UXVwfLyw+VDmPRY9khYketvCrYWDoXM59zPXm5kAmmUaBBoBG7eYBJg34BwXg/s5BxEwPu1xTl3HRIwhxtftcFGs/XKQcasbTNeVlVQBAdJDN+kls9tbEBv9TS1Z0wT+YnfYXWfhTW/RBVpF6xcU13jKQ/sFWcj6W9+pETBgpSATmbt11ArFleLpMc4ldDfAWaGcfblegvGXaflp0VbTcjNPSnEih51usekieKVXco3yHCMSMfEZ6+Ip/YLzRq/e0Yap0RIq6DG5VTngUU/Ve68o38cGXEgoHIsse8EYA8Oqat17hLE1AHIg5VdZUiwnFH6dXdYZZ9hcDdDTUQGPOBmDBRA1zBOUvcYULqk+iOS0jjaXiNuR5tnWGKcREhNTRnIC/4/nJ6lTt0ht3N/aVvF/Wrs5nGDvPaGHHq1N7m/ho1Pa+qGRslTvG/Zes9S6rp4nvgZKgi0Q1gwwpe2twY6sAHOSdYCjV5GFlxw5XdjPTDGqVibHDyKL69ZYjg5fSYjS5H7xTwHwe/jXD2WUYR5wHl3sYjGLp99MwaDgv2ZoCeXww1R9+Vjfjq9L9o0dqiEf5X63mgb+jRy4WApz6tOF7amiW0Fwaf/6MkR8+Bufg/W1QwCHw+ZDGMkGy+HgrOtiiD+1Pb/dqETJ3rvcqUmMVzF8k+M6dJx6b2o99WK82IHLcDPXUlf2GuewPx8BdtDUQ==
Accept-Encoding: gzip

 [aws-classification=DEBUG caller=route53/route53.go:92 dnsName=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com domain=75b2296e-65a9-4c25-954b-d0b283c6bfd2.com logger=cert-manager.controller.Present resource_kind=Challenge resource_name=www-1-2762490819-449052295 resource_namespace=default resource_version=v1 type=DNS-01]
[2024-09-20 15:22:44] re-queuing item due to error processing [caller=controller/controller.go:158 err=failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 404, RequestID: <REDACTED>, NoSuchHostedZone: No hosted zone found with ID: DEADBEEF logger=cert-manager.controller]
[2024-09-20 15:22:44] Event(v1.ObjectReference{Kind:"Challenge", Namespace:"default", Name:"www-1-2762490819-449052295", UID:"46da37ca-5ecc-44d0-b55c-c0973787d5aa", APIVersion:"acme.cert-manager.io/v1", ResourceVersion:"7702", FieldPath:""}): type: 'Warning' reason: 'PresentError' Error presenting challenge: failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 404, RequestID: <REDACTED>, NoSuchHostedZone: No hosted zone found with ID: DEADBEEF [caller=logs/logs.go:197 logger=cert-manager.controller]
```