### PR TITLE
Quote node selector values

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,9 +136,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+      {{- if .Values.cainjector.nodeSelector }}
       nodeSelector:
-      {{- range $key, $value := .Values.cainjector.nodeSelector }}
+        {{- range $key, $value := .Values.cainjector.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.cainjector.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,9 +136,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.cainjector.nodeSelector }}
+      {{- range $key, $value := .Values.cainjector.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.cainjector.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,8 +136,8 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- range $key, $value := .Values.cainjector.nodeSelector }}
       nodeSelector:
+      {{- range $key, $value := .Values.cainjector.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.cainjector.affinity }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,9 +136,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if .Values.cainjector.nodeSelector }}
+      {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.cainjector.nodeSelector }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,9 +209,9 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,8 +209,8 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
+      {{- range $key, $value := .Values.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,9 +209,11 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,9 +209,9 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,8 +76,8 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
       nodeSelector:
+      {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.startupapicheck.affinity }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,9 +76,11 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.startupapicheck.nodeSelector }}
       nodeSelector:
-      {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
+        {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.startupapicheck.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,9 +76,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if .Values.startupapicheck.nodeSelector }}
+      {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,9 +76,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.startupapicheck.nodeSelector }}
+      {{- range $key, $value := .Values.startupapicheck.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.startupapicheck.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,7 +188,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with Values.webhook.nodeSelector }}
+      {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,8 +188,8 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- range $key, $value := .Values.webhook.nodeSelector }}
       nodeSelector:
+      {{- range $key, $value := .Values.webhook.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.webhook.affinity }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,9 +188,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if Values.webhook.nodeSelector }}
+      {{- with Values.webhook.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.webhook.nodeSelector }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,9 +188,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+      {{- if Values.webhook.nodeSelector }}
       nodeSelector:
-      {{- range $key, $value := .Values.webhook.nodeSelector }}
+        {{- range $key, $value := .Values.webhook.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.webhook.affinity }}
       affinity:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -188,9 +188,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.webhook.nodeSelector }}
+      {{- range $key, $value := .Values.webhook.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.webhook.affinity }}
       affinity:

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -59,9 +59,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
-      {{- if .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -59,9 +59,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
-      {{- with .Values.nodeSelector }}
+      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
-      {{- range $key, $value := .Values.nodeSelector }}
       nodeSelector:
+      {{- range $key, $value := .Values.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- with .Values.affinity }}

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -59,9 +59,11 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{- range $key, $value := .Values.nodeSelector }}
+        {{- range $key, $value := .Values.nodeSelector }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
### Pull Request Motivation

This pr updates the Helm Chart to add quotes to values for _nodeSelector_ entries. This is needed if the value is a _boolean_. An example is using [Spot VMs](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) on _GCP_:
````
apiVersion: v1
kind: Pod
spec:
  nodeSelector:
    cloud.google.com/gke-spot: "true"
````

Currently, the Helm Chart uses the _toYaml_ function when adding the _nodeSelector_ values, however, _toYaml_ does not quote the values as discussed [here](https://github.com/helm/helm/issues/4262).

### Kind

/kind bug

### Release Note

```release-note
Quote nodeSelector values in Helm Chart
```
