### PR TITLE
Migrate use of deprecated functions/fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.8
 	github.com/go-logr/logr v1.4.2
 	github.com/google/gnostic-models v0.6.9
+	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/hashicorp/vault/api v1.15.0
 	github.com/hashicorp/vault/sdk v0.14.0
@@ -106,7 +107,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -19,13 +19,12 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -328,8 +327,8 @@ func TestScheduleN(t *testing.T) {
 			if err == nil && test.err {
 				t.Errorf("expected to get an error, but got none")
 			}
-			if !reflect.DeepEqual(chs, test.expected) {
-				t.Errorf("expected did not match actual: %v", diff.ObjectDiff(test.expected, chs))
+			if diff := cmp.Diff(test.expected, chs); diff != "" {
+				t.Errorf("expected did not match actual (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -29,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/diff"
 	coretesting "k8s.io/client-go/testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -295,8 +295,8 @@ func TestCleanupIngresses(t *testing.T) {
 					t.Errorf("error getting ingress resource: %v", err)
 				}
 
-				if !reflect.DeepEqual(expectedIng, actualIng) {
-					t.Errorf("expected did not match actual: %v", diff.ObjectDiff(expectedIng, actualIng))
+				if diff := cmp.Diff(expectedIng, actualIng); diff != "" {
+					t.Errorf("expected did not match actual (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -394,8 +394,8 @@ func TestCleanupIngresses(t *testing.T) {
 					t.Errorf("error getting ingress resource: %v", err)
 				}
 
-				if !reflect.DeepEqual(expectedIng, actualIng) {
-					t.Errorf("expected did not match actual: %v", diff.ObjectDiff(expectedIng, actualIng))
+				if diff := cmp.Diff(expectedIng, actualIng); diff != "" {
+					t.Errorf("expected did not match actual (-want +got):\n%s", diff)
 				}
 			},
 		},

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -124,7 +124,7 @@ func buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
 				{
 					Name:       "http",
 					Port:       acmeSolverListenPort,
-					TargetPort: intstr.FromInt(acmeSolverListenPort),
+					TargetPort: intstr.FromInt32(acmeSolverListenPort),
 				},
 			},
 			Selector: podLabels,

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -70,7 +70,7 @@ func TestEnsureService(t *testing.T) {
 					{
 						Name:       "http",
 						Port:       acmeSolverListenPort,
-						TargetPort: intstr.FromInt(acmeSolverListenPort),
+						TargetPort: intstr.FromInt32(acmeSolverListenPort),
 					},
 				},
 				Selector: podLabels(chal),
@@ -200,7 +200,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 					{
 						Name:       "http",
 						Port:       acmeSolverListenPort,
-						TargetPort: intstr.FromInt(acmeSolverListenPort),
+						TargetPort: intstr.FromInt32(acmeSolverListenPort),
 					},
 				},
 				Selector: podLabels(chal),

--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -703,8 +703,8 @@ func (v *VaultInitializer) CreateKubernetesRole(ctx context.Context, client kube
 		ctx,
 		v.role,
 		schema.KubernetesWriteAuthRoleRequest{
-			Period:                        "24h",
-			Policies:                      []string{v.role},
+			TokenPeriod:                   "24h",
+			TokenPolicies:                 []string{v.role},
 			BoundServiceAccountNames:      []string{boundSA},
 			BoundServiceAccountNamespaces: []string{boundNS},
 		},

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -394,7 +394,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 											Path: "/",
 											Backend: networkingv1beta1.IngressBackend{
 												ServiceName: "doesnotexist",
-												ServicePort: intstr.FromInt(443),
+												ServicePort: intstr.FromInt32(443),
 											},
 										},
 									},

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -291,7 +291,7 @@ func NewV1Beta1Ingress(name, secretName string, annotations map[string]string, d
 									Path: "/",
 									Backend: networkingv1beta1.IngressBackend{
 										ServiceName: "somesvc",
-										ServicePort: intstr.FromInt(80),
+										ServicePort: intstr.FromInt32(80),
 									},
 								},
 							},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I noticed the use of deprecated code that was simple to migrate. It's mainly changing test code, but please let me know if I should split this up.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
