### PR TITLE
WIP: Add cookie jar to Acme client

### DIFF
--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"time"
 
 	acmeapi "golang.org/x/crypto/acme"
@@ -84,6 +85,11 @@ func BuildHTTPClientWithCABundle(metrics *metrics.Metrics, skipTLSVerify bool, c
 		}
 	}
 
+	jar, err := cookiejar.New(nil)
+	if err != nil { 
+  		panic(err)
+	}
+
 	return acmecl.NewInstrumentedClient(
 		metrics,
 		&http.Client{
@@ -100,6 +106,7 @@ func BuildHTTPClientWithCABundle(metrics *metrics.Metrics, skipTLSVerify bool, c
 				ExpectContinueTimeout: 1 * time.Second,
 			},
 			Timeout: defaultACMEHTTPTimeout,
+			Jar: jar,
 		},
 	)
 }


### PR DESCRIPTION
Adding cookie jar to acme client, for acme servers that are behind L7 http proxies (such as AWS ALB) that rely on cookies for stickiness (required for nonce)

