### PR TITLE
Move duration validation test functions to helper

### DIFF
--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -21,9 +21,11 @@ import (
 	"crypto"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificaterequests"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
@@ -52,6 +54,27 @@ func (h *Helper) ValidateCertificate(certificate *cmapi.Certificate, validations
 			errs = append(errs, h.describeKubeObject(secret))
 
 			return kerrors.NewAggregate(errs)
+		}
+	}
+
+	return nil
+}
+
+// ValidateCertificateRequest retrieves the issued certificate and runs all validation functions
+func (h *Helper) ValidateCertificateRequest(name types.NamespacedName, key crypto.Signer, validations ...certificaterequests.ValidationFunc) error {
+	if len(validations) == 0 {
+		validations = validation.DefaultCertificateRequestSet()
+	}
+
+	cr, err := h.CMClient.CertmanagerV1().CertificateRequests(name.Namespace).Get(context.TODO(), name.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, fn := range validations {
+		err := fn(cr, key)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/test/e2e/framework/helper/validation/certificaterequests/certificaterequests.go
+++ b/test/e2e/framework/helper/validation/certificaterequests/certificaterequests.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequests
+
+import (
+	"crypto"
+	"fmt"
+	"time"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+)
+
+// ValidationFunc describes a CertificateRequest validation helper function
+type ValidationFunc func(certificaterequest *cmapi.CertificateRequest, key crypto.Signer) error
+
+func ExpectDuration(duration, fuzz time.Duration) func(certificaterequest *cmapi.CertificateRequest, key crypto.Signer) error {
+	return func(certificaterequest *cmapi.CertificateRequest, key crypto.Signer) error {
+		certBytes := certificaterequest.Status.Certificate
+		if len(certBytes) == 0 {
+			return fmt.Errorf("no certificate data found in CertificateRequest.Status.Certificate")
+		}
+		cert, err := pki.DecodeX509CertificateBytes(certBytes)
+		if err != nil {
+			return err
+		}
+
+		certDuration := cert.NotAfter.Sub(cert.NotBefore)
+		if certDuration > (duration+fuzz) || certDuration < duration {
+			return fmt.Errorf("expected duration of %s, got %s (fuzz: %s) [NotBefore: %s, NotAfter: %s]", duration, certDuration,
+				fuzz, cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+		}
+
+		return nil
+	}
+}

--- a/test/e2e/framework/helper/validation/validation.go
+++ b/test/e2e/framework/helper/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/featureset"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificaterequests"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificatesigningrequests"
 )
@@ -57,6 +58,12 @@ func DefaultCertificateSigningRequestSet() []certificatesigningrequests.Validati
 		certificatesigningrequests.ExpectConditionApproved,
 		certificatesigningrequests.ExpectConditiotNotDenied,
 		certificatesigningrequests.ExpectConditionNotFailed,
+	}
+}
+
+func DefaultCertificateRequestSet() []certificaterequests.ValidationFunc {
+	return []certificaterequests.ValidationFunc{
+		// TODO: add validation functions
 	}
 }
 

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -236,7 +237,8 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 				err = f.Helper().ValidateCertificate(cert)
 				Expect(err).NotTo(HaveOccurred())
 
-				f.CertificateDurationValid(ctx, cert, v.expectedDuration, 0)
+				err = f.Helper().ValidateCertificate(cert, certificates.ExpectDuration(v.expectedDuration, 0))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		}
 	})

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -143,7 +144,8 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 			err = f.Helper().ValidateCertificate(cert)
 			Expect(err).NotTo(HaveOccurred())
 
-			f.CertificateDurationValid(ctx, cert, v.expectedDuration, 0)
+			err = f.Helper().ValidateCertificate(cert, certificates.ExpectDuration(v.expectedDuration, 0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	}
 

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -21,8 +21,10 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificaterequests"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -183,9 +185,11 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 				By("Verifying the CertificateRequest is valid")
 				err = h.WaitCertificateRequestIssuedValid(ctx, f.Namespace.Name, certificateRequestName, time.Second*30, rootRSAKeySigner)
 				Expect(err).NotTo(HaveOccurred())
-				cr, err := crClient.Get(ctx, certificateRequestName, metav1.GetOptions{})
+				err = h.ValidateCertificateRequest(types.NamespacedName{
+					Namespace: f.Namespace.Name,
+					Name:      certificateRequestName,
+				}, rootRSAKeySigner, certificaterequests.ExpectDuration(v.expectedDuration, 0))
 				Expect(err).NotTo(HaveOccurred())
-				f.CertificateRequestDurationValid(cr, v.expectedDuration, 0)
 			})
 		}
 	})

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -27,6 +27,7 @@ import (
 	vaultaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/vault"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/featureset"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -266,7 +267,8 @@ func runVaultAppRoleTests(issuerKind string, testWithRoot bool, unsupportedFeatu
 			Expect(err).NotTo(HaveOccurred())
 
 			// Vault subtract 30 seconds to the NotBefore date.
-			f.CertificateDurationValid(ctx, cert, v.expectedDuration, time.Second*30)
+			err = f.Helper().ValidateCertificate(cert, certificates.ExpectDuration(v.expectedDuration, time.Second*30))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }

--- a/test/e2e/suite/issuers/vault/certificate/cert_auth.go
+++ b/test/e2e/suite/issuers/vault/certificate/cert_auth.go
@@ -28,6 +28,7 @@ import (
 	vaultaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/vault"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/featureset"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificates"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -276,7 +277,8 @@ func runVaultClientCertAuthTest(issuerKind string, testWithRoot bool, unsupporte
 			Expect(err).NotTo(HaveOccurred())
 
 			// Vault subtract 30 seconds to the NotBefore date.
-			f.CertificateDurationValid(ctx, cert, v.expectedDuration, time.Second*30)
+			err = f.Helper().ValidateCertificate(cert, certificates.ExpectDuration(v.expectedDuration, time.Second*30))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -23,10 +23,12 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon"
 	vaultaddon "github.com/cert-manager/cert-manager/e2e-tests/framework/addon/vault"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificaterequests"
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -257,10 +259,14 @@ func runVaultAppRoleTests(issuerKind string) {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the Certificate is valid")
-			cr, err = crClient.Get(ctx, cr.Name, metav1.GetOptions{})
+			_, err = crClient.Get(ctx, cr.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			// Vault can issue certificates with slightly skewed duration.
-			f.CertificateRequestDurationValid(cr, v.expectedDuration, 30*time.Second)
+			err = h.ValidateCertificateRequest(types.NamespacedName{
+				Namespace: f.Namespace.Name,
+				Name:      certificateRequestName,
+			}, key, certificaterequests.ExpectDuration(v.expectedDuration, 30*time.Second))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }


### PR DESCRIPTION
Moves validation functions to helper. This groups them with the other existing validation functions.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
