### PR TITLE
Add Shutdown function to KubeInformerFactory interface and call Shutdown on shutdown

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -266,6 +266,14 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 	}
 	log.V(logf.InfoLevel).Info("control loops exited")
 
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) && opts.EnableGatewayAPI {
+		ctx.GWShared.Shutdown()
+	}
+
+	ctx.HTTP01ResourceMetadataInformersFactory.Shutdown()
+	ctx.KubeSharedInformerFactory.Shutdown()
+	ctx.SharedInformerFactory.Shutdown()
+
 	return nil
 }
 

--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -44,6 +44,7 @@ const pleaseOpenIssue = "Please report this by opening an issue with this error 
 type KubeInformerFactory interface {
 	Start(<-chan struct{})
 	WaitForCacheSync(<-chan struct{}) map[string]bool
+	Shutdown()
 	Ingresses() networkingv1informers.IngressInformer
 	Secrets() SecretInformer
 	CertificateSigningRequests() certificatesv1.CertificateSigningRequestInformer

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -64,6 +64,10 @@ func (bf *baseFactory) WaitForCacheSync(stopCh <-chan struct{}) map[string]bool 
 	return ret
 }
 
+func (bf *baseFactory) Shutdown() {
+	bf.f.Shutdown()
+}
+
 func (bf *baseFactory) Ingresses() networkingv1informers.IngressInformer {
 	return bf.f.Networking().V1().Ingresses()
 }

--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -115,6 +115,11 @@ func (bf *filteredSecretsFactory) WaitForCacheSync(stopCh <-chan struct{}) map[s
 	return caches
 }
 
+func (bf *filteredSecretsFactory) Shutdown() {
+	bf.typedInformerFactory.Shutdown()
+	bf.metadataInformerFactory.Shutdown()
+}
+
 func (bf *filteredSecretsFactory) Ingresses() networkingv1informers.IngressInformer {
 	return bf.typedInformerFactory.Networking().V1().Ingresses()
 }


### PR DESCRIPTION
Call the `Shutdown()` function on all informer factories before shutting down. See https://github.com/kubernetes/client-go/blob/v0.31.3/informers/factory.go#L263 for more info.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
