### PR TITLE
Support for passwordless PKCS#12 keystores encoding

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -262,14 +262,16 @@ spec:
                           description: |-
                             Password provides a literal password used to encrypt the PKCS#12 keystore.
                             Mutually exclusive with passwordSecretRef.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                            One of password or passwordSecretRef must provide a password with a non-zero length or
+                            profile set to Passwordless.
                           type: string
                         passwordSecretRef:
                           description: |-
                             PasswordSecretRef is a reference to a non-empty key in a Secret resource
                             containing the password used to encrypt the PKCS#12 keystore.
                             Mutually exclusive with password.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                            One of password or passwordSecretRef must provide a password with a non-zero length or
+                            profile set to Passwordless.
                           type: object
                           required:
                             - name
@@ -296,6 +298,8 @@ spec:
                             `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
                             (eg. because of company policy). Please note that the security of the algorithm is not that important
                             in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                            `Passwordless`: Encodes PKCS#12 files without any encryption or MACs. It's an error to specify
+                            password or passwordSecretRef if using this profile,
                           type: string
                           enum:
                             - LegacyRC2

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -466,17 +466,21 @@ type PKCS12Keystore struct {
 	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
+	// `Passwordless`: Encodes PKCS#12 files without any encryption or MACs. It's an error to specify
+	// password or passwordSecretRef if using Passwordless profile,
 	Profile PKCS12Profile
 
 	// containing the password used to encrypt the PKCS#12 keystore.
 	// Mutually exclusive with password.
-	// One of password or passwordSecretRef must provide a password with a non-zero length.
+	// One of password or passwordSecretRef must provide a password with a non-zero length or
+	// profile set to Passwordless.
 	// +optional
 	PasswordSecretRef cmmeta.SecretKeySelector
 
 	// Password provides a literal password used to encrypt the PKCS#12 keystore.
 	// Mutually exclusive with passwordSecretRef.
-	// One of password or passwordSecretRef must provide a password with a non-zero length.
+	// One of password or passwordSecretRef must provide a password with a non-zero length or
+	// profile set to Passwordless.
 	// +optional
 	Password *string
 }
@@ -492,6 +496,9 @@ const (
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
 	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
+
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Passwordless
+	PasswordlessPKCS12Profile PKCS12Profile = "Passwordless"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -514,19 +514,23 @@ type PKCS12Keystore struct {
 	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
 	// (eg. because of company policy). Please note that the security of the algorithm is not that important
 	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
+	// `Passwordless`: Encodes PKCS#12 files without any encryption or MACs. It's an error to specify
+	// password or passwordSecretRef if using this profile,
 	// +optional
 	Profile PKCS12Profile `json:"profile,omitempty"`
 
 	// PasswordSecretRef is a reference to a non-empty key in a Secret resource
 	// containing the password used to encrypt the PKCS#12 keystore.
 	// Mutually exclusive with password.
-	// One of password or passwordSecretRef must provide a password with a non-zero length.
+	// One of password or passwordSecretRef must provide a password with a non-zero length or
+	// profile set to Passwordless.
 	// +optional
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef,omitempty"`
 
 	// Password provides a literal password used to encrypt the PKCS#12 keystore.
 	// Mutually exclusive with passwordSecretRef.
-	// One of password or passwordSecretRef must provide a password with a non-zero length.
+	// One of password or passwordSecretRef must provide a password with a non-zero length or
+	// profile set to Passwordless.
 	// +optional
 	Password *string `json:"password,omitempty"`
 }
@@ -543,6 +547,9 @@ const (
 
 	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
 	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
+
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Passwordless
+	PasswordlessPKCS12Profile PKCS12Profile = "Passwordless"
 )
 
 // CertificateStatus defines the observed state of Certificate

--- a/pkg/controller/certificates/issuing/internal/keystore.go
+++ b/pkg/controller/certificates/issuing/internal/keystore.go
@@ -63,6 +63,8 @@ func encodePKCS12Keystore(profile cmapi.PKCS12Profile, password string, rawKey [
 	}
 
 	switch profile {
+	case cmapi.PasswordlessPKCS12Profile:
+		return pkcs12.Passwordless.Encode(key, certs[0], cas, password)
 	case cmapi.Modern2023PKCS12Profile:
 		return pkcs12.Modern2023.Encode(key, certs[0], cas, password)
 	case cmapi.LegacyDESPKCS12Profile:
@@ -81,6 +83,8 @@ func encodePKCS12Truststore(profile cmapi.PKCS12Profile, password string, caPem 
 	}
 
 	switch profile {
+	case cmapi.PasswordlessPKCS12Profile:
+		return pkcs12.Passwordless.EncodeTrustStore(cas, password)
 	case cmapi.Modern2023PKCS12Profile:
 		return pkcs12.Modern2023.EncodeTrustStore(cas, password)
 	case cmapi.LegacyDESPKCS12Profile:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR adds support for passwordless encoding of PKCS#12 keystores. The keystores will then be created without any encryption or MACs. While a lot of software has trouble reading such files, it can be useful in specific scenarios. See the linked issue for an example.

I suggest NOT adding this option to JKS keystores, as I think JKS keystores should be deprecated. Relates to https://github.com/cert-manager/trust-manager/pull/603.

Fixes https://github.com/cert-manager/cert-manager/issues/6783

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add support for passwordless encoding of PKCS#12 keystores
```
