### PR TITLE
chore(issuer/cloudflare): ensure we set ZoneID

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -233,6 +233,9 @@ func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn, content string) (
 
 	for _, rec := range records {
 		if rec.Name == util.UnFqdn(fqdn) && rec.Content == content {
+			// Cloudflare made a breaking change to their API and removed the ZoneID from responses:
+			// https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-11-30
+			// The simplest fix is to set the ZoneID manually here
 			rec.ZoneID = zoneID
 			return &rec, nil
 		}

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -233,6 +233,7 @@ func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn, content string) (
 
 	for _, rec := range records {
 		if rec.Name == util.UnFqdn(fqdn) && rec.Content == content {
+			rec.ZoneID = zoneID
 			return &rec, nil
 		}
 	}


### PR DESCRIPTION
Cloudflare have stopped including zone IDs in their record responses now, 2 months after they said they did and with their trademark zero effort in outreach to consumers of their API. Ensure that findTxtRecord returns a record struct with the zone ID set regardless.

Fixes #7540

### Pull Request Motivation

Make issuing certificates using DNS01 challenges work on Cloudflare again.

### Kind

/kind bug

### Release Note

```release-note
Fix issuing of certificates via DNS01 challenges on Cloudflare
```
