### PR TITLE
helm: use port names rather than numbers

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -710,13 +710,14 @@ The namespace that the service monitor should live in, defaults to the cert-mana
 > ```
 
 Specifies the `prometheus` label on the created ServiceMonitor. This is used when different Prometheus instances have label selectors matching different ServiceMonitors.
-#### **prometheus.servicemonitor.targetPort** ~ `number`
+#### **prometheus.servicemonitor.targetPort** ~ `string,integer`
 > Default value:
 > ```yaml
-> 9402
+> http-metrics
 > ```
 
 The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics.
+
 #### **prometheus.servicemonitor.path** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -137,11 +137,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /livez
-              {{- if $config.healthzPort }}
-              port: {{ $config.healthzPort }}
-              {{- else }}
-              port: 6080
-              {{- end }}
+              port: healthcheck
               scheme: HTTP
             initialDelaySeconds: {{ .Values.webhook.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webhook.livenessProbe.periodSeconds }}
@@ -151,11 +147,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              {{- if $config.healthzPort }}
-              port: {{ $config.healthzPort }}
-              {{- else }}
-              port: 6080
-              {{- end }}
+              port: healthcheck
               scheme: HTTP
             initialDelaySeconds: {{ .Values.webhook.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webhook.readinessProbe.periodSeconds }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1185,9 +1185,8 @@
       "type": "string"
     },
     "helm-values.prometheus.servicemonitor.targetPort": {
-      "default": 9402,
-      "description": "The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics.",
-      "type": "number"
+      "default": "http-metrics",
+      "description": "The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics."
     },
     "helm-values.replicaCount": {
       "default": 1,

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -525,7 +525,8 @@ prometheus:
 
     # The target port to set on the ServiceMonitor. This must match the port that the
     # cert-manager controller is listening on for metrics.
-    targetPort: 9402
+    # +docs:type=string,integer
+    targetPort: http-metrics
 
     # The path to scrape for metrics.
     path: /metrics


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes: #7720 

Use port names rather than numbers to map connections

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Switched service/servicemon definitions to use port names instead of numbers.
```
