### PR TITLE
Removes rsync dependency introduced by commit 8122c024091ab58c7139257…

### DIFF
--- a/make/_shared/generate-verify/util/verify.sh
+++ b/make/_shared/generate-verify/util/verify.sh
@@ -44,7 +44,8 @@ cleanup() {
 }
 trap "cleanup" EXIT SIGINT
 
-rsync -aEq "${projectdir}/." "${tmp}" --exclude "_bin/"
+cp -a "${projectdir}/." "${tmp}"
+rm -rf "${tmp}/_bin" # clear all cached files
 pushd "${tmp}" >/dev/null
 
 "$@"

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -619,7 +619,6 @@ $(DOWNLOAD_DIR)/tools/preflight@$(PREFLIGHT_VERSION)_linux_$(HOST_ARCH): | $(DOW
 missing=$(shell (command -v curl >/dev/null || echo curl) \
              && (command -v sha256sum >/dev/null || command -v shasum >/dev/null || echo sha256sum) \
              && (command -v git >/dev/null || echo git) \
-             && (command -v rsync >/dev/null || echo rsync) \
              && (command -v bash >/dev/null || echo bash))
 ifneq ($(missing),)
 $(error Missing required tools: $(missing))


### PR DESCRIPTION
…95187ade46853909e


### Pull Request Motivation

Removes unneeded dependency on rsync introduced by a prior autogenerated change: https://github.com/cert-manager/cert-manager/pull/6953

This adds additional dependencies on downstream projects to add rsync to their images and it's unclear why its needed.

### Kind

/kind cleanup


### Release Note

```release-note
NONE
```
