### PR TITLE
Remove remaining usage of deprecated CertificateRequest test helper

### DIFF
--- a/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/dns01.go
@@ -118,9 +118,13 @@ func testRFC2136DNSProvider() bool {
 
 			crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-				[]string{dnsDomain}, nil, nil, x509.RSA)
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(dnsDomain), gen.SetCSRDNSNames(dnsDomain))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 
 			_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -131,9 +135,13 @@ func testRFC2136DNSProvider() bool {
 		It("should obtain a signed certificate for a wildcard domain", func() {
 			By("Creating a CertificateRequest")
 
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-				[]string{"*." + dnsDomain}, nil, nil, x509.RSA)
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName("*."+dnsDomain), gen.SetCSRDNSNames("*."+dnsDomain))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 
 			_, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -144,9 +152,13 @@ func testRFC2136DNSProvider() bool {
 		It("should obtain a signed certificate for a wildcard and apex domain", func() {
 			By("Creating a CertificateRequest")
 
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-				[]string{"*." + dnsDomain, dnsDomain}, nil, nil, x509.RSA)
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName("*."+dnsDomain), gen.SetCSRDNSNames("*."+dnsDomain, dnsDomain))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 
 			_, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/acme/certificaterequest/http01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/http01.go
@@ -127,9 +127,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 		crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{acmeIngressDomain}, nil, nil, x509.RSA)
+		csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(acmeIngressDomain), gen.SetCSRDNSNames(acmeIngressDomain))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -143,9 +147,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 		crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{acmeIngressDomain}, nil, nil, x509.ECDSA)
+		csr, key, err := gen.CSR(x509.ECDSA, gen.SetCSRCommonName(acmeIngressDomain), gen.SetCSRDNSNames(acmeIngressDomain))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -160,13 +168,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 		// the maximum length of a single segment of the domain being requested
 		const maxLengthOfDomainSegment = 63
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{
-				acmeIngressDomain,
-				e2eutil.RandomSubdomainLength(acmeIngressDomain, maxLengthOfDomainSegment),
-			},
-			nil, nil, x509.RSA)
+		csr, key, err := gen.CSR(x509.ECDSA, gen.SetCSRCommonName(acmeIngressDomain), gen.SetCSRDNSNames(acmeIngressDomain, e2eutil.RandomSubdomainLength(acmeIngressDomain, maxLengthOfDomainSegment)))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -178,10 +186,14 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 		crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{e2eutil.RandomSubdomain(acmeIngressDomain)},
-			nil, nil, x509.RSA)
+		dnsName := e2eutil.RandomSubdomain(acmeIngressDomain)
+		csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(dnsName), gen.SetCSRDNSNames(dnsName))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -193,9 +205,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 	It("should fail to obtain a certificate for an invalid ACME dns name", func() {
 		// create test fixture
 		By("Creating a CertificateRequest")
-		cr, _, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{"google.com"}, nil, nil, x509.RSA)
+		csr, _, err := gen.CSR(x509.RSA, gen.SetCSRCommonName("google.com"), gen.SetCSRDNSNames("google.com"))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		cr, err = f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -212,9 +228,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 		crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind, nil,
-			[]string{acmeIngressDomain}, nil, nil, x509.RSA)
+		csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(acmeIngressDomain), gen.SetCSRDNSNames(acmeIngressDomain))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/ca/certificaterequest.go
+++ b/test/e2e/suite/issuers/ca/certificaterequest.go
@@ -58,7 +58,6 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 		[]byte{8, 8, 8, 8},
 		[]byte{1, 1, 1, 1},
 	}
-	exampleURIs := []string{"spiffe://foo.foo.example.net", "spiffe://foo.bar.example.net"}
 
 	JustBeforeEach(func() {
 		By("Creating an Issuer")
@@ -96,12 +95,14 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 			certRequestClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 			By("Creating a CertificateRequest")
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind,
-				&metav1.Duration{
-					Duration: time.Hour * 24 * 90,
-				},
-				exampleDNSNames, exampleIPAddresses, exampleURIs, x509.RSA)
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(exampleDNSNames[0]), gen.SetCSRDNSNames(exampleDNSNames...), gen.SetCSRIPAddresses(exampleIPAddresses...), gen.SetCSRURIs(exampleURLs()...))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour * 24 * 90}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 			_, err = certRequestClient.Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
@@ -113,12 +114,14 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 			certRequestClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 			By("Creating a CertificateRequest")
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind,
-				&metav1.Duration{
-					Duration: time.Hour * 24 * 90,
-				},
-				exampleDNSNames, exampleIPAddresses, exampleURIs, x509.ECDSA)
+			csr, key, err := gen.CSR(x509.ECDSA, gen.SetCSRCommonName(exampleDNSNames[0]), gen.SetCSRDNSNames(exampleDNSNames...), gen.SetCSRIPAddresses(exampleIPAddresses...), gen.SetCSRURIs(exampleURLs()...))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour * 24 * 90}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 			_, err = certRequestClient.Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
@@ -130,12 +133,14 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 			certRequestClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
 			By("Creating a CertificateRequest")
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuerName, v1.IssuerKind,
-				&metav1.Duration{
-					Duration: time.Hour * 24 * 90,
-				},
-				exampleDNSNames, exampleIPAddresses, exampleURIs, x509.Ed25519)
+			csr, key, err := gen.CSR(x509.Ed25519, gen.SetCSRCommonName(exampleDNSNames[0]), gen.SetCSRDNSNames(exampleDNSNames...), gen.SetCSRIPAddresses(exampleIPAddresses...), gen.SetCSRURIs(exampleURLs()...))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour * 24 * 90}),
+				gen.SetCertificateRequestCSR(csr),
+			)
 			_, err = certRequestClient.Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -158,12 +158,14 @@ func runVaultAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating a CertificateRequest")
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, vaultIssuerName, issuerKind,
-			&metav1.Duration{
-				Duration: time.Hour * 24 * 90,
-			},
-			crDNSNames, crIPAddresses, nil, x509.RSA)
+		csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(crDNSNames[0]), gen.SetCSRDNSNames(crDNSNames...), gen.SetCSRIPAddresses(crIPAddresses...))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: issuerKind, Name: vaultIssuerName}),
+			gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour * 24 * 90}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -249,9 +251,14 @@ func runVaultAppRoleTests(issuerKind string) {
 			By("Creating a CertificateRequest")
 			crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
 
-			cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, vaultIssuerName,
-				issuerKind, v.inputDuration, crDNSNames, crIPAddresses, nil, x509.RSA)
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(crDNSNames[0]), gen.SetCSRDNSNames(crDNSNames...), gen.SetCSRIPAddresses(crIPAddresses...))
 			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: issuerKind, Name: vaultIssuerName}),
+				gen.SetCertificateRequestDuration(v.inputDuration),
+				gen.SetCertificateRequestCSR(csr),
+			)
 			_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/venafi/tpp/certificaterequest.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificaterequest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cert-manager/cert-manager/e2e-tests/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,8 +84,13 @@ var _ = TPPDescribe("CertificateRequest with a properly configured Issuer", func
 
 		dnsNames := []string{rand.String(10) + ".venafi-e2e.example"}
 
-		cr, key, err := util.NewCertManagerBasicCertificateRequest(certificateRequestName, f.Namespace.Name, issuer.Name, cmapi.IssuerKind, nil, dnsNames, nil, nil, x509.RSA)
+		csr, key, err := gen.CSR(x509.RSA, gen.SetCSRCommonName(dnsNames[0]), gen.SetCSRDNSNames(dnsNames...))
 		Expect(err).NotTo(HaveOccurred())
+		cr := gen.CertificateRequest(certificateRequestName,
+			gen.SetCertificateRequestNamespace(f.Namespace.Name),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: cmapi.IssuerKind, Name: issuer.Name}),
+			gen.SetCertificateRequestCSR(csr),
+		)
 
 		By("Creating a CertificateRequest")
 		_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I noticed the deprecated test helper `NewCertManagerBasicCertificateRequest` was currently in use. This removes all usage of the helper in this project, but I've kept the function as others might still be using it.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
