### PR TITLE
Support custom ACME account key type.

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -152,6 +152,9 @@ spec:
                         - keyID
                         - keySecretRef
                       type: object
+                    keyType:
+                      description: KeyType is the type of the account key (RSA or ECC), such as "RSA2048", "RSA4096", "P256", "P384"
+                      type: string
                     preferredChain:
                       description: |-
                         PreferredChain is the chain to use if the ACME server outputs multiple.

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -151,6 +151,9 @@ spec:
                         - keyID
                         - keySecretRef
                       type: object
+                    keyType:
+                      description: KeyType is the type of the account key (RSA or ECC), such as "RSA2048", "RSA4096", "P256", "P384"
+                      type: string
                     preferredChain:
                       description: |-
                         PreferredChain is the chain to use if the ACME server outputs multiple.

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -152,6 +152,10 @@ spec:
                     - keyID
                     - keySecretRef
                     type: object
+                  keyType:
+                    description: KeyType is the type of the account key (RSA or ECC),
+                      such as "RSA2048", "RSA4096", "P256", "P384"
+                    type: string
                   preferredChain:
                     description: |-
                       PreferredChain is the chain to use if the ACME server outputs multiple.

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -151,6 +151,10 @@ spec:
                     - keyID
                     - keySecretRef
                     type: object
+                  keyType:
+                    description: KeyType is the type of the account key (RSA or ECC),
+                      such as "RSA2048", "RSA4096", "P256", "P384"
+                    type: string
                   preferredChain:
                     description: |-
                       PreferredChain is the chain to use if the ACME server outputs multiple.

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -106,6 +106,8 @@ type ACMEIssuer struct {
 	// Profile allows requesting a certificate profile from the ACME server.
 	// Supported profiles are listed by the server's ACME directory URL.
 	Profile string `json:"profile,omitempty"`
+
+	KeyType string
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -989,6 +989,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *acmev1.ACMEIssuer, out *ac
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
 	out.Profile = in.Profile
+	out.KeyType = in.KeyType
 	return nil
 }
 
@@ -1024,6 +1025,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *acme
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
 	out.Profile = in.Profile
+	out.KeyType = in.KeyType
 	return nil
 }
 

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -42,7 +42,7 @@ type NewClientOptions struct {
 	SkipTLSVerify bool
 	CABundle      []byte
 	Server        string
-	PrivateKey    *rsa.PrivateKey
+	PrivateKey    crypto.Signer
 }
 
 // NewClientFunc is a function type for building a new ACME client.

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"crypto/rsa"
+	"crypto"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -31,7 +31,7 @@ type FakeRegistry struct {
 	RemoveClientFunc        func(uid string)
 	GetClientFunc           func(uid string) (acmecl.Interface, error)
 	ListClientsFunc         func() map[string]acmecl.Interface
-	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 }
 
 func (f *FakeRegistry) AddClient(uid string, options accounts.NewClientOptions) {
@@ -50,6 +50,6 @@ func (f *FakeRegistry) ListClients() map[string]acmecl.Interface {
 	return f.ListClientsFunc()
 }
 
-func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	return f.IsKeyCheckSumCachedFunc(lastPrivateKeyHash, privateKey)
 }

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -119,6 +119,10 @@ type ACMEIssuer struct {
 	// Supported profiles are listed by the server's ACME directory URL.
 	// +optional
 	Profile string `json:"profile,omitempty"`
+
+	// KeyType is the type of the account key (RSA or ECC), such as "RSA2048", "RSA4096", "P256", "P384"
+	// +optional
+	KeyType string `json:"keyType,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
@@ -36,6 +36,7 @@ type ACMEIssuerApplyConfiguration struct {
 	DisableAccountKeyGeneration *bool                                         `json:"disableAccountKeyGeneration,omitempty"`
 	EnableDurationFeature       *bool                                         `json:"enableDurationFeature,omitempty"`
 	Profile                     *string                                       `json:"profile,omitempty"`
+	KeyType                     *string                                       `json:"keyType,omitempty"`
 }
 
 // ACMEIssuerApplyConfiguration constructs a declarative configuration of the ACMEIssuer type for use with
@@ -136,5 +137,13 @@ func (b *ACMEIssuerApplyConfiguration) WithEnableDurationFeature(value bool) *AC
 // If called multiple times, the Profile field is set to the value of the last call.
 func (b *ACMEIssuerApplyConfiguration) WithProfile(value string) *ACMEIssuerApplyConfiguration {
 	b.Profile = &value
+	return b
+}
+
+// WithKeyType sets the KeyType field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KeyType field is set to the value of the last call.
+func (b *ACMEIssuerApplyConfiguration) WithKeyType(value string) *ACMEIssuerApplyConfiguration {
+	b.KeyType = &value
 	return b
 }

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -66,8 +66,7 @@ func TestAcme_Setup(t *testing.T) {
 			gen.SetIssuerConditionLastTransitionTime(&nowMetaTime))
 		issuerSecretKeyName = "test"
 
-		ecdsaPrivKey = mustGenerateEDCSAKey(t)
-		rsaPrivKey   = mustGenerateRSAKey(t)
+		rsaPrivKey = mustGenerateRSAKey(t)
 
 		notFoundErr    = apierrors.NewNotFound(corev1.Resource("test"), "test")
 		invalidDataErr = errors.NewInvalidData("test")
@@ -209,16 +208,6 @@ func TestAcme_Setup(t *testing.T) {
 					gen.SetIssuerConditionMessage(messageAccountVerificationFailed+someErr.Error())),
 			},
 			wantsErr: true,
-		},
-		"ACME account's key is not an RSA key": {
-			issuer: gen.IssuerFrom(baseIssuer,
-				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
-			kfsKey: ecdsaPrivKey,
-			expectedConditions: []cmapi.IssuerCondition{
-				*gen.IssuerConditionFrom(readyFalseCondition,
-					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateNotRSA, issuerSecretKeyName))),
-			},
 		},
 		"ACME server URL is an invalid URL": {
 			issuer: gen.IssuerFrom(baseIssuer,
@@ -538,7 +527,7 @@ func TestAcme_Setup(t *testing.T) {
 				AddClientFunc: func(string, accounts.NewClientOptions) {
 					addClientWasCalled = true
 				},
-				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 					return true
 				},
 			}
@@ -638,15 +627,6 @@ func clientBuilderMock(cl acmecl.Interface) accounts.NewClientFunc {
 func parseURLErr(s string) error {
 	_, err := url.Parse(s)
 	return err
-}
-
-func mustGenerateEDCSAKey(t *testing.T) crypto.Signer {
-	t.Helper()
-	key, err := pki.GenerateECPrivateKey(256)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return key
 }
 
 func mustGenerateRSAKey(t *testing.T) crypto.Signer {

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -222,3 +222,19 @@ func PublicKeysEqual(a, b crypto.PublicKey) (bool, error) {
 		return false, fmt.Errorf("unrecognised public key type: %T", a)
 	}
 }
+
+func MarshalPrivateKey(privateKey crypto.Signer) []byte {
+	if privateKey == nil {
+		return nil
+	}
+	var privateKeyBytes []byte
+	switch key := privateKey.(type) {
+	case *rsa.PrivateKey:
+		privateKeyBytes = x509.MarshalPKCS1PrivateKey(key)
+	case *ecdsa.PrivateKey:
+		privateKeyBytes, _ = x509.MarshalECPrivateKey(key)
+	default:
+		return nil
+	}
+	return privateKeyBytes
+}


### PR DESCRIPTION
## Pull Request Motivation
fixes: #7510 
## Kind
/kind feature
## Release Note
```release-note
Add a new parameter `keyType` to support specifying the key type for ACME account.
```