### PR TITLE
Migrate usage of deprecated logr testing package

### DIFF
--- a/internal/controller/certificates/policies/gatherer_test.go
+++ b/internal/controller/certificates/policies/gatherer_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -145,7 +145,7 @@ func TestDataForCertificate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			fakeClockStart, _ := time.Parse(time.RFC3339, "2021-01-02T15:04:05Z07:00")
-			log := logtesting.NewTestLogger(t)
+			log := testr.New(t)
 			turnOnKlogIfVerboseTest()
 
 			test.builder.T = t

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -411,7 +411,7 @@ func TestCertificateRequestsToDelete(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			log := logtesting.NewTestLogger(t)
+			log := testr.New(t)
 			output := certificateRequestsToDelete(log, test.limit, test.input)
 			if !reflect.DeepEqual(test.exp, output) {
 				t.Errorf("unexpected prune sort response, exp=%v got=%v",

--- a/pkg/controller/certificates/trigger/trigger_controller_test.go
+++ b/pkg/controller/certificates/trigger/trigger_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -818,7 +818,7 @@ func Test_shouldBackoffReissuingOnFailure(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotBackoff, gotDelay := shouldBackoffReissuingOnFailure(logtesting.NewTestLogger(t), clock, test.givenCert, test.givenNextCR)
+			gotBackoff, gotDelay := shouldBackoffReissuingOnFailure(testr.New(t), clock, test.givenCert, test.givenNextCR)
 			assert.Equal(t, test.wantBackoff, gotBackoff)
 			assert.Equal(t, test.wantDelay, gotDelay)
 		})

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -246,7 +246,7 @@ func TestCertificateMetrics(t *testing.T) {
 	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
-			m := New(logtesting.NewTestLogger(t), clock.RealClock{})
+			m := New(testr.New(t), clock.RealClock{})
 			m.UpdateCertificate(test.crt)
 
 			if err := testutil.CollectAndCompare(m.certificateNotAfterTimeSeconds,
@@ -288,7 +288,7 @@ func TestCertificateMetrics(t *testing.T) {
 }
 
 func TestCertificateCache(t *testing.T) {
-	m := New(logtesting.NewTestLogger(t), clock.RealClock{})
+	m := New(testr.New(t), clock.RealClock{})
 
 	crt1 := gen.Certificate("crt1",
 		gen.SetCertificateUID("uid-1"),

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 
 func Test_clockTimeSeconds(t *testing.T) {
 	fixedClock := fakeclock.NewFakeClock(time.Now())
-	m := New(logtesting.NewTestLogger(t), fixedClock)
+	m := New(testr.New(t), fixedClock)
 
 	tests := map[string]struct {
 		metricName string

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	testlogr "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +43,7 @@ import (
 // Integration tests for the authority can be found in `test/integration/webhook/dynamic_authority_test.go`.
 
 func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAuthority {
-	logger := testlogr.NewTestLoggerWithOptions(t, testlogr.Options{
+	logger := testr.NewWithOptions(t, testr.Options{
 		Verbosity: 3,
 	})
 	logger = logger.WithName(name)

--- a/pkg/server/tls/file_source_test.go
+++ b/pkg/server/tls/file_source_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"golang.org/x/sync/errgroup"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -56,9 +56,9 @@ func TestFileSource_ReadsFile(t *testing.T) {
 		CertPath:       certFile,
 		KeyPath:        pkFile,
 		UpdateInterval: interval,
-		log:            logtesting.NewTestLogger(t),
+		log:            testr.New(t),
 	}
-	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)))
+	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), testr.New(t)))
 	errGroup := new(errgroup.Group)
 	errGroup.Go(func() error {
 		return source.Start(ctx)
@@ -107,7 +107,7 @@ func TestFileSource_UpdatesFile(t *testing.T) {
 		KeyPath:        pkFile,
 		UpdateInterval: interval,
 	}
-	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)))
+	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), testr.New(t)))
 	errGroup := new(errgroup.Group)
 	errGroup.Go(func() error {
 		return source.Start(ctx)

--- a/test/integration/rfc2136_dns01/provider_test.go
+++ b/test/integration/rfc2136_dns01/provider_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ import (
 )
 
 func TestRunSuiteWithTSIG(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:             t,
 		Zones:         []string{rfc2136TestZone},
@@ -75,7 +75,7 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 }
 
 func TestRunSuiteNoTSIG(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:     t,
 		Zones: []string{rfc2136TestZone},

--- a/test/integration/rfc2136_dns01/rfc2136_test.go
+++ b/test/integration/rfc2136_dns01/rfc2136_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +52,7 @@ var (
 const defaultPort = "53"
 
 func TestRFC2136CanaryLocalTestServer(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:       t,
 		Zones:   []string{rfc2136TestZone},
@@ -79,7 +79,7 @@ func TestRFC2136CanaryLocalTestServer(t *testing.T) {
 }
 
 func TestRFC2136ServerSuccess(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:       t,
 		Zones:   []string{rfc2136TestZone},
@@ -104,7 +104,7 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 }
 
 func TestRFC2136ServerError(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:       t,
 		Zones:   []string{rfc2136TestZone},
@@ -131,7 +131,7 @@ func TestRFC2136ServerError(t *testing.T) {
 }
 
 func TestRFC2136TsigClient(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:             t,
 		Zones:         []string{rfc2136TestZone},
@@ -320,7 +320,7 @@ func TestRFC2136InvalidTSIGAlgorithm(t *testing.T) {
 }
 
 func TestRFC2136ValidUpdatePacket(t *testing.T) {
-	ctx := logf.NewContext(context.TODO(), logtesting.NewTestLogger(t), t.Name())
+	ctx := logf.NewContext(context.TODO(), testr.New(t), t.Name())
 	server := &testserver.BasicServer{
 		T:     t,
 		Zones: []string{rfc2136TestZone},

--- a/test/integration/webhook/dynamic_authority_test.go
+++ b/test/integration/webhook/dynamic_authority_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ import (
 // Ensure that when the controller is running against an empty API server, it
 // creates and stores a new CA keypair.
 func TestDynamicAuthority_Bootstrap(t *testing.T) {
-	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)), time.Second*40)
+	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), testr.New(t)), time.Second*40)
 	defer cancel()
 
 	config, stop := framework.RunControlPlane(t, ctx)
@@ -93,7 +93,7 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 // Ensures that when the controller is running and the CA Secret is deleted,
 // it is automatically recreated within a bounded amount of time.
 func TestDynamicAuthority_Recreates(t *testing.T) {
-	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)), time.Second*40)
+	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), testr.New(t)), time.Second*40)
 	defer cancel()
 
 	config, stop := framework.RunControlPlane(t, ctx)

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ import (
 // Ensure that when the source is running against an apiserver, it bootstraps
 // a CA and signs a valid certificate.
 func TestDynamicSource_Bootstrap(t *testing.T) {
-	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)), time.Second*40)
+	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), testr.New(t)), time.Second*40)
 	defer cancel()
 
 	config, stop := framework.RunControlPlane(t, ctx)
@@ -110,7 +110,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 // Ensure that when the source is running against an apiserver, it bootstraps
 // a CA and signs a valid certificate.
 func TestDynamicSource_CARotation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)), time.Second*40)
+	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), testr.New(t)), time.Second*40)
 	defer cancel()
 
 	config, stop := framework.RunControlPlane(t, ctx)
@@ -223,7 +223,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 func TestDynamicSource_leaderelection(t *testing.T) {
 	const nrManagers = 2 // number of managers to start for this test
 
-	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), logtesting.NewTestLogger(t)), time.Second*40)
+	ctx, cancel := context.WithTimeout(logr.NewContext(context.Background(), testr.New(t)), time.Second*40)
 	defer cancel()
 
 	env, stop := apiserver.RunBareControlPlane(t)

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	logtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -56,7 +56,7 @@ type ServerOptions struct {
 }
 
 func StartWebhookServer(t *testing.T, ctx context.Context, args []string, argumentsForNewServerWithOptions ...func(*server.Server)) (ServerOptions, StopFunc) {
-	log := logtesting.NewTestLogger(t)
+	log := testr.New(t)
 
 	fs := pflag.NewFlagSet("testset", pflag.ExitOnError)
 	webhookFlags := options.NewWebhookFlags()


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While looking at some code I want to work with, I noticed that the [logr testing package](https://pkg.go.dev/github.com/go-logr/logr@v1.4.2/testing) is deprecated. This PR migrates all usage to the replacement [testr package](https://pkg.go.dev/github.com/go-logr/logr@v1.4.2/testr).

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
