### PR TITLE
feat: allow server name to be set on the vault client

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -3540,6 +3540,11 @@ spec:
                     server:
                       description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
                       type: string
+                    serverName:
+                      description: |-
+                        ServerName is used to verify the hostname on the returned certificates
+                        by the Vault server.
+                      type: string
                 venafi:
                   description: |-
                     Venafi configures this issuer to sign certificates using a Venafi TPP

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -3540,6 +3540,11 @@ spec:
                     server:
                       description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
                       type: string
+                    serverName:
+                      description: |-
+                        ServerName is used to verify the hostname on the returned certificates
+                        by the Vault server.
+                      type: string
                 venafi:
                   description: |-
                     Venafi configures this issuer to sign certificates using a Venafi TPP

--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -179,6 +179,10 @@ type VaultIssuer struct {
 	// Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".
 	Server string
 
+	// ServerName is used to verify the hostname on the returned certificates
+	// by the Vault server.
+	ServerName string
+
 	// Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
 	// "my_pki_mount/sign/my-role-name".
 	Path string

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1578,6 +1578,7 @@ func autoConvert_v1_VaultIssuer_To_certmanager_VaultIssuer(in *v1.VaultIssuer, o
 		return err
 	}
 	out.Server = in.Server
+	out.ServerName = in.ServerName
 	out.Path = in.Path
 	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
@@ -1621,6 +1622,7 @@ func autoConvert_certmanager_VaultIssuer_To_v1_VaultIssuer(in *certmanager.Vault
 		return err
 	}
 	out.Server = in.Server
+	out.ServerName = in.ServerName
 	out.Path = in.Path
 	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -264,6 +264,10 @@ func (v *Vault) newConfig() (*vault.Config, error) {
 		cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{*clientCertificate}
 	}
 
+	if serverName := v.issuer.GetSpec().Vault.ServerName; len(serverName) != 0 {
+		cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.ServerName = serverName
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -200,6 +200,11 @@ type VaultIssuer struct {
 	// Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".
 	Server string `json:"server"`
 
+	// ServerName is used to verify the hostname on the returned certificates
+	// by the Vault server.
+	// +optional
+	ServerName string `json:"serverName,omitempty"`
+
 	// Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
 	// "my_pki_mount/sign/my-role-name".
 	Path string `json:"path"`


### PR DESCRIPTION
### Pull Request Motivation

Allows the server name used to validate Vault certificates to be configured. This is for the use case where Vault is hosted in cluster, has a public certificate, but you want to access it over the *.cluster.local address to avoid going out and back into the cluster.

resolves #7661

### Kind

/kind feature


### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add config to the Vault issuer to allow the server-name to be specified when validating the certificates the Vault server presents.
```
