### PR TITLE
feat: gated feature to have ca-injector merge in and not replace the ca bundle

### DIFF
--- a/internal/cainjector/bundle/bundle.go
+++ b/internal/cainjector/bundle/bundle.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bundle
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"k8s.io/utils/set"
+
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+)
+
+// AppendCertificatesToBundle will append the provided certificates to the
+// provided bundle, if the certificate already exists in the bundle then it is
+// not re-added.
+//
+// Additionally expired certificates are removed from the bundle.
+func AppendCertificatesToBundle(bundle []byte, additional []byte) ([]byte, error) {
+	certificatesFromBundle, err := pki.DecodeX509CertificateSetBytes(bundle)
+	if err != nil && len(bundle) != 0 {
+		return nil, fmt.Errorf("failed to parse bundle: %w", err)
+	}
+
+	certificatesToMerge, err := pki.DecodeX509CertificateSetBytes(additional)
+	if err != nil && len(additional) != 0 {
+		return nil, fmt.Errorf("failed to parse additional certificates: %w", err)
+	}
+
+	certificatesSeen := set.New[string]()
+	certificatesMerged := make([]*x509.Certificate, 0, len(certificatesFromBundle)+len(certificatesToMerge))
+
+	// We delete expired certificates from the bundle, for this we will
+	// repeatedly need the current time
+	now := time.Now()
+
+	// Merge in all certificates that already exist in the bundle
+	for _, certificate := range certificatesFromBundle {
+		raw := string(certificate.Raw)
+		if !certificatesSeen.Has(raw) && !now.After(certificate.NotAfter) {
+			certificatesMerged = append(certificatesMerged, certificate)
+			certificatesSeen.Insert(raw)
+		}
+	}
+
+	// Merge in all additional certificates
+	for _, certificate := range certificatesToMerge {
+		raw := string(certificate.Raw)
+		if !certificatesSeen.Has(raw) && !now.After(certificate.NotAfter) {
+			certificatesMerged = append(certificatesMerged, certificate)
+			certificatesSeen.Insert(raw)
+		}
+	}
+
+	// Build the chain
+	buff := bytes.NewBuffer([]byte{})
+	for _, certificate := range certificatesMerged {
+		if err := pem.Encode(buff, &pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw}); err != nil {
+			return nil, fmt.Errorf("failed encode certificate in PEM format: %w", err)
+		}
+	}
+
+	return buff.Bytes(), nil
+}

--- a/internal/cainjector/bundle/bundle_test.go
+++ b/internal/cainjector/bundle/bundle_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bundle
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+)
+
+func TestAppendCertificatesToBundle(t *testing.T) {
+	// Create certificates for use in tests
+	expired := mustCreateCertificate(t, "expired", time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC))
+	valid1 := mustCreateCertificate(t, "valid-1", time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
+	valid2 := mustCreateCertificate(t, "valid-2", time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	cases := []struct {
+		Name       string
+		Bundle     []byte
+		Additional []byte
+		Expected   []byte
+		ExpectErr  bool
+	}{
+		{
+			Name:       "append_to_empty_bundle",
+			Bundle:     nil,
+			Additional: valid1,
+			Expected:   valid1,
+		},
+		{
+			Name:       "append_to_non_empty_bundle",
+			Bundle:     valid1,
+			Additional: valid2,
+			Expected:   joinPEM(valid1, valid2),
+		},
+		{
+			Name:       "removes_expired_certificates",
+			Bundle:     joinPEM(valid1, expired),
+			Additional: valid2,
+			Expected:   joinPEM(valid1, valid2),
+		},
+		{
+			Name:       "removes_duplicate_certificates",
+			Bundle:     joinPEM(valid1, valid1),
+			Additional: valid2,
+			Expected:   joinPEM(valid1, valid2),
+		},
+		{
+			Name:       "does_not_append_existing_certificates",
+			Bundle:     joinPEM(valid1),
+			Additional: valid1,
+			Expected:   joinPEM(valid1),
+		},
+		{
+			Name:       "does_not_append_expired_certificates",
+			Bundle:     joinPEM(valid1),
+			Additional: expired,
+			Expected:   joinPEM(valid1),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			result, err := AppendCertificatesToBundle(test.Bundle, test.Additional)
+
+			if (err != nil) != test.ExpectErr {
+				t.Fatalf("unexpected error, expected error %t, got %q", test.ExpectErr, err)
+			}
+
+			if !bytes.Equal(result, test.Expected) {
+				t.Fatalf("unexpected result, expected %q, got %q", test.Expected, result)
+			}
+		})
+	}
+}
+
+var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+func mustCreateCertificate(t *testing.T, name string, notBefore, notAfter time.Time) []byte {
+	pk, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          serialNumber,
+		PublicKeyAlgorithm:    x509.ECDSA,
+		PublicKey:             pk.Public(),
+		IsCA:                  true,
+		Subject: pkix.Name{
+			CommonName: name,
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+
+	var (
+		issuerKey  crypto.PrivateKey
+		issuerCert *x509.Certificate
+	)
+
+	issuerKey = pk
+	issuerCert = template
+
+	certPEM, _, err := pki.SignCertificate(template, issuerCert, pk.Public(), issuerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return certPEM
+}
+
+func joinPEM(first []byte, rest ...[]byte) []byte {
+	for _, b := range rest {
+		first = append(first, b...)
+	}
+
+	return first
+}

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -46,6 +46,13 @@ const (
 	//
 	// ServerSideApply enables the use of ServerSideApply in all API calls.
 	ServerSideApply featuregate.Feature = "ServerSideApply"
+
+	// Owner: @ThatsMrTalbot
+	// Alpha: v1.17
+	//
+	// CAInjectorMerging changes the ca-injector to merge new certs in instead
+	// of replacing them outright.
+	CAInjectorMerging featuregate.Feature = "CAInjectorMerging"
 )
 
 func init() {
@@ -60,5 +67,6 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	ServerSideApply: {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideApply:   {Default: false, PreRelease: featuregate.Alpha},
+	CAInjectorMerging: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -265,7 +265,7 @@ comma = ,
 # for "--set featureGates". That's why we have "\$(comma)".
 feature_gates_controller := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% ValidateCAA=% ExperimentalCertificateSigningRequestControllers=% ExperimentalGatewayAPISupport=% ServerSideApply=% LiteralCertificateSubject=% UseCertificateRequestBasicConstraints=% NameConstraints=% SecretsFilteredCaching=% OtherNames=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 feature_gates_webhook := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% AdditionalCertificateOutputFormats=% LiteralCertificateSubject=% NameConstraints=% OtherNames=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
-feature_gates_cainjector := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% ServerSideApply=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
+feature_gates_cainjector := $(subst $(space),\$(comma),$(filter AllAlpha=% AllBeta=% ServerSideApply=% CAInjectorMerging=%, $(subst $(comma),$(space),$(FEATURE_GATES))))
 
 # When testing an published chart the repo can be configured using
 # E2E_CERT_MANAGER_REPO


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Currently the ca-injector replaces the bundle in the webhook configuration whenever the cert is renewed, however if the pod backing the webhook is slow to pick up the change then it may still be presenting the old cert.

This adds a feature to the ca-injector to instead merge the new ca into the bundle. It also removes expired certificates from the bundle to ensure it does not just continue to grow in size each rotation.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add CAInjectorMerging feature gate to the ca-injector, enabling this will change the behaviour of the ca-injector to merge in new CA certificates instead of outright replacing the existing one.
```
