### PR TITLE
feat(metrics): adding `certmanager_certificate_challenge_status` metric

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -110,6 +110,8 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on prometheus address %s: %v", opts.MetricsListenAddress, err)
 	}
+
+	ctx.Metrics.SetupACMECollector(ctx.SharedInformerFactory.Acme().V1().Challenges().Lister())
 	metricsServer := ctx.Metrics.NewServer(metricsLn)
 
 	g.Go(func() error {

--- a/internal/collectors/acme_collector.go
+++ b/internal/collectors/acme_collector.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/labels"
+
+	acmemeta "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
+)
+
+var (
+	challengeValidStatuses  = [...]acmemeta.State{acmemeta.Ready, acmemeta.Valid, acmemeta.Errored, acmemeta.Expired, acmemeta.Invalid, acmemeta.Processing, acmemeta.Unknown, acmemeta.Pending}
+	certChallengeMetricDesc = prometheus.NewDesc("certmanager_certificate_challenge_status", "The status of certificate challenges", []string{"status", "domain", "reason", "processing", "name", "namespace", "type"}, nil)
+)
+
+type ACMECollector struct {
+	challengesLister                 cmacmelisters.ChallengeLister
+	certificateChallengeStatusMetric *prometheus.Desc
+}
+
+func NewACMECollector(acmeInformers cmacmelisters.ChallengeLister) prometheus.Collector {
+	return &ACMECollector{
+		challengesLister:                 acmeInformers,
+		certificateChallengeStatusMetric: certChallengeMetricDesc,
+	}
+}
+
+func (ac *ACMECollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- ac.certificateChallengeStatusMetric
+}
+
+func (ac *ACMECollector) Collect(ch chan<- prometheus.Metric) {
+	challengesList, err := ac.challengesLister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+
+	for _, challenge := range challengesList {
+		for _, status := range challengeValidStatuses {
+			value := 0.0
+			if string(challenge.Status.State) == string(status) {
+				value = 1.0
+			}
+
+			metric := prometheus.MustNewConstMetric(
+				ac.certificateChallengeStatusMetric, prometheus.GaugeValue,
+				value,
+				string(status),
+				challenge.Spec.DNSName,
+				challenge.Status.Reason,
+				fmt.Sprint(challenge.Status.Processing),
+				challenge.Name,
+				challenge.Namespace,
+				string(challenge.Spec.Type),
+			)
+
+			ch <- metric
+		}
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	fakeclock "k8s.io/utils/clock/testing"
+
+	acmemeta "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 func Test_clockTimeSeconds(t *testing.T) {
@@ -56,6 +61,76 @@ certmanager_clock_time_seconds %f
 # TYPE certmanager_clock_time_seconds_gauge gauge
 certmanager_clock_time_seconds_gauge %f
 	`, float64(fixedClock.Now().Unix())),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t,
+				testutil.CollectAndCompare(test.metric, strings.NewReader(test.expected), test.metricName),
+			)
+		})
+	}
+}
+
+func Test_ACMEChallenges(t *testing.T) {
+	fixedClock := fakeclock.NewFakeClock(time.Now())
+	m := New(testr.New(t), fixedClock)
+
+	challenges := make([]*acmemeta.Challenge, 0)
+	challenges = append(challenges, gen.Challenge("test-challenge-status",
+		gen.SetChallengeDNSName("example.com"),
+		gen.SetChallengeProcessing(false),
+		gen.SetChallengeType(acmemeta.ACMEChallengeTypeDNS01),
+		gen.SetChallengeState(acmemeta.Pending),
+		gen.SetChallengeNamespace("test-challenge"),
+	), gen.Challenge("test-challenge-status-1",
+		gen.SetChallengeDNSName("example.com"),
+		gen.SetChallengeProcessing(false),
+		gen.SetChallengeType(acmemeta.ACMEChallengeTypeDNS01),
+		gen.SetChallengeState(acmemeta.Ready),
+		gen.SetChallengeNamespace("test-challenge"),
+	))
+
+	fakeClient := fake.NewSimpleClientset()
+	factory := externalversions.NewSharedInformerFactory(fakeClient, 0)
+	challengesInformer := factory.Acme().V1().Challenges()
+	for _, ch := range challenges {
+		err := challengesInformer.Informer().GetIndexer().Add(ch)
+		assert.NoError(t, err)
+	}
+
+	m.SetupACMECollector(challengesInformer.Lister())
+
+	tests := map[string]struct {
+		metricName string
+		metric     prometheus.Collector
+
+		expected string
+	}{
+		"challenge_status": {
+			metricName: "certmanager_certificate_challenge_status",
+			metric:     m.challengeCollector,
+			expected: `
+# HELP certmanager_certificate_challenge_status The status of certificate challenges
+# TYPE certmanager_certificate_challenge_status gauge
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="errored",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="expired",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="invalid",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="pending",type="DNS-01"} 1
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="processing",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="ready",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status",namespace="test-challenge",processing="false",reason="",status="valid",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="errored",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="expired",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="invalid",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="pending",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="processing",type="DNS-01"} 0
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="ready",type="DNS-01"} 1
+certmanager_certificate_challenge_status{domain="example.com",name="test-challenge-status-1",namespace="test-challenge",processing="false",reason="",status="valid",type="DNS-01"} 0
+	`,
 		},
 	}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### feature
Fixes https://github.com/cert-manager/cert-manager/issues/7700. This PR adds the new challenge status metric with a controller which monitors the challenges.
<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added `certmanager_certificate_challenge_status` prometheus metric.
```
