### PR TITLE
Fix behavior when running with --namespace=<namespace>

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/controller"
-	"github.com/cert-manager/cert-manager/pkg/controller/clusterissuers"
 	"github.com/cert-manager/cert-manager/pkg/healthz"
 	dnsutil "github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -108,7 +107,6 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 		server.WithTLSCipherSuites(opts.MetricsTLSConfig.CipherSuites),
 		server.WithTLSMinVersion(opts.MetricsTLSConfig.MinTLSVersion),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to listen on prometheus address %s: %v", opts.MetricsListenAddress, err)
 	}
@@ -223,12 +221,6 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 		// only run a controller if it's been enabled
 		if !enabledControllers.Has(n) {
 			log.V(logf.InfoLevel).Info("skipping disabled controller")
-			continue
-		}
-
-		// don't run clusterissuers controller if scoped to a single namespace
-		if ctx.Namespace != "" && n == clusterissuers.ControllerName {
-			log.V(logf.InfoLevel).Info("skipping as cert-manager is scoped to a single namespace")
 			continue
 		}
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -267,5 +267,12 @@ func EnabledControllers(o *config.ControllerConfiguration) sets.Set[string] {
 		logf.Log.Info("the ValidateCAA feature flag has been removed and is now a no-op")
 	}
 
+	// If running namespaced, remove all cluster-scoped controllers.
+	if o.Namespace != "" {
+		logf.Log.Info("disabling all cluster-scoped controllers as cert-manager is scoped to a single namespace",
+			"controllers", strings.Join(defaults.ClusterScopedControllers, ", "))
+		enabled = enabled.Delete(defaults.ClusterScopedControllers...)
+	}
+
 	return enabled
 }

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -154,6 +154,15 @@ var (
 		csrvaultcontroller.CSRControllerName,
 	}
 
+	ClusterScopedControllers = []string{
+		clusterissuerscontroller.ControllerName,
+		csracmecontroller.CSRControllerName,
+		csrcacontroller.CSRControllerName,
+		csrselfsignedcontroller.CSRControllerName,
+		csrvenaficontroller.CSRControllerName,
+		csrvaultcontroller.CSRControllerName,
+	}
+
 	// Annotations that will be copied from Certificate to CertificateRequest and to Order.
 	// By default, copy all annotations except for the ones applied by kubectl, fluxcd, argocd.
 	defaultCopiedAnnotationPrefixes = []string{
@@ -300,7 +309,6 @@ func SetDefaults_ACMEHTTP01Config(obj *v1alpha1.ACMEHTTP01Config) {
 	if len(obj.SolverNameservers) == 0 {
 		obj.SolverNameservers = defaultACMEHTTP01SolverNameservers
 	}
-
 }
 
 func SetDefaults_ACMEDNS01Config(obj *v1alpha1.ACMEDNS01Config) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation


The controller [CLI reference](https://cert-manager.io/docs/cli/controller/) documents parameter `--namespace string`

> If set, this limits the scope of cert-manager to a single namespace and ClusterIssuers are disabled. If not specified, all namespaces will be watched

Currently, even if providing the parameter cert-manager still attempts to access cluster-scoped resources. As a result, it fails to operate correctly if deployed without cluster-wide RBAC permissions. Following error gets repreatedly printed:

```
W0411 17:31:32.444733       1 reflector.go:569] k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User "system:serviceaccount:cert-manager:cert-manager" cannot list resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
E0411 17:31:32.444750       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: Failed to watch *v1.ClusterIssuer: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError"
```


<details>
<summary>full logs before applying the PR</summary>

```
I0411 17:23:46.689496       1 controller.go:292] "configured acme dns01 nameservers" logger="cert-manager.controller.build-context" nameservers=["10.0.0.16:53"]
I0411 17:23:46.689717       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0411 17:23:46.689724       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0411 17:23:46.689727       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0411 17:23:46.689729       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0411 17:23:46.694838       1 options.go:262] "enabling the sig-network Gateway API certificate-shim and HTTP-01 solver" logger="cert-manager"
I0411 17:23:46.694866       1 controller.go:89] "enabled controllers: [certificaterequests-approver certificaterequests-issuer-acme certificaterequests-issuer-ca certificaterequests-issuer-selfsigned certificaterequests-issuer-vault certificaterequests-issuer-venafi certificates-issuing certificates-key-manager certificates-metrics certificates-readiness certificates-request-manager certificates-revision-manager certificates-trigger challenges clusterissuers gateway-shim ingress-shim issuers orders]" logger="cert-manager.controller"
I0411 17:23:46.694878       1 controller.go:444] "serving insecurely as tls certificate data not provided" logger="cert-manager.controller"
I0411 17:23:46.694886       1 controller.go:102] "listening for insecure connections" logger="cert-manager.controller" address="0.0.0.0:9402"
I0411 17:23:46.695143       1 controller.go:127] "starting metrics server" logger="cert-manager.controller" address="[::]:9402"
I0411 17:23:46.695161       1 controller.go:178] "starting leader election" logger="cert-manager.controller"
I0411 17:23:46.695181       1 controller.go:171] "starting healthz server" logger="cert-manager.controller" address="[::]:9403"
I0411 17:23:46.696802       1 leaderelection.go:257] attempting to acquire leader lease cert-manager/cert-manager-controller...
I0411 17:23:46.698975       1 leaderelection.go:271] successfully acquired lease cert-manager/cert-manager-controller
I0411 17:23:46.699061       1 controller.go:225] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-acme"
I0411 17:23:46.699070       1 controller.go:225] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-selfsigned"
I0411 17:23:46.700926       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-ca"
I0411 17:23:46.703130       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-selfsigned"
I0411 17:23:46.705409       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="ingress-shim"
I0411 17:23:46.707248       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-issuing"
I0411 17:23:46.708875       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-metrics"
I0411 17:23:46.711305       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="orders"
I0411 17:23:46.712949       1 controller.go:225] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-ca"
I0411 17:23:46.712990       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-venafi"
I0411 17:23:46.714833       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="gateway-shim"
I0411 17:23:46.716383       1 controller.go:225] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-vault"
I0411 17:23:46.716401       1 controller.go:225] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-venafi"
I0411 17:23:46.716409       1 controller.go:231] "skipping as cert-manager is scoped to a single namespace" logger="cert-manager.controller" controller="clusterissuers"
I0411 17:23:46.716508       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-key-manager"
I0411 17:23:46.718425       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="issuers"
I0411 17:23:46.720120       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-acme"
I0411 17:23:46.723291       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-approver"
I0411 17:23:46.724805       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-readiness"
I0411 17:23:46.726203       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-revision-manager"
I0411 17:23:46.727843       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-trigger"
I0411 17:23:46.729592       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="challenges"
I0411 17:23:46.731868       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificates-request-manager"
I0411 17:23:46.733387       1 controller.go:248] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-vault"
I0411 17:23:46.735032       1 reflector.go:376] Caches populated for *v1.Ingress from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.735144       1 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.735311       1 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.735325       1 reflector.go:376] Caches populated for *v1.Secret from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.735648       1 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
W0411 17:23:46.736096       1 reflector.go:569] k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User "system:serviceaccount:cert-manager:cert-manager" cannot list resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
E0411 17:23:46.736134       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: Failed to watch *v1.ClusterIssuer: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError"
I0411 17:23:46.742177       1 reflector.go:376] Caches populated for *v1.Certificate from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.794261       1 reflector.go:376] Caches populated for *v1.HTTPRoute from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.805607       1 reflector.go:376] Caches populated for *v1.Issuer from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.818865       1 reflector.go:376] Caches populated for *v1.Challenge from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.840145       1 reflector.go:376] Caches populated for *v1.Gateway from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.845608       1 reflector.go:376] Caches populated for *v1.CertificateRequest from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 17:23:46.850450       1 reflector.go:376] Caches populated for *v1.Order from k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
W0411 17:23:47.851672       1 reflector.go:569] k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User "system:serviceaccount:cert-manager:cert-manager" cannot list resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
E0411 17:23:47.851699       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: Failed to watch *v1.ClusterIssuer: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError"
W0411 17:23:50.875330       1 reflector.go:569] k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User "system:serviceaccount:cert-manager:cert-manager" cannot list resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
E0411 17:23:50.875418       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: Failed to watch *v1.ClusterIssuer: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError"
W0411 17:23:55.118646       1 reflector.go:569] k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User "system:serviceaccount:cert-manager:cert-manager" cannot list resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
E0411 17:23:55.118762       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: Failed to watch *v1.ClusterIssuer: failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError"
...
```
</details>

For full information on how to reproduce the problem see #7676.

This PR includes following changes when user gives `--namespace=<namespace>` parameter

- Disable controllers that require cluster-scoped RBAC permissions by design.
- In the self-signed issuer, skip listing `ClusterIssuer` resources to respect  the `--namespace` parameter.

After applying the PR the errors in log are gone and issuing certificates with self-signed issuer works.


<details>
<summary>full logs after applying the PR</summary>

```
I0411 21:06:55.234615  109967 controller.go:284] "configured acme dns01 nameservers" logger="cert-manager.controller.build-context" nameservers=["10.0.0.16:53"]
I0411 21:06:55.236257  109967 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0411 21:06:55.236298  109967 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0411 21:06:55.236309  109967 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0411 21:06:55.236317  109967 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0411 21:06:55.244927  109967 options.go:262] "enabling the sig-network Gateway API certificate-shim and HTTP-01 solver" logger="cert-manager"
I0411 21:06:55.244963  109967 options.go:272] "disabling all cluster-scoped controllers as cert-manager is scoped to a single namespace" logger="cert-manager" controllers="clusterissuers, certificatesigningrequests-issuer-acme, certificatesigningrequests-issuer-ca, certificatesigningrequests-issuer-selfsigned, certificatesigningrequests-issuer-venafi, certificatesigningrequests-issuer-vault"
I0411 21:06:55.245023  109967 controller.go:88] "enabled controllers: [certificaterequests-approver certificaterequests-issuer-acme certificaterequests-issuer-ca certificaterequests-issuer-selfsigned certificaterequests-issuer-vault certificaterequests-issuer-venafi certificates-issuing certificates-key-manager certificates-metrics certificates-readiness certificates-request-manager certificates-revision-manager certificates-trigger challenges gateway-shim ingress-shim issuers orders]" logger="cert-manager.controller"
I0411 21:06:55.245051  109967 controller.go:436] "serving insecurely as tls certificate data not provided" logger="cert-manager.controller"
I0411 21:06:55.245071  109967 controller.go:101] "listening for insecure connections" logger="cert-manager.controller" address="0.0.0.0:9402"
I0411 21:06:55.248330  109967 controller.go:176] "starting leader election" logger="cert-manager.controller"
I0411 21:06:55.248328  109967 controller.go:125] "starting metrics server" logger="cert-manager.controller" address="[::]:9402"
I0411 21:06:55.248334  109967 controller.go:169] "starting healthz server" logger="cert-manager.controller" address="[::]:9403"
I0411 21:06:55.251569  109967 leaderelection.go:257] attempting to acquire leader lease cert-manager/cert-manager-controller...
I0411 21:06:55.256241  109967 leaderelection.go:271] successfully acquired lease cert-manager/cert-manager-controller
I0411 21:06:55.261010  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="gateway-shim"
I0411 21:06:55.263915  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="ingress-shim"
I0411 21:06:55.268572  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-metrics"
I0411 21:06:55.272537  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-trigger"
I0411 21:06:55.276034  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-acme"
I0411 21:06:55.278840  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-selfsigned"
I0411 21:06:55.278860  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="clusterissuers"
I0411 21:06:55.278857  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-venafi"
I0411 21:06:55.282311  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-issuing"
I0411 21:06:55.285229  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-readiness"
I0411 21:06:55.289254  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-request-manager"
I0411 21:06:55.293641  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-venafi"
I0411 21:06:55.293750  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-revision-manager"
I0411 21:06:55.297322  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="issuers"
I0411 21:06:55.300142  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificates-key-manager"
I0411 21:06:55.303287  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="orders"
I0411 21:06:55.307474  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-ca"
I0411 21:06:55.307495  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-vault"
I0411 21:06:55.307550  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-selfsigned"
I0411 21:06:55.310729  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="challenges"
I0411 21:06:55.313537  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-approver"
I0411 21:06:55.316449  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-ca"
I0411 21:06:55.322156  109967 controller.go:223] "skipping disabled controller" logger="cert-manager.controller" controller="certificatesigningrequests-issuer-acme"
I0411 21:06:55.322203  109967 controller.go:240] "starting controller" logger="cert-manager.controller" controller="certificaterequests-issuer-vault"
I0411 21:06:55.323654  109967 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 21:06:55.324009  109967 reflector.go:376] Caches populated for *v1.CertificateRequest from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 21:06:55.324097  109967 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 21:06:55.324116  109967 reflector.go:376] Caches populated for *v1.PartialObjectMetadata from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 21:06:55.324312  109967 reflector.go:376] Caches populated for *v1.HTTPRoute from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0411 21:06:55.324327  109967 reflector.go:376] Caches populated for *v1.Certificate from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
...
```

</details>




<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fix behavior when running with --namespace=<namespace>: limit the scope of cert-manager to a single namespace and disable cluster-scoped controllers.
```

Fixes #7676, fixes #5524 