### PR TITLE
remove unnecessary warning when booting the controller and the webhook service

### DIFF
--- a/internal/kube/config.go
+++ b/internal/kube/config.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func BuildClientConfig(apiServerHost string, kubeConfig string) (*rest.Config, error) {
+	if apiServerHost == "" && kubeConfig == "" {
+		return rest.InClusterConfig()
+	}
+	return clientcmd.BuildConfigFromKubeconfigGetter(apiServerHost, getKubeConfigGetter(kubeConfig))
+}
+
+func getKubeConfigGetter(kubeConfig string) clientcmd.KubeconfigGetter {
+	return func() (*clientcmdapi.Config, error) {
+		if len(kubeConfig) == 0 {
+			return clientcmdapi.NewConfig(), nil
+		}
+		cfg, err := clientcmd.LoadFromFile(kubeConfig)
+		if os.IsNotExist(err) {
+			return clientcmdapi.NewConfig(), err
+		}
+
+		if err != nil {
+			return clientcmdapi.NewConfig(), fmt.Errorf("error loading config file \"%s\": %v", kubeConfig, err)
+		}
+
+		return cfg, nil
+	}
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -35,6 +34,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/shared"
 	config "github.com/cert-manager/cert-manager/internal/apis/config/webhook"
 	metainstall "github.com/cert-manager/cert-manager/internal/apis/meta/install"
+	"github.com/cert-manager/cert-manager/internal/kube"
 	crapproval "github.com/cert-manager/cert-manager/internal/webhook/admission/certificaterequest/approval"
 	cridentity "github.com/cert-manager/cert-manager/internal/webhook/admission/certificaterequest/identity"
 	"github.com/cert-manager/cert-manager/internal/webhook/admission/resourcevalidation"
@@ -49,8 +49,7 @@ import (
 // resource types, validation, defaulting and conversion functions.
 func NewCertManagerWebhookServer(log logr.Logger, opts config.WebhookConfiguration, optionFunctions ...func(*server.Server)) (*server.Server, error) {
 	crlog.SetLogger(log)
-
-	restcfg, err := clientcmd.BuildConfigFromFlags(opts.APIServerHost, opts.KubeConfig)
+	restcfg, err := kube.BuildClientConfig(opts.APIServerHost, opts.KubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
@@ -49,6 +48,7 @@ import (
 
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
+	"github.com/cert-manager/cert-manager/internal/kube"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
@@ -258,7 +258,7 @@ type ContextFactory struct {
 // corresponding QPS and Burst buckets.
 func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactory, error) {
 	// Load the users Kubernetes config
-	restConfig, err := clientcmd.BuildConfigFromFlags(opts.APIServerHost, opts.Kubeconfig)
+	restConfig, err := kube.BuildClientConfig(opts.APIServerHost, opts.Kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("error creating rest config: %w", err)
 	}


### PR DESCRIPTION
### Pull Request Motivation

https://github.com/cert-manager/cert-manager/issues/7251
Remove unnecessary warnings coming from kubeclient.

/cleanup


### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Remove `Neither --kubeconfig nor --master was specified` warning message when the controller and the webhook services boot
```
