### PR TITLE
ClusterIssuer read caBundle from Secret 

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -90,6 +90,28 @@ spec:
                         the container is used to validate the TLS connection.
                       type: string
                       format: byte
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                        which will be used to validate the certificate chain presented by the TPP server.
+                        Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
                     disableAccountKeyGeneration:
                       description: |-
                         Enables or disables generating a new ACME account key.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -90,6 +90,28 @@ spec:
                         the container is used to validate the TLS connection.
                       type: string
                       format: byte
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                        which will be used to validate the certificate chain presented by the TPP server.
+                        Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
                     disableAccountKeyGeneration:
                       description: |-
                         Enables or disables generating a new ACME account key.

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -57,6 +57,13 @@ type ACMEIssuer struct {
 	// the container is used to validate the TLS connection.
 	CABundle []byte
 
+	// Reference to a Secret containing a base64-encoded bundle of PEM CAs
+	// which will be used to validate the certificate chain presented by the TPP server.
+	// Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+	// If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+	// the cert-manager controller container is used to validate the TLS connection.
+	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
 	// INSECURE: Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have the TLS certificate chain
 	// validated.

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -962,6 +962,15 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 	out.Server = in.Server
 	out.PreferredChain = in.PreferredChain
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
+	if in.CABundleSecretRef != nil {
+		in, out := &in.CABundleSecretRef, &out.CABundleSecretRef
+		*out = new(meta.SecretKeySelector)
+		if err := metav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.CABundleSecretRef = nil
+	}
 	out.SkipTLSVerify = in.SkipTLSVerify
 	if in.ExternalAccountBinding != nil {
 		in, out := &in.ExternalAccountBinding, &out.ExternalAccountBinding
@@ -996,6 +1005,15 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 	out.Server = in.Server
 	out.PreferredChain = in.PreferredChain
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
+	if in.CABundleSecretRef != nil {
+		in, out := &in.CABundleSecretRef, &out.CABundleSecretRef
+		*out = new(apismetav1.SecretKeySelector)
+		if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.CABundleSecretRef = nil
+	}
 	out.SkipTLSVerify = in.SkipTLSVerify
 	if in.ExternalAccountBinding != nil {
 		in, out := &in.ExternalAccountBinding, &out.ExternalAccountBinding

--- a/internal/apis/acme/zz_generated.deepcopy.go
+++ b/internal/apis/acme/zz_generated.deepcopy.go
@@ -487,6 +487,11 @@ func (in *ACMEIssuer) DeepCopyInto(out *ACMEIssuer) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.CABundleSecretRef != nil {
+		in, out := &in.CABundleSecretRef, &out.CABundleSecretRef
+		*out = new(meta.SecretKeySelector)
+		**out = **in
+	}
 	if in.ExternalAccountBinding != nil {
 		in, out := &in.ExternalAccountBinding, &out.ExternalAccountBinding
 		*out = new(ACMEExternalAccountBinding)

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -414,6 +414,47 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				field.Invalid(fldPath.Child("skipTLSVerify"), true, "caBundle and skipTLSVerify are mutually exclusive and cannot both be set"),
 			},
 		},
+		"acme issuer with both a CA bundle from caBundleSecretRef and SkipTLSVerify": {
+			spec: &cmacme.ACMEIssuer{
+				Email:             "valid-email",
+				Server:            "valid-server",
+				CABundleSecretRef: &validSecretKeyRef,
+				SkipTLSVerify:     true,
+				PrivateKey:        validSecretKeyRef,
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &validCloudDNSProvider,
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("caBundleSecretRef"), "", "caBundleSecretRef and skipTLSVerify are mutually exclusive and cannot both be set"),
+				field.Invalid(fldPath.Child("skipTLSVerify"), true, "caBundleSecretRef and skipTLSVerify are mutually exclusive and cannot both be set"),
+			},
+		},
+		"acme issuer with both a CA bundle and caBundleSecretRef": {
+			spec: &cmacme.ACMEIssuer{
+				Email:             "valid-email",
+				Server:            "valid-server",
+				CABundleSecretRef: &validSecretKeyRef,
+				CABundle:          caBundle,
+				PrivateKey:        validSecretKeyRef,
+				SkipTLSVerify:     false,
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &validCloudDNSProvider,
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("caBundle"), "", "caBundle and caBundleSecretRef are mutually exclusive and cannot both be set"),
+				field.Invalid(fldPath.Child("caBundleSecretRef"), "", "caBundle and caBundleSecretRef are mutually exclusive and cannot both be set"),
+			},
+		},
 		"acme solver without any config": {
 			spec: &cmacme.ACMEIssuer{
 				Email:      "valid-email",

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -64,6 +64,13 @@ type ACMEIssuer struct {
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 
+	// Reference to a Secret containing a base64-encoded bundle of PEM CAs
+	// which will be used to validate the certificate chain presented by the TPP server.
+	// Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+	// If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+	// the cert-manager controller container is used to validate the TLS connection.
+	CABundleSecretRef *cmmeta.SecretKeySelector `json:"caBundleSecretRef,omitempty"`
+
 	// INSECURE: Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have the TLS certificate chain
 	// validated.

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -487,6 +487,11 @@ func (in *ACMEIssuer) DeepCopyInto(out *ACMEIssuer) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.CABundleSecretRef != nil {
+		in, out := &in.CABundleSecretRef, &out.CABundleSecretRef
+		*out = new(metav1.SecretKeySelector)
+		**out = **in
+	}
 	if in.ExternalAccountBinding != nil {
 		in, out := &in.ExternalAccountBinding, &out.ExternalAccountBinding
 		*out = new(ACMEExternalAccountBinding)

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -49,6 +49,12 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 					continue
 				}
 			}
+			if iss.Spec.ACME.CABundleSecretRef != nil {
+				if iss.Spec.ACME.CABundleSecretRef.Name == secret.Name {
+					affected = append(affected, iss)
+					continue
+				}
+			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
 				affected = append(affected, iss)

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -51,6 +51,12 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 					continue
 				}
 			}
+			if iss.Spec.ACME.CABundleSecretRef != nil {
+				if iss.Spec.ACME.CABundleSecretRef.Name == secret.Name {
+					affected = append(affected, iss)
+					continue
+				}
+			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
 				affected = append(affected, iss)

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/acme/client"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -160,7 +161,12 @@ func (a *Acme) Setup(ctx context.Context) error {
 	// this function.
 	a.accountRegistry.RemoveClient(string(a.issuer.GetUID()))
 
-	httpClient := accounts.BuildHTTPClientWithCABundle(a.metrics, a.issuer.GetSpec().ACME.SkipTLSVerify, a.issuer.GetSpec().ACME.CABundle)
+	caBundle, err := a.getACMECaBundle(ctx, ns, a.issuer.GetSpec().ACME)
+	if err != nil {
+		return err
+	}
+
+	httpClient := accounts.BuildHTTPClientWithCABundle(a.metrics, a.issuer.GetSpec().ACME.SkipTLSVerify, caBundle)
 
 	cl := a.clientBuilder(httpClient, *a.issuer.GetSpec().ACME, rsaPk, a.userAgent)
 
@@ -326,6 +332,39 @@ func (a *Acme) Setup(ctx context.Context) error {
 	a.accountRegistry.AddClient(httpClient, string(a.issuer.GetUID()), *a.issuer.GetSpec().ACME, rsaPk, a.userAgent)
 
 	return nil
+}
+
+func (a *Acme) getACMECaBundle(ctx context.Context, namespace string, acmeIssuer *cmacme.ACMEIssuer) (caBundle []byte, err error) {
+	if len(acmeIssuer.CABundle) > 0 {
+		return acmeIssuer.CABundle, nil
+	}
+	secretRef := acmeIssuer.CABundleSecretRef
+	if secretRef == nil {
+		return nil, nil
+	}
+
+	var ok bool
+
+	secret, err := a.secretsClient.Secrets(namespace).Get(ctx, acmeIssuer.CABundleSecretRef.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not access secret '%s/%s': %s", namespace, secretRef.Name, err)
+	}
+
+	var key string
+	if secretRef.Key != "" {
+		key = secretRef.Key
+	} else {
+		key = cmmeta.TLSCAKey
+	}
+
+	caBundle, ok = secret.Data[key]
+	if !ok {
+		return nil, fmt.Errorf("no data for %q in secret '%s/%s'", key, namespace, secretRef.Name)
+	}
+	return
 }
 
 func ensureEmailUpToDate(ctx context.Context, cl client.Interface, acc *acmeapi.Account, specEmail string) (*acmeapi.Account, string, error) {


### PR DESCRIPTION
### Pull Request Motivation

Implement issue #7520.

### Kind

/kind feature

### Release Note

```release-note
ClusterIssuer allows specifying `.caBundleSecretRef` to support using a caBundle from a Secret instead of the inline value in `.caBundle`.
```
