### PR TITLE
Cleanup key gen / RSA key sizes

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -148,8 +148,8 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	if crt.PrivateKey != nil {
 		switch crt.PrivateKey.Algorithm {
 		case "", internalcmapi.RSAKeyAlgorithm:
-			if crt.PrivateKey.Size > 0 && (crt.PrivateKey.Size < 2048 || crt.PrivateKey.Size > 8192) {
-				el = append(el, field.Invalid(fldPath.Child("privateKey", "size"), crt.PrivateKey.Size, "must be between 2048 & 8192 for rsa keyAlgorithm"))
+			if crt.PrivateKey.Size > 0 && (crt.PrivateKey.Size < pki.MinRSAKeySize || crt.PrivateKey.Size > pki.MaxRSAKeySize) {
+				el = append(el, field.Invalid(fldPath.Child("privateKey", "size"), crt.PrivateKey.Size, fmt.Sprintf("must be between %d and %d for rsa keyAlgorithm", pki.MinRSAKeySize, pki.MaxRSAKeySize)))
 			}
 		case internalcmapi.ECDSAKeyAlgorithm:
 			if crt.PrivateKey.Size > 0 && crt.PrivateKey.Size != 256 && crt.PrivateKey.Size != 384 && crt.PrivateKey.Size != 521 {

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -362,7 +362,7 @@ func TestValidateCertificate(t *testing.T) {
 			},
 			a: someAdmissionRequest,
 			errs: []*field.Error{
-				field.Invalid(fldPath.Child("privateKey", "size"), 1024, "must be between 2048 & 8192 for rsa keyAlgorithm"),
+				field.Invalid(fldPath.Child("privateKey", "size"), 1024, "must be between 2048 and 8192 for rsa keyAlgorithm"),
 			},
 		},
 		"certificate with rsa keyAlgorithm specified and invalid keysize 8196": {
@@ -379,7 +379,7 @@ func TestValidateCertificate(t *testing.T) {
 			},
 			a: someAdmissionRequest,
 			errs: []*field.Error{
-				field.Invalid(fldPath.Child("privateKey", "size"), 8196, "must be between 2048 & 8192 for rsa keyAlgorithm"),
+				field.Invalid(fldPath.Child("privateKey", "size"), 8196, "must be between 2048 and 8192 for rsa keyAlgorithm"),
 			},
 		},
 		"certificate with ecdsa keyAlgorithm specified and invalid keysize": {

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -17,8 +17,7 @@ limitations under the License.
 package util
 
 import (
-	"crypto/rand"
-	"math/big"
+	"math/rand/v2"
 	"net/http"
 	"time"
 )
@@ -45,10 +44,8 @@ func RetryBackoff(n int, r *http.Request, resp *http.Response) time.Duration {
 		return -1
 	}
 
-	var jitter time.Duration
-	if x, err := rand.Int(rand.Reader, big.NewInt(1000)); err == nil {
-		jitter = (1 + time.Duration(x.Int64())) * time.Millisecond
-	}
+	// No need for a cryptographically secure RNG here
+	jitter := 1 + time.Millisecond*time.Duration(rand.Int64N(1000)) // #nosec G404
 
 	// the exponent is calculated slightly contrived to allow the gosec:G115
 	// linter to recognise the safe type conversion.

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -31,6 +31,7 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
 var (
@@ -244,7 +245,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 
 		switch algorithm {
 		case cmapi.RSAKeyAlgorithm:
-			if size < 2048 || size > 8192 {
+			if size < pki.MinRSAKeySize || size > pki.MaxRSAKeySize {
 				return fmt.Errorf("%w %q: invalid private key size for RSA algorithm %q", errInvalidIngressAnnotation, cmapi.PrivateKeySizeAnnotationKey, privateKeySize)
 			}
 		case cmapi.ECDSAKeyAlgorithm:

--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -19,7 +19,6 @@ package vault
 import (
 	"context"
 	cryptorand "crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -37,9 +36,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
+	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
 const vaultToken = "vault-root-token"
@@ -70,7 +71,7 @@ func NewVaultInitializerClientCertificate(
 	details Details,
 	configureWithRoot bool,
 ) *VaultInitializer {
-	testId := rand.String(10)
+	testId := k8srand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -94,7 +95,7 @@ func NewVaultInitializerAppRole(
 	details Details,
 	configureWithRoot bool,
 ) *VaultInitializer {
-	testId := rand.String(10)
+	testId := k8srand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -119,7 +120,7 @@ func NewVaultInitializerKubernetes(
 	configureWithRoot bool,
 	apiServerURL string,
 ) *VaultInitializer {
-	testId := rand.String(10)
+	testId := k8srand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -145,7 +146,7 @@ func NewVaultInitializerAllAuth(
 	configureWithRoot bool,
 	apiServerURL string,
 ) *VaultInitializer {
-	testId := rand.String(10)
+	testId := k8srand.String(10)
 	rootMount := fmt.Sprintf("%s-root-ca", testId)
 	intermediateMount := fmt.Sprintf("%s-intermediate-ca", testId)
 	role := fmt.Sprintf("%s-role", testId)
@@ -828,7 +829,7 @@ func (v *VaultInitializer) setupClientCertAuth(ctx context.Context) error {
 }
 
 func (v *VaultInitializer) CreateClientCertRole(ctx context.Context) (key []byte, cert []byte, _ error) {
-	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	privateKey, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Pull Request Motivation

Spotted these while doing other work; these are simple cleanups and improvements which should have no observable impact.

Each commit is self-contained and can be reviewed individually.

Description of changes:

1) Use `math/rand/v2` for calculating acme jitter. We don't need cryptographically secure RNG there and the resulting code is much simpler.
2) Change hardcoded magic numbers to reference Min/Max RSA key size vars we already have.
3) Change calls (mostly in tests) to the stdlib key generation to use our functions instead.
4) Add error handling in vault e2e addon. Panicing is fine here - better IMO than not knowing if an error occurred in these functions

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
