### PR TITLE
fix: annotate account private key secrets

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -30,6 +30,8 @@ const (
 	// See https://github.com/cert-manager/cert-manager/blob/master/design/20221205-memory-management.md#risks-and-mitigations
 	PartOfCertManagerControllerLabelKey = "controller.cert-manager.io/fao"
 
+	AccountPrivateKeyLabelKey = "controller.cert-manager.io/account-private-key"
+
 	// Common annotation keys added to resources
 
 	// Annotation key for DNS subjectAltNames.

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -429,10 +429,20 @@ func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKey
 		return nil, err
 	}
 
+	gvk := a.issuer.GetObjectKind().GroupVersionKind()
 	_, err = a.secretsClient.Secrets(ns).Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sel.Name,
 			Namespace: ns,
+			Labels: map[string]string{
+				v1.PartOfCertManagerControllerLabelKey: "true",
+				v1.AccountPrivateKeyLabelKey:           "true",
+			},
+			Annotations: map[string]string{
+				v1.IssuerNameAnnotationKey:  a.issuer.GetName(),
+				v1.IssuerGroupAnnotationKey: gvk.Group,
+				v1.IssuerKindAnnotationKey:  gvk.Kind,
+			},
 		},
 		Data: map[string][]byte{
 			sel.Key: pki.EncodePKCS1PrivateKey(accountPrivKey),


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Currently cert-manager does not add any labels or annotations when creating a secret to hold account private keys for acme issuers. Given that cert-manager does not manage the lifecycle of these secrets it is useful to mark these secrets with labels and annotations. These can be used by consumers to remove unused private keys.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add annotations and labels to secrets that hold acme account private keys
```
