### PR TITLE
Don't unnecessarily reconcile resources marked for deletion and don't log that a resource no longer exist

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -207,14 +207,14 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	ch, err := c.challengeLister.Challenges(namespace).Get(name)
-
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			log.Error(err, "challenge in work queue no longer exists")
-			return nil
-		}
-
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
+	}
+	// WARNING: we do want to call Sync when ch.DeletionTimestamp != nil, such that
+	// we can perform the required cleanup and remove the finalizer.
+	if ch == nil {
+		// Challenge does no longer exist
+		return nil
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, ch))

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -213,7 +213,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	// WARNING: we do want to call Sync when ch.DeletionTimestamp != nil, such that
 	// we can perform the required cleanup and remove the finalizer.
 	if ch == nil {
-		// Challenge does no longer exist
+		// Challenge object no longer exists
 		return nil
 	}
 

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -166,13 +166,13 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	order, err := c.orderLister.Orders(namespace).Get(name)
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			log.Error(err, "order in work queue no longer exists")
-			return nil
-		}
-
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
+	}
+	if order == nil || order.DeletionTimestamp != nil {
+		// If the Order object was/ is being deleted, we don't want to update its status or
+		// create new Challenges.
+		return nil
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, order))

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -88,14 +88,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	gateway, err := c.gatewayLister.Gateways(namespace).Get(name)
-
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("Gateway '%s' in work queue no longer exists", key))
-			return nil
-		}
-
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
+	}
+	if gateway == nil || gateway.DeletionTimestamp != nil {
+		// If the Gateway object was/ is being deleted, we don't want to start creating Certificates.
+		return nil
 	}
 
 	return c.sync(ctx, gateway)

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -172,17 +172,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
-		return nil
-	}
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-
-	// If the Certificate object is being deleted, we don't want to create any
-	// new Secret objects
-	if crt.DeletionTimestamp != nil {
+	if crt == nil || crt.DeletionTimestamp != nil {
+		// If the Certificate object was/ is being deleted, we don't want to update its status or
+		// create/ update any Secret resources.
 		return nil
 	}
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -145,12 +145,13 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
-		return nil
-	}
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+	if crt == nil || crt.DeletionTimestamp != nil {
+		// If the Certificate object was/ is being deleted, we don't want to create any
+		// new Secret resources.
+		return nil
 	}
 
 	// Discover all 'owned' secrets that have the `next-private-key` label

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -150,12 +150,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
-		return nil
-	}
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+	if crt == nil || crt.DeletionTimestamp != nil {
+		// If the Certificate object was/ is being deleted, we don't want to update its status.
+		return nil
 	}
 
 	input, err := c.gatherer.DataForCertificate(ctx, crt)

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -143,7 +143,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return err
 	}
 	if crt == nil || crt.DeletionTimestamp != nil {
-		// If the Certificate object is being deleted, we don't want to create any
+		// If the Certificate object was/ is being deleted, we don't want to create any
 		// new CertificateRequests objects
 		return nil
 	}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -139,17 +139,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
-		return nil
-	}
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-
-	// If the Certificate object is being deleted, we don't want to create any
-	// new CertificateRequests objects
-	if crt.DeletionTimestamp != nil {
+	if crt == nil || crt.DeletionTimestamp != nil {
+		// If the Certificate object is being deleted, we don't want to create any
+		// new CertificateRequests objects
 		return nil
 	}
 

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -157,7 +157,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return err
 	}
 	if crt == nil || crt.DeletionTimestamp != nil {
-		// If the Issuer object was/ is being deleted, we don't want to start scheduling
+		// If the Certificate object was/ is being deleted, we don't want to start scheduling
 		// renewals.
 		return nil
 	}

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -153,13 +153,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	namespace, name := key.Namespace, key.Name
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
-		return nil
-	}
-	if err != nil {
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
 	}
+	if crt == nil || crt.DeletionTimestamp != nil {
+		// If the Issuer object was/ is being deleted, we don't want to start scheduling
+		// renewals.
+		return nil
+	}
+
 	if apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionIssuing,
 		Status: cmmeta.ConditionTrue,


### PR DESCRIPTION
Continuation of the work started in https://github.com/cert-manager/cert-manager/pull/7361.
Should additionally make the logs less noisy.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
