### PR TITLE
fix: don't create certificaterequests while being deleted

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -180,6 +180,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return err
 	}
 
+	// If the Certificate object is being deleted, we don't want to create any
+	// new Secret objects
+	if crt.DeletionTimestamp != nil {
+		return nil
+	}
+
 	log = logf.WithResource(log, crt)
 	ctx = logf.NewContext(ctx, log)
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -147,6 +147,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return err
 	}
 
+	// If the Certificate object is being deleted, we don't want to create any
+	// new CertificateRequests objects
+	if crt.DeletionTimestamp != nil {
+		return nil
+	}
+
 	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionIssuing,
 		Status: cmmeta.ConditionTrue,

--- a/test/e2e/suite/certificates/foregrounddeletion.go
+++ b/test/e2e/suite/certificates/foregrounddeletion.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/util"
+	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/util/predicate"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// This test ensures that if a Certificates using --cascade=foreground then it
+// does not re-create the CertificateRequest and Secret objects
+var _ = framework.CertManagerDescribe("Certificate Foreground Deletion", func() {
+	const (
+		issuerName = "certificate-foreground-deletion"
+		secretName = "test-foreground-deletion"
+		finalizer  = "e2e.cert-manager.io/foreground-deletion"
+	)
+
+	f := framework.NewDefaultFramework("certificates-foreground-deletion")
+	ctx := context.Background()
+
+	var crt *cmapi.Certificate
+
+	BeforeEach(func() {
+		By("creating a self-signing issuer")
+		issuer := gen.Issuer(issuerName+"-self-signed",
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}))
+		Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
+
+		By("waiting for self-signing Issuer to become Ready")
+		err := e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName+"-self-signed", cmapi.IssuerCondition{Type: cmapi.IssuerConditionReady, Status: cmmeta.ConditionTrue})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a CA Certificate")
+		ca := gen.Certificate(issuerName,
+			gen.SetCertificateNamespace(f.Namespace.Name),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName + "-self-signed"}),
+			gen.SetCertificateDNSNames("example.com"),
+			gen.SetCertificateIsCA(true),
+			gen.SetCertificateSecretName("ca-issuer"),
+		)
+		Expect(f.CRClient.Create(ctx, ca)).To(Succeed())
+		_, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, ca, time.Second*10)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a CA issuer")
+		issuer = gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerCA(cmapi.CAIssuer{SecretName: "ca-issuer"}),
+		)
+		Expect(f.CRClient.Create(ctx, issuer)).To(Succeed())
+
+		By("waiting for CA Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName, cmapi.IssuerCondition{Type: cmapi.IssuerConditionReady, Status: cmmeta.ConditionTrue})
+		Expect(err).NotTo(HaveOccurred())
+
+		crt = &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-foreground-deletion-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: cmapi.CertificateSpec{
+				CommonName: "test",
+				SecretName: secretName,
+				PrivateKey: &cmapi.CertificatePrivateKey{RotationPolicy: cmapi.RotationPolicyAlways},
+				IssuerRef: cmmeta.ObjectReference{
+					Name: issuerName, Kind: "Issuer", Group: "cert-manager.io",
+				},
+			},
+		}
+
+		By("creating a Certificate")
+		crt, err = f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(ctx, crt, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		crt, err = f.Helper().WaitForCertificateReadyAndDoneIssuing(ctx, crt, time.Minute*2)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
+
+		By("adding a finalizer to the Certificate")
+		Eventually(util.AddFinalizer).
+			WithContext(ctx).
+			WithArguments(f.CRClient, crt, finalizer).
+			Should(Succeed())
+
+		By("performing a foreground deletion of the Certificate")
+		Expect(f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Delete(ctx, crt.Name, metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)})).ToNot(HaveOccurred(), "failed to delete the Certificate")
+
+		// Deleting the secret would normally trigger a new issuance, creating a certificate request
+		By("deleting the Certificate secret")
+		Expect(f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, crt.Spec.SecretName, metav1.DeleteOptions{})).ToNot(HaveOccurred(), "failed to delete the Secret")
+	})
+
+	AfterEach(func() {
+		By("deleting the self-signed issuer")
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.Background(), issuerName+"-self-signed", metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("deleting the CA issuer")
+		err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.Background(), issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the finalizer from the Certificate")
+		Eventually(util.RemoveFinalizer).
+			WithContext(ctx).
+			WithArguments(f.CRClient, crt, finalizer).
+			Should(Succeed())
+	})
+
+	It("should not create a CertificateRequest while the Certificate is being deleted", func() {
+		By("ensuring all CertificateRequest objects are deleted")
+		Eventually(util.ListMatchingPredicates[cmapi.CertificateRequest, cmapi.CertificateRequestList]).
+			WithContext(ctx).
+			WithArguments(
+				f.CRClient,
+				predicate.ResourceOwnedBy(crt),
+			).
+			WithTimeout(time.Second * 10).
+			MustPassRepeatedly(10).
+			Should(BeEmpty())
+	})
+
+	It("should not create a Secret while the Certificate is being deleted", func() {
+		By("ensuring all Secret objects are deleted")
+		Eventually(util.ListMatchingPredicates[corev1.Secret, corev1.SecretList]).
+			WithContext(ctx).
+			WithArguments(
+				f.CRClient,
+				func(obj runtime.Object) bool {
+					secret := obj.(*corev1.Secret)
+					return secret.Annotations != nil &&
+						secret.Annotations["cert-manager.io/certificate-name"] == crt.Name &&
+						secret.Namespace == crt.Namespace
+				},
+			).
+			WithTimeout(time.Second * 10).
+			MustPassRepeatedly(10).
+			Should(BeEmpty())
+	})
+})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
If you delete a Certificate resource with ["foreground" cascading deletion](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion), the child objects such as the Secret and the CertificateRequest objects will be deleted first. This causes the Certificate controllers to re-create these even though the Certificate resource is being deleted itself.

We can check if a Certificate is being deleted by testing the metadata.deletionTimestamp field is set, this PR adds this test to the controllers responsible for creating the CertificateRequest and Secret objects.

resolves #7358

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### TODO

- [x] E2E test for foreground deletion

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The Certificate object will no longer create CertificateRequest or Secret objects while being deleted
```
