### PR TITLE
Deprecate ValidateCAA

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -261,5 +261,9 @@ func EnabledControllers(o *config.ControllerConfiguration) sets.Set[string] {
 		enabled = enabled.Insert(shimgatewaycontroller.ControllerName)
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ValidateCAA) {
+		logf.Log.Info("the ValidateCAA feature flag is scheduled for removal in v1.18 and will become a no-op")
+	}
+
 	return enabled
 }


### PR DESCRIPTION

### Pull Request Motivation

`ValidateCAA` hasn't progressed for ages, it doesn't have test coverage or a champion.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Deprecated: `ValidateCAA` with removal scheduled for 1.18.
```
