### PR TITLE
[release-1.17] Bump Go to v1.23.8

### DIFF
--- a/cmd/acmesolver/go.mod
+++ b/cmd/acmesolver/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/acmesolver-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cainjector-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/controller-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/startupapicheck/go.mod
+++ b/cmd/startupapicheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/startupapicheck-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/webhook-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -162,7 +162,7 @@ tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
 # NOTE: The version of Go here has been manually updated!
-VENDORED_GO_VERSION := 1.23.6
+VENDORED_GO_VERSION := 1.23.8
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -381,10 +381,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=9379441ea310de000f33a4dc767bd966e72ab2826270e038e78b2c53c2e7802d
-go_linux_arm64_SHA256SUM=561c780e8f4a8955d32bf72e46af0b5ee5e0debe1e4633df9a03781878219202
-go_darwin_amd64_SHA256SUM=782da50ce8ec5e98fac2cd3cdc6a1d7130d093294fc310038f651444232a3fb0
-go_darwin_arm64_SHA256SUM=5cae2450a1708aeb0333237a155640d5562abaf195defebc4306054565536221
+go_linux_amd64_SHA256SUM=45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f
+go_linux_arm64_SHA256SUM=9d6d938422724a954832d6f806d397cf85ccfde8c581c201673e50e634fdc992
+go_darwin_amd64_SHA256SUM=4a0f0a5eb539013c1f4d989e0864aed45973c0a9d4b655ff9fd56013e74c1303
+go_darwin_arm64_SHA256SUM=d4f53dcaecd67d9d2926eab7c3d674030111c2491e68025848f6839e04a4d3d1
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/e2e-tests
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/integration-tests
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a


### PR DESCRIPTION
I bumped the Go version to 1.23.8 in 12a41ee59971f5a42d6c490460d92d80a7eb1bf0 and then ran the following commands, in subsequent commits:

```
_bin/tools/go get go@1.23.8
make go-tidy
```

See:
* https://go.dev/doc/toolchain#get

/kind bug

```release-note
Bump Go to v1.23.8 to fix CVE-2025-22871
```


## Testing

I ran `make trivy-scan-controller` before and after bumping Go and diffed the output, to see which of the CVEs have been fixed:

```diff
$ diff -u original bump-go

@@ -28,7 +24,7 @@
       "Family": "debian",
       "Name": "12.9"
     },
-    "ImageID": "sha256:e827801dd01ce5e06752a7dd17c3dd2319b934a601d5b8af118323c7b38e8f75",
+    "ImageID": "sha256:538b60e5851790f039027a353cd2b50193b3c20b82ecc3a9513c61bc33b82507",
     "DiffIDs": [
       "sha256:f920c5680b0b677741c5500dc365a9b074aa263ab43c3eb6be6a465b1caadd8e",
       "sha256:8fa10c0194df9b7c054c90dbe482585f768a54428fc90a5b78a0066a123b1bba",
@@ -41,13 +37,13 @@
       "sha256:1a73b54f556b477f0a8b939d13c504a3b4f4db71f7a09c63afbc10acb3de5849",
       "sha256:f4aee9e53c42a22ed82451218c3ea03d1eea8d6ca8fbe8eb4e950304ba8a8bb3",
       "sha256:b336e209998fa5cf0eec3dabf93a21194198a35f4f75612d8da03693f8c30217",
-      "sha256:a88b7aef4008b9bab1798617d51b1c810e8490129bbafcd44bf97a151b769d93",
-      "sha256:39ce8bd889340be9c18f07b5c98ce6307207411e5bb251fc0166810930aab415",
-      "sha256:e922fccc61a807242dc8844bb9a0e05efdd3c32beaa9a75c85b9de57cd6abe5f"
+      "sha256:34c8e0003d8460982dc038ade511806c15a5912a0c6ccd32c7c8b81cc281cca7",
+      "sha256:80e369736fa28f77e4e0b14c980bb9c15aebc20b4f33bfc98913989ab6ddd769",
+      "sha256:38fe839577b944c4ddfd89b54ec5f3cdef4bb296a7836b180bcd7c0199bfa0da"
     ],
     "ImageConfig": {
       "architecture": "amd64",
-      "created": "2025-04-22T15:30:21.621577432+01:00",
+      "created": "2025-04-22T15:48:34.668860303+01:00",
       "history": [
         {
           "created": "0001-01-01T00:00:00Z"
@@ -83,34 +79,34 @@
           "created": "0001-01-01T00:00:00Z"
         },
         {
-          "created": "2025-04-22T15:30:21.34601264+01:00",
+          "created": "2025-04-22T15:48:34.443643027+01:00",
           "created_by": "LABEL org.opencontainers.image.source=https://github.com/cert-manager/cert-manager",
           "comment": "buildkit.dockerfile.v0",
           "empty_layer": true
         },
         {
-          "created": "2025-04-22T15:30:21.34601264+01:00",
+          "created": "2025-04-22T15:48:34.443643027+01:00",
           "created_by": "USER 1000",
           "comment": "buildkit.dockerfile.v0",
           "empty_layer": true
         },
         {
-          "created": "2025-04-22T15:30:21.34601264+01:00",
+          "created": "2025-04-22T15:48:34.443643027+01:00",
           "created_by": "COPY controller /app/cmd/controller/controller # buildkit",
           "comment": "buildkit.dockerfile.v0"
         },
         {
-          "created": "2025-04-22T15:30:21.528585293+01:00",
+          "created": "2025-04-22T15:48:34.567901566+01:00",
           "created_by": "COPY cert-manager.license /licenses/LICENSE # buildkit",
           "comment": "buildkit.dockerfile.v0"
         },
         {
-          "created": "2025-04-22T15:30:21.621577432+01:00",
+          "created": "2025-04-22T15:48:34.668860303+01:00",
           "created_by": "COPY cert-manager.licenses_notice /licenses/LICENSES # buildkit",
           "comment": "buildkit.dockerfile.v0"
         },
         {
-          "created": "2025-04-22T15:30:21.621577432+01:00",
+          "created": "2025-04-22T15:48:34.668860303+01:00",
           "created_by": "ENTRYPOINT [\"/app/cmd/controller/controller\"]",
           "comment": "buildkit.dockerfile.v0",
           "empty_layer": true
@@ -131,9 +127,9 @@
           "sha256:1a73b54f556b477f0a8b939d13c504a3b4f4db71f7a09c63afbc10acb3de5849",
           "sha256:f4aee9e53c42a22ed82451218c3ea03d1eea8d6ca8fbe8eb4e950304ba8a8bb3",
           "sha256:b336e209998fa5cf0eec3dabf93a21194198a35f4f75612d8da03693f8c30217",
-          "sha256:a88b7aef4008b9bab1798617d51b1c810e8490129bbafcd44bf97a151b769d93",
-          "sha256:39ce8bd889340be9c18f07b5c98ce6307207411e5bb251fc0166810930aab415",
-          "sha256:e922fccc61a807242dc8844bb9a0e05efdd3c32beaa9a75c85b9de57cd6abe5f"
+          "sha256:34c8e0003d8460982dc038ade511806c15a5912a0c6ccd32c7c8b81cc281cca7",
+          "sha256:80e369736fa28f77e4e0b14c980bb9c15aebc20b4f33bfc98913989ab6ddd769",
+          "sha256:38fe839577b944c4ddfd89b54ec5f3cdef4bb296a7836b180bcd7c0199bfa0da"
         ]
       },
       "config": {
@@ -174,7 +170,7 @@
           "FixedVersion": "0.38.0",
           "Status": "fixed",
           "Layer": {
-            "DiffID": "sha256:a88b7aef4008b9bab1798617d51b1c810e8490129bbafcd44bf97a151b769d93"
+            "DiffID": "sha256:34c8e0003d8460982dc038ade511806c15a5912a0c6ccd32c7c8b81cc281cca7"
           },
           "SeveritySource": "ghsa",
           "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-22872",
@@ -208,56 +204,6 @@
           ],
           "PublishedDate": "2025-04-16T18:16:04.183Z",
           "LastModifiedDate": "2025-04-17T20:22:16.24Z"
-        },
-        {
-          "VulnerabilityID": "CVE-2025-22871",
-          "PkgName": "stdlib",
-          "PkgIdentifier": {
-            "PURL": "pkg:golang/stdlib@1.23.6",
-            "UID": "9abf68d349e805a5"
-          },
-          "InstalledVersion": "1.23.6",
-          "FixedVersion": "1.23.8, 1.24.2",
-          "Status": "fixed",
-          "Layer": {
-            "DiffID": "sha256:a88b7aef4008b9bab1798617d51b1c810e8490129bbafcd44bf97a151b769d93"
-          },
-          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2025-22871",
-          "DataSource": {
-            "ID": "govulndb",
-            "Name": "The Go Vulnerability Database",
-            "URL": "https://pkg.go.dev/vuln/"
-          },
-          "Title": "net/http: Request smuggling due to acceptance of invalid chunked data in net/http",
-          "Description": "The net/http package improperly accepts a bare LF as a line terminator in chunked data chunk-size lines. This can permit request smuggling if a net/http server is used in conjunction with a server that incorrectly accepts a bare LF as part of a chunk-ext.",
-          "Severity": "MEDIUM",
-          "VendorSeverity": {
-            "amazon": 3,
-            "bitnami": 4,
-            "redhat": 2
-          },
-          "CVSS": {
-            "bitnami": {
-              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
-              "V3Score": 9.1
-            },
-            "redhat": {
-              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:N",
-              "V3Score": 5.4
-            }
-          },
-          "References": [
-            "http://www.openwall.com/lists/oss-security/2025/04/04/4",
-            "https://access.redhat.com/security/cve/CVE-2025-22871",
-            "https://go.dev/cl/652998",
-            "https://go.dev/issue/71988",
-            "https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk",
-            "https://nvd.nist.gov/vuln/detail/CVE-2025-22871",
-            "https://pkg.go.dev/vuln/GO-2025-3563",
-            "https://www.cve.org/CVERecord?id=CVE-2025-22871"
-          ],
-          "PublishedDate": "2025-04-08T20:15:20.183Z",
-          "LastModifiedDate": "2025-04-18T15:15:57.923Z"
         }
       ]
     }
```