### PR TITLE
Allow extra environment variables to be added to  cainjector, webhook and startupapicheck

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -435,7 +435,14 @@ extraArgs:
 > []
 > ```
 
-Additional environment variables to pass to cert-manager controller binary.
+Additional environment variables to pass to cert-manager controller binary.  
+For example:
+
+```yaml
+extraEnv:
+- name: SOME_VAR
+  value: 'some value'
+```
 #### **resources** ~ `object`
 > Default value:
 > ```yaml
@@ -1002,6 +1009,20 @@ Configure spec.namespaceSelector for mutating webhooks.
 > ```
 
 Additional command line flags to pass to cert-manager webhook binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-webhook:<version> --help`.
+#### **webhook.extraEnv** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional environment variables to pass to cert-manager webhook binary.  
+For example:
+
+```yaml
+extraEnv:
+- name: SOME_VAR
+  value: 'some value'
+```
 #### **webhook.featureGates** ~ `string`
 > Default value:
 > ```yaml
@@ -1432,6 +1453,20 @@ Optional additional annotations to add to the cainjector metrics Service.
 > ```
 
 Additional command line flags to pass to cert-manager cainjector binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-cainjector:<version> --help`.
+#### **cainjector.extraEnv** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional environment variables to pass to cert-manager cainjector binary.  
+For example:
+
+```yaml
+extraEnv:
+- name: SOME_VAR
+  value: 'some value'
+```
 #### **cainjector.featureGates** ~ `string`
 > Default value:
 > ```yaml
@@ -1717,6 +1752,20 @@ Additional command line flags to pass to startupapicheck binary. To see all avai
   
 Verbose logging is enabled by default so that if startupapicheck fails, you can know what exactly caused the failure. Verbose logs include details of the webhook URL, IP address and TCP connect errors for example.
 
+#### **startupapicheck.extraEnv** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional environment variables to pass to cert-manager startupapicheck binary.  
+For example:
+
+```yaml
+extraEnv:
+- name: SOME_VAR
+  value: 'some value'
+```
 #### **startupapicheck.resources** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -109,6 +109,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.cainjector.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.cainjector.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -60,6 +60,14 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          {{- with .Values.startupapicheck.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.startupapicheck.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -165,6 +165,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.webhook.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.webhook.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -268,6 +268,9 @@
         "extraArgs": {
           "$ref": "#/$defs/helm-values.cainjector.extraArgs"
         },
+        "extraEnv": {
+          "$ref": "#/$defs/helm-values.cainjector.extraEnv"
+        },
         "featureGates": {
           "$ref": "#/$defs/helm-values.cainjector.featureGates"
         },
@@ -366,6 +369,12 @@
     "helm-values.cainjector.extraArgs": {
       "default": [],
       "description": "Additional command line flags to pass to cert-manager cainjector binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-cainjector:<version> --help`.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.cainjector.extraEnv": {
+      "default": [],
+      "description": "Additional environment variables to pass to cert-manager cainjector binary.\nFor example:\nextraEnv:\n- name: SOME_VAR\n  value: 'some value'",
       "items": {},
       "type": "array"
     },
@@ -649,7 +658,7 @@
     },
     "helm-values.extraEnv": {
       "default": [],
-      "description": "Additional environment variables to pass to cert-manager controller binary.",
+      "description": "Additional environment variables to pass to cert-manager controller binary.\nFor example:\nextraEnv:\n- name: SOME_VAR\n  value: 'some value'",
       "items": {},
       "type": "array"
     },
@@ -1276,6 +1285,9 @@
         "extraArgs": {
           "$ref": "#/$defs/helm-values.startupapicheck.extraArgs"
         },
+        "extraEnv": {
+          "$ref": "#/$defs/helm-values.startupapicheck.extraEnv"
+        },
         "image": {
           "$ref": "#/$defs/helm-values.startupapicheck.image"
         },
@@ -1360,6 +1372,12 @@
         "-v"
       ],
       "description": "Additional command line flags to pass to startupapicheck binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-startupapicheck:<version> --help`.\n\nVerbose logging is enabled by default so that if startupapicheck fails, you can know what exactly caused the failure. Verbose logs include details of the webhook URL, IP address and TCP connect errors for example.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.startupapicheck.extraEnv": {
+      "default": [],
+      "description": "Additional environment variables to pass to cert-manager startupapicheck binary.\nFor example:\nextraEnv:\n- name: SOME_VAR\n  value: 'some value'",
       "items": {},
       "type": "array"
     },
@@ -1588,6 +1606,9 @@
         "extraArgs": {
           "$ref": "#/$defs/helm-values.webhook.extraArgs"
         },
+        "extraEnv": {
+          "$ref": "#/$defs/helm-values.webhook.extraEnv"
+        },
         "featureGates": {
           "$ref": "#/$defs/helm-values.webhook.featureGates"
         },
@@ -1726,6 +1747,12 @@
     "helm-values.webhook.extraArgs": {
       "default": [],
       "description": "Additional command line flags to pass to cert-manager webhook binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-webhook:<version> --help`.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.webhook.extraEnv": {
+      "default": [],
+      "description": "Additional environment variables to pass to cert-manager webhook binary.\nFor example:\nextraEnv:\n- name: SOME_VAR\n  value: 'some value'",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -284,9 +284,11 @@ approveSignerNames:
 extraArgs: []
 
 # Additional environment variables to pass to cert-manager controller binary.
+# For example:
+#  extraEnv:
+#  - name: SOME_VAR
+#    value: 'some value'
 extraEnv: []
-# - name: SOME_VAR
-#   value: 'some value'
 
 # Resources to provide to the cert-manager controller pod.
 #
@@ -752,6 +754,13 @@ webhook:
   # Path to a file containing a WebhookConfiguration object used to configure the webhook.
   # - --config=<path-to-config-file>
 
+  # Additional environment variables to pass to cert-manager webhook binary.
+  # For example:
+  #  extraEnv:
+  #  - name: SOME_VAR
+  #    value: 'some value'
+  extraEnv: []
+
   # Comma separated list of feature gates that should be enabled on the
   # webhook pod.
   featureGates: ""
@@ -1079,6 +1088,13 @@ cainjector:
   # Enable profiling for cainjector.
   # - --enable-profiling=true
 
+  # Additional environment variables to pass to cert-manager cainjector binary.
+  # For example:
+  #  extraEnv:
+  #  - name: SOME_VAR
+  #    value: 'some value'
+  extraEnv: []
+
   # Comma separated list of feature gates that should be enabled on the
   # cainjector pod.
   featureGates: ""
@@ -1284,6 +1300,13 @@ startupapicheck:
   # +docs:property
   extraArgs:
   - -v
+
+  # Additional environment variables to pass to cert-manager startupapicheck binary.
+  # For example:
+  #  extraEnv:
+  #  - name: SOME_VAR
+  #    value: 'some value'
+  extraEnv: []
 
   # Resources to provide to the cert-manager controller pod.
   #


### PR DESCRIPTION
Fixes: #7316 
 * #7316 

```release-note
Helm: New value `webhook.extraEnv`, allows you to set custom environment variables in the webhook Pod.
Helm: New value `cainjector.extraEnv`, allows you to set custom environment variables in the cainjector Pod.
Helm: New value `startupapicheck.extraEnv`, allows you to set custom environment variables in the startupapicheck Pod.
```

## Testing

I tested this by installing cert-manager with the following Helm values, to enable the WatchListClient feature in all the components.

```yaml
# values.cert-manager.yaml
global:
  logLevel: 6
extraEnv:
  - name: KUBE_FEATURE_WatchListClient
    value: "true"
cainjector:
  extraEnv:
    - name: KUBE_FEATURE_WatchListClient
      value: "true"
webhook:
  extraEnv:
    - name: KUBE_FEATURE_WatchListClient
      value: "true"
startupapicheck:
  extraEnv:
    - name: KUBE_FEATURE_WatchListClient
      value: "true"
```

```bash
kind create cluster
export KO_REGISTRY=ttl.sh/b0c82fa3-22a7-4299-a9c1-57714b6a75e1
export KO_HELM_VALUES_FILES=$PWD/values.cert-manager.yaml
make -j4 ko-deploy-certmanager
```

```bash
kubectl logs -n cert-manager -l app.kubernetes.io/instance=cert-manager  --tail -1  --prefix | grep -i feature
```

> [pod/cert-manager-686b464cdb-hfztj/cert-manager-controller] I1001 16:21:45.861764       1 envvar.go:172] "Feature gate default state"
>  feature="InformerResourceVersion" enabled=false
> [pod/cert-manager-686b464cdb-hfztj/cert-manager-controller] I1001 16:21:45.861807       1 envvar.go:169] "Feature gate updated state"
>  feature="WatchListClient" enabled=true
> [pod/cert-manager-cainjector-66c858c666-zbj2b/cert-manager-cainjector] I1001 16:21:51.112822       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
> [pod/cert-manager-cainjector-66c858c666-zbj2b/cert-manager-cainjector] I1001 16:21:51.112870       1 envvar.go:169] "Feature gate updated state" feature="WatchListClient" enabled=true
> [pod/cert-manager-webhook-64cdf54fcf-mvzdb/cert-manager-webhook] I1001 16:21:57.058953       1 envvar.go:169] "Feature gate updated state" feature="WatchListClient" enabled=true
> [pod/cert-manager-webhook-64cdf54fcf-mvzdb/cert-manager-webhook] I1001 16:21:57.059040       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
> 

```console
$ kubectl describe pod -n cert-manager
 | grep -A 2 Environment
    Environment:
      POD_NAMESPACE:                 cert-manager (v1:metadata.namespace)
      KUBE_FEATURE_WatchListClient:  true
--
    Environment:
      POD_NAMESPACE:                 cert-manager (v1:metadata.namespace)
      KUBE_FEATURE_WatchListClient:  true
--
    Environment:
      POD_NAMESPACE:                 cert-manager (v1:metadata.namespace)
      KUBE_FEATURE_WatchListClient:  true
```
