### PR TITLE
BUGFIX: use correct resource namespace for Cluster Issuers

### DIFF
--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -31,6 +31,21 @@ func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
 	return ns
 }
 
+// ResourceNamespaceRef returns the Kubernetes namespace where resources
+// created or read by the referenced issuer are located.
+// This function is identical to CanUseAmbientCredentials, but takes a reference to
+// the issuer instead of the issuer itself (which means we don't need to fetch the
+// issuer from the API server).
+func (o IssuerOptions) ResourceNamespaceRef(ref cmmeta.ObjectReference, challengeNamespace string) string {
+	switch ref.Kind {
+	case cmapi.ClusterIssuerKind:
+		return o.ClusterResourceNamespace
+	case "", cmapi.IssuerKind:
+		return challengeNamespace
+	}
+	return challengeNamespace // Should not be reached
+}
+
 // CanUseAmbientCredentials returns whether `iss` will attempt to configure itself
 // from ambient credentials (e.g. from a cloud metadata service).
 func (o IssuerOptions) CanUseAmbientCredentials(iss cmapi.GenericIssuer) bool {

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -114,9 +114,10 @@ const informerResyncPeriod = time.Second
 // for any unset fields.
 func (b *Builder) Init() {
 	if b.Context == nil {
-		b.Context = &controller.Context{
-			RootContext: context.Background(),
-		}
+		b.Context = &controller.Context{}
+	}
+	if b.Context.RootContext == nil {
+		b.Context.RootContext = context.Background()
 	}
 	if b.StringGenerator == nil {
 		b.StringGenerator = rand.String

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -181,7 +181,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 	log := logf.FromContext(ctx, "solverForChallenge")
 	dbg := log.V(logf.DebugLevel)
 
-	resourceNamespace := ch.Namespace
+	resourceNamespace := s.ResourceNamespaceRef(ch.Spec.IssuerRef, ch.Namespace)
 	canUseAmbientCredentials := s.CanUseAmbientCredentialsFromRef(ch.Spec.IssuerRef)
 
 	providerConfig, err := extractChallengeSolverConfig(ch)
@@ -460,7 +460,7 @@ func (s *Solver) prepareChallengeRequest(ctx context.Context, ch *cmacme.Challen
 		return nil, nil, err
 	}
 
-	resourceNamespace := ch.Namespace
+	resourceNamespace := s.ResourceNamespaceRef(ch.Spec.IssuerRef, ch.Namespace)
 	canUseAmbientCredentials := s.CanUseAmbientCredentialsFromRef(ch.Spec.IssuerRef)
 
 	// construct a ChallengeRequest which can be passed to DNS solvers.


### PR DESCRIPTION
fixes https://github.com/cert-manager/cert-manager/issues/7331

see https://github.com/cert-manager/cert-manager/pull/7285#discussion_r1789623611

TODO: in a follow-up PR, we have to figure out why there is no e2e test that tests ACME cluster issuers with Secrets.

### Kind

/kind bug

### Release Note

```release-note
❗BUGFIX: A change in v1.16.0 caused cert-manager's ACME ClusterIssuer to look in the wrong namespace for resources required for the issuance (eg. credential Secrets). This is now fixed in v1.16.1.
```
