### PR TITLE
fixes #5864: cert-manager CA to issue certs after verify with CA Certs Validity

### DIFF
--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -117,6 +117,14 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 	template.OCSPServer = issuerObj.GetSpec().CA.OCSPServers
 	template.IssuingCertificateURL = issuerObj.GetSpec().CA.IssuingCertificateURLs
 
+	template.NotAfter, err = pki.CertificateNotAfterValidity(template, caCerts)
+	if err != nil {
+		message := "Error calculating certificate validity"
+		c.reporter.Failed(cr, err, "SigningError", message)
+		log.Error(err, message)
+		return nil, err
+	}
+
 	bundle, err := c.signingFn(caCerts, caKey, template)
 	if err != nil {
 		message := "Error signing certificate"

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -513,6 +513,11 @@ func TestCA_Sign(t *testing.T) {
 				// injecting a time (instead of time.Now) to the template
 				// functions. This work is being tracked in this issue:
 				// https://github.com/cert-manager/cert-manager/issues/3738
+				//
+				// Leaf Cert expectNotAfter will honor Signing CA Validity
+				// As self-signed Signing CA is valid for a minute, the client
+				// expectNotAfter will be a minute. Refer:
+				// https://github.com/cert-manager/cert-manager/issues/5864
 				expectNotAfter := time.Now().UTC().Add(time.Minute)
 				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
 				assert.LessOrEqualf(t, deltaSec, 1., "expected a time delta lower than 1 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -513,7 +513,7 @@ func TestCA_Sign(t *testing.T) {
 				// injecting a time (instead of time.Now) to the template
 				// functions. This work is being tracked in this issue:
 				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(30 * time.Minute)
+				expectNotAfter := time.Now().UTC().Add(time.Minute)
 				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
 				assert.LessOrEqualf(t, deltaSec, 1., "expected a time delta lower than 1 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
 			},

--- a/pkg/util/pki/validity.go
+++ b/pkg/util/pki/validity.go
@@ -26,7 +26,7 @@ import (
 // should be valid, based on the template and the earliest expiration date of the CA certificates.
 func CertificateNotAfterValidity(template *x509.Certificate, caCerts []*x509.Certificate) (time.Time, error) {
 	if len(caCerts) == 0 {
-		return time.Now(), fmt.Errorf("no CA certificates provided")
+		return time.Time{}, fmt.Errorf("no CA certificates provided")
 	}
 
 	// Find the earliest expiration date of the CA certificates

--- a/pkg/util/pki/validity.go
+++ b/pkg/util/pki/validity.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+)
+
+// CertificateNotAfterValidity returns the duration for which the certificate
+// should be valid, based on the template and the earlist expiration date of the CA certificates.
+func CertificateNotAfterValidity(template *x509.Certificate, caCerts []*x509.Certificate) (time.Time, error) {
+	if len(caCerts) == 0 {
+		return time.Now(), fmt.Errorf("no CA certificates provided")
+	}
+
+	// Find the earlist expiration date of the CA certificates
+	earlist := caCerts[0].NotAfter
+	for _, caCert := range caCerts[1:] {
+		if caCert.NotAfter.Before(earlist) {
+			earlist = caCert.NotAfter
+		}
+	}
+
+	// Return the earlist expiration date if it is before the template's NotAfter
+	if earlist.Before(template.NotAfter) {
+		return earlist, nil
+	}
+
+	return template.NotAfter, nil
+}

--- a/pkg/util/pki/validity.go
+++ b/pkg/util/pki/validity.go
@@ -23,23 +23,23 @@ import (
 )
 
 // CertificateNotAfterValidity returns the duration for which the certificate
-// should be valid, based on the template and the earlist expiration date of the CA certificates.
+// should be valid, based on the template and the earliest expiration date of the CA certificates.
 func CertificateNotAfterValidity(template *x509.Certificate, caCerts []*x509.Certificate) (time.Time, error) {
 	if len(caCerts) == 0 {
 		return time.Now(), fmt.Errorf("no CA certificates provided")
 	}
 
-	// Find the earlist expiration date of the CA certificates
-	earlist := caCerts[0].NotAfter
+	// Find the earliest expiration date of the CA certificates
+	earliest := caCerts[0].NotAfter
 	for _, caCert := range caCerts[1:] {
-		if caCert.NotAfter.Before(earlist) {
-			earlist = caCert.NotAfter
+		if caCert.NotAfter.Before(earliest) {
+			earliest = caCert.NotAfter
 		}
 	}
 
-	// Return the earlist expiration date if it is before the template's NotAfter
-	if earlist.Before(template.NotAfter) {
-		return earlist, nil
+	// Return the earliest expiration date if it is before the template's NotAfter
+	if earliest.Before(template.NotAfter) {
+		return earliest, nil
 	}
 
 	return template.NotAfter, nil

--- a/pkg/util/pki/validity_test.go
+++ b/pkg/util/pki/validity_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+func TestCertificateNotAfterValidity(t *testing.T) {
+	testCases := []struct {
+		name      string
+		template  *x509.Certificate
+		caCerts   []*x509.Certificate
+		expected  time.Time
+		expectErr bool
+	}{
+		{
+			name: "no CA certificates",
+			template: &x509.Certificate{
+				NotAfter: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			caCerts:   nil,
+			expected:  time.Time{},
+			expectErr: true,
+		},
+		{
+			name: "CA certificate with earlier expiration",
+			template: &x509.Certificate{
+				NotAfter: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			caCerts: []*x509.Certificate{
+				{
+					NotAfter: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expected:  time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+		{
+			name: "CA certificate with later expiration",
+			template: &x509.Certificate{
+				NotAfter: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			caCerts: []*x509.Certificate{
+				{
+					NotAfter: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expected:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+		{
+			name: "multiple CA certificates with different expirations",
+			template: &x509.Certificate{
+				NotAfter: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			caCerts: []*x509.Certificate{
+				{
+					NotAfter: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					NotAfter: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					NotAfter: time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expected:  time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := CertificateNotAfterValidity(tc.template, tc.caCerts)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !result.Equal(tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
fixes #5864: cert-manager issuer to issue certs with CA Certs Validity.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
This PR addresses issues mentioned in the Issues #5864 and #6323.

We ran into similar issue where cert-manager CA issued a Certifiacte Validity which was longer than the Issuer CA Validity. This PR creates a function `CertificateNotAfterValidity` that takes in Certificate template and list of CA Certificates, finds the earliest CA Certs expiration and compares with template Certificate `NotAfter`. The issued Certificate will issued with earliest time (tempate.NotAfter and earliest CA Validity).

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->

/kind bug feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note

Ensure Issued certificate validity honors the CA Certificates Validity.

```
