### PR TITLE
[release-1.12] Bump go to supported version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -56,7 +56,7 @@ KUBEBUILDER_ASSETS_VERSION=1.27.1
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.21.13
+VENDORED_GO_VERSION := 1.23.6
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
The version of Go used for release-1.12 hasn't been supported for a while now, and right now the next supported version is go1.23.x which will be supported past the remaining lifetime of 1.12.x LTS

This commit bumps to a supported version of Go to address several reported vulnerabilties present in the image for cert-manager v1.12.15 including:

- CVE-2024-34156
- CVE-2024-34155
- CVE-2024-34158
- CVE-2024-45336
- CVE-2024-45341
- CVE-2025-22866

### Kind

/kind bug

### Release Note

```release-note
⚠️ Bump go to latest version of 1.23.x to address reported vulnerabilities
```
