### PR TITLE
BUGFIX: Update schema validation to accept both string and integer values

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -228,14 +228,16 @@ Enable or disable the PodDisruptionBudget resource.
   
 This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining cert-manager  
 Pod is currently running.
-#### **podDisruptionBudget.minAvailable** ~ `number`
+#### **podDisruptionBudget.minAvailable** ~ `unknown`
 
 This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).  
 It cannot be used if `maxUnavailable` is set.
 
-#### **podDisruptionBudget.maxUnavailable** ~ `number`
+
+#### **podDisruptionBudget.maxUnavailable** ~ `unknown`
 
 This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set.
+
 
 #### **featureGates** ~ `string`
 > Default value:
@@ -952,15 +954,17 @@ Enable or disable the PodDisruptionBudget resource.
   
 This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining cert-manager  
 Pod is currently running.
-#### **webhook.podDisruptionBudget.minAvailable** ~ `number`
+#### **webhook.podDisruptionBudget.minAvailable** ~ `unknown`
 
 This property configures the minimum available pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).  
 It cannot be used if `maxUnavailable` is set.
 
-#### **webhook.podDisruptionBudget.maxUnavailable** ~ `number`
+
+#### **webhook.podDisruptionBudget.maxUnavailable** ~ `unknown`
 
 This property configures the maximum unavailable pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).  
 It cannot be used if `minAvailable` is set.
+
 
 #### **webhook.deploymentAnnotations** ~ `object`
 
@@ -1422,17 +1426,19 @@ Enable or disable the PodDisruptionBudget resource.
   
 This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining cert-manager  
 Pod is currently running.
-#### **cainjector.podDisruptionBudget.minAvailable** ~ `number`
+#### **cainjector.podDisruptionBudget.minAvailable** ~ `unknown`
 
 `minAvailable` configures the minimum available pods for disruptions. It can either be set to  
 an integer (e.g. 1) or a percentage value (e.g. 25%).  
 Cannot be used if `maxUnavailable` is set.
 
-#### **cainjector.podDisruptionBudget.maxUnavailable** ~ `number`
+
+#### **cainjector.podDisruptionBudget.maxUnavailable** ~ `unknown`
 
 `maxUnavailable` configures the maximum unavailable pods for disruptions. It can either be set to  
 an integer (e.g. 1) or a percentage value (e.g. 25%).  
 Cannot be used if `minAvailable` is set.
+
 
 #### **cainjector.deploymentAnnotations** ~ `object`
 

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -458,12 +458,10 @@
       "type": "boolean"
     },
     "helm-values.cainjector.podDisruptionBudget.maxUnavailable": {
-      "description": "`maxUnavailable` configures the maximum unavailable pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `minAvailable` is set.",
-      "type": "number"
+      "description": "`maxUnavailable` configures the maximum unavailable pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `minAvailable` is set."
     },
     "helm-values.cainjector.podDisruptionBudget.minAvailable": {
-      "description": "`minAvailable` configures the minimum available pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "description": "`minAvailable` configures the minimum available pods for disruptions. It can either be set to\nan integer (e.g. 1) or a percentage value (e.g. 25%).\nCannot be used if `maxUnavailable` is set."
     },
     "helm-values.cainjector.podLabels": {
       "default": {},
@@ -963,12 +961,10 @@
       "type": "boolean"
     },
     "helm-values.podDisruptionBudget.maxUnavailable": {
-      "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set.",
-      "type": "number"
+      "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set."
     },
     "helm-values.podDisruptionBudget.minAvailable": {
-      "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set."
     },
     "helm-values.podDnsConfig": {
       "description": "Pod DNS configuration. The podDnsConfig field is optional and can work with any podDnsPolicy settings. However, when a Pod's dnsPolicy is set to \"None\", the dnsConfig field has to be specified. For more information, see [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).",
@@ -1948,12 +1944,10 @@
       "type": "boolean"
     },
     "helm-values.webhook.podDisruptionBudget.maxUnavailable": {
-      "description": "This property configures the maximum unavailable pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `minAvailable` is set.",
-      "type": "number"
+      "description": "This property configures the maximum unavailable pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `minAvailable` is set."
     },
     "helm-values.webhook.podDisruptionBudget.minAvailable": {
-      "description": "This property configures the minimum available pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set.",
-      "type": "number"
+      "description": "This property configures the minimum available pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set."
     },
     "helm-values.webhook.podLabels": {
       "default": {},

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -120,12 +120,14 @@ podDisruptionBudget:
   # an integer (e.g. 1) or a percentage value (e.g. 25%).
   # It cannot be used if `maxUnavailable` is set.
   # +docs:property
+  # +docs:type=unknown
   # minAvailable: 1
 
   # This configures the maximum unavailable pods for disruptions. It can either be set to
   # an integer (e.g. 1) or a percentage value (e.g. 25%).
   # it cannot be used if `minAvailable` is set.
   # +docs:property
+  # +docs:type=unknown
   # maxUnavailable: 1
 
 # A comma-separated list of feature gates that should be enabled on the
@@ -697,12 +699,14 @@ webhook:
     # an integer (e.g. 1) or a percentage value (e.g. 25%).
     # It cannot be used if `maxUnavailable` is set.
     # +docs:property
+    # +docs:type=unknown
     # minAvailable: 1
 
     # This property configures the maximum unavailable pods for disruptions. Can either be set to
     # an integer (e.g. 1) or a percentage value (e.g. 25%).
     # It cannot be used if `minAvailable` is set.
     # +docs:property
+    # +docs:type=unknown
     # maxUnavailable: 1
 
   # Optional additional annotations to add to the webhook Deployment.
@@ -1062,12 +1066,14 @@ cainjector:
     # an integer (e.g. 1) or a percentage value (e.g. 25%).
     # Cannot be used if `maxUnavailable` is set.
     # +docs:property
+    # +docs:type=unknown
     # minAvailable: 1
 
     # `maxUnavailable` configures the maximum unavailable pods for disruptions. It can either be set to
     # an integer (e.g. 1) or a percentage value (e.g. 25%).
     # Cannot be used if `minAvailable` is set.
     # +docs:property
+    # +docs:type=unknown
     # maxUnavailable: 1
 
   # Optional additional annotations to add to the cainjector Deployment.


### PR DESCRIPTION
Fixes https://github.com/cert-manager/cert-manager/issues/7340

For `podDisruptionBudget.minAvailable` and `podDisruptionBudget.maxAvailable`, we should accept both string and integer values.

Affected values:
- podDisruptionBudget.minAvailable
- cainjector.podDisruptionBudget.minAvailable
- webhook.podDisruptionBudget.minAvailable
- podDisruptionBudget.maxAvailable
- cainjector.podDisruptionBudget.maxAvailable
- webhook.podDisruptionBudget.maxAvailable

### Kind

/kind bug

### Release Note

```release-note
BUGFIX: Helm will now accept percentages for the podDisruptionBudget.minAvailable and podDisruptionBudget.maxAvailable values.
```
