### PR TITLE
refactor: make CRDs really optionally installable

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -1,5 +1,5 @@
-# {{- include "cert-manager.crd-check" . }}
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -316,4 +316,4 @@ spec:
       served: true
       storage: true
 
-# END crd {{- end }}
+{{- end }}

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -1,4 +1,5 @@
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -763,4 +764,4 @@ spec:
       served: true
       storage: true
 
-# END crd {{- end }}
+{{- end }}

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -1,4 +1,5 @@
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3201,4 +3202,4 @@ spec:
       subresources:
         status: {}
 
-# END crd {{- end }}
+{{- end }}

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1,4 +1,5 @@
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3721,4 +3722,4 @@ spec:
       served: true
       storage: true
 
-# END crd {{- end }}
+{{- end }}

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1,4 +1,5 @@
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3721,4 +3722,4 @@ spec:
       served: true
       storage: true
 
-# END crd {{- end }}
+{{- end }}

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -1,4 +1,5 @@
-# START crd {{- if or .Values.crds.enabled .Values.installCRDs }}
+{{- include "cert-manager.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -263,4 +264,4 @@ spec:
       served: true
       storage: true
 
-# END crd {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Currently, when deploying with helm, the CRDs are always installed as the conditional code to handle this is commented out and / or incomplete.

This PR fixes this so it follows the default (not installing the CRDs) and also allows users to enable them.

Fixes #7255

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The CRDs installation option now follows the value set through --set crds.enabled
```
