### PR TITLE
Make ACME Authorization Timeout Configurable

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -69,6 +69,14 @@ spec:
                     ACME configures this issuer to communicate with a RFC8555 (ACME) server
                     to obtain signed x509 certificates.
                   properties:
+                    authorizationTimeout:
+                      description: |-
+                        Sets the overall timeout for creating certificates in seconds. For most
+                        Issuers the default should be sufficient, however e.g. letsencrypt
+                        staging sometimes takes longer, especially on slow local environments.
+                        Defaults to 20s
+                      format: duration
+                      type: string
                     caBundle:
                       description: |-
                         Base64-encoded bundle of PEM CAs which can be used to validate the certificate

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -68,6 +68,14 @@ spec:
                     ACME configures this issuer to communicate with a RFC8555 (ACME) server
                     to obtain signed x509 certificates.
                   properties:
+                    authorizationTimeout:
+                      description: |-
+                        Sets the overall timeout for creating certificates in seconds. For most
+                        Issuers the default should be sufficient, however e.g. letsencrypt
+                        staging sometimes takes longer, especially on slow local environments.
+                        Defaults to 20s
+                      format: duration
+                      type: string
                     caBundle:
                       description: |-
                         Base64-encoded bundle of PEM CAs which can be used to validate the certificate

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -68,6 +68,14 @@ spec:
                   ACME configures this issuer to communicate with a RFC8555 (ACME) server
                   to obtain signed x509 certificates.
                 properties:
+                  authorizationTimeout:
+                    description: |-
+                      Sets the overall timeout for creating certificates in seconds. For most
+                      Issuers the default should be sufficient, however e.g. letsencrypt
+                      staging sometimes takes longer, especially on slow local environments.
+                      Defaults to 20s
+                    format: duration
+                    type: string
                   caBundle:
                     description: |-
                       Base64-encoded bundle of PEM CAs which can be used to validate the certificate

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -67,6 +67,14 @@ spec:
                   ACME configures this issuer to communicate with a RFC8555 (ACME) server
                   to obtain signed x509 certificates.
                 properties:
+                  authorizationTimeout:
+                    description: |-
+                      Sets the overall timeout for creating certificates in seconds. For most
+                      Issuers the default should be sufficient, however e.g. letsencrypt
+                      staging sometimes takes longer, especially on slow local environments.
+                      Defaults to 20s
+                    format: duration
+                    type: string
                   caBundle:
                     description: |-
                       Base64-encoded bundle of PEM CAs which can be used to validate the certificate

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -19,6 +19,7 @@ package acme
 import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	cmmeta "github.com/cert-manager/cert-manager/internal/apis/meta"
@@ -106,6 +107,12 @@ type ACMEIssuer struct {
 	// Profile allows requesting a certificate profile from the ACME server.
 	// Supported profiles are listed by the server's ACME directory URL.
 	Profile string `json:"profile,omitempty"`
+
+	// Sets the overall timeout for creating certificates in seconds. For most
+	// Issuers the default should be sufficient, however e.g. letsencrypt
+	// staging sometimes takes longer, especially on slow local environments.
+	// Defaults to 20s
+	AuthorizationTimeout *metav1.Duration
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -28,10 +28,10 @@ import (
 	meta "github.com/cert-manager/cert-manager/internal/apis/meta"
 	metav1 "github.com/cert-manager/cert-manager/internal/apis/meta/v1"
 	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
-	apismetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	pkgapismetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	pkgapismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apisv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -989,6 +989,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *acmev1.ACMEIssuer, out *ac
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
 	out.Profile = in.Profile
+	out.AuthorizationTimeout = (*apismetav1.Duration)(unsafe.Pointer(in.AuthorizationTimeout))
 	return nil
 }
 
@@ -1024,6 +1025,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *acme
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
 	out.Profile = in.Profile
+	out.AuthorizationTimeout = (*apismetav1.Duration)(unsafe.Pointer(in.AuthorizationTimeout))
 	return nil
 }
 
@@ -1120,7 +1122,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1_ACMEIssuerDNS01Provi
 	out.ClientID = in.ClientID
 	if in.ClientSecret != nil {
 		in, out := &in.ClientSecret, &out.ClientSecret
-		*out = new(apismetav1.SecretKeySelector)
+		*out = new(pkgapismetav1.SecretKeySelector)
 		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
 			return err
 		}
@@ -1164,7 +1166,7 @@ func Convert_v1_ACMEIssuerDNS01ProviderCloudDNS_To_acme_ACMEIssuerDNS01ProviderC
 func autoConvert_acme_ACMEIssuerDNS01ProviderCloudDNS_To_v1_ACMEIssuerDNS01ProviderCloudDNS(in *acme.ACMEIssuerDNS01ProviderCloudDNS, out *acmev1.ACMEIssuerDNS01ProviderCloudDNS, s conversion.Scope) error {
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
-		*out = new(apismetav1.SecretKeySelector)
+		*out = new(pkgapismetav1.SecretKeySelector)
 		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
 			return err
 		}
@@ -1213,7 +1215,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderCloudflare_To_v1_ACMEIssuerDNS01Pro
 	out.Email = in.Email
 	if in.APIKey != nil {
 		in, out := &in.APIKey, &out.APIKey
-		*out = new(apismetav1.SecretKeySelector)
+		*out = new(pkgapismetav1.SecretKeySelector)
 		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
 			return err
 		}
@@ -1222,7 +1224,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderCloudflare_To_v1_ACMEIssuerDNS01Pro
 	}
 	if in.APIToken != nil {
 		in, out := &in.APIToken, &out.APIToken
-		*out = new(apismetav1.SecretKeySelector)
+		*out = new(pkgapismetav1.SecretKeySelector)
 		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
 			return err
 		}
@@ -1324,7 +1326,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderRoute53_To_v1_ACMEIssuerDNS01Provid
 	out.AccessKeyID = in.AccessKeyID
 	if in.SecretAccessKeyID != nil {
 		in, out := &in.SecretAccessKeyID, &out.SecretAccessKeyID
-		*out = new(apismetav1.SecretKeySelector)
+		*out = new(pkgapismetav1.SecretKeySelector)
 		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
 			return err
 		}
@@ -1667,7 +1669,7 @@ func autoConvert_v1_OrderSpec_To_acme_OrderSpec(in *acmev1.OrderSpec, out *acme.
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	out.Profile = in.Profile
 	return nil
 }
@@ -1685,7 +1687,7 @@ func autoConvert_acme_OrderSpec_To_v1_OrderSpec(in *acme.OrderSpec, out *acmev1.
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	out.Profile = in.Profile
 	return nil
 }
@@ -1702,7 +1704,7 @@ func autoConvert_v1_OrderStatus_To_acme_OrderStatus(in *acmev1.OrderStatus, out 
 	out.Certificate = *(*[]byte)(unsafe.Pointer(&in.Certificate))
 	out.State = acme.State(in.State)
 	out.Reason = in.Reason
-	out.FailureTime = (*pkgapismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 
@@ -1718,7 +1720,7 @@ func autoConvert_acme_OrderStatus_To_v1_OrderStatus(in *acme.OrderStatus, out *a
 	out.State = acmev1.State(in.State)
 	out.Reason = in.Reason
 	out.Authorizations = *(*[]acmev1.ACMEAuthorization)(unsafe.Pointer(&in.Authorizations))
-	out.FailureTime = (*pkgapismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 

--- a/internal/apis/acme/zz_generated.deepcopy.go
+++ b/internal/apis/acme/zz_generated.deepcopy.go
@@ -500,6 +500,11 @@ func (in *ACMEIssuer) DeepCopyInto(out *ACMEIssuer) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AuthorizationTimeout != nil {
+		in, out := &in.AuthorizationTimeout, &out.AuthorizationTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -19,10 +19,12 @@ package validation
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -368,6 +370,14 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 	}{
 		"valid acme issuer": {
 			spec: &validACMEIssuer,
+		},
+		"valid acme issuer with Timeout": {
+			spec: &cmacme.ACMEIssuer{
+				Email:                "valid-email",
+				Server:               "valid-server",
+				PrivateKey:           validSecretKeyRef,
+				AuthorizationTimeout: &metav1.Duration{Duration: time.Second * 90},
+			},
 		},
 		"acme issuer with missing fields": {
 			spec: &cmacme.ACMEIssuer{},

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1324,12 +1324,18 @@ func schema_pkg_apis_acme_v1_ACMEIssuer(ref common.ReferenceCallback) common.Ope
 							Format:      "",
 						},
 					},
+					"authorizationTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Sets the overall timeout for creating certificates in seconds. For most Issuers the default should be sufficient, however e.g. letsencrypt staging sometimes takes longer, especially on slow local environments. Defaults to 20s",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 				Required: []string{"server", "privateKeySecretRef"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/cert-manager/cert-manager/pkg/apis/acme/v1.ACMEChallengeSolver", "github.com/cert-manager/cert-manager/pkg/apis/acme/v1.ACMEExternalAccountBinding", "github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector"},
+			"github.com/cert-manager/cert-manager/pkg/apis/acme/v1.ACMEChallengeSolver", "github.com/cert-manager/cert-manager/pkg/apis/acme/v1.ACMEExternalAccountBinding", "github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -19,6 +19,7 @@ package v1
 import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -120,6 +121,15 @@ type ACMEIssuer struct {
 	// Supported profiles are listed by the server's ACME directory URL.
 	// +optional
 	Profile string `json:"profile,omitempty"`
+
+	// Sets the overall timeout for creating certificates in seconds. For most
+	// Issuers the default should be sufficient, however e.g. letsencrypt
+	// staging sometimes takes longer, especially on slow local environments.
+	// Defaults to 20s
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
+	AuthorizationTimeout *metav1.Duration `json:"authorizationTimeout,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -22,10 +22,10 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	apismetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apisv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -500,6 +500,11 @@ func (in *ACMEIssuer) DeepCopyInto(out *ACMEIssuer) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AuthorizationTimeout != nil {
+		in, out := &in.AuthorizationTimeout, &out.AuthorizationTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 
@@ -554,7 +559,7 @@ func (in *ACMEIssuerDNS01ProviderAzureDNS) DeepCopyInto(out *ACMEIssuerDNS01Prov
 	*out = *in
 	if in.ClientSecret != nil {
 		in, out := &in.ClientSecret, &out.ClientSecret
-		*out = new(metav1.SecretKeySelector)
+		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
 	if in.ManagedIdentity != nil {
@@ -580,7 +585,7 @@ func (in *ACMEIssuerDNS01ProviderCloudDNS) DeepCopyInto(out *ACMEIssuerDNS01Prov
 	*out = *in
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
-		*out = new(metav1.SecretKeySelector)
+		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
 	return
@@ -601,12 +606,12 @@ func (in *ACMEIssuerDNS01ProviderCloudflare) DeepCopyInto(out *ACMEIssuerDNS01Pr
 	*out = *in
 	if in.APIKey != nil {
 		in, out := &in.APIKey, &out.APIKey
-		*out = new(metav1.SecretKeySelector)
+		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
 	if in.APIToken != nil {
 		in, out := &in.APIToken, &out.APIToken
-		*out = new(metav1.SecretKeySelector)
+		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
 	return
@@ -666,7 +671,7 @@ func (in *ACMEIssuerDNS01ProviderRoute53) DeepCopyInto(out *ACMEIssuerDNS01Provi
 	}
 	if in.SecretAccessKeyID != nil {
 		in, out := &in.SecretAccessKeyID, &out.SecretAccessKeyID
-		*out = new(metav1.SecretKeySelector)
+		*out = new(apismetav1.SecretKeySelector)
 		**out = **in
 	}
 	out.SecretAccessKey = in.SecretAccessKey
@@ -946,7 +951,7 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 	}
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
-		*out = new(apismetav1.Duration)
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	return

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	metav1 "github.com/cert-manager/cert-manager/pkg/client/applyconfigurations/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ACMEIssuerApplyConfiguration represents a declarative configuration of the ACMEIssuer type for use
@@ -36,6 +37,7 @@ type ACMEIssuerApplyConfiguration struct {
 	DisableAccountKeyGeneration *bool                                         `json:"disableAccountKeyGeneration,omitempty"`
 	EnableDurationFeature       *bool                                         `json:"enableDurationFeature,omitempty"`
 	Profile                     *string                                       `json:"profile,omitempty"`
+	AuthorizationTimeout        *apismetav1.Duration                          `json:"authorizationTimeout,omitempty"`
 }
 
 // ACMEIssuerApplyConfiguration constructs a declarative configuration of the ACMEIssuer type for use with
@@ -136,5 +138,13 @@ func (b *ACMEIssuerApplyConfiguration) WithEnableDurationFeature(value bool) *AC
 // If called multiple times, the Profile field is set to the value of the last call.
 func (b *ACMEIssuerApplyConfiguration) WithProfile(value string) *ACMEIssuerApplyConfiguration {
 	b.Profile = &value
+	return b
+}
+
+// WithAuthorizationTimeout sets the AuthorizationTimeout field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AuthorizationTimeout field is set to the value of the last call.
+func (b *ACMEIssuerApplyConfiguration) WithAuthorizationTimeout(value apismetav1.Duration) *ACMEIssuerApplyConfiguration {
+	b.AuthorizationTimeout = &value
 	return b
 }

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -302,6 +302,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.cert-manager.cert-manager.pkg.apis.acme.v1.ACMEIssuer
   map:
     fields:
+    - name: authorizationTimeout
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Duration
     - name: caBundle
       type:
         scalar: string

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -44,7 +45,7 @@ const (
 
 	// How long to wait for an authorization response from the ACME server in acceptChallenge()
 	// before giving up
-	authorizationTimeout = 2 * time.Minute
+	authorizationDefaultTimeout = 2 * time.Minute
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -184,7 +185,7 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 		return nil
 	}
 
-	err = c.acceptChallenge(ctx, cl, ch)
+	err = c.acceptChallenge(ctx, cl, ch, genericIssuer.GetSpec().ACME.AuthorizationTimeout)
 	if err != nil {
 		return err
 	}
@@ -337,7 +338,7 @@ func (c *controller) syncChallengeStatus(ctx context.Context, cl acmecl.Interfac
 // It will update the challenge's status to reflect the final state of the
 // challenge if it failed, or the final state of the challenge's authorization
 // if accepting the challenge succeeds.
-func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, ch *cmacme.Challenge) error {
+func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, ch *cmacme.Challenge, atoOriginal *metav1.Duration) error {
 	log := logf.FromContext(ctx, "acceptChallenge")
 
 	log.V(logf.DebugLevel).Info("accepting challenge with ACME server")
@@ -364,7 +365,13 @@ func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 	// blocking the challenge's processing. Here, we defensively add a timeout for this exchange
 	// with the ACME server and a "context deadline reached" error will be returned by WaitAuthorization
 	// in the err variable.
-	ctxTimeout, cancelAuthorization := context.WithTimeout(ctx, authorizationTimeout)
+	var ato time.Duration
+	if atoOriginal.Size() > 0 {
+		ato = atoOriginal.Duration
+	} else {
+		ato = authorizationDefaultTimeout
+	}
+	ctxTimeout, cancelAuthorization := context.WithTimeout(ctx, ato)
 	defer cancelAuthorization()
 	authorization, err := cl.WaitAuthorization(ctxTimeout, ch.Spec.AuthorizationURL)
 	if err != nil {


### PR DESCRIPTION

### Pull Request Motivation

In my CI Environment cert-manager sometimes times out getting a cert from Letsencrypt staging. Making the authorization timeout configurable and setting it to 2m solved the issue.

Issue #7444 seems related, but I cannot verify if it is solved by this PR since I don have a dns01 challenge available for testing.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

```release-note
Make ACME Auhtorization Timeout Configurable
```
