### PR TITLE
[VC-39805] Change the default `privateKey.rotationPolicy` to `Always`

### DIFF
--- a/deploy/charts/cert-manager/templates/NOTES.txt
+++ b/deploy/charts/cert-manager/templates/NOTES.txt
@@ -1,6 +1,12 @@
 {{- if .Values.installCRDs }}
 ⚠️  WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.
+
 {{- end }}
+⚠️  WARNING: New default private key rotation policy for Certificate resources.
+The default private key rotation policy for Certificate resources was
+changed to `Always` in cert-manager >= v1.18.0.
+Learn more in the [1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18).
+
 cert-manager {{ .Chart.AppVersion }} has been deployed successfully!
 
 In order to begin issuing certificates, you will need to set up a ClusterIssuer

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -447,7 +447,11 @@ spec:
                         to await user intervention.
                         If set to `Always`, a private key matching the specified requirements
                         will be generated whenever a re-issuance occurs.
-                        Default is `Never` for backward compatibility.
+                        Default is `Always`.
+                        The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
+                        The new default can be disabled by setting the
+                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
+                        the controller component.
                       type: string
                       enum:
                         - Never

--- a/internal/apis/certmanager/v1/defaults.go
+++ b/internal/apis/certmanager/v1/defaults.go
@@ -18,8 +18,37 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+// SetRuntimeDefaults_Certificate sets the rotation policy to Always by default or
+// Never if the DefaultPrivateKeyRotationPolicyAlways feature is disabled.
+//
+// NOTE: This is deliberately not called `SetObjectDefault_`, because that would
+// cause defaultergen to add this to the scheme default, which would be
+// confusing because we don't (yet) have a defaulting webhook or use API default
+// annotations.
+//
+// TODO(wallrj): When DefaultPrivateKeyRotationPolicyAlways is GA, the default
+// value can probably be added as an API default by adding:
+//
+//	`// +default="Always"`
+//
+// ... to the API struct.
+func SetRuntimeDefaults_Certificate(in *cmapi.Certificate) {
+	if in.Spec.PrivateKey == nil {
+		in.Spec.PrivateKey = &cmapi.CertificatePrivateKey{}
+	}
+	defaultRotationPolicy := cmapi.RotationPolicyNever
+	if utilfeature.DefaultFeatureGate.Enabled(feature.DefaultPrivateKeyRotationPolicyAlways) {
+		defaultRotationPolicy = cmapi.RotationPolicyAlways
+	}
+	in.Spec.PrivateKey.RotationPolicy = defaultRotationPolicy
 }

--- a/internal/apis/certmanager/v1/defaults.go
+++ b/internal/apis/certmanager/v1/defaults.go
@@ -28,7 +28,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetRuntimeDefaults_Certificate sets the rotation policy to Always by default or
+// SetRuntimeDefaults_Certificate sets the default rotation policy to Always, or
 // Never if the DefaultPrivateKeyRotationPolicyAlways feature is disabled.
 //
 // NOTE: This is deliberately not called `SetObjectDefault_`, because that would
@@ -46,9 +46,11 @@ func SetRuntimeDefaults_Certificate(in *cmapi.Certificate) {
 	if in.Spec.PrivateKey == nil {
 		in.Spec.PrivateKey = &cmapi.CertificatePrivateKey{}
 	}
-	defaultRotationPolicy := cmapi.RotationPolicyNever
-	if utilfeature.DefaultFeatureGate.Enabled(feature.DefaultPrivateKeyRotationPolicyAlways) {
-		defaultRotationPolicy = cmapi.RotationPolicyAlways
+	if in.Spec.PrivateKey.RotationPolicy == "" {
+		defaultRotationPolicy := cmapi.RotationPolicyNever
+		if utilfeature.DefaultFeatureGate.Enabled(feature.DefaultPrivateKeyRotationPolicyAlways) {
+			defaultRotationPolicy = cmapi.RotationPolicyAlways
+		}
+		in.Spec.PrivateKey.RotationPolicy = defaultRotationPolicy
 	}
-	in.Spec.PrivateKey.RotationPolicy = defaultRotationPolicy
 }

--- a/internal/apis/certmanager/v1/defaults_test.go
+++ b/internal/apis/certmanager/v1/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
+)
+
+// Test_SetRuntimeDefaults_Certificate_PrivateKey_RotationPolicy demonstrates that
+// the default rotation policy is set by the defaulting function and that the
+// old default (`Never`) can be re-instated by disabling the
+// DefaultPrivateKeyRotationPolicyAlways feature gate.
+func Test_SetRuntimeDefaults_Certificate_PrivateKey_RotationPolicy(t *testing.T) {
+	t.Run("feature-enabled", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.DefaultPrivateKeyRotationPolicyAlways, true)
+		in := &cmapi.Certificate{}
+		SetRuntimeDefaults_Certificate(in)
+		assert.Equal(t, cmapi.RotationPolicyAlways, in.Spec.PrivateKey.RotationPolicy)
+	})
+	t.Run("feature-disabled", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.DefaultPrivateKeyRotationPolicyAlways, false)
+		in := &cmapi.Certificate{}
+		SetRuntimeDefaults_Certificate(in)
+		assert.Equal(t, cmapi.RotationPolicyNever, in.Spec.PrivateKey.RotationPolicy)
+	})
+}

--- a/internal/apis/certmanager/v1/defaults_test.go
+++ b/internal/apis/certmanager/v1/defaults_test.go
@@ -44,4 +44,17 @@ func Test_SetRuntimeDefaults_Certificate_PrivateKey_RotationPolicy(t *testing.T)
 		SetRuntimeDefaults_Certificate(in)
 		assert.Equal(t, cmapi.RotationPolicyNever, in.Spec.PrivateKey.RotationPolicy)
 	})
+	t.Run("explicit-rotation-policy", func(t *testing.T) {
+		const expectedRotationPolicy = cmapi.PrivateKeyRotationPolicy("neither-always-nor-never")
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.DefaultPrivateKeyRotationPolicyAlways, false)
+		in := &cmapi.Certificate{
+			Spec: cmapi.CertificateSpec{
+				PrivateKey: &cmapi.CertificatePrivateKey{
+					RotationPolicy: expectedRotationPolicy,
+				},
+			},
+		}
+		SetRuntimeDefaults_Certificate(in)
+		assert.Equal(t, expectedRotationPolicy, in.Spec.PrivateKey.RotationPolicy)
+	})
 }

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -234,10 +234,13 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	return el
 }
 
-func ValidateCertificate(a *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+func ValidateCertificate(a *admissionv1.AdmissionRequest, obj runtime.Object) (allErrs field.ErrorList, warnings []string) {
 	crt := obj.(*internalcmapi.Certificate)
-	allErrs := ValidateCertificateSpec(&crt.Spec, field.NewPath("spec"))
-	return allErrs, nil
+	allErrs = ValidateCertificateSpec(&crt.Spec, field.NewPath("spec"))
+	if crt.Spec.PrivateKey == nil || crt.Spec.PrivateKey.RotationPolicy == "" {
+		warnings = append(warnings, newDefaultPrivateKeyRotationPolicy)
+	}
+	return allErrs, warnings
 }
 
 func ValidateUpdateCertificate(a *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {

--- a/internal/apis/certmanager/validation/warnings.go
+++ b/internal/apis/certmanager/validation/warnings.go
@@ -21,4 +21,6 @@ package validation
 const (
 	// deprecatedACMEEABKeyAlgorithmField is raised when the deprecated keyAlgorithm field for an ACME issuer's external account binding (EAB) is set.
 	deprecatedACMEEABKeyAlgorithmField = "ACME issuer spec field 'externalAccount.keyAlgorithm' is deprecated. The value of this field will be ignored."
+	// newDefaultPrivateKeyRotationPolicy is raised when the Certificate.Spec.PrivateKey.RotationPolicy is omitted.
+	newDefaultPrivateKeyRotationPolicy = "spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`."
 )

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -154,6 +154,22 @@ const (
 	// hit with "unknown feature gate" errors which crash the controller, but this is a no-op
 	// and only prints a log line if added.
 	ValidateCAA featuregate.Feature = "ValidateCAA"
+
+	// Owner: @wallrj
+	// Alpha: v1.18.0
+	// Beta: v1.18.0
+	//
+	// DefaultPrivateKeyRotationPolicyAlways change the default value of
+	// `Certificate.Spec.PrivateKey.RotationPolicy` to `Always`.
+	// Why? Because the old default (`Never`) was unintuitive and insecure. For
+	// example, if a private key is exposed, users may (reasonably) assume that
+	// re-issuing a certificate (e.g. using cmctl renew) will generate a new
+	// private key, but it won't unless the user has explicitly set
+	// rotationPolicy: Always on the Certificate resource.
+	// This feature skipped the Alpha phase and was instead introduced as a Beta
+	// feature, because it is thought be low-risk feature and because we want to
+	// accelerate the adoption of this important security feature.
+	DefaultPrivateKeyRotationPolicyAlways featuregate.Feature = "DefaultPrivateKeyRotationPolicyAlways"
 )
 
 func init() {
@@ -177,6 +193,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	NameConstraints:                                  {Default: true, PreRelease: featuregate.Beta},
 	OtherNames:                                       {Default: false, PreRelease: featuregate.Alpha},
 	UseDomainQualifiedFinalizer:                      {Default: true, PreRelease: featuregate.Beta},
+	DefaultPrivateKeyRotationPolicyAlways:            {Default: true, PreRelease: featuregate.Beta},
 
 	// NB: Deprecated + removed feature gates are kept here.
 	// `featuregate.Deprecated` exists, but will cause the featuregate library

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -341,7 +341,11 @@ type CertificatePrivateKey struct {
 	// to await user intervention.
 	// If set to `Always`, a private key matching the specified requirements
 	// will be generated whenever a re-issuance occurs.
-	// Default is `Never` for backward compatibility.
+	// Default is `Always`.
+	// The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
+	// The new default can be disabled by setting the
+	// `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
+	// the controller component.
 	// +optional
 	RotationPolicy PrivateKeyRotationPolicy `json:"rotationPolicy,omitempty"`
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -173,7 +173,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	// if there is no existing Secret resource, create a new one
 	if len(secrets) == 0 {
-		rotationPolicy := cmapi.RotationPolicyNever
+		rotationPolicy := cmapi.RotationPolicyAlways
 		if crt.Spec.PrivateKey != nil && crt.Spec.PrivateKey.RotationPolicy != "" {
 			rotationPolicy = crt.Spec.PrivateKey.RotationPolicy
 		}

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -323,7 +323,10 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 			Status:     cmapi.CertificateStatus{NextPrivateKeySecretName: crt.Status.NextPrivateKeySecretName},
 		})
 	} else {
-		_, err := c.client.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+		_, err := c.client.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, &cmapi.Certificate{
+			ObjectMeta: crt.ObjectMeta,
+			Status:     crt.Status,
+		}, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -173,7 +173,10 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	// if there is no existing Secret resource, create a new one
 	if len(secrets) == 0 {
-		rotationPolicy := cmapi.RotationPolicyAlways
+		rotationPolicy := cmapi.RotationPolicyNever
+		if utilfeature.DefaultFeatureGate.Enabled(feature.DefaultPrivateKeyRotationPolicyAlways) {
+			rotationPolicy = cmapi.RotationPolicyAlways
+		}
 		if crt.Spec.PrivateKey != nil && crt.Spec.PrivateKey.RotationPolicy != "" {
 			rotationPolicy = crt.Spec.PrivateKey.RotationPolicy
 		}

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -668,6 +668,9 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 					SecretName: "testcert-tls",
 					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
 					IssuerRef:  issuerRef,
+					PrivateKey: &cmapi.CertificatePrivateKey{
+						RotationPolicy: cmapi.RotationPolicyNever,
+					},
 				},
 			}
 			By("Creating a Certificate")

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -708,7 +708,7 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 			crt2, err := pki.DecodeX509CertificateBytes(crtPEM2)
 			Expect(err).NotTo(HaveOccurred(), "failed to get decode second signed certificate data")
 
-			By("Ensuing both certificates are signed by same private key")
+			By("Ensuring both certificates are signed by same private key")
 			match, err := pki.PublicKeysEqual(crt1.PublicKey, crt2.PublicKey)
 			Expect(err).NotTo(HaveOccurred(), "failed to check public keys of both signed certificates")
 

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -669,6 +669,10 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
 					IssuerRef:  issuerRef,
 					PrivateKey: &cmapi.CertificatePrivateKey{
+						// Explicitly set RotationPolicy to Never to test the
+						// behavior of reusing the same private key when a
+						// certificate is reissued.
+						// The default value is Always.
 						RotationPolicy: cmapi.RotationPolicyNever,
 					},
 				},

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,7 +45,6 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -18,7 +18,6 @@ package certificates
 
 import (
 	"context"
-	"crypto"
 	"fmt"
 	"testing"
 	"time"
@@ -340,10 +339,6 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 	match, err := pki.PublicKeysEqual(csr1.PublicKey, csr2.PublicKey)
 	require.NoError(t, err)
 	assert.False(t, match, "expected the two requests to have been signed by distinct private keys, but the private key has been reused")
-}
-
-type comparablePublicKey interface {
-	Equal(crypto.PublicKey) bool
 }
 
 func runAllControllers(t *testing.T, config *rest.Config) framework.StopFunc {


### PR DESCRIPTION
The motivation for this change is described by @SgtCoDFish  in #7601:
> Security; if a private key is exposed, users may (reasonably) assume that re-issuing a certificate (e.g. using cmctl renew) will generate a new private key. Flynn's point is that unless a user has already deeply read the cert-manager docs (which most won't have, it's pretty simple to get cert-manager working for most) this is highly surprising and will mean that cert-manager isn't protecting the user from something they expect.
> 
> Users who need to not change the private key on rotation (e.g. if they want to preserve it and just change the cert, which is less common but still happens) would need to explicitly set the rotation policy to never to avoid losing the key.

There were two proposed strategies and the team decided on the first, which this PR now implements:
> Timeline 1: Add to cert-manager v1.18 at beta level
> Quickest: just change the default in v1.18. I think we've made bigger "breaking" changes than this in past minor releases, so we could justify making the change without giving people months to prepare.
> 
> This is equivalent to introducing the feature gate at "beta" level in v1.18.

Fixes:  https://github.com/cert-manager/cert-manager/issues/7601
 * https://github.com/cert-manager/cert-manager/issues/7601

You can read the draft documentation for this change at:
 * https://github.com/cert-manager/website/pull/1681
 * https://deploy-preview-1681--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.18/#the-default-value-of-certificatespecprivatekeyrotationpolicy-is-now-always

```release-note
The default value of `Certificate.Spec.PrivateKey.RotationPolicy` changed from `Never` to `Always`.
```

/kind feature

## Testing

### Feature Gates Disabled

 * https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/7723/pull-cert-manager-master-e2e-v1-32-feature-gates-disabled/1920154554146492416

### Feature Gate Flag
```
$ go run ./cmd/controller/ --help
...
      --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                             AdditionalCertificateOutputFormats=true|false (BETA - default=true)
                                                             AllAlpha=true|false (ALPHA - default=false)
                                                             AllBeta=true|false (BETA - default=false)
                                                             DefaultPrivateKeyRotationPolicyAlways=true|false (BETA - default=true)
                                                             ExperimentalCertificateSigningRequestControllers=true|false (ALPHA - default=false)
                                                             ExperimentalGatewayAPISupport=true|false (BETA - default=true)
                                                             LiteralCertificateSubject=true|false (BETA - default=true)
                                                             NameConstraints=true|false (BETA - default=true)
                                                             OtherNames=true|false (ALPHA - default=false)
                                                             SecretsFilteredCaching=true|false (BETA - default=true)
                                                             ServerSideApply=true|false (ALPHA - default=false)
                                                             StableCertificateRequestName=true|false (BETA - default=true)
                                                             UseCertificateRequestBasicConstraints=true|false (ALPHA - default=false)
                                                             UseDomainQualifiedFinalizer=true|false (BETA - default=true)
                                                             ValidateCAA=true|false (ALPHA - default=false)

```

### Helm chart notes

```
$ make helm-chart
$ helm install --dry-run test  _bin/cert-manager-v1.17.0-274-g3253cfae813f82-dirty.tgz --set installCRDs=true
...
NOTES:
⚠️  WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.
⚠️  WARNING: New default private key rotation policy for Certificate resources.
The default private key rotation policy for Certificate resources was
changed to `Always` in cert-manager >= v1.18.0.
Learn more in the [1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18).

cert-manager v1.17.0-274-g3253cfae813f82-dirty has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://cert-manager.io/docs/configuration/

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://cert-manager.io/docs/usage/ingress/

```