### PR TITLE
Helm: Fix naming format of tokenrequest RBAC resources

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -49,7 +49,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "cert-manager.serviceAccountName" . }}-tokenrequest
+  name: {{ template "cert-manager.fullname" . }}-tokenrequest
   namespace: {{ include "cert-manager.namespace" . }}
   labels:
     app: {{ include "cert-manager.name" . }}
@@ -69,7 +69,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "cert-manager.fullname" . }}-{{ template "cert-manager.serviceAccountName" .  }}-tokenrequest
+  name: {{ include "cert-manager.fullname" . }}-tokenrequest
   namespace: {{ include "cert-manager.namespace" . }}
   labels:
     app: {{ include "cert-manager.name" . }}
@@ -80,7 +80,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "cert-manager.serviceAccountName" . }}-tokenrequest
+  name: {{ template "cert-manager.fullname" . }}-tokenrequest
 subjects:
   - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}


### PR DESCRIPTION
### Pull Request Motivation

cert-manager controller tokenrequest RoleBinding name is rendered as `cert-manager-cert-manager-tokenrequest`, which is less consistent than its corresponding Role name `cert-manager-tokenrequest`. Meanwhile it would be more accurate to use `{{ template "cert-manager.fullname" . }}` instead of `{{ template "cert-manager.serviceAccountName" . }}`

Follow-up #7213

### Verification

The renamed RoleBinding `cert-manager-tokenrequest` was created successfully, meanwhile the orphan RoleBinding `cert-manager-cert-manager-tokenrequest` was cleaned up automatically.

```
# Install the latest v1.18.2
$ k get role,rolebinding -n cert-manager
NAME                                                                  CREATED AT
role.rbac.authorization.k8s.io/cert-manager-tokenrequest              2025-08-17T07:20:30Z
role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving   2025-08-17T07:20:30Z

NAME                                                                           ROLE                                        AGE
rolebinding.rbac.authorization.k8s.io/cert-manager-cert-manager-tokenrequest   Role/cert-manager-tokenrequest              2m36s
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving     Role/cert-manager-webhook:dynamic-serving   2m36s

# Upgrade to the patch version
$ k get role,rolebinding -n cert-manager
NAME                                                                  CREATED AT
role.rbac.authorization.k8s.io/cert-manager-tokenrequest              2025-08-17T07:20:30Z
role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving   2025-08-17T07:20:30Z

NAME                                                                         ROLE                                        AGE
rolebinding.rbac.authorization.k8s.io/cert-manager-tokenrequest              Role/cert-manager-tokenrequest              56s
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving   Role/cert-manager-webhook:dynamic-serving   8m20s
```

### Kind

/kind cleanup

### Release Note

```release-note
Helm: Fix naming template of tokenrequest RoleBinding resource to improve consistency
```
