### PR TITLE
make test-upgrade was stuck using 1.9.2 as a starting point

### DIFF
--- a/hack/build/version.sh
+++ b/hack/build/version.sh
@@ -157,7 +157,7 @@ kube::version::last_published_release() {
     local git=(git --work-tree "${REPO_ROOT}")
 
     # Find the last git tag which is not alpha or beta tag
-    local latest=$("${git[@]}" tag --list 'v*' | grep -v 'alpha\|beta' | tail -n1)
+    local latest=$("${git[@]}" tag --list 'v*' | sort -V | grep -v 'alpha\|beta' | tail -n1)
 
 
     if [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)([-].*)?([+].*)?$ ]]; then


### PR DESCRIPTION
While responding to [this email](https://groups.google.com/g/cert-manager-dev/c/rn7OwGLweyE/m/f0_DnjaMCQAJ) on the mailing list, I noted that the logs [2] were indicating that the upgrade test was always upgrading from 1.9.2 to 1.16.2. 1.9.2 has long been deprecated, and I found that there is a bug in the "finding out the latest cert-manager tag" logic that force `make test-upgrade` to use 1.9.2 instead of the actual latest tag.

[1]: https://github.com/cert-manager/testing/blob/3abe3250b30370c700f4226e79ad4b3e99e89087/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml#L913C17-L913C24
[2]: https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-release-1.16-e2e-v1-31-upgrade/1875263680220762112

/kind cleanup

```release-note
NONE
```
