### PR TITLE
add more detailed logging when service certificate is generated

### DIFF
--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -174,6 +174,8 @@ func (d *DynamicAuthority) Run(ctx context.Context) error {
 	return nil
 }
 
+var ErrCertificateNotAvailable = errors.New("certificate not available")
+
 // Sign will sign the given certificate template using the current version of
 // the managed CA.
 // It will automatically set the NotBefore and NotAfter times appropriately.
@@ -182,7 +184,7 @@ func (d *DynamicAuthority) Sign(template *x509.Certificate) (*x509.Certificate, 
 	defer d.signMutex.Unlock()
 
 	if d.currentCertData == nil || d.currentPrivateKeyData == nil {
-		return nil, fmt.Errorf("no tls.Certificate available yet, try again later")
+		return nil, ErrCertificateNotAvailable
 	}
 
 	// tls.X509KeyPair performs a number of verification checks against the

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/cert-manager/cert-manager/pkg/server/tls/authority"
 	"sync"
 	"time"
 
@@ -217,11 +218,16 @@ func (f *DynamicSource) Healthy() bool {
 
 func (f *DynamicSource) tryRegenerateCertificate(ctx context.Context, nextRenewCh chan<- time.Time) error {
 	return wait.PollUntilContextCancel(ctx, f.RetryInterval, true, func(ctx context.Context) (done bool, err error) {
+		f.log.Info("try to generate a certificate")
 		if err := f.regenerateCertificate(ctx, nextRenewCh); err != nil {
-			f.log.Error(err, "Failed to generate serving certificate, retrying...", "interval", f.RetryInterval)
+			if errors.Is(err, authority.ErrCertificateNotAvailable) {
+				f.log.Info(fmt.Sprintf("Certificate is not yet created. Will attempt again after %d seconds", f.RetryInterval/time.Second))
+			} else {
+				f.log.Error(err, "Failed to generate serving certificate, retrying...", "interval", f.RetryInterval)
+			}
 			return false, nil
 		}
-
+		f.log.Info("Generating serving certificate completed")
 		return true, nil
 	})
 }


### PR DESCRIPTION
### Pull Request Motivation

Issue: https://github.com/cert-manager/cert-manager/issues/7138

During the webhook service's booting, for a short period of time `regenerateCertificate` returns an error because the certificate has not yet been generated. However, during that time we print the following message in the logs `Failed to generate serving certificate`  which is a bit misleading. This PR fixes this by charging the following:
1. Add a log message that the certificate is successfully generated
2. Change the error message printed during service boot

/bug



