### PR TITLE
skip score cards for forks with other default branches

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,12 +14,13 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
+    if: github.event.repository.default_branch == github.ref_name
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Used to receive a badge.
       id-token: write
-    
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,7 +14,7 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
-    if: github.event.repository.default_branch == github.ref_name
+    if: github.ref_name == github.event.repository.default_branch
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
### Pull Request Motivation

My forks often have a different default branch than upstreams. cert-manager's scorecard workflow ❌ when i pull in upstream master which is annoying.

https://github.com/check-spelling-sandbox/cert-manager/actions/runs/13138950431

### Kind

/kind bug

### Release Note

```release-note
NONE
```
