### PR TITLE
Implement a single package for controlling cert-manager RNG

### DIFF
--- a/pkg/cmrand/rand.go
+++ b/pkg/cmrand/rand.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmrand provides cryptographically secure random number generation utilities for use in
+// cert-manager code. The default RNG source in this package is `crypto/rand`, which is suitable for
+// most use-cases, but can be configured if desired.
+// WARNING: Cryptographically secure RNG is critical for secure operation of cert-manager. Don't
+// change the RNG unless you're certain you know what you're doing.
+package cmrand
+
+import (
+	"crypto/rand"
+	"io"
+	"math/big"
+)
+
+// Reader is a centralized point of configuration for random number generation across cert-manager.
+// It defaults to pointing at `crypto/rand.Reader`.
+// A custom / hardware RNG can be configured globally instead by changing this variable on startup.
+var Reader io.Reader = rand.Reader
+
+var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+// SerialNumber returns a random serial number suitable for use in an X.509 certificate.
+// This function may change the size of serial number it generates between versions of cert-manager;
+// do not rely on SerialNumber to return a constant-sized number.
+func SerialNumber() (*big.Int, error) {
+	return rand.Int(Reader, serialNumberLimit)
+}

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
@@ -42,6 +41,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/util"
@@ -629,12 +629,15 @@ func TestCA_Sign(t *testing.T) {
 // Returns a map that is meant to be used for creating a certificate Secret
 // that contains the fields "tls.crt" and "tls.key".
 func secretDataFor(t *testing.T, caKey *ecdsa.PrivateKey, caCrt *x509.Certificate) (secretData map[string][]byte) {
-	rootCADER, err := x509.CreateCertificate(rand.Reader, caCrt, caCrt, caKey.Public(), caKey)
+	rootCADER, err := x509.CreateCertificate(cmrand.Reader, caCrt, caCrt, caKey.Public(), caKey)
 	require.NoError(t, err)
+
 	caCrt, err = x509.ParseCertificate(rootCADER)
 	require.NoError(t, err)
+
 	caKeyPEM, err := pki.EncodeECPrivateKey(caKey)
 	require.NoError(t, err)
+
 	caCrtPEM, err := pki.EncodeX509(caCrt)
 	require.NoError(t, err)
 

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -35,6 +34,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/fake"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -73,7 +73,7 @@ func generateSelfSignedCert(t *testing.T, cr *cmapi.CertificateRequest, key cryp
 	template.NotAfter = notAfter
 	template.NotBefore = notBefore
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	derBytes, err := x509.CreateCertificate(cmrand.Reader, template, template, key.Public(), key)
 	if err != nil {
 		t.Errorf("error signing cert: %v", err)
 		t.FailNow()

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -41,6 +40,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -70,7 +70,7 @@ func generateSelfSignedCertFromCR(cr *cmapi.CertificateRequest, key crypto.Signe
 		return nil, fmt.Errorf("error generating template: %v", err)
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	derBytes, err := x509.CreateCertificate(cmrand.Reader, template, template, key.Public(), key)
 	if err != nil {
 		return nil, fmt.Errorf("error signing cert: %v", err)
 	}

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -19,11 +19,9 @@ package venafi
 import (
 	"context"
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
-	"math/big"
 	"testing"
 	"time"
 
@@ -41,6 +39,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -77,7 +76,7 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := cmrand.SerialNumber()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/certificates/issuing/internal/keystore_test.go
+++ b/pkg/controller/certificates/issuing/internal/keystore_test.go
@@ -41,10 +41,12 @@ func mustGeneratePrivateKey(t *testing.T, encoding cmapi.PrivateKeyEncoding) []b
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	pkBytes, err := pki.EncodePrivateKey(pk, encoding)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return pkBytes
 }
 

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
@@ -45,6 +44,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
@@ -785,7 +785,7 @@ func TestCA_Sign(t *testing.T) {
 // Returns a map that is meant to be used for creating a certificate Secret
 // that contains the fields "tls.crt" and "tls.key".
 func secretDataFor(t *testing.T, caKey *ecdsa.PrivateKey, caCrt *x509.Certificate) (secretData map[string][]byte) {
-	rootCADER, err := x509.CreateCertificate(rand.Reader, caCrt, caCrt, caKey.Public(), caKey)
+	rootCADER, err := x509.CreateCertificate(cmrand.Reader, caCrt, caCrt, caKey.Public(), caKey)
 	require.NoError(t, err)
 	caCrt, err = x509.ParseCertificate(rootCADER)
 	require.NoError(t, err)

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -19,9 +19,6 @@ package tls
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -41,7 +38,7 @@ import (
 
 func signUsingTempCA(t *testing.T, template *x509.Certificate) *x509.Certificate {
 	// generate random ca private key
-	caPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	caPrivateKey, err := pki.GenerateECPrivateKey(521)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/tls/file_source_test.go
+++ b/pkg/server/tls/file_source_test.go
@@ -18,10 +18,8 @@ package tls
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -157,8 +156,6 @@ func TestFileSource_UpdatesFile(t *testing.T) {
 	}
 }
 
-var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
-
 func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []byte) {
 	pk, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
@@ -169,7 +166,7 @@ func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []by
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	serialNumber, err := cmrand.SerialNumber()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pki
 
 import (
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -31,6 +30,7 @@ import (
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	experimentalapi "github.com/cert-manager/cert-manager/pkg/apis/experimental/v1alpha1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 )
 
 type CertificateTemplateValidatorMutator func(*x509.CertificateRequest, *x509.Certificate) error
@@ -144,7 +144,7 @@ func (k printKeyUsage) String() string {
 // CertificateTemplateFromCSR will create a x509.Certificate for the
 // given *x509.CertificateRequest.
 func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators ...CertificateTemplateValidatorMutator) (*x509.Certificate, error) {
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	serialNumber, err := cmrand.SerialNumber()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate serial number: %s", err.Error())
 	}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -20,9 +20,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -38,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/util"
 )
 
@@ -1088,7 +1087,17 @@ func TestEncodeX509Chain(t *testing.T) {
 func rsaKey(t *testing.T, size int) crypto.Signer {
 	t.Helper()
 
-	key, err := rsa.GenerateKey(rand.Reader, size)
+	var key crypto.Signer
+	var err error
+
+	if size < MinRSAKeySize {
+		// Special case; GenerateRSAPrivateKey doesn't support insecure keys but we want one for
+		// testing in this case.
+		key, err = rsa.GenerateKey(cmrand.Reader, size)
+	} else {
+		key, err = GenerateRSAPrivateKey(size)
+	}
+
 	if err != nil {
 		t.Fatalf("failed to generate RSA key with size %d: %s", size, err)
 	}
@@ -1096,12 +1105,23 @@ func rsaKey(t *testing.T, size int) crypto.Signer {
 	return key
 }
 
-func ecdsaKey(t *testing.T, curve elliptic.Curve) crypto.Signer {
+func ecdsaKey(t *testing.T, size int) crypto.Signer {
 	t.Helper()
 
-	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	var key crypto.Signer
+	var err error
+
+	if size == 224 {
+		// Special case; we don't support P224 in our keygen (because it's not widely used in
+		// web PKI).
+		// So we have to manually generate a curve here with different logic
+		key, err = ecdsa.GenerateKey(elliptic.P224(), cmrand.Reader)
+	} else {
+		key, err = GenerateECPrivateKey(size)
+	}
+
 	if err != nil {
-		t.Fatalf("failed to generate ECDSA key with curve %s: %s", curve, err)
+		t.Fatalf("failed to generate ECDSA key with curve %d: %s", size, err)
 	}
 
 	return key
@@ -1110,7 +1130,7 @@ func ecdsaKey(t *testing.T, curve elliptic.Curve) crypto.Signer {
 func ed25519Key(t *testing.T) crypto.Signer {
 	t.Helper()
 
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	priv, err := GenerateEd25519PrivateKey()
 	if err != nil {
 		t.Fatalf("failed to generate ed25519 key: %s", err)
 	}
@@ -1146,20 +1166,20 @@ func Test_SignCertificate_Signatures(t *testing.T) {
 			ExpectErr:                  true,
 		},
 		"ECDSA P-224 should error": {
-			SignerKey:                  ecdsaKey(t, elliptic.P224()),
+			SignerKey:                  ecdsaKey(t, 224),
 			ExpectedSignatureAlgorithm: x509.UnknownSignatureAlgorithm,
 			ExpectErr:                  true,
 		},
 		"ECDSA P-256": {
-			SignerKey:                  ecdsaKey(t, elliptic.P256()),
+			SignerKey:                  ecdsaKey(t, 256),
 			ExpectedSignatureAlgorithm: x509.ECDSAWithSHA256,
 		},
 		"ECDSA P-384": {
-			SignerKey:                  ecdsaKey(t, elliptic.P384()),
+			SignerKey:                  ecdsaKey(t, 384),
 			ExpectedSignatureAlgorithm: x509.ECDSAWithSHA384,
 		},
 		"ECDSA P-521": {
-			SignerKey:                  ecdsaKey(t, elliptic.P521()),
+			SignerKey:                  ecdsaKey(t, 521),
 			ExpectedSignatureAlgorithm: x509.ECDSAWithSHA512,
 		},
 		"Ed25519": {
@@ -1175,7 +1195,7 @@ func Test_SignCertificate_Signatures(t *testing.T) {
 			signerKey := spec.SignerKey
 			pub := signerKey.Public()
 
-			serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+			serialNumber, err := cmrand.SerialNumber()
 			if err != nil {
 				t.Fatalf("failed to generate serial number for certificate: %s", err)
 			}

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -21,13 +21,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 )
 
 const (
@@ -92,7 +92,7 @@ func GenerateRSAPrivateKey(keySize int) (*rsa.PrivateKey, error) {
 		return nil, fmt.Errorf("rsa key size specified too big: %d. maximum key size: %d", keySize, MaxRSAKeySize)
 	}
 
-	return rsa.GenerateKey(rand.Reader, keySize)
+	return rsa.GenerateKey(cmrand.Reader, keySize)
 }
 
 // GenerateECPrivateKey will generate an ECDSA private key of the given size.
@@ -111,12 +111,12 @@ func GenerateECPrivateKey(keySize int) (*ecdsa.PrivateKey, error) {
 		return nil, fmt.Errorf("unsupported ecdsa key size specified: %d", keySize)
 	}
 
-	return ecdsa.GenerateKey(ecCurve, rand.Reader)
+	return ecdsa.GenerateKey(ecCurve, cmrand.Reader)
 }
 
 // GenerateEd25519PrivateKey will generate an Ed25519 private key
 func GenerateEd25519PrivateKey() (ed25519.PrivateKey, error) {
-	_, prvkey, err := ed25519.GenerateKey(rand.Reader)
+	_, prvkey, err := ed25519.GenerateKey(cmrand.Reader)
 
 	return prvkey, err
 }
@@ -157,6 +157,7 @@ func EncodePKCS8PrivateKey(pk interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	block := &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}
 
 	return pem.EncodeToMemory(block), nil

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -32,6 +31,7 @@ import (
 	"time"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 )
 
 func buildCertificateWithKeyParams(keyAlgo v1.PrivateKeyAlgorithm, keySize int) *v1.Certificate {
@@ -249,7 +249,7 @@ func TestGeneratePrivateKeyForCertificate(t *testing.T) {
 func signTestCert(key crypto.Signer) *x509.Certificate {
 	commonName := "testingcert"
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	serialNumber, err := cmrand.SerialNumber()
 	if err != nil {
 		panic(fmt.Errorf("failed to generate serial number: %s", err.Error()))
 	}
@@ -325,11 +325,11 @@ func TestPublicKeyMatchesCertificateRequest(t *testing.T) {
 		},
 	}
 
-	csr1, err := x509.CreateCertificateRequest(rand.Reader, template, privKey1)
+	csr1, err := x509.CreateCertificateRequest(cmrand.Reader, template, privKey1)
 	if err != nil {
 		t.Errorf("error generating csr1: %v", err)
 	}
-	csr2, err := x509.CreateCertificateRequest(rand.Reader, template, privKey2)
+	csr2, err := x509.CreateCertificateRequest(cmrand.Reader, template, privKey2)
 	if err != nil {
 		t.Errorf("error generating csr2: %v", err)
 	}
@@ -477,13 +477,13 @@ O7WnDn8nuLFdW+NzzbIrTw==
 }
 
 func TestPublicKeysEqualECDSA(t *testing.T) {
-	key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key1, err := ecdsa.GenerateKey(elliptic.P256(), cmrand.Reader)
 	if err != nil {
 		t.Fatalf("couldn't generate P256 key: %v", err)
 	}
 
 	// note the different curve type
-	key2, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	key2, err := ecdsa.GenerateKey(elliptic.P521(), cmrand.Reader)
 	if err != nil {
 		t.Fatalf("couldn't generate P521 key: %v", err)
 	}

--- a/pkg/util/pki/match_test.go
+++ b/pkg/util/pki/match_test.go
@@ -18,7 +18,6 @@ package pki_test
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/asn1"
 	"reflect"
@@ -27,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -443,7 +443,7 @@ func selfSignCertificate(t *testing.T, spec cmapi.CertificateSpec) *x509.Certifi
 	}
 
 	// Marshal and unmarshal to ensure all fields are set correctly
-	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pk.Public(), pk)
+	certDER, err := x509.CreateCertificate(cmrand.Reader, template, template, pk.Public(), pk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/pki/parse_certificate_chain_test.go
+++ b/pkg/util/pki/parse_certificate_chain_test.go
@@ -18,7 +18,6 @@ package pki
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
@@ -26,6 +25,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 )
 
 type testBundle struct {
@@ -40,7 +41,7 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	serialNumber, err := cmrand.SerialNumber()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -18,7 +18,6 @@ package vault
 
 import (
 	"context"
-	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -843,7 +843,7 @@ func (v *VaultInitializer) CreateClientCertRole(ctx context.Context) (key []byte
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 
-	certificateBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	certificateBytes, err := x509.CreateCertificate(cmrand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -19,7 +19,6 @@ package vault
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -43,6 +42,7 @@ import (
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon/chart"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/addon/internal"
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/config"
+	"github.com/cert-manager/cert-manager/pkg/cmrand"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -473,7 +473,7 @@ func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName 
 		panic(err)
 	}
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
+	certBytes, err := x509.CreateCertificate(cmrand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
 	if err != nil {
 		panic(err)
 	}
@@ -516,7 +516,7 @@ func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, 
 		panic(err)
 	}
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
+	certBytes, err := x509.CreateCertificate(cmrand.Reader, cert, ca, &privateKey.PublicKey, catls.PrivateKey)
 	if err != nil {
 		panic(err)
 	}
@@ -549,7 +549,7 @@ func GenerateCA() ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &privateKey.PublicKey, privateKey)
+	caBytes, err := x509.CreateCertificate(cmrand.Reader, ca, ca, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Pull Request Motivation

cmrand is intended to be the single point which configures RNG across cert-manager, allowing for the RNG to be swapped out (e.g. for a HWRNG) but mostly ensuring that errors are minimised.

Importing `math/rand` instead of `crypto/rand` is catastrophic in most cases where cryptographically secure RNG is required. This change minimises that.

It also adds a single function for generating appropriate serial numbers for certificates, since that logic was duplicated several times.

In addition, many previous calls to the standard library key generation functions (mostly in tests) have been replaced with calls to our own generation functions, in turn removing another reference to an RNG.

### Kind

/kind feature

### Release Note

```release-note
Add cmrand, an internal cert-manager package for helping to ensure cryptographically secure RNG is used properly.
```
