### PR TITLE
[release-1.15] chore(issuer/cloudflare): ensure we set ZoneID

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -233,6 +233,10 @@ func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn, content string) (
 
 	for _, rec := range records {
 		if rec.Name == util.UnFqdn(fqdn) && rec.Content == content {
+			// Cloudflare made a breaking change to their API and removed the ZoneID from responses:
+			// https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-11-30
+			// The simplest fix is to set the ZoneID manually here
+			rec.ZoneID = zoneID
 			return &rec, nil
 		}
 	}


### PR DESCRIPTION
### Pull Request Motivation
Cloudflare have stopped including zone IDs in their record responses now. Ensure that findTxtRecord returns a record struct with the zone ID set. 

Fixes [7540](https://github.com/cert-manager/cert-manager/issues/7540)

### Kind

/kind bug

### Release Note


```release-note
Fix issuing of certificates via DNS01 challenges on Cloudflare after a breaking change to the Cloudflare API
```
