### PR TITLE
Implement fallback for git_version creation in forked environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 # Git and versioning information #
 ##################################
 
-# Check if tags are available before running git describe and fail back to the GitHub API
+# Check if tags are available before running git describe and fall back to the GitHub API
 # This is necessary as helm package in the integration test would fail with no valid semver version
 # When forking this repo, you don't have tags by default
 # this enables easier onboarding for new contributors


### PR DESCRIPTION
### Pull Request Motivation

During the ContribFest Session at the KubeCon it came appearent that forks by default do not contain tags. This leads to issues for new contributors as helm package requires a valid semver version to be set in order to build successfully.
This PR introduces a fallback that pulls the latest tag from the Github API, so that new contributors can start more easily.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
