### PR TITLE
Support for ACME servers that don't finalize within the ACME client finalizer retry window

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -237,6 +237,22 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 
 		return nil
 
+	// ACME orders transition from ready -> processing -> (valid|invalid). If a server takes a long time
+	// to fulfill an order, the underlying order finalizer may return an order still in the processing state.
+	// In that case the worker should continue to poll the ACME server until the order transitions to either
+	// valid or invalid.
+	case acmeOrder.Status == acmeapi.StatusProcessing:
+		log.V(logf.InfoLevel).Info("Order is in processing state, waiting for ACME server to update the status of the order...")
+		c.setOrderState(&o.Status, string(cmacme.Processing))
+
+		// Re-queue the Order to be processed again after RequeuePeriod has passed.
+		c.scheduledWorkQueue.Add(types.NamespacedName{
+			Name:      o.Name,
+			Namespace: o.Namespace,
+		}, RequeuePeriod)
+
+		return nil
+
 	case !anyChallengesFailed(challenges) && allChallengesFinal(challenges):
 		log.V(logf.DebugLevel).Info("All challenges are in a final state, updating order state")
 		_, err := c.updateOrderStatusFromACMEOrder(o, acmeOrder)

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -266,6 +266,8 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 	}
 
 	testOrderPending := gen.OrderFrom(testOrder, gen.SetOrderStatus(pendingStatus))
+	testOrderProcessing := testOrderPending.DeepCopy()
+	testOrderProcessing.Status.State = cmacme.Processing
 	testOrderInvalid := testOrderPending.DeepCopy()
 	testOrderInvalid.Status.State = cmacme.Invalid
 	testOrderInvalid.Status.FailureTime = &nowMetaTime
@@ -798,6 +800,45 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 					return "key", nil
 				},
 			},
+		},
+		"reschedule if the ACME Order is still processing": {
+			order: gen.OrderFrom(testOrder, gen.SetOrderStatus(
+				cmacme.OrderStatus{
+					State:       cmacme.Processing,
+					URL:         "http://testurl.com/abcde",
+					FinalizeURL: "http://testurl.com/abcde/finalize",
+					Authorizations: []cmacme.ACMEAuthorization{
+						{
+							URL:          "http://authzurl",
+							Identifier:   "test.com",
+							InitialState: cmacme.Valid,
+							Challenges: []cmacme.ACMEChallenge{
+								{
+									URL:   "http://chalurl",
+									Token: "token",
+									Type:  "http-01",
+								},
+							},
+						},
+					},
+				},
+			)),
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestCom, testOrderProcessing},
+				ExpectedActions:    []testpkg.Action{},
+				ExpectedEvents:     []string{},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeGetOrder: func(ctx context.Context, url string) (*acmeapi.Order, error) {
+					return &acmeapi.Order{
+						URI:         "http://testurl.com/abcde",
+						Status:      acmeapi.StatusProcessing,
+						FinalizeURL: "http://testurl.com/abcde/finalize",
+						CertURL:     "",
+					}, nil
+				},
+			},
+			shouldSchedule: true,
 		},
 		"preferred chain is default cert chain": {
 			order: testOrderReady.DeepCopy(),


### PR DESCRIPTION
### Pull Request Motivation

After an ACME order is finalized, it can (should) transition to a processing state where the ACME server fulfills the order in the background, [referenced here in RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555#page-33). Currently cert-manager does not handle the processing state and the order is only fulfilled if cert-manager is restarted and order state is re-synced.

[This is the same issue raised here](https://github.com/cert-manager/cert-manager/issues/5062), but we can't compile custom cert-manager, so I've contributed changes.

### Kind

/kind bug

### Release Note

```release-note
Added support for retrying orders in the processing state.
```
