### PR TITLE
Avoid mutating the client-go informer cache

### DIFF
--- a/internal/apis/certmanager/v1/defaults.go
+++ b/internal/apis/certmanager/v1/defaults.go
@@ -28,8 +28,15 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetRuntimeDefaults_Certificate sets the default rotation policy to Always, or
-// Never if the DefaultPrivateKeyRotationPolicyAlways feature is disabled.
+// SetRuntimeDefaults_Certificate mutates the supplied Certificate object,
+// setting defaults for certain missing fields:
+// - Sets the default  private key rotation policy to:
+//   - Always, if the DefaultPrivateKeyRotationPolicyAlways feature is enabled
+//   - Never, if the DefaultPrivateKeyRotationPolicyAlways feature is disabled.
+//
+// NOTE: Do not supply Certificate objects retrieved from a client-go lister
+// because you may corrupt the cache. Do a DeepCopy first. See:
+// https://pkg.go.dev/github.com/cert-manager/cert-manager@v1.17.2/pkg/client/listers/certmanager/v1#CertificateNamespaceLister
 //
 // NOTE: This is deliberately not called `SetObjectDefault_`, because that would
 // cause defaultergen to add this to the scheme default, which would be

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -157,6 +157,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	// Apply runtime defaults to apply default values that are governed by
 	// controller feature gates, such as DefaultPrivateKeyRotationPolicyAlways.
+	// We deep copy the object to avoid mutating the client-go cache.
+	crt = crt.DeepCopy()
 	cminternal.SetRuntimeDefaults_Certificate(crt)
 
 	// Discover all 'owned' secrets that have the `next-private-key` label


### PR DESCRIPTION

See  https://github.com/cert-manager/cert-manager/pull/7723#discussion_r2080108272 for context.

/kind bug

```release-note
NONE
```
