### PR TITLE
Fix AWS Route53 error detection for not-found errors during deletion

### DIFF
--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -57,6 +57,19 @@ var ListHostedZonesByNameResponse = `<?xml version="1.0" encoding="UTF-8"?>
    <MaxItems>1</MaxItems>
 </ListHostedZonesByNameResponse>`
 
+// An example of an error returned by the ListHostedZonesByName API when the
+// request contains an invalid domain name:
+// - https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByName.html#API_ListHostedZonesByName_Errors
+var ListHostedZonesByName400ResponseInvalidDomainName = `<?xml version="1.0" encoding="UTF-8"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+	<Code>InvalidDomainName</Code>
+	<Message>Simulated message</Message>
+	<Resource></Resource>
+	<RequestId>SOMEREQUESTID</RequestId>
+  </Error>
+</ErrorResponse>`
+
 var GetChangeResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
    <ChangeInfo>

--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -75,3 +75,18 @@ var ChangeResourceRecordSets403Response = `<?xml version="1.0"?>
   </Error>
   <RequestId>SOMEREQUESTID</RequestId>
 </ErrorResponse>`
+
+// An example of an error returned by the ChangeResourceRecordSets API when the
+// request refers to a record set that does not exist:
+// - https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html#API_ChangeResourceRecordSets_Errors
+//
+// This sample error XML was derived from examples and user reported log messages in the following pages:
+// - https://github.com/aws/aws-sdk-go-v2/blob/f529add9a2cd0d97281fd81f711c620c1e95cfb8/service/route53/internal/customizations/doc.go#L16C1-L21C25
+// - https://github.com/cert-manager/cert-manager/issues/7547
+// - https://github.com/cert-manager/cert-manager/pull/7548
+var ChangeResourceRecordSets400Response = `<?xml version="1.0"?>
+<InvalidChangeBatch xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Messages>
+    <Message>Tried to delete resource record set [name='_acme-challenge.example.com.', type='TXT', set-identifier='"5CiRHXrp9tvpLNX8F9M8qbi8u9kwb3xnHrKdLNDlRQA"'] but it was not found</Message>
+  </Messages>
+</InvalidChangeBatch>`

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -311,10 +311,10 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		}
 		resp, err := r.client.GetChange(ctx, reqParams)
 		if err != nil {
-			return false, fmt.Errorf("failed to query Route 53 change status: %w", err)
+			return true, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
 		if resp.ChangeInfo == nil {
-			return false, fmt.Errorf("failed to query Route 53 change status: %w", err)
+			return true, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
 		if resp.ChangeInfo.Status == route53types.ChangeStatusInsync {
 			return true, nil

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -281,7 +281,7 @@ func (r *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.ChangeAction, fqdn, value string, ttl int) error {
 	hostedZoneID, err := r.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %v", err)
+		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %w", err)
 	}
 
 	recordSet := newTXTRecordSet(fqdn, value, ttl)
@@ -311,9 +311,6 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		}
 		resp, err := r.client.GetChange(ctx, reqParams)
 		if err != nil {
-			return true, fmt.Errorf("failed to query Route 53 change status: %w", err)
-		}
-		if resp.ChangeInfo == nil {
 			return true, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
 		if resp.ChangeInfo.Status == route53types.ChangeStatusInsync {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -25,6 +25,7 @@ import (
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
@@ -283,6 +284,28 @@ func TestRoute53Present(t *testing.T) {
 	err = provider.Present(ctx, "bar.example.com", "bar.example.com.", keyAuth)
 	require.Error(t, err, "Expected Present to return an error")
 	assert.Equal(t, `failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 403, RequestID: <REDACTED>, api error AccessDenied: User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU`, err.Error())
+}
+
+func TestRoute53Cleanup(t *testing.T) {
+	l := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+	ctx := logr.NewContext(context.Background(), l)
+
+	mockResponses := MockResponseMap{
+		"/2013-04-01/hostedzonesbyname":        MockResponse{StatusCode: 200, Body: ListHostedZonesByNameResponse},
+		"/2013-04-01/hostedzone/ABCDEFG/rrset": MockResponse{StatusCode: 400, Body: ChangeResourceRecordSets400Response},
+	}
+
+	ts := newMockServer(t, mockResponses)
+	defer ts.Close()
+
+	provider, err := makeRoute53Provider(ts)
+	require.NoError(t, err, "Expected to make a Route 53 provider without error")
+
+	domain := "example.com"
+	keyAuth := "123456d=="
+
+	err = provider.CleanUp(ctx, domain, "_acme-challenge."+domain+".", keyAuth)
+	require.NoError(t, err, "Expected Cleanup to return no error")
 }
 
 func TestAssumeRole(t *testing.T) {

--- a/pkg/issuer/acme/dns/route53/testutil_test.go
+++ b/pkg/issuer/acme/dns/route53/testutil_test.go
@@ -29,6 +29,7 @@ type MockResponseMap map[string]MockResponse
 
 func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("%s: %s", r.Method, r.URL)
 		path := r.URL.Path
 		resp, ok := responses[path]
 		if !ok {

--- a/pkg/issuer/acme/dns/route53/testutil_test.go
+++ b/pkg/issuer/acme/dns/route53/testutil_test.go
@@ -25,9 +25,8 @@ type MockResponse struct {
 type MockResponseMap map[string]MockResponse
 
 func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
-	var ts *httptest.Server
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("%s: %s", r.Method, r.URL)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("Mock API Server: %s %s", r.Method, r.URL)
 		path := r.URL.Path
 		resp, ok := responses[path]
 		if !ok {

--- a/pkg/issuer/acme/dns/route53/testutil_test.go
+++ b/pkg/issuer/acme/dns/route53/testutil_test.go
@@ -9,13 +9,10 @@ this directory.
 package route53
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 // MockResponse represents a predefined response used by a mock server
@@ -28,13 +25,14 @@ type MockResponse struct {
 type MockResponseMap map[string]MockResponse
 
 func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("%s: %s", r.Method, r.URL)
 		path := r.URL.Path
 		resp, ok := responses[path]
 		if !ok {
-			msg := fmt.Sprintf("Requested path not found in response map: %s", path)
-			require.FailNow(t, msg)
+			http.NotFound(w, r)
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/xml")
@@ -42,7 +40,6 @@ func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write([]byte(resp.Body))
 	}))
-
 	time.Sleep(100 * time.Millisecond)
 	return ts
 }

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -511,7 +511,7 @@ func WaitFor(timeout, interval time.Duration, f func() (bool, error)) error {
 
 		stop, err := f()
 		if stop {
-			return nil
+			return err
 		}
 		if err != nil {
 			lastErr = err.Error()


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes https://github.com/cert-manager/cert-manager/issues/7547

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fix AWS Route53 error detection for not-found errors during deletion of DNS records.
```
