### PR TITLE
[release-1.16] Bump Go to v1.23.8 to fix CVE-2025-22871

### DIFF
--- a/cmd/acmesolver/go.mod
+++ b/cmd/acmesolver/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/acmesolver-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cainjector-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/controller-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/startupapicheck/go.mod
+++ b/cmd/startupapicheck/go.mod
@@ -1,8 +1,6 @@
 module github.com/cert-manager/cert-manager/startupapicheck-binary
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/webhook-binary
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -159,7 +159,7 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.23.6
+VENDORED_GO_VERSION := 1.23.8
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -378,10 +378,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=9379441ea310de000f33a4dc767bd966e72ab2826270e038e78b2c53c2e7802d
-go_linux_arm64_SHA256SUM=561c780e8f4a8955d32bf72e46af0b5ee5e0debe1e4633df9a03781878219202
-go_darwin_amd64_SHA256SUM=782da50ce8ec5e98fac2cd3cdc6a1d7130d093294fc310038f651444232a3fb0
-go_darwin_arm64_SHA256SUM=5cae2450a1708aeb0333237a155640d5562abaf195defebc4306054565536221
+go_linux_amd64_SHA256SUM=45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f
+go_linux_arm64_SHA256SUM=9d6d938422724a954832d6f806d397cf85ccfde8c581c201673e50e634fdc992
+go_darwin_amd64_SHA256SUM=4a0f0a5eb539013c1f4d989e0864aed45973c0a9d4b655ff9fd56013e74c1303
+go_darwin_arm64_SHA256SUM=d4f53dcaecd67d9d2926eab7c3d674030111c2491e68025848f6839e04a4d3d1
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/e2e-tests
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/integration-tests
 
-go 1.23.0
+go 1.23.8
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a


### PR DESCRIPTION
Updates the Go binary and the stdlib to 1.23.8.
> go1.23.8 (released 2025-04-01) includes security fixes to the net/http
package, as well as bug fixes to the runtime and the go command. See the Go
1.23.8 milestone on our issue tracker for details.
-- https://go.dev/doc/devel/release#go1.23.0

This will partially fix the failures that we're seeing in our periodic trivy tests and and ArtifactHub:
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.16

I bumped the Go version to 1.23.8 and then ran the following commands, in subsequent commits:

```
_bin/tools/go get go@1.23.8
make go-tidy
```

See:
* https://go.dev/doc/toolchain#get

/kind bug

```release-note
Bump Go to v1.23.8 to fix CVE-2025-22871
```


## Testing

