### PR TITLE
Set the default RevisionHistoryLimit to 1 for CertificateRequest revisions

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -507,8 +507,8 @@ spec:
                     revisions exceeds this number.
 
                     If set, revisionHistoryLimit must be a value of `1` or greater.
-                    If unset (`nil`), revisions will not be garbage collected.
-                    Default value is `nil`.
+                    If set to 0, revisions will not be garbage collected.
+                    Default value is `1`.
                   type: integer
                   format: int32
                 secretName:

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -507,7 +507,6 @@ spec:
                     revisions exceeds this number.
 
                     If set, revisionHistoryLimit must be a value of `1` or greater.
-                    If set to 0, revisions will not be garbage collected.
                     Default value is `1`.
                   type: integer
                   format: int32

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -252,8 +252,8 @@ type CertificateSpec struct {
 	// revisions exceeds this number.
 	//
 	// If set, revisionHistoryLimit must be a value of `1` or greater.
-	// If unset (`nil`), revisions will not be garbage collected.
-	// Default value is `nil`.
+	// If set to 0, revisions will not be garbage collected.
+	// Default value is `1`.
 	RevisionHistoryLimit *int32
 
 	// Defines extra output formats of the private key and signed certificate chain

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -252,7 +252,6 @@ type CertificateSpec struct {
 	// revisions exceeds this number.
 	//
 	// If set, revisionHistoryLimit must be a value of `1` or greater.
-	// If set to 0, revisions will not be garbage collected.
 	// Default value is `1`.
 	RevisionHistoryLimit *int32
 

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -292,7 +292,6 @@ type CertificateSpec struct {
 	// revisions exceeds this number.
 	//
 	// If set, revisionHistoryLimit must be a value of `1` or greater.
-	// If set to 0, revisions will not be garbage collected.
 	// Default value is `1`.
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -292,8 +292,8 @@ type CertificateSpec struct {
 	// revisions exceeds this number.
 	//
 	// If set, revisionHistoryLimit must be a value of `1` or greater.
-	// If unset (`nil`), revisions will not be garbage collected.
-	// Default value is `nil`.
+	// If set to 0, revisions will not be garbage collected.
+	// Default value is `1`.
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -117,12 +117,6 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	log = logf.WithResource(log, crt)
 
-	// If RevisionHistoryLimit is nil, then default to 1
-	if crt.Spec.RevisionHistoryLimit == nil {
-		defaultRevisionHistoryLimit := int32(1)
-		crt.Spec.RevisionHistoryLimit = &defaultRevisionHistoryLimit
-	}
-
 	// Only garbage collect over Certificates that are in a Ready=True condition.
 	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionReady,
@@ -139,7 +133,14 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	// Fetch and delete all CertificateRequests that need to be deleted
-	limit := int(*crt.Spec.RevisionHistoryLimit)
+	// If RevisionHistoryLimit is nil, then default to 1
+	var limit int
+	if crt.Spec.RevisionHistoryLimit == nil {
+		limit = 1
+	} else {
+		limit = int(*crt.Spec.RevisionHistoryLimit)
+	}
+
 	toDelete := certificateRequestsToDelete(log, limit, requests)
 
 	for _, req := range toDelete {

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -117,9 +117,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	log = logf.WithResource(log, crt)
 
-	// If RevisionHistoryLimit is nil, don't attempt to garbage collect old
-	// CertificateRequests
+	// If RevisionHistoryLimit is nil, then default to 1
 	if crt.Spec.RevisionHistoryLimit == nil {
+		defaultRevisionHistoryLimit := int32(1)
+		crt.Spec.RevisionHistoryLimit = &defaultRevisionHistoryLimit
+	}
+
+	// If RevisionHistoryLimit is 0, don't attempt to garbage collect old
+	// CertificateRequests
+	if *crt.Spec.RevisionHistoryLimit == 0 {
 		return nil
 	}
 

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -123,12 +123,6 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		crt.Spec.RevisionHistoryLimit = &defaultRevisionHistoryLimit
 	}
 
-	// If RevisionHistoryLimit is 0, don't attempt to garbage collect old
-	// CertificateRequests
-	if *crt.Spec.RevisionHistoryLimit == 0 {
-		return nil
-	}
-
 	// Only garbage collect over Certificates that are in a Ready=True condition.
 	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionReady,

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -142,22 +142,6 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
-		"do nothing if revision limit is not set to 0": {
-			certificate: gen.CertificateFrom(baseCrt,
-				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
-				gen.SetCertificateRevisionHistoryLimit(0),
-			),
-			requests: []runtime.Object{
-				gen.CertificateRequestFrom(baseCR,
-					gen.SetCertificateRequestName("cr-1"),
-					gen.SetCertificateRequestRevision("1"),
-				),
-				gen.CertificateRequestFrom(baseCR,
-					gen.SetCertificateRequestName("cr-2"),
-					gen.SetCertificateRequestRevision("2"),
-				),
-			},
-		},
 		"delete 1 request if 2 requests exist since the default limit is 1": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -81,7 +81,6 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if Certificate is not in a Ready=True state": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse}),
-				gen.SetCertificateRevisionHistoryLimit(1),
 			),
 			requests: []runtime.Object{
 				gen.CertificateRequestFrom(baseCR,
@@ -96,13 +95,11 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if no requests exist": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
-				gen.SetCertificateRevisionHistoryLimit(1),
 			),
 		},
 		"do nothing if requests don't have or bad revisions set": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
-				gen.SetCertificateRevisionHistoryLimit(1),
 			),
 			requests: []runtime.Object{
 				gen.CertificateRequestFrom(baseCR,
@@ -117,7 +114,6 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if requests aren't owned by this Certificate": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
-				gen.SetCertificateRevisionHistoryLimit(1),
 			),
 			requests: []runtime.Object{
 				gen.CertificateRequestFrom(baseCRNoOwner,
@@ -146,9 +142,10 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
-		"do nothing if revision limit is not set": {
+		"do nothing if revision limit is not set to 0": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(0),
 			),
 			requests: []runtime.Object{
 				gen.CertificateRequestFrom(baseCR,
@@ -161,10 +158,9 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
-		"delete 1 request if limit is 1 and 2 requests exist": {
+		"delete 1 request if 2 requests exist since the default limit is 1": {
 			certificate: gen.CertificateFrom(baseCrt,
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
-				gen.SetCertificateRevisionHistoryLimit(1),
 			),
 			requests: []runtime.Object{
 				gen.CertificateRequestFrom(baseCR,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
As highlighted in this [issue](https://github.com/cert-manager/cert-manager/issues/3958), the default value for the revisionHistoryLimit should not be nil as if the user doesn't set it then no revisions will be garbage collected. Most users do want the revisions garbage collected so it would be good to provide it right out of the box.
### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
⚠️ might be breaking: Set the default revisionHistoryLimit to 1 for the CertificateRequest revisions
```
