### PR TITLE
Add specialised PEM decoder for trust bundles

### DIFF
--- a/internal/pem/decode.go
+++ b/internal/pem/decode.go
@@ -32,8 +32,8 @@ import (
 // RSA keys grow proportional to the size of the RSA key used. For example:
 // PEM-encoded RSA Keys: 4096-bit is ~3kB, 8192-bit is ~6kB and a 16k-bit key is ~12kB.
 
-// Certificates have two variables; the public key of the cert, and the signature from the signing cert.
-// An N-bit key produces an N-byte signature, so as a worst case for us, a 16kB RSA key will create a 2kB signature.
+// Certificates have two variables that we can estimate easily; the public key of the cert, and the signature from the signing cert.
+// An N-bit key produces an (N/8)-byte signature, so as a worst case for us, a 16kB RSA key will create a 2kB signature.
 
 // PEM-encoded RSA X.509 certificates:
 // Signed with  1k-bit RSA key: 4096-bit is ~1.4kB, 8192-bit is ~2kB, 16k-bit is ~3.5kB
@@ -43,10 +43,10 @@ import (
 
 const (
 	// maxCertificatePEMSize is the maximum size, in bytes, of a single PEM-encoded X.509 certificate which SafeDecodeSingleCertificate will accept.
-	// The value is based on how large a "realistic" (but still very large) self-signed 16k-bit RSA certficate might be.
+	// The value is based on how large a "realistic" (but still very large) self-signed 16k-bit RSA certificate might be.
 	// 16k-bit RSA keys are impractical on most on modern hardware due to how slow they can be,
 	// so we can reasonably assume that no real-world PEM-encoded X.509 cert will be this large.
-	// Note that X.509 certificates can contain extra abitrary data (e.g. DNS names, policy names, etc) whose size is hard to predict.
+	// Note that X.509 certificates can contain extra arbitrary data (e.g. DNS names, policy names, etc) whose size is hard to predict.
 	// So we guess at how much of that data we'll allow in very large certs and allow about 1kB of such data.
 	maxCertificatePEMSize = 6500
 
@@ -57,10 +57,31 @@ const (
 	// we can reasonably assume that no real-world PEM-encoded key will be this large.
 	maxPrivateKeyPEMSize = 13000
 
-	// maxChainSize is the maximum number of 16k-bit RSA certificates signed by 16k-bit RSA CAs we'll allow in a given call to SafeDecodeMultipleCertificates.
+	// maxChainSize is the maximum number of 16k-bit RSA certificates signed by 16k-bit RSA CAs we'll allow in a given call to SafeDecodeCertificateChain.
 	// This is _not_ the maximum number of certificates cert-manager will process in a given chain, which could be much larger.
 	// This is simply the maximum number of worst-case certificates we'll accept in a chain.
 	maxChainSize = 10
+
+	// maxCertsInTrustBundle is an estimated upper-bound for how many large certs might appear in a PEM-encoded trust bundle,
+	// based on the cert-manager `cert-manager-package-debian` bundle [1] which contains 129 certificates.
+	// This isn't an upper bound on how many certificates can appear and be parsed; just a reasonable upper bound if using
+	// exclusively large RSA certs (see estimatedCACertSize)
+	// In practice, trust stores will contain ECDSA/EdDSA certificates which are smaller than RSA certs, and so will be able to have more certificates
+	// than maxCertsInTrustBundle if needed.
+	// [1] quay.io/jetstack/cert-manager-package-debian:20210119.0@sha256:116133f68938ef568aca17a0c691d5b1ef73a9a207029c9a068cf4230053fed5
+	maxCertsInTrustBundle = 150
+
+	// estimatedCACertSize is a guess of how many bytes a large realistic trust bundle cert might be. This is slightly larger
+	// than a typical self-signed 4096-bit RSA cert (which is just under 2kB).
+	// For other estimates (such as maxCertificatePEMSize) we use a much larger RSA key, but using such a large RSA key would make
+	// maxBundleSize's estimate unrealistically large.
+	estimatedCACertSize = 2200
+
+	// maxBundleSize is an estimate for the max reasonable size for a PEM-encoded TLS trust bundle.
+	// See also comments for maxCertsInTrustBundle and estimatedCACertSize.
+	// This estimate is ultimately based on the cert-manager `cert-manager-package-debian` bundle [1] which contains 129 certificates, totalling ~196kB of data.
+	// [1] quay.io/jetstack/cert-manager-package-debian:20210119.0@sha256:116133f68938ef568aca17a0c691d5b1ef73a9a207029c9a068cf4230053fed5
+	maxBundleSize = maxCertsInTrustBundle * estimatedCACertSize
 )
 
 var (
@@ -113,12 +134,21 @@ func SafeDecodeSingleCertificate(b []byte) (*stdpem.Block, []byte, error) {
 	return safeDecodeInternal(b, maxCertificatePEMSize)
 }
 
-// SafeDecodeMultipleCertificates calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
+// SafeDecodeCertificateChain calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
 // how large we expect a reasonable-length PEM-encoded X.509 certificate chain to be.
 // The baseline is several 16k-bit RSA certificates, all signed by 16k-bit RSA keys, which is larger than the maximum
 // supported by cert-manager for key generation.
 // The maximum number of chains supported by this function is not reflective of the maximum chain length supported by
 // cert-manager; a larger chain of smaller certificate should be supported.
-func SafeDecodeMultipleCertificates(b []byte) (*stdpem.Block, []byte, error) {
+func SafeDecodeCertificateChain(b []byte) (*stdpem.Block, []byte, error) {
 	return safeDecodeInternal(b, maxCertificatePEMSize*maxChainSize)
+}
+
+// SafeDecodeCertificateBundle calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
+// how large we expect a reasonable-length PEM-encoded X.509 certificate bundle (such as a TLS trust store) to be.
+// The baseline is a bundle of 4k-bit RSA certificates, all self signed. This is smaller than the 16k-bit RSA keys
+// we use in other functions, because using such large keys would make our estimate several times
+// too large for a realistic bundle which would be used in practice.
+func SafeDecodeCertificateBundle(b []byte) (*stdpem.Block, []byte, error) {
+	return safeDecodeInternal(b, maxBundleSize)
 }

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -244,7 +244,7 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 	decodeAll := func(pemBytes []byte) [][]byte {
 		var blocks [][]byte
 		for {
-			block, rest, _ := pem.SafeDecodeMultipleCertificates(pemBytes)
+			block, rest, _ := pem.SafeDecodeCertificateBundle(pemBytes)
 			if block == nil {
 				break
 			}


### PR DESCRIPTION
### Pull Request Motivation

Follow up to #7400

A [slack discussion](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1733440158060159) reported that the size limit for `SafeDecodeMultipleCertificates` was too small in the case that a user was trying to decode a trust store (such as a publicly trusted cert bundle).

That use case wasn't really captured before because cert-manager (the repo) doesn't really concern itself with trust stores. The issue is that other projects import cert-manager as a library and can use `DecodeX509CertificateSetBytes` to parse a trust bundle. For example, [istio-csr uses `DecodeX509CertificateChainBytes` to decode trust bundles](https://github.com/cert-manager/istio-csr/blob/a8b288583b61e3ce6df5c29ecee24515441186d0/pkg/tls/rootca/rootca.go#L139-L166).

There's an important distinction between `DecodeX509CertificateChainBytes` and `DecodeX509CertificateSetBytes`. Decoding a chain specifically is important context, and is much more relevant to cert-manager than an arbitrary "set".

As such, this PR changes `DecodeX509CertificateSetBytes` to be able to parse trust bundles, and leaves `DecodeX509CertificateChainBytes` focused on chains, to maximise security.

### Longer Term

Longer term, we've discussed having these kinds of utility functions in a separate package with separate compatibility guarantees since we don't promise to maintain backwards compatibility in cert-manager when imported as a library. But that's out of scope for here.

### Benchmarking

Benchmark results for my laptop are pasted below, confirming that the worst case isn't too bad and is significantly less than the several hundred millisecond results we saw before #7400 was merged.

```console
$ go test -bench=. ./internal/pem/...
goos: darwin
goarch: arm64
pkg: github.com/cert-manager/cert-manager/internal/pem
cpu: Apple M3 Max
BenchmarkPathologicalInput-16                 57          21108022 ns/op
PASS
ok      github.com/cert-manager/cert-manager/internal/pem       2.367s
$ go test -v ./internal/pem/...
=== RUN   TestFuzzData
--- PASS: TestFuzzData (0.00s)
=== RUN   TestPathologicalInput
    decode_test.go:179: pathological input: took 36.547375ms to execute
--- PASS: TestPathologicalInput (0.04s)
PASS
ok      github.com/cert-manager/cert-manager/internal/pem       0.416s
```

### Kind

/kind feature

### Release Note

```release-note
Increase the amount of PEM data pki.DecodeX509CertificateSetBytes is able to parse, to enable reading larger TLS trust bundles
```
