### PR TITLE
WIP: Speed up E2E tests by Configuring Pebble to run at full speed

### DIFF
--- a/make/config/pebble/chart/templates/deployment.yaml
+++ b/make/config/pebble/chart/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
           args:
           - -config=/config/config.json
           - -strict={{ .Values.strict }}
+          env:
+          # https://github.com/letsencrypt/pebble/tree/main?tab=readme-ov-file#testing-at-full-speed
+          - name: PEBBLE_VA_NOSLEEP
+            value: "1"
+          # https://github.com/letsencrypt/pebble/tree/main?tab=readme-ov-file#invalid-anti-replay-nonce-errors
+          - name: PEBBLE_WFE_NONCEREJECT
+            value: "0"
           volumeMounts:
           - name: config
             mountPath: /config


### PR DESCRIPTION
Configure Pebble to run at full speed without artificial delays and client rejections


```release-note
NONE
```
