### PR TITLE
Make DynamicAuthority CN and secret labels configurable

### DIFF
--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -306,6 +306,7 @@ func buildCertificateSource(tlsConfig shared.TLSConfig, restCfg *rest.Config) cm
 			Authority: &authority.DynamicAuthority{
 				SecretNamespace: tlsConfig.Dynamic.SecretNamespace,
 				SecretName:      tlsConfig.Dynamic.SecretName,
+				SecretLabels:    map[string]string{"app.kubernetes.io/managed-by": "cert-manager-cainjector"},
 				LeafDuration:    tlsConfig.Dynamic.LeafDuration,
 				RESTConfig:      restCfg,
 			},

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -436,6 +436,7 @@ func buildCertificateSource(log logr.Logger, tlsConfig shared.TLSConfig, restCfg
 			Authority: &authority.DynamicAuthority{
 				SecretNamespace: tlsConfig.Dynamic.SecretNamespace,
 				SecretName:      tlsConfig.Dynamic.SecretName,
+				SecretLabels:    map[string]string{"app.kubernetes.io/managed-by": "cert-manager"},
 				LeafDuration:    tlsConfig.Dynamic.LeafDuration,
 				RESTConfig:      restCfg,
 			},

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -135,6 +135,7 @@ func buildCertificateSource(log logr.Logger, tlsConfig shared.TLSConfig, restCfg
 			Authority: &authority.DynamicAuthority{
 				SecretNamespace: tlsConfig.Dynamic.SecretNamespace,
 				SecretName:      tlsConfig.Dynamic.SecretName,
+				SecretLabels:    map[string]string{"app.kubernetes.io/managed-by": "cert-manager-webhook"},
 				LeafDuration:    tlsConfig.Dynamic.LeafDuration,
 				RESTConfig:      restCfg,
 			},

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -51,6 +51,7 @@ func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAu
 	da := &DynamicAuthority{
 		SecretNamespace: "test-namespace",
 		SecretName:      "test-secret",
+		CommonName:      "test-common-name",
 		CADuration:      365 * 24 * time.Hour,
 		LeafDuration:    7 * 24 * time.Hour,
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Mainly motivated by the ability to address https://github.com/cert-manager/approver-policy/issues/505, but also to clean up the somehow misleading CA secret labels and CA subject CN.

In this PR, I suggest setting more exact managed-by labels based on the workload using the dynamic authority. But it could also make sense to set `app.kubernetes.io/managed-by: cert-manager` for all use in this project. It depends on whether we consider cert-manager the app here or the components in cert-manager as dedicated apps.

I am tempted to change the CA subject CN, as it appears a bit misleading for all the currentuse of the DynamicAuthority, but I am unsure of the consequences. Please advice!

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
