### PR TITLE
feat: Add certificate issuance time and duration metrics

### DIFF
--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -30,7 +30,6 @@ func (m *Metrics) UpdateCertificate(crt *cmapi.Certificate) {
 	m.updateCertificateStatus(crt)
 	m.updateCertificateIssuance(crt)
 	m.updateCertificateExpiry(crt)
-	m.updateCertificateTotalIssueDuration(crt)
 	m.updateCertificateRenewalTime(crt)
 }
 
@@ -82,23 +81,6 @@ func (m *Metrics) updateCertificateRenewalTime(crt *cmapi.Certificate) {
 		"issuer_group": crt.Spec.IssuerRef.Group}).Set(renewalTime)
 }
 
-// updateCertificateTotalIssueDuration will update the metric for that Certificate
-func (m *Metrics) updateCertificateTotalIssueDuration(crt *cmapi.Certificate) {
-	totalIssueDuration := cmapi.DefaultCertificateDuration
-	if crt.Spec.Duration != nil {
-		totalIssueDuration = crt.Spec.Duration.Duration
-	}
-
-	totalIssueDurationSeconds := float64(totalIssueDuration.Seconds())
-
-	m.certificateTotalIssueDurationSeconds.With(prometheus.Labels{
-		"name":         crt.Name,
-		"namespace":    crt.Namespace,
-		"issuer_name":  crt.Spec.IssuerRef.Name,
-		"issuer_kind":  crt.Spec.IssuerRef.Kind,
-		"issuer_group": crt.Spec.IssuerRef.Group}).Set(totalIssueDurationSeconds)
-}
-
 // updateCertificateStatus will update the metric for that Certificate
 func (m *Metrics) updateCertificateStatus(crt *cmapi.Certificate) {
 	for _, c := range crt.Status.Conditions {
@@ -140,5 +122,4 @@ func (m *Metrics) RemoveCertificate(key types.NamespacedName) {
 	m.certificateIssuanceTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
 	m.certificateRenewalTimeSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
 	m.certificateReadyStatus.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
-	m.certificateTotalIssueDurationSeconds.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
 }

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 const issuanceMetadata = `
-	# HELP certmanager_certificate_issuance_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
-	# TYPE certmanager_certificate_issuance_timestamp_seconds gauge
+	# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+	# TYPE certmanager_certificate_not_before_timestamp_seconds gauge
 `
 
 const expiryMetadata = `
@@ -78,7 +78,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 100
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 100
 `,
 
 			expectedExpiry: `
@@ -104,7 +104,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedExpiry: `
 		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
@@ -139,7 +139,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
 `,
 			expectedExpiry: `
 		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 100
@@ -173,7 +173,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
 `,
 			expectedExpiry: `
 		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 99999
@@ -210,7 +210,7 @@ func TestCertificateMetrics(t *testing.T) {
 				}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 10
 `,
 			expectedExpiry: `
 		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
@@ -235,7 +235,7 @@ func TestCertificateMetrics(t *testing.T) {
 				gen.SetCertificateDuration(&metav1.Duration{Duration: time.Second * 100}),
 			),
 			expectedIssuance: `
-		certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
+		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
 `,
 			expectedExpiry: `
 		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
@@ -257,7 +257,7 @@ func TestCertificateMetrics(t *testing.T) {
 
 			if err := testutil.CollectAndCompare(m.certificateIssuanceTimeSeconds,
 				strings.NewReader(issuanceMetadata+test.expectedIssuance),
-				"certmanager_certificate_issuance_timestamp_seconds",
+				"certmanager_certificate_not_before_timestamp_seconds",
 			); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
@@ -378,11 +378,11 @@ func TestCertificateCache(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(m.certificateIssuanceTimeSeconds,
 		strings.NewReader(issuanceMetadata+`
-        certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 99
-        certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 199
-        certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 299
+        certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 99
+        certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt2",namespace="default-unit-test-ns"} 199
+        certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 299
 `),
-		"certmanager_certificate_issuance_timestamp_seconds",
+		"certmanager_certificate_not_before_timestamp_seconds",
 	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -440,10 +440,10 @@ func TestCertificateCache(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(m.certificateIssuanceTimeSeconds,
 		strings.NewReader(issuanceMetadata+`
-        certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 99
-        certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 299
+        certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt1",namespace="default-unit-test-ns"} 99
+        certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="crt3",namespace="default-unit-test-ns"} 299
 `),
-		"certmanager_certificate_issuance_timestamp_seconds",
+		"certmanager_certificate_not_before_timestamp_seconds",
 	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -467,7 +467,7 @@ func TestCertificateCache(t *testing.T) {
 	if testutil.CollectAndCount(m.certificateExpiryTimeSeconds, "certmanager_certificate_expiration_timestamp_seconds") != 0 {
 		t.Errorf("unexpected collecting result")
 	}
-	if testutil.CollectAndCount(m.certificateExpiryTimeSeconds, "certmanager_certificate_issuance_timestamp_seconds") != 0 {
+	if testutil.CollectAndCount(m.certificateExpiryTimeSeconds, "certmanager_certificate_not_before_timestamp_seconds") != 0 {
 		t.Errorf("unexpected collecting result")
 	}
 }

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -243,34 +243,6 @@ func TestCertificateMetrics(t *testing.T) {
 		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 		},
-		"certificate with duration explicitly set has a matching duration metric": {
-			crt: gen.Certificate("test-certificate",
-				gen.SetCertificateNamespace("test-ns"),
-				gen.SetCertificateIssuer(cmmeta.ObjectReference{
-					Name:  "test-issuer",
-					Kind:  "test-issuer-kind",
-					Group: "test-issuer-group",
-				}),
-				gen.SetCertificateDuration(&metav1.Duration{Duration: time.Second * 100}),
-			),
-			expectedNotAfter: `
-		certmanager_certificate_not_after_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-`,
-			expectedNotBefore: `
-		certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-`,
-			expectedExpiry: `
-		certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-`,
-			expectedReady: `
-        certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="True",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-        certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 1
-`,
-			expectedRenewalTime: `
-		certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="test-issuer-kind",issuer_name="test-issuer",name="test-certificate",namespace="test-ns"} 0
-`,
-		},
 	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
@@ -517,7 +489,10 @@ func TestCertificateCache(t *testing.T) {
 	if testutil.CollectAndCount(m.certificateExpiryTimeSeconds, "certmanager_certificate_expiration_timestamp_seconds") != 0 {
 		t.Errorf("unexpected collecting result")
 	}
-	if testutil.CollectAndCount(m.certificateExpiryTimeSeconds, "certmanager_certificate_not_before_timestamp_seconds") != 0 {
+	if testutil.CollectAndCount(m.certificateNotAfterTimeSeconds, "certmanager_certificate_not_after_timestamp_seconds") != 0 {
+		t.Errorf("unexpected collecting result")
+	}
+	if testutil.CollectAndCount(m.certificateNotBeforeTimeSeconds, "certmanager_certificate_not_before_timestamp_seconds") != 0 {
 		t.Errorf("unexpected collecting result")
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -105,7 +105,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		certificateIssuanceTimeSeconds = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "certificate_issuance_timestamp_seconds",
+				Name:      "certificate_not_before_timestamp_seconds",
 				Help:      "The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.",
 			},
 			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,18 +53,17 @@ type Metrics struct {
 	log      logr.Logger
 	registry *prometheus.Registry
 
-	clockTimeSeconds                     prometheus.CounterFunc
-	clockTimeSecondsGauge                prometheus.GaugeFunc
-	certificateIssuanceTimeSeconds       *prometheus.GaugeVec
-	certificateExpiryTimeSeconds         *prometheus.GaugeVec
-	certificateRenewalTimeSeconds        *prometheus.GaugeVec
-	certificateTotalIssueDurationSeconds *prometheus.GaugeVec
-	certificateReadyStatus               *prometheus.GaugeVec
-	acmeClientRequestDurationSeconds     *prometheus.SummaryVec
-	acmeClientRequestCount               *prometheus.CounterVec
-	venafiClientRequestDurationSeconds   *prometheus.SummaryVec
-	controllerSyncCallCount              *prometheus.CounterVec
-	controllerSyncErrorCount             *prometheus.CounterVec
+	clockTimeSeconds                   prometheus.CounterFunc
+	clockTimeSecondsGauge              prometheus.GaugeFunc
+	certificateIssuanceTimeSeconds     *prometheus.GaugeVec
+	certificateExpiryTimeSeconds       *prometheus.GaugeVec
+	certificateRenewalTimeSeconds      *prometheus.GaugeVec
+	certificateReadyStatus             *prometheus.GaugeVec
+	acmeClientRequestDurationSeconds   *prometheus.SummaryVec
+	acmeClientRequestCount             *prometheus.CounterVec
+	venafiClientRequestDurationSeconds *prometheus.SummaryVec
+	controllerSyncCallCount            *prometheus.CounterVec
+	controllerSyncErrorCount           *prometheus.CounterVec
 }
 
 var readyConditionStatuses = [...]cmmeta.ConditionStatus{cmmeta.ConditionTrue, cmmeta.ConditionFalse, cmmeta.ConditionUnknown}
@@ -126,17 +125,6 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Namespace: namespace,
 				Name:      "certificate_renewal_timestamp_seconds",
 				Help:      "The number of seconds before expiration time the certificate should renew.",
-			},
-			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
-		)
-
-		// Because this comes from a spec field, it will always have a value regardless of whether or
-		// not the certificate has been issued.
-		certificateTotalIssueDurationSeconds = prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "certificate_total_issue_duration_seconds",
-				Help:      "The total amount of time that the certificate is, or will be issued for, in seconds.",
 			},
 			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
@@ -220,18 +208,17 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		log:      log.WithName("metrics"),
 		registry: registry,
 
-		clockTimeSeconds:                     clockTimeSeconds,
-		clockTimeSecondsGauge:                clockTimeSecondsGauge,
-		certificateIssuanceTimeSeconds:       certificateIssuanceTimeSeconds,
-		certificateExpiryTimeSeconds:         certificateExpiryTimeSeconds,
-		certificateRenewalTimeSeconds:        certificateRenewalTimeSeconds,
-		certificateTotalIssueDurationSeconds: certificateTotalIssueDurationSeconds,
-		certificateReadyStatus:               certificateReadyStatus,
-		acmeClientRequestCount:               acmeClientRequestCount,
-		acmeClientRequestDurationSeconds:     acmeClientRequestDurationSeconds,
-		venafiClientRequestDurationSeconds:   venafiClientRequestDurationSeconds,
-		controllerSyncCallCount:              controllerSyncCallCount,
-		controllerSyncErrorCount:             controllerSyncErrorCount,
+		clockTimeSeconds:                   clockTimeSeconds,
+		clockTimeSecondsGauge:              clockTimeSecondsGauge,
+		certificateIssuanceTimeSeconds:     certificateIssuanceTimeSeconds,
+		certificateExpiryTimeSeconds:       certificateExpiryTimeSeconds,
+		certificateRenewalTimeSeconds:      certificateRenewalTimeSeconds,
+		certificateReadyStatus:             certificateReadyStatus,
+		acmeClientRequestCount:             acmeClientRequestCount,
+		acmeClientRequestDurationSeconds:   acmeClientRequestDurationSeconds,
+		venafiClientRequestDurationSeconds: venafiClientRequestDurationSeconds,
+		controllerSyncCallCount:            controllerSyncCallCount,
+		controllerSyncErrorCount:           controllerSyncErrorCount,
 	}
 
 	return m
@@ -244,7 +231,6 @@ func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.certificateIssuanceTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.certificateRenewalTimeSeconds)
-	m.registry.MustRegister(m.certificateTotalIssueDurationSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)
 	m.registry.MustRegister(m.venafiClientRequestDurationSeconds)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,16 +53,18 @@ type Metrics struct {
 	log      logr.Logger
 	registry *prometheus.Registry
 
-	clockTimeSeconds                   prometheus.CounterFunc
-	clockTimeSecondsGauge              prometheus.GaugeFunc
-	certificateExpiryTimeSeconds       *prometheus.GaugeVec
-	certificateRenewalTimeSeconds      *prometheus.GaugeVec
-	certificateReadyStatus             *prometheus.GaugeVec
-	acmeClientRequestDurationSeconds   *prometheus.SummaryVec
-	acmeClientRequestCount             *prometheus.CounterVec
-	venafiClientRequestDurationSeconds *prometheus.SummaryVec
-	controllerSyncCallCount            *prometheus.CounterVec
-	controllerSyncErrorCount           *prometheus.CounterVec
+	clockTimeSeconds                     prometheus.CounterFunc
+	clockTimeSecondsGauge                prometheus.GaugeFunc
+	certificateIssuanceTimeSeconds       *prometheus.GaugeVec
+	certificateExpiryTimeSeconds         *prometheus.GaugeVec
+	certificateRenewalTimeSeconds        *prometheus.GaugeVec
+	certificateTotalIssueDurationSeconds *prometheus.GaugeVec
+	certificateReadyStatus               *prometheus.GaugeVec
+	acmeClientRequestDurationSeconds     *prometheus.SummaryVec
+	acmeClientRequestCount               *prometheus.CounterVec
+	venafiClientRequestDurationSeconds   *prometheus.SummaryVec
+	controllerSyncCallCount              *prometheus.CounterVec
+	controllerSyncErrorCount             *prometheus.CounterVec
 }
 
 var readyConditionStatuses = [...]cmmeta.ConditionStatus{cmmeta.ConditionTrue, cmmeta.ConditionFalse, cmmeta.ConditionUnknown}
@@ -101,6 +103,15 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			},
 		)
 
+		certificateIssuanceTimeSeconds = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "certificate_issuance_timestamp_seconds",
+				Help:      "The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.",
+			},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
+		)
+
 		certificateExpiryTimeSeconds = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -115,6 +126,17 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Namespace: namespace,
 				Name:      "certificate_renewal_timestamp_seconds",
 				Help:      "The number of seconds before expiration time the certificate should renew.",
+			},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
+		)
+
+		// Because this comes from a spec field, it will always have a value regardless of whether or
+		// not the certificate has been issued.
+		certificateTotalIssueDurationSeconds = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "certificate_total_issue_duration_seconds",
+				Help:      "The total amount of time that the certificate is, or will be issued for, in seconds.",
 			},
 			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
@@ -198,16 +220,18 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		log:      log.WithName("metrics"),
 		registry: registry,
 
-		clockTimeSeconds:                   clockTimeSeconds,
-		clockTimeSecondsGauge:              clockTimeSecondsGauge,
-		certificateExpiryTimeSeconds:       certificateExpiryTimeSeconds,
-		certificateRenewalTimeSeconds:      certificateRenewalTimeSeconds,
-		certificateReadyStatus:             certificateReadyStatus,
-		acmeClientRequestCount:             acmeClientRequestCount,
-		acmeClientRequestDurationSeconds:   acmeClientRequestDurationSeconds,
-		venafiClientRequestDurationSeconds: venafiClientRequestDurationSeconds,
-		controllerSyncCallCount:            controllerSyncCallCount,
-		controllerSyncErrorCount:           controllerSyncErrorCount,
+		clockTimeSeconds:                     clockTimeSeconds,
+		clockTimeSecondsGauge:                clockTimeSecondsGauge,
+		certificateIssuanceTimeSeconds:       certificateIssuanceTimeSeconds,
+		certificateExpiryTimeSeconds:         certificateExpiryTimeSeconds,
+		certificateRenewalTimeSeconds:        certificateRenewalTimeSeconds,
+		certificateTotalIssueDurationSeconds: certificateTotalIssueDurationSeconds,
+		certificateReadyStatus:               certificateReadyStatus,
+		acmeClientRequestCount:               acmeClientRequestCount,
+		acmeClientRequestDurationSeconds:     acmeClientRequestDurationSeconds,
+		venafiClientRequestDurationSeconds:   venafiClientRequestDurationSeconds,
+		controllerSyncCallCount:              controllerSyncCallCount,
+		controllerSyncErrorCount:             controllerSyncErrorCount,
 	}
 
 	return m
@@ -217,8 +241,10 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.clockTimeSeconds)
 	m.registry.MustRegister(m.clockTimeSecondsGauge)
+	m.registry.MustRegister(m.certificateIssuanceTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.certificateRenewalTimeSeconds)
+	m.registry.MustRegister(m.certificateTotalIssueDurationSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)
 	m.registry.MustRegister(m.venafiClientRequestDurationSeconds)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,7 +55,8 @@ type Metrics struct {
 
 	clockTimeSeconds                   prometheus.CounterFunc
 	clockTimeSecondsGauge              prometheus.GaugeFunc
-	certificateIssuanceTimeSeconds     *prometheus.GaugeVec
+	certificateNotAfterTimeSeconds     *prometheus.GaugeVec
+	certificateNotBeforeTimeSeconds    *prometheus.GaugeVec
 	certificateExpiryTimeSeconds       *prometheus.GaugeVec
 	certificateRenewalTimeSeconds      *prometheus.GaugeVec
 	certificateReadyStatus             *prometheus.GaugeVec
@@ -102,11 +103,20 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			},
 		)
 
-		certificateIssuanceTimeSeconds = prometheus.NewGaugeVec(
+		certificateNotBeforeTimeSeconds = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "certificate_not_before_timestamp_seconds",
-				Help:      "The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.",
+				Help:      "The timestamp before which the certificate is invalid, expressed as a Unix Epoch Time.",
+			},
+			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
+		)
+
+		certificateNotAfterTimeSeconds = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "certificate_not_after_timestamp_seconds",
+				Help:      "The timestamp after which the certificate is invalid, expressed as a Unix Epoch Time.",
 			},
 			[]string{"name", "namespace", "issuer_name", "issuer_kind", "issuer_group"},
 		)
@@ -210,7 +220,8 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 
 		clockTimeSeconds:                   clockTimeSeconds,
 		clockTimeSecondsGauge:              clockTimeSecondsGauge,
-		certificateIssuanceTimeSeconds:     certificateIssuanceTimeSeconds,
+		certificateNotAfterTimeSeconds:     certificateNotAfterTimeSeconds,
+		certificateNotBeforeTimeSeconds:    certificateNotBeforeTimeSeconds,
 		certificateExpiryTimeSeconds:       certificateExpiryTimeSeconds,
 		certificateRenewalTimeSeconds:      certificateRenewalTimeSeconds,
 		certificateReadyStatus:             certificateReadyStatus,
@@ -228,7 +239,8 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.clockTimeSeconds)
 	m.registry.MustRegister(m.clockTimeSecondsGauge)
-	m.registry.MustRegister(m.certificateIssuanceTimeSeconds)
+	m.registry.MustRegister(m.certificateNotAfterTimeSeconds)
+	m.registry.MustRegister(m.certificateNotBeforeTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.certificateRenewalTimeSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -192,7 +192,10 @@ func TestMetricsController(t *testing.T) {
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
-# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# HELP certmanager_certificate_not_after_timestamp_seconds The timestamp after which the certificate is invalid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_not_after_timestamp_seconds gauge
+certmanager_certificate_not_after_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp before which the certificate is invalid, expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_not_before_timestamp_seconds gauge
 certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
@@ -234,7 +237,10 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
-# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# HELP certmanager_certificate_not_after_timestamp_seconds The timestamp after which the certificate is invalid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_not_after_timestamp_seconds gauge
+certmanager_certificate_not_after_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
+# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp before which the certificate is invalid, expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_not_before_timestamp_seconds gauge
 certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 200
 # HELP certmanager_certificate_ready_status The ready status of the certificate.

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -192,6 +192,9 @@ func TestMetricsController(t *testing.T) {
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+# HELP certmanager_certificate_issuance_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_issuance_timestamp_seconds gauge
+certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
@@ -209,6 +212,9 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	// Set Certificate Expiry and Ready status True
 	crt.Status.NotAfter = &metav1.Time{
 		Time: time.Unix(100, 0),
+	}
+	crt.Status.NotBefore = &metav1.Time{
+		Time: time.Unix(200, 0),
 	}
 	crt.Status.Conditions = []cmapi.CertificateCondition{
 		{
@@ -228,6 +234,9 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
+# HELP certmanager_certificate_issuance_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_issuance_timestamp_seconds gauge
+certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 200
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -192,9 +192,9 @@ func TestMetricsController(t *testing.T) {
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
-# HELP certmanager_certificate_issuance_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
-# TYPE certmanager_certificate_issuance_timestamp_seconds gauge
-certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
+# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_not_before_timestamp_seconds gauge
+certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
@@ -234,9 +234,9 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 	waitForMetrics(`# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 certmanager_certificate_expiration_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
-# HELP certmanager_certificate_issuance_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
-# TYPE certmanager_certificate_issuance_timestamp_seconds gauge
-certmanager_certificate_issuance_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 200
+# HELP certmanager_certificate_not_before_timestamp_seconds The timestamp after which the certificate is valid, expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_not_before_timestamp_seconds gauge
+certmanager_certificate_not_before_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 200
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
 certmanager_certificate_ready_status{condition="False",issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Currently, there are no metrics exposed for certificates that show information about when a certificate was issued. This makes it difficult to determine how long it will be until a certificate expires, relative to how long it was issued for. This is important for monitoring of renewals, as alerts and dashboards based around absolute threshold (e.g. an alert when a certificate is 2 weeks from expiring) are largely useless when using a mix of short lived and long lived certificates. This mix of short and long lived certificates is somewhat common, where root CAs may be issued for years, intermediary CAs issued for months, and leaf certs issued for days or hours.

To address this, this PR adds a `certmanager_certificate_not_before_timestamp_seconds` metric, who's value is the timestamp before which the certificate is invalid, expressed as a Unix Epoch Time. To keep naming consistent, a `certmanager_certificate_not_after_timestamp_seconds` metric has been added that is identical to the `certmanager_certificate_expiration_timestamp_seconds` metric.

Here's an example of what can be done with this metric + the existing ones:
![image](https://github.com/user-attachments/assets/35153251-94c5-46c4-9e5b-28175e79bfb3)


### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added certificate issuance and expiration time metrics (`certmanager_certificate_not_before_timestamp_seconds`, `certmanager_certificate_not_after_timestamp_seconds`).
```
