### PR TITLE
feat: Add ClusterIssuer and Issuer metrics

### DIFF
--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -33,6 +33,7 @@ import (
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 )
 
 type controller struct {
@@ -62,6 +63,8 @@ type controller struct {
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
+
+	metrics *metrics.Metrics
 }
 
 // Register registers and constructs the controller using the provided context.
@@ -107,6 +110,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
 	c.clusterResourceNamespace = ctx.IssuerOptions.ClusterResourceNamespace
+	c.metrics = ctx.Metrics
 
 	return c.queue, mustSync, nil
 }
@@ -143,6 +147,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	issuer, err := c.clusterIssuerLister.Get(name)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
+			c.metrics.RemoveClusterIssuer(key)
 			log.Error(err, "clusterissuer in work queue no longer exists")
 			return nil
 		}
@@ -151,6 +156,10 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
+
+	// Update ClusterIssuer metrics
+	c.metrics.UpdateClusterIssuer(issuer)
+
 	return c.Sync(ctx, issuer)
 }
 

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -33,6 +33,7 @@ import (
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 )
 
 type controller struct {
@@ -58,6 +59,8 @@ type controller struct {
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
+
+	metrics *metrics.Metrics
 }
 
 // Register registers and constructs the controller using the provided context.
@@ -102,6 +105,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	c.cmClient = ctx.CMClient
 	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
+	c.metrics = ctx.Metrics
 
 	return c.queue, mustSync, nil
 }
@@ -136,6 +140,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	issuer, err := c.issuerLister.Issuers(namespace).Get(name)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
+			c.metrics.RemoveIssuer(key)
 			log.Error(err, "issuer in work queue no longer exists")
 			return nil
 		}
@@ -144,6 +149,10 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
+
+	// Update Issuer metrics
+	c.metrics.UpdateIssuer(issuer)
+
 	return c.Sync(ctx, issuer)
 }
 

--- a/pkg/metrics/clusterissuer.go
+++ b/pkg/metrics/clusterissuer.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specissfic language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+// UpdateClusterIssuer will update the given ClusterIssuer metrics for its expiry, renewal, and status
+// condition.
+func (m *Metrics) UpdateClusterIssuer(ciss *cmapi.ClusterIssuer) {
+	m.UpdateClusterIssuerStatus(ciss)
+}
+
+// UpdateClusterIssuerStatus will update the metric for that ClusterIssuer
+func (m *Metrics) UpdateClusterIssuerStatus(ciss *cmapi.ClusterIssuer) {
+	for _, c := range ciss.Status.Conditions {
+		if c.Type == cmapi.IssuerConditionReady {
+			m.UpdateClusterIssuerReadyStatus(ciss, c.Status)
+			return
+		}
+	}
+
+	// If no status condition set yet, set to Unknown
+	m.UpdateClusterIssuerReadyStatus(ciss, cmmeta.ConditionUnknown)
+}
+
+func (m *Metrics) UpdateClusterIssuerReadyStatus(ciss *cmapi.ClusterIssuer, current cmmeta.ConditionStatus) {
+	for _, condition := range readyConditionStatuses {
+		value := 0.0
+
+		if current == condition {
+			value = 1.0
+		}
+
+		m.clusterIssuerReadyStatus.With(prometheus.Labels{
+			"name":      ciss.Name,
+			"condition": string(condition),
+		}).Set(value)
+	}
+}
+
+// RemoveClusterIssuer will delete the ClusterIssuer metrics from continuing to be
+// exposed.
+func (m *Metrics) RemoveClusterIssuer(key types.NamespacedName) {
+	name := key.Name
+	m.clusterIssuerReadyStatus.DeletePartialMatch(prometheus.Labels{"name": name})
+}

--- a/pkg/metrics/clusterissuer_test.go
+++ b/pkg/metrics/clusterissuer_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	logtesting "github.com/go-logr/logr/testing"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+const cissReadyMetadata = `
+	# HELP certmanager_clusterissuer_ready_status The ready status of the clusterissuer
+	# TYPE certmanager_clusterissuer_ready_status gauge
+`
+
+func TestClusterIssuerMetrics(t *testing.T) {
+	type testT struct {
+		ciss          *cmapi.ClusterIssuer
+		expectedReady string
+	}
+	tests := map[string]testT{
+		"clusterissuer with ready status": {
+			ciss: gen.ClusterIssuer("test-clusterissuer"),
+			expectedReady: `
+		certmanager_clusterissuer_ready_status{condition="False",name="test-clusterissuer"} 0
+		certmanager_clusterissuer_ready_status{condition="True",name="test-clusterissuer"} 0
+		certmanager_clusterissuer_ready_status{condition="Unknown",name="test-clusterissuer"} 1
+`,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			m := New(logtesting.NewTestLogger(t), clock.RealClock{})
+			m.UpdateClusterIssuer(test.ciss)
+
+			if err := testutil.CollectAndCompare(m.clusterIssuerReadyStatus,
+				strings.NewReader(cissReadyMetadata+test.expectedReady),
+				"certmanager_clusterissuer_ready_status",
+			); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+
+			m.RemoveClusterIssuer(types.NamespacedName{
+				Name: "test-clusterissuer",
+			})
+
+			if testutil.CollectAndCount(m.clusterIssuerReadyStatus, "certmanager_clusterissuer_ready_status") != 0 {
+				t.Errorf("unexpected collecting result")
+			}
+		})
+	}
+}

--- a/pkg/metrics/issuer.go
+++ b/pkg/metrics/issuer.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the speissfic language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+// UpdateIssuer will update the given Issuer metrics for its expiry, renewal, and status
+// condition.
+func (m *Metrics) UpdateIssuer(iss *cmapi.Issuer) {
+	m.UpdateIssuerStatus(iss)
+}
+
+// UpdateIssuerStatus will update the metric for that Issuer
+func (m *Metrics) UpdateIssuerStatus(iss *cmapi.Issuer) {
+	for _, c := range iss.Status.Conditions {
+		if c.Type == cmapi.IssuerConditionReady {
+			m.UpdateIssuerReadyStatus(iss, c.Status)
+			return
+		}
+	}
+
+	// If no status condition set yet, set to Unknown
+	m.UpdateIssuerReadyStatus(iss, cmmeta.ConditionUnknown)
+}
+
+func (m *Metrics) UpdateIssuerReadyStatus(iss *cmapi.Issuer, current cmmeta.ConditionStatus) {
+	for _, condition := range readyConditionStatuses {
+		value := 0.0
+
+		if current == condition {
+			value = 1.0
+		}
+
+		m.issuerReadyStatus.With(prometheus.Labels{
+			"name":      iss.Name,
+			"namespace": iss.Namespace,
+			"condition": string(condition),
+		}).Set(value)
+	}
+}
+
+// RemoveIssuer will delete the Issuer metrics from continuing to be
+// exposed.
+func (m *Metrics) RemoveIssuer(key types.NamespacedName) {
+	namespace, name := key.Namespace, key.Name
+
+	m.issuerReadyStatus.DeletePartialMatch(prometheus.Labels{"name": name, "namespace": namespace})
+}

--- a/pkg/metrics/issuer_test.go
+++ b/pkg/metrics/issuer_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	logtesting "github.com/go-logr/logr/testing"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+const issReadyMetadata = `
+		# HELP certmanager_issuer_ready_status The ready status of the issuer
+		# TYPE certmanager_issuer_ready_status gauge
+`
+
+func TestIssuerMetrics(t *testing.T) {
+	type testT struct {
+		ciss          *cmapi.Issuer
+		expectedReady string
+	}
+	tests := map[string]testT{
+		"issuer with ready status": {
+			ciss: gen.Issuer("test-issuer", gen.SetIssuerNamespace("default")),
+			expectedReady: `
+		certmanager_issuer_ready_status{condition="False",name="test-issuer",namespace="default"} 0
+		certmanager_issuer_ready_status{condition="True",name="test-issuer",namespace="default"} 0
+		certmanager_issuer_ready_status{condition="Unknown",name="test-issuer",namespace="default"} 1
+`,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			m := New(logtesting.NewTestLogger(t), clock.RealClock{})
+			m.UpdateIssuer(test.ciss)
+
+			if err := testutil.CollectAndCompare(m.issuerReadyStatus,
+				strings.NewReader(issReadyMetadata+test.expectedReady),
+				"certmanager_issuer_ready_status",
+			); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+
+			m.RemoveIssuer(types.NamespacedName{
+				Name:      "test-issuer",
+				Namespace: "default",
+			})
+
+			if testutil.CollectAndCount(m.issuerReadyStatus, "certmanager_issuer_ready_status") != 0 {
+				t.Errorf("unexpected collecting result")
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -65,6 +65,8 @@ type Metrics struct {
 	venafiClientRequestDurationSeconds *prometheus.SummaryVec
 	controllerSyncCallCount            *prometheus.CounterVec
 	controllerSyncErrorCount           *prometheus.CounterVec
+	issuerReadyStatus                  *prometheus.GaugeVec
+	clusterIssuerReadyStatus           *prometheus.GaugeVec
 }
 
 var readyConditionStatuses = [...]cmmeta.ConditionStatus{cmmeta.ConditionTrue, cmmeta.ConditionFalse, cmmeta.ConditionUnknown}
@@ -205,6 +207,24 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			},
 			[]string{"controller"},
 		)
+
+		clusterIssuerReadyStatus = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "clusterissuer_ready_status",
+				Help:      "The ready status of the clusterissuer",
+			},
+			[]string{"name", "condition"},
+		)
+
+		issuerReadyStatus = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "issuer_ready_status",
+				Help:      "The ready status of the issuer",
+			},
+			[]string{"name", "namespace", "condition"},
+		)
 	)
 
 	// Create Registry and register the recommended collectors
@@ -230,6 +250,8 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		venafiClientRequestDurationSeconds: venafiClientRequestDurationSeconds,
 		controllerSyncCallCount:            controllerSyncCallCount,
 		controllerSyncErrorCount:           controllerSyncErrorCount,
+		clusterIssuerReadyStatus:           clusterIssuerReadyStatus,
+		issuerReadyStatus:                  issuerReadyStatus,
 	}
 
 	return m
@@ -249,6 +271,8 @@ func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.acmeClientRequestCount)
 	m.registry.MustRegister(m.controllerSyncCallCount)
 	m.registry.MustRegister(m.controllerSyncErrorCount)
+	m.registry.MustRegister(m.clusterIssuerReadyStatus)
+	m.registry.MustRegister(m.issuerReadyStatus)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}))


### PR DESCRIPTION
### Pull Request Motivation

Hello,

This PR introduces new built-in "Ready" status metrics for both ClusterIssuer and Issuer resources in cert-manager.

These metrics are particularly useful for operators who want to be alerted when an Issuer or ClusterIssuer becomes unhealthy. While this data can currently be extracted via kube-state-metrics, having native support within cert-manager simplifies observability and reduces external dependencies for users who prefer not to rely on kube-state-metrics.

I briefly discussed this feature with @erikgb during KubeCon 2025 in London, at the cert-manager booth, and wanted to follow up with a concrete implementation.

Relevant existing issue: https://github.com/cert-manager/cert-manager/issues/6312

### Kind

/kind feature


### Release Note

```release-note
Add built-in "Ready" status metrics for ClusterIssuer and Issuer resources.
```
