### PR TITLE
Fix Route53 unit test

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -286,6 +286,7 @@ func TestRoute53Present(t *testing.T) {
 }
 
 func TestAssumeRole(t *testing.T) {
+	t.Setenv("AWS_CONFIG_FILE", "/foo/bar")
 	creds := &ststypes.Credentials{
 		AccessKeyId:     aws.String("foo"),
 		SecretAccessKey: aws.String("bar"),

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -286,7 +286,9 @@ func TestRoute53Present(t *testing.T) {
 }
 
 func TestAssumeRole(t *testing.T) {
-	t.Setenv("AWS_CONFIG_FILE", "/foo/bar")
+	// Set the AWS config file to a non-existent file to ensure that the
+	// SDK does not load any local configuration.
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
 	creds := &ststypes.Credentials{
 		AccessKeyId:     aws.String("foo"),
 		SecretAccessKey: aws.String("bar"),


### PR DESCRIPTION
Hi,

The unit test for Route53 in `pkg/issuer/acme/dns/route53/` loads any existing AWS configuration which invalid the test.

This PR sets a dummy AWS configuration file by setting `AWS_CONFIG_FILE` to a non-existing file to ensure the AWS SDK loads without configuration.

Thanks for the Contribfest event in Kubecon London.
