### PR TITLE
[VC-39414] Patch the third_party/forked/acme package with support for ACME profiles

### DIFF
--- a/third_party/forked/acme/acme.go
+++ b/third_party/forked/acme/acme.go
@@ -186,10 +186,11 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Nonce     string `json:"newNonce"`
 		KeyChange string `json:"keyChange"`
 		Meta      struct {
-			Terms        string   `json:"termsOfService"`
-			Website      string   `json:"website"`
-			CAA          []string `json:"caaIdentities"`
-			ExternalAcct bool     `json:"externalAccountRequired"`
+			Terms        string            `json:"termsOfService"`
+			Website      string            `json:"website"`
+			CAA          []string          `json:"caaIdentities"`
+			ExternalAcct bool              `json:"externalAccountRequired"`
+			Profiles     map[string]string `json:"profiles"`
 		}
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
@@ -209,6 +210,7 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Website:                 v.Meta.Website,
 		CAA:                     v.Meta.CAA,
 		ExternalAccountRequired: v.Meta.ExternalAcct,
+		Profiles:                v.Meta.Profiles,
 	}
 	return *c.dir, nil
 }

--- a/third_party/klone.yaml
+++ b/third_party/klone.yaml
@@ -1,9 +1,15 @@
 # Clone folders from third_party repos and forks.
 # More info can be found here: https://github.com/cert-manager/klone
+#
+# - acme
+#   We vendor just the acme package, from a cert-manager fork of
+#   golang.org/x/crypto. The acme-profiles branch has a patch by @sigmavirus24,
+#   with support for ACME profiles.
+#   See https://github.com/golang/go/issues/73101#issuecomment-2764923702
 targets:
   forked:
     - folder_name: acme
-      repo_url: https://go.googlesource.com/crypto
-      repo_ref: v0.38.0
-      repo_hash: aae6e61070421a51c1ba3bd9bba4b9b3979ed488
+      repo_url: https://github.com/cert-manager/crypto
+      repo_ref: acme-profiles
+      repo_hash: 20ccc126e2ac0b2d9da2e78f84f5bb7649d8100a
       repo_path: acme


### PR DESCRIPTION
This PR patches the `third_party/forked/acme` package to add support for ACME profiles via new options, error variables, and tests. Key changes include:

- Updating the vendor reference and documentation in third_party/klone.yaml.
- Adding new error definitions, functions, and options in types.go to support profiles.
- Introducing new tests and updates in rfc8555_test.go and rfc8555.go along with JSON decoding changes in acme.go to validate profile support.

Stack:
1.  [ ] #7752
2.  [x] #7776
3.  [ ] #7777

- https://github.com/cert-manager/crypto/commit/20ccc126e2ac0b2d9da2e78f84f5bb7649d8100a

```release-note
Patch the `third_party/forked/acme` package with support for the ACME profiles extension.
```
