### PR TITLE
Fix AWS Route53 error detection for not-found errors during deletion

### DIFF
--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -57,6 +57,19 @@ var ListHostedZonesByNameResponse = `<?xml version="1.0" encoding="UTF-8"?>
    <MaxItems>1</MaxItems>
 </ListHostedZonesByNameResponse>`
 
+// An example of an error returned by the ListHostedZonesByName API when the
+// request contains an invalid domain name:
+// - https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByName.html#API_ListHostedZonesByName_Errors
+var ListHostedZonesByName400ResponseInvalidDomainName = `<?xml version="1.0" encoding="UTF-8"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+	<Code>InvalidDomainName</Code>
+	<Message>Simulated message</Message>
+	<Resource></Resource>
+	<RequestId>SOMEREQUESTID</RequestId>
+  </Error>
+</ErrorResponse>`
+
 var GetChangeResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
    <ChangeInfo>
@@ -72,6 +85,35 @@ var ChangeResourceRecordSets403Response = `<?xml version="1.0"?>
     <Type>Sender</Type>
     <Code>AccessDenied</Code>
     <Message>User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU</Message>
+  </Error>
+  <RequestId>SOMEREQUESTID</RequestId>
+</ErrorResponse>`
+
+// An example of an error returned by the ChangeResourceRecordSets API when the
+// request refers to a record set that does not exist:
+// - https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html#API_ChangeResourceRecordSets_Errors
+//
+// This sample XML error was obtained by capturing an API response from AWS
+// using `mitmproxy`, while running `HTTPS_PROXY=localhost:8080 go test ./pkg/issuer/acme/dns/route53/... - v -run Test_Cleanup`,
+// with the following ad-hoc Go test:
+//
+//	func Test_Cleanup(t *testing.T) {
+//		l := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+//		ctx := logr.NewContext(context.Background(), l)
+//		p, err := NewDNSProvider(ctx, "", "", "Z0984294TRL0R8AT3SQA", "", "", "", true, []string{}, "cert-manager/tests")
+//		require.NoError(t, err)
+//		err = p.CleanUp(ctx, "example.com", "www", "foo")
+//		require.NoError(t, err)
+//	}
+//
+// NB: This does not match the example in the following file, which may just be out-of-date:
+// - https://github.com/aws/aws-sdk-go-v2/blob/f529add9a2cd0d97281fd81f711c620c1e95cfb8/service/route53/internal/customizations/doc.go#L16C1-L21C25
+var ChangeResourceRecordSets400Response = `<?xml version="1.0"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+    <Type>Sender</Type>
+      <Code>InvalidChangeBatch</Code>
+      <Message>Tried to delete resource record set [name='_acme-challenge.example.com.', type='TXT', set-identifier='"5CiRHXrp9tvpLNX8F9M8qbi8u9kwb3xnHrKdLNDlRQA"'] but it was not found</Message>
   </Error>
   <RequestId>SOMEREQUESTID</RequestId>
 </ErrorResponse>`

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -25,6 +25,7 @@ import (
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
@@ -283,6 +284,78 @@ func TestRoute53Present(t *testing.T) {
 	err = provider.Present(ctx, "bar.example.com", "bar.example.com.", keyAuth)
 	require.Error(t, err, "Expected Present to return an error")
 	assert.Equal(t, `failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 403, RequestID: <REDACTED>, api error AccessDenied: User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU`, err.Error())
+}
+
+func TestRoute53Cleanup(t *testing.T) {
+	type testCase struct {
+		name          string
+		responses     MockResponseMap
+		expectedError string
+	}
+
+	tests := []testCase{
+		{
+			// Cleanup succeeds if the hosted zone is found and the submitted
+			// change action (to delete the challenge record) is eventually
+			// synced by AWS.
+			name: "success",
+			responses: MockResponseMap{
+				"/2013-04-01/hostedzonesbyname":        MockResponse{StatusCode: 200, Body: ListHostedZonesByNameResponse},
+				"/2013-04-01/hostedzone/ABCDEFG/rrset": MockResponse{StatusCode: 200, Body: ChangeResourceRecordSetsResponse},
+				"/2013-04-01/change/123456":            MockResponse{StatusCode: 200, Body: GetChangeResponse},
+			},
+		},
+		{
+			// Cleanup fails if the hostedzonesbyname API call returns an error.
+			name: "hosted-zone-lookup-failure",
+			responses: MockResponseMap{
+				"/2013-04-01/hostedzonesbyname": MockResponse{StatusCode: 400, Body: ListHostedZonesByName400ResponseInvalidDomainName},
+			},
+			expectedError: `failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 400, RequestID: <REDACTED>, InvalidDomainName: Simulated message`,
+		},
+		{
+			// Cleanup fails if the changeresourcerecordsets API call returns an error.
+			name: "change-resource-records-failure",
+			responses: MockResponseMap{
+				"/2013-04-01/hostedzonesbyname":        MockResponse{StatusCode: 200, Body: ListHostedZonesByNameResponse},
+				"/2013-04-01/hostedzone/ABCDEFG/rrset": MockResponse{StatusCode: 400, Body: ChangeResourceRecordSets403Response},
+			},
+			expectedError: `failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: <REDACTED>, api error AccessDenied: User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU`,
+		},
+		{
+			// Cleanup succeeds if the record has already been deleted; the
+			// changeresourcerecordsets API call returns an expected error:
+			// InvalidChangeBatch.
+			name: "change-resource-records-failure-ignore-not-found",
+			responses: MockResponseMap{
+				"/2013-04-01/hostedzonesbyname":        MockResponse{StatusCode: 200, Body: ListHostedZonesByNameResponse},
+				"/2013-04-01/hostedzone/ABCDEFG/rrset": MockResponse{StatusCode: 400, Body: ChangeResourceRecordSets400Response},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(6)))
+			ctx := logr.NewContext(context.Background(), l)
+
+			ts := newMockServer(t, tc.responses)
+			defer ts.Close()
+
+			provider, err := makeRoute53Provider(ts)
+			require.NoError(t, err, "Expected to make a Route 53 provider without error")
+
+			domain := "example.com"
+			keyAuth := "123456d=="
+
+			err = provider.CleanUp(ctx, domain, "_acme-challenge."+domain+".", keyAuth)
+			if tc.expectedError == "" {
+				assert.NoError(t, err, "Expected Cleanup to return no error")
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
 }
 
 func TestAssumeRole(t *testing.T) {


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/6671#discussion_r1470884367 @wallrj made a careless code review remark which resulted in a bug in the cleaning up the Route53 challenge txt record.

> nit: invalidChangeBatchErr seems to be unused. Consider using errors.Is instead.

But `route53types.InvalidChangeBatch` is not a sentinel error and can't be used with `errors.Is`.

@alex-berger wrote the fix for this in #7548 using a generic smithy error, and I have now adjusted that change to use `*route53types.InvalidChangeBatch` instead and added some unit tests.

I originally tried pushing my changes to his branch but was unable to force-push after I'd made some unnecessary changes,
so I've moved everything to this branch on my fork.

Fixes: https://github.com/cert-manager/cert-manager/issues/7547
Supplants: https://github.com/cert-manager/cert-manager/pull/7548

/kind bug

```release-note
Fix AWS Route53 error detection for not-found errors during deletion of DNS records.
```

## Testing

### Unit testing

The new unit-tests in this branch fail if you run them against the **master** branch, demonstrating the problem:

```
$ go test ./pkg/issuer/acme/dns/route53/...  -v -run TestRoute53Cleanup
=== RUN   TestRoute53Cleanup
=== RUN   TestRoute53Cleanup/success
    wait.go:376: I0415 15:40:45.574572] Caching DNS response fqdn="_acme-challenge.example.com." ttl=1202
=== RUN   TestRoute53Cleanup/hosted-zone-lookup-failure
    wait.go:314: I0415 15:40:45.682335] Returning cached DNS response fqdn="_acme-challenge.example.com."
=== RUN   TestRoute53Cleanup/change-resource-records-failure
    wait.go:314: I0415 15:40:45.785860] Returning cached DNS response fqdn="_acme-challenge.example.com."
=== RUN   TestRoute53Cleanup/change-resource-records-failure-ignore-not-found
    wait.go:314: I0415 15:40:45.890132] Returning cached DNS response fqdn="_acme-challenge.example.com."
    route53_test.go:353:
                Error Trace:    /home/richard/projects/cert-manager/cert-manager/pkg/issuer/acme/dns/route53/route53_test.go:353
                Error:          Received unexpected error:
                                failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: <REDACTED>, InvalidChangeBatch: Tried to delete resource record set [name='_acme-challenge.example.com.', type='TXT', set-identifier='"5CiRHXrp9tvpLNX8F9M8qbi8u9kwb3xnHrKdLNDlRQA"'] but it was not found
                Test:           TestRoute53Cleanup/change-resource-records-failure-ignore-not-found
                Messages:       Expected Cleanup to return no error
--- FAIL: TestRoute53Cleanup (0.45s)
    --- PASS: TestRoute53Cleanup/success (0.14s)
    --- PASS: TestRoute53Cleanup/hosted-zone-lookup-failure (0.10s)
    --- PASS: TestRoute53Cleanup/change-resource-records-failure (0.10s)
    --- FAIL: TestRoute53Cleanup/change-resource-records-failure-ignore-not-found (0.10s)
FAIL
FAIL    github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/route53        0.463s
FAIL
```


### E2E

I have deployed this branch to an EKS cluster and observed the new info log message:

```
# values.yaml
crds:
  enabled: true
global:
  logLevel: 4
```


```bash
export KO_REGISTRY=ttl.sh/$(uuidgen)
export KO_HELM_VALUES_FILES=$PWD/values.yaml
make -j4 ko-deploy-certmanager VERSION=v0.0.0
```

```
kubectl -n cert-manager logs deployments/cert-manager --follow
```

Then following the AWS getting started examples: 
 * https://cert-manager.io/docs/tutorials/getting-started-aws-letsencrypt/#create-a-production-ready-certificate

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: www
  namespace: default
spec:
  commonName: www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net
  dnsNames:
  - foo.cert-manager-aws-tutorial.richard-gcp.jetstacker.net
  - www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net
  issuerRef:
    kind: ClusterIssuer
    name: letsencrypt-production
  privateKey:
    rotationPolicy: Always
  revisionHistoryLimit: 1
  secretName: www-tls
  usages:
  - digital signature
  - key encipherment
  - server auth

```

I observe the new info message when the cleanup function attempts to operate on a  txt record that has already been deleted:

> I0415 14:56:26.013960       1 route53.go:289] "Got InvalidChangeBatch error when attempting to delete the TXT record. Ignoring the error and asssuming that the TXT record has already been deleted." logger="cert-manager.controller.CleanUp" resource_name="www-9-2993115025-2978259221" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="foo.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-9-2993115025-2978259221" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="foo.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" error="operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: 41dc7b5b-dd31-4661-824d-3f0c4123dfeb, InvalidChangeBatch: [Tried to delete resource record set [name='_acme-challenge.foo.cert-manager-aws-tutorial.richard-gcp.jetstacker.net.', type='TXT', set-identifier='\"6j6dCynI_ax31ozHvh16pvkaeTVKN2AkiIoTceiQPC8\"'] but it was not found]"