### PR TITLE
Quote node selector values (gave up signoff)

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,9 +136,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.cainjector.nodeSelector }}
+      {{- range $key, $value := .Values.cainjector.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.cainjector.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,9 +209,9 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,9 +76,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.startupapicheck.nodeSelector }}
+      {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.startupapicheck.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,9 +188,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.webhook.nodeSelector }}
+      {{- range $key, $value := .Values.webhook.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.webhook.affinity }}
       affinity:

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -59,9 +59,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
-      {{- with .Values.nodeSelector }}
+      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
### Pull Request Motivation

This pr updates the Helm Chart to add quotes to values for _nodeSelector_ entries. This is needed if the value is a _boolean_. An example is using [Spot VMs](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) on _GCP_:
````
apiVersion: v1
kind: Pod
spec:
  nodeSelector:
    cloud.google.com/gke-spot: "true"
````

Currently, the Helm Chart uses the _toYaml_ function when adding the _nodeSelector_ values, however, _toYaml_ does not quote the values as discussed [here](https://github.com/helm/helm/issues/4262).

### Kind

/kind bug

### Release Note

```release-note
Quote nodeSelector values in Helm Chart
```
