### PR TITLE
Lower the minimum certificate duration from 1 hour to 5 minutes

### DIFF
--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -774,9 +774,10 @@ func TestValidateCertificate(t *testing.T) {
 func TestValidateDuration(t *testing.T) {
 	usefulDurations := map[string]*metav1.Duration{
 		"one second":  {Duration: time.Second},
-		"ten minutes": {Duration: time.Minute * 10},
+		"one minute":  {Duration: time.Minute},
+		"two minutes": {Duration: time.Minute * 2},
 		"half hour":   {Duration: time.Minute * 30},
-		"one hour":    {Duration: time.Hour},
+		"one day":     {Duration: time.Hour * 24},
 		"one month":   {Duration: time.Hour * 24 * 30},
 		"half year":   {Duration: time.Hour * 24 * 180},
 		"one year":    {Duration: time.Hour * 24 * 365},
@@ -811,7 +812,7 @@ func TestValidateDuration(t *testing.T) {
 		"unset duration, valid renewBefore for default": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
-					RenewBefore: usefulDurations["one month"],
+					RenewBefore: usefulDurations["one day"],
 					CommonName:  "testcn",
 					SecretName:  "abc",
 					IssuerRef:   validIssuerRef,
@@ -865,7 +866,7 @@ func TestValidateDuration(t *testing.T) {
 		"renewBefore and renewBeforePercentage both set": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
-					RenewBefore:           usefulDurations["one month"],
+					RenewBefore:           usefulDurations["one day"],
 					RenewBeforePercentage: ptr.To(int32(95)),
 					CommonName:            "testcn",
 					SecretName:            "abc",
@@ -873,7 +874,7 @@ func TestValidateDuration(t *testing.T) {
 				},
 			},
 			errs: []*field.Error{
-				field.Invalid(fldPath.Child("renewBefore"), usefulDurations["one month"].Duration, "renewBefore and renewBeforePercentage are mutually exclusive and cannot both be set"),
+				field.Invalid(fldPath.Child("renewBefore"), usefulDurations["one day"].Duration, "renewBefore and renewBeforePercentage are mutually exclusive and cannot both be set"),
 				field.Invalid(fldPath.Child("renewBeforePercentage"), int32(95), "renewBefore and renewBeforePercentage are mutually exclusive and cannot both be set"),
 			},
 		},
@@ -923,14 +924,14 @@ func TestValidateDuration(t *testing.T) {
 		"duration is less than the minimum permitted value": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
-					Duration:    usefulDurations["half hour"],
-					RenewBefore: usefulDurations["ten minutes"],
+					Duration:    usefulDurations["two minutes"],
+					RenewBefore: usefulDurations["one minute"],
 					CommonName:  "testcn",
 					SecretName:  "abc",
 					IssuerRef:   validIssuerRef,
 				},
 			},
-			errs: []*field.Error{field.Invalid(fldPath.Child("duration"), usefulDurations["half hour"].Duration, fmt.Sprintf("certificate duration must be greater than %s", cmapi.MinimumCertificateDuration))},
+			errs: []*field.Error{field.Invalid(fldPath.Child("duration"), usefulDurations["two minutes"].Duration, fmt.Sprintf("certificate duration must be greater than %s", cmapi.MinimumCertificateDuration))},
 		},
 	}
 	for n, s := range scenarios {

--- a/pkg/apis/certmanager/v1/const.go
+++ b/pkg/apis/certmanager/v1/const.go
@@ -20,13 +20,13 @@ import "time"
 
 const (
 	// minimum permitted certificate duration by cert-manager
-	MinimumCertificateDuration = time.Hour
+	MinimumCertificateDuration = 5 * time.Minute
 
 	// default certificate duration if Issuer.spec.duration is not set
-	DefaultCertificateDuration = time.Hour * 24 * 90
+	DefaultCertificateDuration = time.Hour * 24 * 30
 
 	// minimum certificate duration before certificate expiration
-	MinimumRenewBefore = time.Minute * 5
+	MinimumRenewBefore = time.Minute
 
 	// Deprecated: the default is now 2/3 of Certificate's duration
 	DefaultRenewBefore = time.Hour * 24 * 30


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Cert-manager currently has a relatively high minimum certificate duration of one hour. Allowing users of cert-manager to set this to a lower value improves user security in several ways:
* If the key is compromised, a shorter duration reduces the usefulness of the key and the impact of the compromise
* In environments where CRLs and OCSP are not widely supported, keeping the duration short reduces the duration in which a certificate trusted after it has been "revoked" or deemed invalid

I've also lowered the default certificate duration from 90 days to 30. The industry has been moving in the direction of shorter and shorter lived certificates since x509 certs started seeing widespread adoption. In the past two years there have been proposals from Google and Apple to CA/Browser Forum proposing lowering the max duration for server auth certs from publicly-trusted CAs to 90 days, and 47 days. While there has been mixed feedback on these proposals, most of the arguments against short-lived certificates come from the lack of automation around renewals. Cert-manager provides this automation for the certs it managers, so users of cert-manager will now get the benefit of shorter-lived certificates (if they don't opt-out by setting the existing `duration` field) without the drawbacks of applying this to all publicly-trusted CAs.

While this change only lowers the _minimum_ and default issuance durations, it will probably break some user's setups that expect the current values, which have not changed in five years. If this change is accepted, the changelog and release notes for the next release should probably need to draw attention to this change rather having it "buried" with other changes.

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Lowered the minimum certificate duration from one hours to five minutes, and set the default certificate issuance duration to 30 days.
```
