### PR TITLE
add tenantID option to azureDNS managedIdentity

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -287,6 +287,9 @@ spec:
                                     resource ID of the managed identity, can not be used at the same time as clientID
                                     Cannot be used for Azure Managed Service Identity
                                   type: string
+                                tenantID:
+                                  description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
                             resourceGroupName:
                               description: resource group the DNS zone is located in
                               type: string

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -394,6 +394,9 @@ spec:
                                           resource ID of the managed identity, can not be used at the same time as clientID
                                           Cannot be used for Azure Managed Service Identity
                                         type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
                                     type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -394,6 +394,9 @@ spec:
                                           resource ID of the managed identity, can not be used at the same time as clientID
                                           Cannot be used for Azure Managed Service Identity
                                         type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
                                     type: string

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -594,6 +594,8 @@ type AzureManagedIdentity struct {
 	ClientID string
 
 	ResourceID string
+
+	TenantID string
 }
 
 type AzureDNSEnvironment string

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1392,6 +1392,7 @@ func Convert_acme_ACMEIssuerStatus_To_v1_ACMEIssuerStatus(in *acme.ACMEIssuerSta
 func autoConvert_v1_AzureManagedIdentity_To_acme_AzureManagedIdentity(in *v1.AzureManagedIdentity, out *acme.AzureManagedIdentity, s conversion.Scope) error {
 	out.ClientID = in.ClientID
 	out.ResourceID = in.ResourceID
+	out.TenantID = in.TenantID
 	return nil
 }
 
@@ -1403,6 +1404,7 @@ func Convert_v1_AzureManagedIdentity_To_acme_AzureManagedIdentity(in *v1.AzureMa
 func autoConvert_acme_AzureManagedIdentity_To_v1_AzureManagedIdentity(in *acme.AzureManagedIdentity, out *v1.AzureManagedIdentity, s conversion.Scope) error {
 	out.ClientID = in.ClientID
 	out.ResourceID = in.ResourceID
+	out.TenantID = in.TenantID
 	return nil
 }
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -466,8 +466,16 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 				if p.AzureDNS.ManagedIdentity != nil {
 					el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managed identity can not be used at the same time as clientID, clientSecretSecretRef or tenantID"))
 				}
-			} else if p.AzureDNS.ManagedIdentity != nil && len(p.AzureDNS.ManagedIdentity.ClientID) > 0 && len(p.AzureDNS.ManagedIdentity.ResourceID) > 0 {
-				el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID and managedIdentityResourceID cannot both be specified"))
+			} else if p.AzureDNS.ManagedIdentity != nil {
+				if len(p.AzureDNS.ManagedIdentity.ClientID) > 0 && len(p.AzureDNS.ManagedIdentity.ResourceID) > 0 {
+					el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID and managedIdentityResourceID cannot both be specified"))
+				}
+				if len(p.AzureDNS.ManagedIdentity.TenantID) > 0 && len(p.AzureDNS.ManagedIdentity.ResourceID) > 0 {
+					el = append(el, field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityTenantID and managedIdentityResourceID cannot both be specified"))
+				}
+				if len(p.AzureDNS.ManagedIdentity.TenantID) > 0 && len(p.AzureDNS.ManagedIdentity.ClientID) == 0 {
+					el = append(el, field.Required(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID is required when using managedIdentityTenantID"))
+				}
 			}
 
 			// SubscriptionID must always be defined

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1274,6 +1274,37 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(fldPath.Child("azureDNS", "resourceGroupName"), ""),
 			},
 		},
+
+		"invalid azuredns managedIdentity tenantID used without managedIdentity clientID ": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					ManagedIdentity: &cmacme.AzureManagedIdentity{
+						TenantID: "some-tenant-id",
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Required(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID is required when using managedIdentityTenantID"),
+				field.Required(fldPath.Child("azureDNS", "subscriptionID"), ""),
+				field.Required(fldPath.Child("azureDNS", "resourceGroupName"), ""),
+			},
+		},
+		"invalid azuredns managedIdentity tenantID used with resourceID": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					SubscriptionID:    "test",
+					ResourceGroupName: "test",
+					ManagedIdentity: &cmacme.AzureManagedIdentity{
+						ResourceID: "test",
+						TenantID:   "some-tenant-id",
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityTenantID and managedIdentityResourceID cannot both be specified"),
+				field.Required(fldPath.Child("azureDNS", "managedIdentity"), "managedIdentityClientID is required when using managedIdentityTenantID"),
+			},
+		},
 		"invalid azuredns clientSecret used with managedIdentity": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -710,6 +710,10 @@ type AzureManagedIdentity struct {
 	// Cannot be used for Azure Managed Service Identity
 	// +optional
 	ResourceID string `json:"resourceID,omitempty"`
+
+	// tenant ID of the managed identity, can not be used at the same time as resourceID
+	// +optional
+	TenantID string `json:"tenantID,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -110,6 +110,9 @@ func getAuthorization(clientOpt policy.ClientOptions, clientID, clientSecret, te
 			if managedIdentity.ClientID != "" {
 				wcOpt.ClientID = managedIdentity.ClientID
 			}
+			if managedIdentity.TenantID != "" {
+				wcOpt.TenantID = managedIdentity.TenantID
+			}
 		}
 
 		return azidentity.NewWorkloadIdentityCredential(wcOpt)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

With using managed identity for AzureDNS it's possible to use a service principal as a managed identity. For service principals it's possible to use it in multiple organization. [Example for multitenant service principal](https://learn.microsoft.com/en-us/azure/container-registry/authenticate-aks-cross-tenant)
You can use federated credentials for service principals in the same way as for[ managed identities](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp)
So if our DNS Zone is in a different tenant than cert-manager we can use this behavior but we have to specify a tenantID.
With this pull request a tenantID option will be added to the managedIdentity section for AzureDNS


### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--
feature
Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
New configuration option tenantID for the AzureDNS provider when using managed identities with service principals. This enhancement allows users to specify the tenant ID when using managed identities, offering better flexibility in multi-tenant environments.
```
