### PR TITLE
fix(acme):  use Exact pathType in Ingresses

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -378,7 +378,7 @@ func (s *Solver) cleanupIngresses(ctx context.Context, ch *cmacme.Challenge) err
 func ingressPath(token, serviceName string) networkingv1.HTTPIngressPath {
 	return networkingv1.HTTPIngressPath{
 		Path:     solverPathFn(token),
-		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeImplementationSpecific; return &s }(),
+		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeExact; return &s }(),
 		Backend: networkingv1.IngressBackend{
 			Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName,


### PR DESCRIPTION
Fixes cert-manager/cert-manager#6805

### Pull Request Motivation

cert-manager's acme http challenge accidentally uses Ingress pathType `ImplementationSpecific`, when it should use the more specific and secure `Exact` one. 

Kubernetes Ingress controllers vary in implementation of the `ImplementationSpecific` pathType, which will make the deterministic behaviour of cert-manager unreliable depending on the ingress controller that is used. Eg. Cilium Ingress.

### Kind

/kind bug

### Release Note

```release-note
Change of the Kubernetes Ingress pathType from `ImplementationSpecific` to `Exact` for a reliable handling of ingress controllers and enhanced security.
```
