### PR TITLE
WIP: acme profile support

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -199,6 +199,11 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                    profile:
+                      description: |-
+                        Profile allows requesting a certificate profile from the ACME server; supported
+                        profiles are listed by the server's ACME directory URL.
+                      type: string
                     server:
                       description: |-
                         Server is the URL used to access the ACME server's 'directory' endpoint.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -199,6 +199,11 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                    profile:
+                      description: |-
+                        Profile allows requesting a certificate profile from the ACME server; supported
+                        profiles are listed by the server's ACME directory URL.
+                      type: string
                     server:
                       description: |-
                         Server is the URL used to access the ACME server's 'directory' endpoint.

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -122,6 +122,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                profile:
+                  description: |-
+                    Profile allows requesting a certificate profile from the ACME server; supported
+                    profiles are listed by the server's ACME directory URL.
+                  type: string
                 request:
                   description: |-
                     Certificate signing request bytes in DER encoding.

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -102,6 +102,10 @@ type ACMEIssuer struct {
 	// it, it will create an error on the Order.
 	// Defaults to false.
 	EnableDurationFeature bool
+
+	// Profile allows requesting a certificate profile from the ACME server; supported
+	// profiles are listed by the server's ACME directory URL.
+	Profile string `json:"profile,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/types_order.go
+++ b/internal/apis/acme/types_order.go
@@ -74,6 +74,11 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	Duration *metav1.Duration
+
+	// Profile allows requesting a certificate profile from the ACME server; supported
+	// profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 type OrderStatus struct {

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -988,6 +988,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *acmev1.ACMEIssuer, out *ac
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1022,6 +1023,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *acme
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1664,6 +1666,7 @@ func autoConvert_v1_OrderSpec_To_acme_OrderSpec(in *acmev1.OrderSpec, out *acme.
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1681,6 +1684,7 @@ func autoConvert_acme_OrderSpec_To_v1_OrderSpec(in *acme.OrderSpec, out *acmev1.
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Profile = in.Profile
 	return nil
 }
 

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -114,6 +114,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Profile allows requesting a certificate profile from the ACME server; supported
+	// profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -82,6 +82,11 @@ type OrderSpec struct {
 	// this is set on order creation as pe the ACME spec.
 	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty"`
+
+	// Profile allows requesting a certificate profile from the ACME server; supported
+	// profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -285,6 +285,11 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, o *cm
 	if o.Spec.Duration != nil {
 		options = append(options, acmeapi.WithOrderNotAfter(c.clock.Now().Add(o.Spec.Duration.Duration)))
 	}
+
+	if o.Spec.Profile != "" {
+		options = append(options, acmeapi.WithOrderProfile(o.Spec.Profile))
+	}
+
 	acmeOrder, err := cl.AuthorizeOrder(ctx, authzIDs, options...)
 	if acmeErr, ok := err.(*acmeapi.Error); ok {
 		if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -141,8 +141,10 @@ func (a *ACME) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuer cm
 		return nil, nil
 	}
 
+	log.Info(fmt.Sprintf("profile: %s", issuer.GetSpec().ACME.Profile))
+
 	// If we fail to build the order we have to hard fail.
-	expectedOrder, err := buildOrder(cr, csr, issuer.GetSpec().ACME.EnableDurationFeature)
+	expectedOrder, err := buildOrder(cr, csr, issuer.GetSpec().ACME.EnableDurationFeature, issuer.GetSpec().ACME.Profile)
 	if err != nil {
 		message := "Failed to build order"
 
@@ -242,7 +244,7 @@ func (a *ACME) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuer cm
 }
 
 // Build order. If we error here it is a terminating failure.
-func buildOrder(cr *cmapi.CertificateRequest, csr *x509.CertificateRequest, enableDurationFeature bool) (*cmacme.Order, error) {
+func buildOrder(cr *cmapi.CertificateRequest, csr *x509.CertificateRequest, enableDurationFeature bool, certificateProfileName string) (*cmacme.Order, error) {
 	var ipAddresses []string
 	for _, ip := range csr.IPAddresses {
 		ipAddresses = append(ipAddresses, ip.String())
@@ -259,6 +261,7 @@ func buildOrder(cr *cmapi.CertificateRequest, csr *x509.CertificateRequest, enab
 		CommonName:  csr.Subject.CommonName,
 		DNSNames:    dnsNames,
 		IPAddresses: ipAddresses,
+		Profile:     certificateProfileName,
 	}
 
 	if enableDurationFeature {


### PR DESCRIPTION
This is a draft PR to share my POC of ACME profile support in cert-manager.

This requires a patched version of golang/x/crypto; if we actually deploy this, we _should not_ fork all of x/crypto, but instead we should only fork the ACME client from x/crypto.

The patch for x/crypto is below. This was tested against a local checkout of https://github.com/golang/crypto, and applied cleanly against commit 9c1aa6af88df97634a66726b66bb12e56d1ef6c

```patch
diff --git c/acme/acme.go w/acme/acme.go
index cfb1dfd..c61165b 100644
--- c/acme/acme.go
+++ w/acme/acme.go
@@ -186,10 +186,11 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Nonce     string `json:"newNonce"`
 		KeyChange string `json:"keyChange"`
 		Meta      struct {
-			Terms        string   `json:"termsOfService"`
-			Website      string   `json:"website"`
-			CAA          []string `json:"caaIdentities"`
-			ExternalAcct bool     `json:"externalAccountRequired"`
+			Terms        string            `json:"termsOfService"`
+			Website      string            `json:"website"`
+			CAA          []string          `json:"caaIdentities"`
+			ExternalAcct bool              `json:"externalAccountRequired"`
+			Profiles     map[string]string `json:"profiles"`
 		}
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
@@ -209,6 +210,7 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Website:                 v.Meta.Website,
 		CAA:                     v.Meta.CAA,
 		ExternalAccountRequired: v.Meta.ExternalAcct,
+		Profiles:                v.Meta.Profiles,
 	}
 	return *c.dir, nil
 }
diff --git c/acme/rfc8555.go w/acme/rfc8555.go
index 3152e53..6754963 100644
--- c/acme/rfc8555.go
+++ w/acme/rfc8555.go
@@ -205,6 +205,7 @@ func (c *Client) AuthorizeOrder(ctx context.Context, id []AuthzID, opt ...OrderO
 		Identifiers []wireAuthzID `json:"identifiers"`
 		NotBefore   string        `json:"notBefore,omitempty"`
 		NotAfter    string        `json:"notAfter,omitempty"`
+		Profile     string        `json:"profile,omitempty"`
 	}{}
 	for _, v := range id {
 		req.Identifiers = append(req.Identifiers, wireAuthzID{
@@ -212,12 +213,15 @@ func (c *Client) AuthorizeOrder(ctx context.Context, id []AuthzID, opt ...OrderO
 			Value: v.Value,
 		})
 	}
+
 	for _, o := range opt {
 		switch o := o.(type) {
 		case orderNotBeforeOpt:
 			req.NotBefore = time.Time(o).Format(time.RFC3339)
 		case orderNotAfterOpt:
 			req.NotAfter = time.Time(o).Format(time.RFC3339)
+		case orderProfileOpt:
+			req.Profile = string(o)
 		default:
 			// Package's fault if we let this happen.
 			panic(fmt.Sprintf("unsupported order option type %T", o))
diff --git c/acme/types.go w/acme/types.go
index 640223c..107ecbf 100644
--- c/acme/types.go
+++ w/acme/types.go
@@ -308,6 +308,10 @@ type Directory struct {
 	// ExternalAccountRequired indicates that the CA requires for all account-related
 	// requests to include external account binding information.
 	ExternalAccountRequired bool
+
+	// Profiles lists any profiles presented by the server which can be chosen for
+	// issuing certificates. The key is the name of the profile, and the value is a description.
+	Profiles map[string]string
 }
 
 // Order represents a client's request for a certificate.
@@ -383,6 +387,11 @@ func WithOrderNotAfter(t time.Time) OrderOption {
 	return orderNotAfterOpt(t)
 }
 
+// WithOrderProfile set order's profile
+func WithOrderProfile(profile string) OrderOption {
+	return orderProfileOpt(profile)
+}
+
 type orderNotBeforeOpt time.Time
 
 func (orderNotBeforeOpt) privateOrderOpt() {}
@@ -391,6 +400,10 @@ type orderNotAfterOpt time.Time
 
 func (orderNotAfterOpt) privateOrderOpt() {}
 
+type orderProfileOpt string
+
+func (orderProfileOpt) privateOrderOpt() {}
+
 // Authorization encodes an authorization response.
 type Authorization struct {
 	// URI uniquely identifies a authorization.
@@ -553,6 +566,7 @@ type wireChallenge struct {
 	Status    string
 	Validated time.Time
 	Error     *wireError
+	Profile   string
 }
 
 func (c *wireChallenge) challenge() *Challenge {

```

### Kind

/kind feature

### Release Note

```release-note
NONE
```
