### PR TITLE
[release-1.12] chore(issuer/cloudflare): ensure we set ZoneID

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -235,6 +235,10 @@ func (c *DNSProvider) findTxtRecord(fqdn string) (*cloudFlareRecord, error) {
 
 	for _, rec := range records {
 		if rec.Name == util.UnFqdn(fqdn) {
+			// Cloudflare made a breaking change to their API and removed the ZoneID from responses:
+			// https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-11-30
+			// The simplest fix is to set the ZoneID manually here
+			rec.ZoneID = zoneID
 			return &rec, nil
 		}
 	}


### PR DESCRIPTION
Cloudflare have stopped including zone IDs in their record responses now, 2 months after they said they did and with their trademark zero effort in outreach to consumers of their API. Ensure that findTxtRecord returns a record struct with the zone ID set regardless.

Fixes #7540

(Manual cherry pick of #7549 fixed up to apply cleanly)

NB: Since release-1.12 doesn't include #6191 (it wasn't ever backported), users issuing with Cloudflare on cert-manager v1.12.x are strongly encouraged to upgrade to a newer version. We'll have to mention that in the release notes for v1.12.16

### Kind

/kind bug

### Release Note

```release-note
Fix issuing of certificates via DNS01 challenges on Cloudflare after a breaking change to the Cloudflare API
```
