### PR TITLE
More fine-grained control over powerful RBAC permission granted via Helm chart

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -122,6 +122,13 @@ Create required ClusterRoles and ClusterRoleBindings for cert-manager.
 > ```
 
 Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
+#### **global.rbac.useControllerChallengesRole** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+By default, we will be deploying the controller-challenges role but if you want to use your own roles, please set this to false.
 #### **global.podSecurityPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -122,13 +122,27 @@ Create required ClusterRoles and ClusterRoleBindings for cert-manager.
 > ```
 
 Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
-#### **global.rbac.useACME** ~ `bool`
+#### **global.rbac.useHttpChallengesRole** ~ `bool`
 > Default value:
 > ```yaml
 > true
 > ```
 
-By default, we will be deploying the controller-challenges and controller-orders role but if you want to use your own roles, please set this to false.
+By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to false.
+#### **global.rbac.useDNSChallengesRole** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.
+#### **global.rbac.useOrderRole** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+By default, we will be deploying the controller-orders role but if you want to use your own roles, please set this to false.
 #### **global.podSecurityPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -128,7 +128,7 @@ Aggregate ClusterRoles to Kubernetes default user-facing roles. For more informa
 > false
 > ```
 
-By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to true.
+To use HTTP-01 ACME challenges, cert-manager needs extra permissions to create pods. If you want to avoid this added permission and disable HTTP-01 set this value.
 #### **global.podSecurityPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -128,7 +128,7 @@ Aggregate ClusterRoles to Kubernetes default user-facing roles. For more informa
 > true
 > ```
 
-By default, we will be deploying the controller-challenges role but if you want to use your own roles, please set this to false.
+By default, we will be deploying the controller-challenges and controller-orders role but if you want to use your own roles, please set this to false.
 #### **global.podSecurityPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -122,27 +122,13 @@ Create required ClusterRoles and ClusterRoleBindings for cert-manager.
 > ```
 
 Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
-#### **global.rbac.useHTTPChallengesRole** ~ `bool`
+#### **global.rbac.disableHTTPChallengesRole** ~ `bool`
 > Default value:
 > ```yaml
-> true
+> false
 > ```
 
-By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to false.
-#### **global.rbac.useDNSChallengesRole** ~ `bool`
-> Default value:
-> ```yaml
-> true
-> ```
-
-By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.
-#### **global.rbac.useOrdersRole** ~ `bool`
-> Default value:
-> ```yaml
-> true
-> ```
-
-By default, we will be deploying the controller-orders role but if you want to use your own roles, please set this to false.
+By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to true.
 #### **global.podSecurityPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -122,7 +122,7 @@ Create required ClusterRoles and ClusterRoleBindings for cert-manager.
 > ```
 
 Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
-#### **global.rbac.useControllerChallengesRole** ~ `bool`
+#### **global.rbac.useACME** ~ `bool`
 > Default value:
 > ```yaml
 > true

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -122,7 +122,7 @@ Create required ClusterRoles and ClusterRoleBindings for cert-manager.
 > ```
 
 Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
-#### **global.rbac.useHttpChallengesRole** ~ `bool`
+#### **global.rbac.useHTTPChallengesRole** ~ `bool`
 > Default value:
 > ```yaml
 > true
@@ -136,7 +136,7 @@ By default, we will be deploying the http01 controller-challenges but if you wan
 > ```
 
 By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.
-#### **global.rbac.useOrderRole** ~ `bool`
+#### **global.rbac.useOrdersRole** ~ `bool`
 > Default value:
 > ```yaml
 > true

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -179,7 +179,7 @@ rules:
 ---
 
 # Orders controller role
-{{ if .Values.global.rbac.useACME }}
+{{ if .Values.global.rbac.useOrdersRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -216,14 +216,15 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 {{- end }}
+
 ---
 
-# Challenges controller role
-{{ if .Values.global.rbac.useACME }}
+# HTTP01 Challenges controller role
+{{ if .Values.global.rbac.useHttpChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-controller-challenges
+  name: {{ template "cert-manager.fullname" . }}-http01-controller-challenges
   labels:
     app: {{ include "cert-manager.name" . }}
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
@@ -251,6 +252,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: [ "acme.cert-manager.io" ]
+    resources: [ "challenges/finalizers" ]
+    verbs: [ "update" ]
   # HTTP01 rules
   - apiGroups: [""]
     resources: ["pods", "services"]
@@ -267,6 +274,43 @@ rules:
   - apiGroups: ["route.openshift.io"]
     resources: ["routes/custom-host"]
     verbs: ["create"]
+{{- end }}
+
+---
+
+# DNS01 Challenges controller role
+{{ if .Values.global.rbac.useDNSChallengesRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-dns01-controller-challenges
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update", "patch"]
+  # Used to watch challenge resources
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "watch"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
@@ -278,6 +322,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
 {{- end }}
+
 ---
 
 # ingress-shim controller role
@@ -381,7 +426,8 @@ subjects:
     kind: ServiceAccount
 
 ---
-{{ if .Values.global.rbac.useACME }}
+
+{{ if .Values.global.rbac.useOrdersRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -401,13 +447,14 @@ subjects:
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
 {{- end}}
+
 ---
 
-{{ if .Values.global.rbac.useACME }}
+{{ if .Values.global.rbac.useHttpChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-controller-challenges
+  name: {{ template "cert-manager.fullname" . }}-http01-controller-challenges
   labels:
     app: {{ include "cert-manager.name" . }}
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
@@ -417,7 +464,30 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "cert-manager.fullname" . }}-controller-challenges
+  name: {{ template "cert-manager.fullname" . }}-http01-controller-challenges
+subjects:
+  - name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ include "cert-manager.namespace" . }}
+    kind: ServiceAccount
+{{- end }}
+
+---
+
+{{ if .Values.global.rbac.useDNSChallengesRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-dns01-controller-challenges
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cert-manager.fullname" . }}-dns01-controller-challenges
 subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -220,7 +220,7 @@ rules:
 ---
 
 # HTTP01 Challenges controller role
-{{ if .Values.global.rbac.useHttpChallengesRole }}
+{{ if .Values.global.rbac.useHTTPChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -450,7 +450,7 @@ subjects:
 
 ---
 
-{{ if .Values.global.rbac.useHttpChallengesRole }}
+{{ if .Values.global.rbac.useHTTPChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -444,7 +444,7 @@ subjects:
 
 ---
 
-{{ if .Values.global.rbac.useHTTPChallengesRole }}
+{{ if .Values.global.rbac.disableHTTPChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -179,7 +179,6 @@ rules:
 ---
 
 # Orders controller role
-{{ if .Values.global.rbac.useOrdersRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -215,12 +214,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-{{- end }}
 
 ---
 
 # HTTP01 Challenges controller role
-{{ if .Values.global.rbac.useHTTPChallengesRole }}
+{{ if not .Values.global.rbac.disableHTTPChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -279,7 +277,6 @@ rules:
 ---
 
 # DNS01 Challenges controller role
-{{ if .Values.global.rbac.useDNSChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -321,7 +318,6 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-{{- end }}
 
 ---
 
@@ -427,7 +423,6 @@ subjects:
 
 ---
 
-{{ if .Values.global.rbac.useOrdersRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -446,7 +441,6 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
-{{- end}}
 
 ---
 
@@ -473,7 +467,6 @@ subjects:
 
 ---
 
-{{ if .Values.global.rbac.useDNSChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -492,7 +485,6 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
-{{- end }}
 
 ---
 

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -444,7 +444,7 @@ subjects:
 
 ---
 
-{{ if .Values.global.rbac.disableHTTPChallengesRole }}
+{{ if not .Values.global.rbac.disableHTTPChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -179,7 +179,7 @@ rules:
 ---
 
 # Orders controller role
-{{ if .Values.global.rbac.useControllerChallengesRole }}
+{{ if .Values.global.rbac.useACME }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -219,7 +219,7 @@ rules:
 ---
 
 # Challenges controller role
-{{ if .Values.global.rbac.useControllerChallengesRole }}
+{{ if .Values.global.rbac.useACME }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -381,7 +381,7 @@ subjects:
     kind: ServiceAccount
 
 ---
-{{ if .Values.global.rbac.useControllerChallengesRole }}
+{{ if .Values.global.rbac.useACME }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -403,7 +403,7 @@ subjects:
 {{- end}}
 ---
 
-{{ if .Values.global.rbac.useControllerChallengesRole }}
+{{ if .Values.global.rbac.useACME }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -179,6 +179,7 @@ rules:
 ---
 
 # Orders controller role
+{{ if .Values.global.rbac.useControllerChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -214,7 +215,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-
+{{- end }}
 ---
 
 # Challenges controller role
@@ -380,7 +381,7 @@ subjects:
     kind: ServiceAccount
 
 ---
-
+{{ if .Values.global.rbac.useControllerChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -399,7 +400,7 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
-
+{{- end}}
 ---
 
 {{ if .Values.global.rbac.useControllerChallengesRole }}

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -218,6 +218,7 @@ rules:
 ---
 
 # Challenges controller role
+{{ if .Values.global.rbac.useControllerChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -275,7 +276,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-
+{{- end }}
 ---
 
 # ingress-shim controller role
@@ -401,6 +402,7 @@ subjects:
 
 ---
 
+{{ if .Values.global.rbac.useControllerChallengesRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -419,6 +421,7 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
+{{- end }}
 
 ---
 

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -796,6 +796,9 @@
         },
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
+        },
+        "selfSigned": {
+          "$ref": "#/$defs/helm-values.global.rbac.selfSigned"
         }
       },
       "type": "object"
@@ -808,6 +811,11 @@
     "helm-values.global.rbac.create": {
       "default": true,
       "description": "Create required ClusterRoles and ClusterRoleBindings for cert-manager.",
+      "type": "boolean"
+    },
+    "helm-values.global.rbac.selfSigned": {
+      "default": false,
+      "description": "Using self-signed certificates",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -815,7 +815,7 @@
     },
     "helm-values.global.rbac.disableHTTPChallengesRole": {
       "default": false,
-      "description": "By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to true.",
+      "description": "To use HTTP-01 ACME challenges, cert-manager needs extra permissions to create pods. If you want to avoid this added permission and disable HTTP-01 set this value.",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -797,8 +797,8 @@
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
         },
-        "useControllerChallengesRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useControllerChallengesRole"
+        "useACME": {
+          "$ref": "#/$defs/helm-values.global.rbac.useACME"
         }
       },
       "type": "object"
@@ -813,7 +813,7 @@
       "description": "Create required ClusterRoles and ClusterRoleBindings for cert-manager.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.useControllerChallengesRole": {
+    "helm-values.global.rbac.useACME": {
       "default": true,
       "description": "By default, we will be deploying the controller-challenges role but if you want to use your own roles, please set this to false.",
       "type": "boolean"

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -800,11 +800,11 @@
         "useDNSChallengesRole": {
           "$ref": "#/$defs/helm-values.global.rbac.useDNSChallengesRole"
         },
-        "useHttpChallengesRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useHttpChallengesRole"
+        "useHTTPChallengesRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useHTTPChallengesRole"
         },
-        "useOrderRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useOrderRole"
+        "useOrdersRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useOrdersRole"
         }
       },
       "type": "object"
@@ -824,12 +824,12 @@
       "description": "By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.useHttpChallengesRole": {
+    "helm-values.global.rbac.useHTTPChallengesRole": {
       "default": true,
       "description": "By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to false.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.useOrderRole": {
+    "helm-values.global.rbac.useOrdersRole": {
       "default": true,
       "description": "By default, we will be deploying the controller-orders role but if you want to use your own roles, please set this to false.",
       "type": "boolean"

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -814,8 +814,8 @@
       "type": "boolean"
     },
     "helm-values.global.rbac.useControllerChallengesRole": {
-      "default": false,
-      "description": "Using self-signed certificates",
+      "default": true,
+      "description": "By default, we will be deploying the controller-challenges role but if you want to use your own roles, please set this to false.",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -797,14 +797,8 @@
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
         },
-        "useDNSChallengesRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useDNSChallengesRole"
-        },
-        "useHTTPChallengesRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useHTTPChallengesRole"
-        },
-        "useOrdersRole": {
-          "$ref": "#/$defs/helm-values.global.rbac.useOrdersRole"
+        "disableHTTPChallengesRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.disableHTTPChallengesRole"
         }
       },
       "type": "object"
@@ -819,19 +813,9 @@
       "description": "Create required ClusterRoles and ClusterRoleBindings for cert-manager.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.useDNSChallengesRole": {
-      "default": true,
-      "description": "By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.",
-      "type": "boolean"
-    },
-    "helm-values.global.rbac.useHTTPChallengesRole": {
-      "default": true,
-      "description": "By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to false.",
-      "type": "boolean"
-    },
-    "helm-values.global.rbac.useOrdersRole": {
-      "default": true,
-      "description": "By default, we will be deploying the controller-orders role but if you want to use your own roles, please set this to false.",
+    "helm-values.global.rbac.disableHTTPChallengesRole": {
+      "default": false,
+      "description": "By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to true.",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -815,7 +815,7 @@
     },
     "helm-values.global.rbac.useACME": {
       "default": true,
-      "description": "By default, we will be deploying the controller-challenges role but if you want to use your own roles, please set this to false.",
+      "description": "By default, we will be deploying the controller-challenges and controller-orders role but if you want to use your own roles, please set this to false.",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -797,8 +797,14 @@
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
         },
-        "useACME": {
-          "$ref": "#/$defs/helm-values.global.rbac.useACME"
+        "useDNSChallengesRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useDNSChallengesRole"
+        },
+        "useHttpChallengesRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useHttpChallengesRole"
+        },
+        "useOrderRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useOrderRole"
         }
       },
       "type": "object"
@@ -813,9 +819,19 @@
       "description": "Create required ClusterRoles and ClusterRoleBindings for cert-manager.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.useACME": {
+    "helm-values.global.rbac.useDNSChallengesRole": {
       "default": true,
-      "description": "By default, we will be deploying the controller-challenges and controller-orders role but if you want to use your own roles, please set this to false.",
+      "description": "By default, we will be deploying the dns01 controller-challenges but if you want to use your own roles, please set this to false.",
+      "type": "boolean"
+    },
+    "helm-values.global.rbac.useHttpChallengesRole": {
+      "default": true,
+      "description": "By default, we will be deploying the http01 controller-challenges but if you want to use your own roles, please set this to false.",
+      "type": "boolean"
+    },
+    "helm-values.global.rbac.useOrderRole": {
+      "default": true,
+      "description": "By default, we will be deploying the controller-orders role but if you want to use your own roles, please set this to false.",
       "type": "boolean"
     },
     "helm-values.global.revisionHistoryLimit": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -797,8 +797,8 @@
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
         },
-        "selfSigned": {
-          "$ref": "#/$defs/helm-values.global.rbac.selfSigned"
+        "useControllerChallengesRole": {
+          "$ref": "#/$defs/helm-values.global.rbac.useControllerChallengesRole"
         }
       },
       "type": "object"
@@ -813,7 +813,7 @@
       "description": "Create required ClusterRoles and ClusterRoleBindings for cert-manager.",
       "type": "boolean"
     },
-    "helm-values.global.rbac.selfSigned": {
+    "helm-values.global.rbac.useControllerChallengesRole": {
       "default": false,
       "description": "Using self-signed certificates",
       "type": "boolean"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -33,8 +33,9 @@ global:
     create: true
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
-    # Using self-signed certificates
-    useControllerChallengesRole: false
+    # By default, we will be deploying the controller-challenges role but if you want to use
+    # your own roles, please set this to false.
+    useControllerChallengesRole: true
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -33,6 +33,8 @@ global:
     create: true
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
+    # Using self-signed certificates
+    useControllerChallengesRole: false
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -34,14 +34,8 @@ global:
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
     # By default, we will be deploying the http01 controller-challenges but if you want to use
-    # your own roles, please set this to false.
-    useHTTPChallengesRole: true
-    # By default, we will be deploying the dns01 controller-challenges but if you want to use
-    # your own roles, please set this to false.
-    useDNSChallengesRole: true
-    # By default, we will be deploying the controller-orders role but if you want to use
-    # your own roles, please set this to false.
-    useOrdersRole: true
+    # your own roles, please set this to true.
+    disableHTTPChallengesRole: false
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -33,8 +33,8 @@ global:
     create: true
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
-    # By default, we will be deploying the http01 controller-challenges but if you want to use
-    # your own roles, please set this to true.
+    # To use HTTP-01 ACME challenges, cert-manager needs extra permissions to create pods.
+    # If you want to avoid this added permission and disable HTTP-01 set this value.
     disableHTTPChallengesRole: false
 
   podSecurityPolicy:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -33,9 +33,15 @@ global:
     create: true
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
-    # By default, we will be deploying the controller-challenges and controller-orders role but if you want to use
+    # By default, we will be deploying the http01 controller-challenges but if you want to use
     # your own roles, please set this to false.
-    useACME: true
+    useHttpChallengesRole: true
+    # By default, we will be deploying the dns01 controller-challenges but if you want to use
+    # your own roles, please set this to false.
+    useDNSChallengesRole: true
+    # By default, we will be deploying the controller-orders role but if you want to use
+    # your own roles, please set this to false.
+    useOrderRole: true
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -35,13 +35,13 @@ global:
     aggregateClusterRoles: true
     # By default, we will be deploying the http01 controller-challenges but if you want to use
     # your own roles, please set this to false.
-    useHttpChallengesRole: true
+    useHTTPChallengesRole: true
     # By default, we will be deploying the dns01 controller-challenges but if you want to use
     # your own roles, please set this to false.
     useDNSChallengesRole: true
     # By default, we will be deploying the controller-orders role but if you want to use
     # your own roles, please set this to false.
-    useOrderRole: true
+    useOrdersRole: true
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -33,7 +33,7 @@ global:
     create: true
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
     aggregateClusterRoles: true
-    # By default, we will be deploying the controller-challenges role but if you want to use
+    # By default, we will be deploying the controller-challenges and controller-orders role but if you want to use
     # your own roles, please set this to false.
     useACME: true
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -35,7 +35,7 @@ global:
     aggregateClusterRoles: true
     # By default, we will be deploying the controller-challenges role but if you want to use
     # your own roles, please set this to false.
-    useControllerChallengesRole: true
+    useACME: true
 
   podSecurityPolicy:
     # Create PodSecurityPolicy for cert-manager.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
This open [issue](https://github.com/cert-manager/cert-manager/issues/7598) highlights that the ClusterRole `...-controller-challenges` would be able to create arbitrary pods in any namespace which means that an attacker who compromised the cert-manager controller could probably escalate their privileges to cluster-admin level. For this reason some people deploy their own roles to prevent this from happening and turning off the deployment of rbac via `global.rbac.create` means they have to deploy all the roles on their own. This PR provides a more fine-grained way of turning off the challenger role only.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Adds the `global.rbac.disableHTTPChallengesRole` helm value to disable HTTP-01 ACME challenges. This allows cert-manager to drop its permission to create pods, improving security when HTTP-01 challenges are not required.
```
