### PR TITLE
Route53 DNS01 Solver: Always fall back on the ambient region

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -539,22 +539,19 @@ spec:
                                 - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
                                 - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
 
-                                Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
-                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
-                                [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+                                If you omit this region field, cert-manager will use the region from
+                                AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                in the cert-manager controller Pod.
 
-                                Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                In this case this `region` field value is ignored.
+
+                                The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
                                 Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
                                 [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
-
-                                Region is not used for computing STS regional endpoints.
-                                If you configure the `role` field, cert-manager will always use the
-                                global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
-                                requests.
-
-                                Region is used unconditionally if ambient credentials mode is disabled, by
-                                `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
-                                controller flags.
+                                In this case this `region` field value is ignored.
                               type: string
                             role:
                               description: |-

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -646,22 +646,19 @@ spec:
                                       - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
                                       - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
 
-                                      Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
-                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
-                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
 
-                                      Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
                                       Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
                                       [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
-
-                                      Region is not used for computing STS regional endpoints.
-                                      If you configure the `role` field, cert-manager will always use the
-                                      global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
-                                      requests.
-
-                                      Region is used unconditionally if ambient credentials mode is disabled, by
-                                      `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
-                                      controller flags.
+                                      In this case this `region` field value is ignored.
                                     type: string
                                   role:
                                     description: |-

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -646,22 +646,19 @@ spec:
                                       - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
                                       - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
 
-                                      Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
-                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
-                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
 
-                                      Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
                                       Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
                                       [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
-
-                                      Region is not used for computing STS regional endpoints.
-                                      If you configure the `role` field, cert-manager will always use the
-                                      global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
-                                      requests.
-
-                                      Region is used unconditionally if ambient credentials mode is disabled, by
-                                      `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
-                                      controller flags.
+                                      In this case this `region` field value is ignored.
                                     type: string
                                   role:
                                     description: |-

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -608,22 +608,19 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 	// - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
 	// - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
 	//
-	// Region is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
-	// Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
-	// [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook),
+	// If you omit this region field, cert-manager will use the region from
+	// AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+	// in the cert-manager controller Pod.
 	//
-	// Region is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+	// The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+	// Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+	// [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+	// In this case this `region` field value is ignored.
+	//
+	// The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
 	// Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
 	// [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
-	//
-	// Region is not used for computing STS regional endpoints.
-	// If you configure the `role` field, cert-manager will always use the
-	// global STS endpoint to make AssumeRole and AssumeRoleWithWebIdentity
-	// requests.
-	//
-	// Region is used unconditionally if ambient credentials mode is disabled, by
-	// `--cluster-issuer-ambient-credentials` or `--isssuer-ambient-credentials`
-	// controller flags.
+	// In this case this `region` field value is ignored.
 	//
 	// +optional
 	Region string `json:"region,omitempty"`

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -27,6 +27,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
@@ -77,24 +78,169 @@ func TestNoCredentialsFromEnv(t *testing.T) {
 	assert.Error(t, err, "Expected error constructing DNSProvider with no credentials and not ambient")
 }
 
-func TestAmbientRegionFromEnv(t *testing.T) {
-	t.Setenv("AWS_REGION", "us-east-1")
+type bitmask byte
 
-	_, ctx := ktesting.NewTestContext(t)
-	provider, err := NewDNSProvider(ctx, "", "", "", "", "", "", true, util.RecursiveNameservers, "cert-manager-test")
-	assert.NoError(t, err, "Expected no error constructing DNSProvider")
-
-	assert.Equal(t, "us-east-1", provider.client.Options().Region, "Expected Region to be set from environment")
+func (haystack bitmask) Has(needle bitmask) bool {
+	return haystack&needle != 0
 }
 
-func TestNoRegionFromEnv(t *testing.T) {
-	t.Setenv("AWS_REGION", "us-east-1")
+// TestSessionProviderGetSessionRegion calls sessionProvider.GetSession with all
+// permutations of those inputs that influence how it selects an AWS region.
+// The desired region selection properties are documented alongside each
+// assertion.
+func TestSessionProviderGetSessionRegion(t *testing.T) {
+	const (
+		fakeAmbientRegion = "ambient-region-1"
+		fakeIssuerRegion  = "issuer-region-1"
+	)
 
-	_, ctx := ktesting.NewTestContext(t)
-	provider, err := NewDNSProvider(ctx, "marx", "swordfish", "", "", "", "", false, util.RecursiveNameservers, "cert-manager-test")
-	assert.NoError(t, err, "Expected no error constructing DNSProvider")
+	testFunc := func(t *testing.T, allowAmbientCredentials, setAmbientRegion, supplyAccessKey, supplyWebIdentity, supplyIssuerRegion bool) {
+		t.Log(
+			"ambient-credentials-allowed", allowAmbientCredentials,
+			"ambient-region-set", setAmbientRegion,
+			"access-key-supplied", supplyAccessKey,
+			"web-identity-supplied", supplyWebIdentity,
+			"issuer-region-supplied", supplyIssuerRegion,
+		)
+		var (
+			accessKeyID      string
+			secretAccessKey  string
+			region           string
+			role             string
+			webIdentityToken string
+			userAgent        string
+		)
+		if supplyAccessKey {
+			accessKeyID = "fake-access-key-id"
+			secretAccessKey = "fake-secret-access-key"
+		}
+		if supplyWebIdentity {
+			webIdentityToken = "fake-web-identity-token"
+			role = "fake-web-identity-role"
+		}
+		if setAmbientRegion {
+			t.Setenv("AWS_REGION", fakeAmbientRegion)
+		}
+		if supplyIssuerRegion {
+			region = fakeIssuerRegion
+		}
 
-	assert.Equal(t, "", provider.client.Options().Region, "Expected Region to not be set from environment")
+		p := newSessionProvider(accessKeyID, secretAccessKey, region, role, webIdentityToken, allowAmbientCredentials, userAgent)
+		p.StsProvider = func(cfg aws.Config) StsClient {
+			return &mockSTS{
+				AssumeRoleWithWebIdentityFn: func(
+					ctx context.Context,
+					params *sts.AssumeRoleWithWebIdentityInput,
+					optFns ...func(*sts.Options),
+				) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+					return &sts.AssumeRoleWithWebIdentityOutput{
+						Credentials: &ststypes.Credentials{
+							AccessKeyId:     aws.String("fake-sts-access-key-id"),
+							SecretAccessKey: aws.String("fake-sts-secret-access-key"),
+							SessionToken:    aws.String("fake-sts-session-token"),
+						},
+					}, nil
+				},
+			}
+		}
+
+		logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+		ctx := klog.NewContext(context.Background(), logger)
+
+		cfg, err := p.GetSession(ctx)
+
+		testingLogger, ok := logger.GetSink().(ktesting.Underlier)
+		require.True(t, ok)
+		logMessages := testingLogger.GetBuffer().String()
+
+		if !supplyAccessKey && !supplyWebIdentity && !allowAmbientCredentials {
+			assert.EqualError(t, err, "unable to construct route53 provider: empty credentials; perhaps you meant to enable ambient credentials?")
+			return
+		} else {
+			require.NoError(t, err)
+		}
+
+		// IRSA and Pod Identity are the most widely used "ambient credential"
+		// mechanisms and both use webhooks to inject the AWS_REGION environment
+		// variable into the cert-manager Pod.
+		// When ambient credentials are in use and an environment region is detected,
+		// cert-manager will use the environment region and ignore any Issuer region.
+		// This if for backwards compatibility with cert-manager < 1.16 where
+		// the Issuer region was a required field, but ignored.
+		if !supplyAccessKey && !supplyWebIdentity && setAmbientRegion {
+			assert.Equal(t, fakeAmbientRegion, cfg.Region,
+				"If using ambient credentials, and there is a region in the environment, "+
+					"use the region from the environment. Ignore the region in the Issuer region.")
+		}
+
+		// If the Issuer region has been ignored (see above), log an info
+		// message to alert the user that the Issuer region is no longer a
+		// required field and can be omitted in this situation.
+		if !supplyAccessKey && !supplyWebIdentity && setAmbientRegion && supplyIssuerRegion {
+			assert.Contains(t, logMessages, "Ignoring Issuer region",
+				"If using ambient credentials, and there is a region in the environment and in the Issuer resource, "+
+					"log a warning to say the Issuer region will be ignored.")
+		}
+
+		// In the case of ambient credentials from EC2 instance metadata service
+		// (IMDS), the AWS_REGION environment variable is not necessarily set
+		// and the Issuer region **should** be used.
+		if !supplyAccessKey && !supplyWebIdentity && !setAmbientRegion && supplyIssuerRegion {
+			assert.Equal(t, fakeIssuerRegion, cfg.Region,
+				"If using ambient credentials but no environment region, "+
+					"use the Issuer region.")
+		}
+
+		// In the general case, the environment region should always be used
+		// if it is set and if the Issuer region is omitted.
+		if setAmbientRegion && !supplyIssuerRegion {
+			assert.Equal(t, fakeAmbientRegion, cfg.Region,
+				"If there is a region in the environment and not in the Issuer resource, "+
+					"the region in the environment should always be used.")
+		}
+
+		// In the general case, the Issuer region should always be used if it is set.
+		// and if the environment region is not detected.
+		if !setAmbientRegion && supplyIssuerRegion {
+			assert.Equal(t, fakeIssuerRegion, cfg.Region,
+				"If there is an Issuer region but no environment region, "+
+					"the Issuer region in the environment should always be used.")
+		}
+
+		// And if no region is detected, log an info message to alert the user
+		// to the mis-configuration
+		if !setAmbientRegion && !supplyIssuerRegion {
+			assert.Contains(t, logMessages, "Region not found",
+				"If no region was detected, "+
+					"log a warning to explain how to set the region.")
+		}
+	}
+
+	const (
+		allowAmbientCredentials bitmask = 1 << iota
+		setAmbientRegion
+		supplyAccessKey
+		supplyWebIdentity
+		supplyIssuerRegion
+	)
+	allFalse := bitmask(0)
+	allTrue := allowAmbientCredentials | setAmbientRegion | supplyAccessKey | supplyWebIdentity | supplyIssuerRegion
+
+	for input := allFalse; input <= allTrue; input++ {
+		t.Run(
+			fmt.Sprintf("%v", input),
+			func(t *testing.T) {
+				testFunc(
+					t,
+					input.Has(allowAmbientCredentials),
+					input.Has(setAmbientRegion),
+					input.Has(supplyAccessKey),
+					input.Has(supplyWebIdentity),
+					input.Has(supplyIssuerRegion),
+				)
+			},
+		)
+	}
 }
 
 func TestRoute53Present(t *testing.T) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -451,7 +451,6 @@ func TestAssumeRole(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			provider := makeMockSessionProvider(func(cfg aws.Config) StsClient {
-				assert.Equal(t, "aws-global", cfg.Region) // verify that the global sts endpoint is used
 				return c.mockSTS
 			}, c.key, c.secret, c.region, c.role, c.webIdentityToken, c.ambient)
 			_, ctx := ktesting.NewTestContext(t)


### PR DESCRIPTION
The code was conflating "ambient credentials" with "ambient region".

On a multi tenant cluster, you should not allow tenants to use the "ambient credentials". For example, the instance role (and associated temporary access key) provided by the EC2 instance metadata service.
Especially if that instance role has been attached to a Policy that grants Route53 permissions.

But there is no risk in allowing cert-manager to use the "ambient region" from AWS_REGION and AWS_DEFAULT_REGION environment variables. Both Issuer and ClusterIssuer linked challenges should be able to use those variables because it saves the application teams from having to know the AWS region of the node where cert-manager is scheduled.
But they can still override the region by adding it to the Issuer, if their Route53 account is in a different "partition" than the node.

In this PR I've updated the GetSession function to always use the environment region as a fall back.
This allows user who supply an ACCESS_KEY via a Secret to make use of the AWS_REGION that  platform administrator may have added to the cert-manager deployment.

I've removed the backwards compatibility hack which forced the STS client to use `aws-global` region,
because we have since realised that best-practice is to use regional STS endpoints. The  Issuer supplied  region or environment region will now be used to compute endpoints for the explicit STS client when it performs STS AssumeRole and AssumeWebIdentity API calls, when the Issuer has been configured with a `role` and / or `auth.kubernetes`.
There is also  an implicit STS client set up by the default AWS SDK credential chain, which is used for IRSA AssumeRoleWithWebIdentity. This always used regional STS endpoints and it will continue to do so.

I've added a matrix of tests which supply 32 different input combinations to the GetSession function and assert that the correct region is chosen based on the inputs.

## About ambient credentials

The risks associated with "ambient credentials" are most clearly documented in the [Azure DNS docs](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#%EF%B8%8F-using-ambient-credentials-with-clusterissuer-and-issuer-resources):

> ⚠️ Using 'Ambient Credentials' with ClusterIssuer and Issuer resources
> This authentication method is an example of what cert-manager calls 'ambient credentials'. Ambient credentials are enabled by default for ClusterIssuer resources, but disabled by default for Issuer resources. This is to prevent unprivileged users, who have permission to create Issuer resources, from issuing certificates using credentials that cert-manager incidentally has access to. ClusterIssuer resources are cluster scoped (not namespaced) and only platform administrators should be granted permission to create them.
> 
> If you are using this authentication mechanism and ambient credentials are not enabled, you will see this error:
> 
> 
> error instantiating azuredns challenge solver: ClientID is not set but neither --cluster-issuer-ambient-credentials nor --issuer-ambient-credentials are set.
> ⚠️ It is possible (but not recommended) to enable this authentication mechanism for Issuer resources, by setting the --issuer-ambient-credentials flag on the cert-manager controller to true.

The CLI flags are also described in the [command line help](https://cert-manager.io/docs/cli/controller/):

> --cluster-issuer-ambient-credentials
> Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. When this flag is enabled, the following sources for credentials are also used: AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata. (default true)

> --issuer-ambient-credentials
> Whether an issuer may make use of ambient credentials. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the Issuer API object. When this flag is enabled, the following sources for credentials are also used: AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.

```release-note
Feature: The Route53 DNS solver of the ACME Issuer will now use regional STS endpoints computed from the region that is supplied in the Issuer spec or in the AWS_REGION environment variable.
Feature: The Route53 DNS solver of the ACME Issuer now uses the "ambient" region (AWS_REGION or AWS_DEFAULT_REGION) if `issuer.spec.acme.solvers.dns01.route53.region` is empty; regardless of the flags `--issuer-ambient-credentials` and `--cluster-issuer-ambient-credentials`.
```
