### PR TITLE
Helm: add enabled to json schema

### DIFF
--- a/deploy/charts/cert-manager/values.linter.exceptions
+++ b/deploy/charts/cert-manager/values.linter.exceptions
@@ -1,3 +1,4 @@
 value missing from templates: crds.enabled
 value missing from templates: crds.keep
 value missing from templates: acmesolver.image.pullPolicy
+value missing from templates: enabled

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -51,6 +51,9 @@
         "enableServiceLinks": {
           "$ref": "#/$defs/helm-values.enableServiceLinks"
         },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.enabled"
+        },
         "extraArgs": {
           "$ref": "#/$defs/helm-values.extraArgs"
         },
@@ -646,6 +649,11 @@
     "helm-values.enableServiceLinks": {
       "default": false,
       "description": "enableServiceLinks indicates whether information about services should be injected into the pod's environment variables, matching the syntax of Docker links.",
+      "type": "boolean"
+    },
+    "helm-values.enabled": {
+      "default": true,
+      "description": "Field that can be used as a condition when cert-manager is a dependency. This definition is only here as a placeholder such that it is included in the json schema. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info.",
       "type": "boolean"
     },
     "helm-values.extraArgs": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1445,3 +1445,11 @@ extraObjects: []
 # the static YAML manifests.
 # +docs:hidden
 creator: "helm"
+
+# Field that can be used as a condition when cert-manager is a dependency.
+# This definition is only here as a placeholder such that it is included in
+# the json schema.
+# See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags
+# for more info.
+# +docs:hidden
+enabled: true


### PR DESCRIPTION
Fixes https://github.com/cert-manager/cert-manager/issues/7334#issuecomment-2396066624 and part 2 from https://github.com/cert-manager/cert-manager/issues/7334#issuecomment-2397034886

Similar to https://github.com/open-telemetry/opentelemetry-helm-charts/pull/262

### Kind

/kind bug

### Release Note

```release-note
Helm: allow `enabled` to be set as a value to toggle cert-manager as a dependency.
```
