### PR TITLE
add ability to inject client-id in tpp secret venafi

### DIFF
--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -44,9 +44,10 @@ const (
 	tppUsernameKey    = "username"
 	tppPasswordKey    = "password"
 	tppAccessTokenKey = "access-token"
-	// Setting ClientId & Scope statically for simplicity
-	tppClientId = "cert-manager.io"
-	tppScopes   = "certificate:manage"
+	tppClientIdKey    = "client-id"
+	tppClientId       = "cert-manager.io"
+	// Setting Scope statically for simplicity
+	tppScopes = "certificate:manage,revoke"
 
 	defaultAPIKeyKey = "api-key"
 )
@@ -167,6 +168,11 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.Se
 
 		username := string(tppSecret.Data[tppUsernameKey])
 		password := string(tppSecret.Data[tppPasswordKey])
+		clientId := string(tppSecret.Data[tppClientIdKey])
+		// fallback to default client-id if not provided
+		if clientId == "" {
+			clientId = tppClientId
+		}
 		accessToken := string(tppSecret.Data[tppAccessTokenKey])
 
 		return &vcert.Config{
@@ -187,6 +193,7 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.Se
 				User:        username,
 				Password:    password,
 				AccessToken: accessToken,
+				ClientId:    clientId,
 			},
 			Client: httpClientForVcert(&httpClientForVcertOptions{
 				UserAgent:               ptr.To(userAgent),
@@ -430,7 +437,7 @@ func (v *Venafi) VerifyCredentials() error {
 			resp, err := v.tppClient.GetRefreshToken(&endpoint.Authentication{
 				User:     v.config.Credentials.User,
 				Password: v.config.Credentials.Password,
-				ClientId: tppClientId,
+				ClientId: v.config.Credentials.ClientId,
 				Scope:    tppScopes,
 			})
 

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -41,13 +41,13 @@ import (
 )
 
 const (
-	tppUsernameKey    = "username"
-	tppPasswordKey    = "password"
-	tppAccessTokenKey = "access-token"
-	tppClientIdKey    = "client-id"
-	tppClientId       = "cert-manager.io"
+	tppUsernameKey     = "username"
+	tppPasswordKey     = "password"
+	tppAccessTokenKey  = "access-token"
+	tppClientIdKey     = "client-id"
+	defaultTppClientId = "cert-manager.io"
 	// Setting Scope statically for simplicity
-	tppScopes = "certificate:manage,revoke"
+	tppScopes = "certificate:manage"
 
 	defaultAPIKeyKey = "api-key"
 )
@@ -171,7 +171,7 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister internalinformers.Se
 		clientId := string(tppSecret.Data[tppClientIdKey])
 		// fallback to default client-id if not provided
 		if clientId == "" {
-			clientId = tppClientId
+			clientId = defaultTppClientId
 		}
 		accessToken := string(tppSecret.Data[tppAccessTokenKey])
 

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -35,6 +35,7 @@ const (
 	zone                = "test-zone"
 	username            = "test-username"
 	password            = "test-password"
+	clientId            = "cert-manager"
 	accessToken         = "KT2EEVTIjWM/37L78dqJAg=="
 	apiKey              = "test-api-key"
 	customKey           = "test-custom-key"
@@ -130,6 +131,7 @@ func TestConfigForIssuerT(t *testing.T) {
 	zone := "test-zone"
 	username := "test-username"
 	password := "test-password"
+	clientId := "test-client-id"
 	accessToken := "KT2EEVTIjWM/37L78dqJAg=="
 	apiKey := "test-api-key"
 	customKey := "test-custom-key"
@@ -235,6 +237,29 @@ func TestConfigForIssuerT(t *testing.T) {
 				}
 				if pass := cnf.Credentials.Password; pass != password {
 					t.Errorf("got unexpected password: %s", pass)
+				}
+				checkZone(t, zone, cnf)
+			},
+			expectedErr: false,
+		},
+		"if TPP and secret returns user/pass/clientId, should return config with those credentials": {
+			iss: tppIssuer,
+			secretsLister: generateSecretLister(&corev1.Secret{
+				Data: map[string][]byte{
+					tppUsernameKey: []byte(username),
+					tppPasswordKey: []byte(password),
+					tppClientIdKey: []byte(clientId),
+				},
+			}, nil),
+			CheckFn: func(t *testing.T, cnf *vcert.Config) {
+				if user := cnf.Credentials.User; user != username {
+					t.Errorf("got unexpected username: %s", user)
+				}
+				if pass := cnf.Credentials.Password; pass != password {
+					t.Errorf("got unexpected password: %s", pass)
+				}
+				if cId := cnf.Credentials.ClientId; cId != clientId {
+					t.Errorf("got unexpected clientId: %s", cId)
 				}
 				checkZone(t, zone, cnf)
 			},

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -35,7 +35,7 @@ const (
 	zone                = "test-zone"
 	username            = "test-username"
 	password            = "test-password"
-	clientId            = "cert-manager"
+	defaultClientId     = "cert-manager.io"
 	accessToken         = "KT2EEVTIjWM/37L78dqJAg=="
 	apiKey              = "test-api-key"
 	customKey           = "test-custom-key"
@@ -237,6 +237,9 @@ func TestConfigForIssuerT(t *testing.T) {
 				}
 				if pass := cnf.Credentials.Password; pass != password {
 					t.Errorf("got unexpected password: %s", pass)
+				}
+				if cId := cnf.Credentials.ClientId; cId != defaultClientId {
+					t.Errorf("got unexpected clientId: %s", cId)
 				}
 				checkZone(t, zone, cnf)
 			},


### PR DESCRIPTION
### Pull Request Motivation

- The goal of the PR is to remove statically defined `clientID` for the venafi client and make it customizable by the user 
- Add the ability to add `client-id` in the TPP secret defined by the user 

### Kind

/kind feature
related topics: 
- https://github.com/cert-manager/cert-manager/pull/7084#discussion_r1644641090
- https://github.com/cert-manager/cert-manager/issues/4653#issuecomment-2566570151

### Release Note

```release-note
Added the ability to customize client ID when using username/password authentification for venafi client
```
### documentation
- https://github.com/cert-manager/website/pull/1618
