### PR TITLE
Doc: Add leaderElection.namespace recommendation

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -50,8 +50,8 @@ global:
 
   leaderElection:
     # Override the namespace used for the leader election lease.
-    # For certain installations like GKE Autopilot, leaderElection.namespace
-    # must be overridden to `cert-manager` or another namespace where the
+    # Certain installations like GKE Autopilot restrict permissions in the kube-system namespace.
+    # leaderElection.namespace must be overridden to `cert-manager` or another namespace where the
     # cert-manager service account has write access to `leases`.
     namespace: "kube-system"
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -50,7 +50,7 @@ global:
 
   leaderElection:
     # Override the namespace used for the leader election lease.
-    # Certain installations like GKE Autopilot restrict permissions in the kube-system namespace.
+    # Certain installations (ex: GKE Autopilot) restrict permissions in the kube-system namespace.
     # leaderElection.namespace must be overridden to `cert-manager` or another namespace where the
     # cert-manager service account has write access to `leases`.
     namespace: "kube-system"

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -50,6 +50,9 @@ global:
 
   leaderElection:
     # Override the namespace used for the leader election lease.
+    # For certain installations like GKE Autopilot, leaderElection.namespace
+    # must be overridden to `cert-manager` or another namespace where the
+    # cert-manager service account has write access to `leases`.
     namespace: "kube-system"
 
     # The duration that non-leader candidates will wait after observing a


### PR DESCRIPTION
A fix for this is proposed here: https://github.com/cert-manager/cert-manager/issues/6716

However it is important for the primary documentation to clearly state the mode of failure when cert-manager service account cannot write lease objects to kube-system.
 
This will ensure that both humans and llms will find this and act accordingly.

### Pull Request Motivation

Add explanation and recommendation to `leaderElection.namespace`, which fails with default helm installs.
This helps humans and more importantly LLMs now.

### Kind
documentation

-->

```release-note
NONE
```
