### PR TITLE
[release-1.12] Ignore the Trivy vulnerability warning for DLA-3972-1

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -23,3 +23,16 @@ CVE-2024-24557
 # the version detection is wrongly looking at apiserver packages with versions < 1 - but all apiserver packages have
 # a major version of 0. In any case this is a vuln in Kubernetes clusters, not in our code.
 CVE-2020-8559
+
+# DLA-3972-1 refers to an out-of-date timezone database in Debian 11 (bullseye).
+# The Debian 11 tzdata package has been updated to address the issue,
+# but cert-manager uses github.com/GoogleContainerTools/distroless base images,
+# where Debian 11 is no longer supported.
+# So we have no easy way to address this vulnerability without switching to Debian 12,
+# which would be too big of a change for a cert-manager 1.12.x patch release.
+# cert-manager 1.12 will be out of support in May 2025 so we have decided to
+# simply suppress this trivy warning until then.
+#
+# https://security-tracker.debian.org/tracker/DLA-3972-1
+# https://lists.debian.org/debian-lts-announce/2024/11/msg00030.html
+DLA-3972-1


### PR DESCRIPTION
The trivy scanner is reporting a vulnerability in the Debian 11 distroless base image used in cert-manager 1.12.

[Debian 11 is no longer supported by the distroless project](https://github.com/GoogleContainerTools/distroless/pull/1656) so we have no easy way to fix this without upgrading to Debian 12.
which would be too big a change for a cert-manager 1.12 patch release.
So we have decided to ignore that warning, for the sake of stopping the daily testgrid failures.

The next version of cert-manager 1.12 may still be flagged as having a vulnerability of unknown rating by scanners [such as used by ArtifactHub](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.12.14?modal=security-report):

![image](https://github.com/user-attachments/assets/b32600d8-5ac0-42e4-8173-7354ac2f8eeb)

cert-manager 1.15 and 1.16 use Debian 12 base images which have an up to date tzdata package. 
cert-manager 1.12 users who are concerned about such warnings should upgrade to the latest cert-manager releases.

- https://security-tracker.debian.org/tracker/DLA-3972-1
- https://lists.debian.org/debian-lts-announce/2024/11/msg00030.html

/kind cleanup

```release-note
None
```

## Testing

> **NB: The golang/x/net and golang/x/crypto vulnerabilities are fixed in https://github.com/cert-manager/cert-manager/pull/7497**

Before:
```console
$ make trivy-scan-acmesolver
...
  "Results": [
    {
      "Target": "_bin/containers/cert-manager-acmesolver-linux-amd64.tar (debian 11.10)",
      "Class": "os-pkgs",
      "Type": "debian",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "DLA-3972-1",
          "VendorIDs": [
            "DLA-3972-1"
          ],
          "PkgName": "tzdata",
          "InstalledVersion": "2024a-0+deb11u1",
          "FixedVersion": "2024b-0+deb11u1",
          "Layer": {
            "DiffID": "sha256:9ed498e122b248a801130d052c25418381ee7bf215cdf7990965bae0dc37dcc2"
          },
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "tzdata - new timezone database",
          "Severity": "UNKNOWN"
        }
      ]
    },
    {
      "Target": "app/cmd/acmesolver/acmesolver",
      "Class": "lang-pkgs",
      "Type": "gobinary",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2024-45338",
          "PkgName": "golang.org/x/net",
          "InstalledVersion": "v0.26.0",
          "FixedVersion": "0.33.0",
          "Layer": {
            "DiffID": "sha256:7599f8f5130cd1fbcb2a8e5bbc4dcc20088f6c74d5e2a36ec9b8fef205a99171"
          },
          "SeveritySource": "ghsa",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-45338",
          "DataSource": {
            "ID": "ghsa",
            "Name": "GitHub Security Advisory Go",
            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
          },
          "Title": "golang.org/x/net/html: Non-linear parsing of case-insensitive content in golang.org/x/net/html",
          "Description": "An attacker can craft an input to the Parse functions that would be processed non-linearly with respect to its length, resulting in extremely slow parsing. This could cause a denial of service.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-1333"
          ],
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
              "V3Score": 7.5
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2024-45338",
            "https://cs.opensource.google/go/x/net",
            "https://github.com/golang/go/issues/70906",
            "https://go.dev/cl/637536",
            "https://go.dev/issue/70906",
            "https://groups.google.com/g/golang-announce/c/wSCRmFnNmPA/m/Lvcd0mRMAwAJ",
            "https://nvd.nist.gov/vuln/detail/CVE-2024-45338",
            "https://pkg.go.dev/vuln/GO-2024-3333",
            "https://www.cve.org/CVERecord?id=CVE-2024-45338"
          ],
          "PublishedDate": "2024-12-18T21:15:08.173Z",
          "LastModifiedDate": "2024-12-31T20:16:06.603Z"
        }
      ]
    }
  ]
}
make: *** [make/scan.mk:30: trivy-scan-acmesolver] Error 1
```

After:
```console
  "Results": [
    {
      "Target": "_bin/containers/cert-manager-acmesolver-linux-amd64.tar (debian 11.10)",
      "Class": "os-pkgs",
      "Type": "debian"
    },
    {
      "Target": "app/cmd/acmesolver/acmesolver",
      "Class": "lang-pkgs",
      "Type": "gobinary",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2024-45338",
          "PkgName": "golang.org/x/net",
          "InstalledVersion": "v0.26.0",
          "FixedVersion": "0.33.0",
          "Layer": {
            "DiffID": "sha256:7599f8f5130cd1fbcb2a8e5bbc4dcc20088f6c74d5e2a36ec9b8fef205a99171"
          },
          "SeveritySource": "ghsa",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-45338",
          "DataSource": {
            "ID": "ghsa",
            "Name": "GitHub Security Advisory Go",
            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
          },
          "Title": "golang.org/x/net/html: Non-linear parsing of case-insensitive content in golang.org/x/net/html",
          "Description": "An attacker can craft an input to the Parse functions that would be processed non-linearly with respect to its length, resulting in extremely slow parsing. This could cause a denial of service.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-1333"
          ],
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
              "V3Score": 7.5
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2024-45338",
            "https://cs.opensource.google/go/x/net",
            "https://github.com/golang/go/issues/70906",
            "https://go.dev/cl/637536",
            "https://go.dev/issue/70906",
            "https://groups.google.com/g/golang-announce/c/wSCRmFnNmPA/m/Lvcd0mRMAwAJ",
            "https://nvd.nist.gov/vuln/detail/CVE-2024-45338",
            "https://pkg.go.dev/vuln/GO-2024-3333",
            "https://www.cve.org/CVERecord?id=CVE-2024-45338"
          ],
          "PublishedDate": "2024-12-18T21:15:08.173Z",
          "LastModifiedDate": "2024-12-31T20:16:06.603Z"
        }
      ]
    }
  ]
}
make: *** [make/scan.mk:30: trivy-scan-acmesolver] Error 1
```