### PR TITLE
Use different hash algorithms for larger RSA keys

### DIFF
--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -50,18 +50,13 @@ type CA struct {
 
 	reporter *crutil.Reporter
 
-	// Used for testing to get reproducible resulting certificates
+	// templateGenerator is used to generate templates to pass to the Go stdlib for signing.
+	// It's a member of the struct so it can be mocked for testing.
 	templateGenerator templateGenerator
-	signingFn         signingFn
-}
 
-func init() {
-	// create certificate request controller for ca issuer
-	controllerpkg.Register(CRControllerName, func(ctx *controllerpkg.ContextFactory) (controllerpkg.Interface, error) {
-		return controllerpkg.NewBuilder(ctx, CRControllerName).
-			For(certificaterequests.New(apiutil.IssuerCA, NewCA)).
-			Complete()
-	})
+	// signingFn is the function called to actually sign certificates.
+	// It's a member of the struct so it can be mocked for testing.
+	signingFn signingFn
 }
 
 func NewCA(ctx *controllerpkg.Context) certificaterequests.Issuer {
@@ -136,4 +131,13 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 		Certificate: bundle.ChainPEM,
 		CA:          bundle.CAPEM,
 	}, nil
+}
+
+func init() {
+	// create certificate request controller for ca issuer
+	controllerpkg.Register(CRControllerName, func(ctx *controllerpkg.ContextFactory) (controllerpkg.Interface, error) {
+		return controllerpkg.NewBuilder(ctx, CRControllerName).
+			For(certificaterequests.New(apiutil.IssuerCA, NewCA)).
+			Complete()
+	})
 }

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -58,7 +58,7 @@ type SelfSigned struct {
 	reporter *crutil.Reporter
 	recorder record.EventRecorder
 
-	// Used for testing to get reproducible resulting certificates
+	// signingFn is the function called to actually sign certificates. It's a member of the struct so it can be mocked for testing.
 	signingFn signingFn
 }
 


### PR DESCRIPTION
See also #7357

A [US DoD document](https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/pdf/unclass-memo_dodcryptoalgorithms.pdf) states that:

> Effective immediately, all Public Key enabled commercial-off-the-shelf
> software and Public Key enabled Open-Source software integrations [...]
> must support at least RSA-3072 (4096 is preferred) and SHA-384.

cert-manager already supports large RSA keys - that's no problem. But we always use SHA256 with all RSA keys currently; this commit changes that so we use SHA512 for RSA keys 4096 bits and above, or else SHA384 for RSA keys 3072 bits and above, or else SHA256.

We discussed in standups / in the issue how to roll this out, and the consensus so far has been to roll this out unilaterally. Albeit we don't have data to support our assumption, we believe there won't be any huge compatibility problems from using this approach.

One potential issue is that SHA512 can take (much) longer on some low powered 32-bit platforms (think older Raspberry Pis). We decided that the risk of slowdown there isn't worth delaying the rollout of this. Plus, people using those devices always have the option of using RSA-2048 or else ECDSA / Ed25519.

## Help for Reviewers

It's easy to get confused about this signature algorithm. The algorithm is decided by the **signer**. For SelfSigned, that's the same as the cert being issued obviously - but for the CA issuer it can be easy to forget.

As an example, a 2048-bit RSA root signing a 4096-bit RSA leaf (or, say, an Ed25519 leaf) should produce a `SHA256WithRSA` signature algorithm.

### Kind

/kind feature

### Release Note

```release-note
Potentially BREAKING: The CA and SelfSigned issuers now use SHA512 when signing with RSA keys 4096 bits and above, and SHA384 when signing with RSA keys 3072 bits and above. If you were previously using a larger RSA key as a CA, be sure to check that your systems support the new hash algorithms.
```
