### PR TITLE
allow string values for minAvailable and maxAvailable helm values

### DIFF
--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -459,11 +459,11 @@
     },
     "helm-values.cainjector.podDisruptionBudget.maxUnavailable": {
       "description": "`maxUnavailable` configures the maximum unavailable pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `minAvailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.cainjector.podDisruptionBudget.minAvailable": {
       "description": "`minAvailable` configures the minimum available pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.cainjector.podLabels": {
       "default": {},
@@ -964,11 +964,11 @@
     },
     "helm-values.podDisruptionBudget.maxUnavailable": {
       "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.podDisruptionBudget.minAvailable": {
       "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.podDnsConfig": {
       "description": "Pod DNS configuration. The podDnsConfig field is optional and can work with any podDnsPolicy settings. However, when a Pod's dnsPolicy is set to \"None\", the dnsConfig field has to be specified. For more information, see [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).",
@@ -1949,11 +1949,11 @@
     },
     "helm-values.webhook.podDisruptionBudget.maxUnavailable": {
       "description": "This property configures the maximum unavailable pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `minAvailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.webhook.podDisruptionBudget.minAvailable": {
       "description": "This property configures the minimum available pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "helm-values.webhook.podLabels": {
       "default": {},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/7340

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixes helm validation errors for string values in `podDisruptionBudget.minAvailable` fields
```
