### PR TITLE
[VC-39414] Add support for ACME profiles

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -199,6 +199,11 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                    profile:
+                      description: |-
+                        Profile allows requesting a certificate profile from the ACME server.
+                        Supported profiles are listed by the server's ACME directory URL.
+                      type: string
                     server:
                       description: |-
                         Server is the URL used to access the ACME server's 'directory' endpoint.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -199,6 +199,11 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                    profile:
+                      description: |-
+                        Profile allows requesting a certificate profile from the ACME server.
+                        Supported profiles are listed by the server's ACME directory URL.
+                      type: string
                     server:
                       description: |-
                         Server is the URL used to access the ACME server's 'directory' endpoint.

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -122,6 +122,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                profile:
+                  description: |-
+                    Profile allows requesting a certificate profile from the ACME server.
+                    Supported profiles are listed by the server's ACME directory URL.
+                  type: string
                 request:
                   description: |-
                     Certificate signing request bytes in DER encoding.

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -102,6 +102,10 @@ type ACMEIssuer struct {
 	// it, it will create an error on the Order.
 	// Defaults to false.
 	EnableDurationFeature bool
+
+	// Profile allows requesting a certificate profile from the ACME server.
+	// Supported profiles are listed by the server's ACME directory URL.
+	Profile string `json:"profile,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/internal/apis/acme/types_order.go
+++ b/internal/apis/acme/types_order.go
@@ -74,6 +74,11 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	Duration *metav1.Duration
+
+	// Profile allows requesting a certificate profile from the ACME server.
+	// Supported profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 type OrderStatus struct {

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -988,6 +988,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *acmev1.ACMEIssuer, out *ac
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1022,6 +1023,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *acme
 	}
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	out.EnableDurationFeature = in.EnableDurationFeature
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1664,6 +1666,7 @@ func autoConvert_v1_OrderSpec_To_acme_OrderSpec(in *acmev1.OrderSpec, out *acme.
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Profile = in.Profile
 	return nil
 }
 
@@ -1681,6 +1684,7 @@ func autoConvert_acme_OrderSpec_To_v1_OrderSpec(in *acme.OrderSpec, out *acmev1.
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	out.Duration = (*pkgapismetav1.Duration)(unsafe.Pointer(in.Duration))
+	out.Profile = in.Profile
 	return nil
 }
 

--- a/make/config/pebble/chart/templates/configmap.yaml
+++ b/make/config/pebble/chart/templates/configmap.yaml
@@ -22,7 +22,17 @@ data:
         "externalAccountMACKeys": {
           "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W"
         },
-        "domainBlocklist": ["google.com"]
+        "domainBlocklist": ["google.com"],
+        "profiles": {
+          "default": {
+            "description": "The profile you know and love",
+            "validityPeriod": 7776000
+          },
+          "shortlived": {
+            "description": "A short-lived cert profile, without actual enforcement",
+            "validityPeriod": 518400
+          }
+        }
       }
     }
   cert.pem: |

--- a/make/config/pebble/chart/templates/configmap.yaml
+++ b/make/config/pebble/chart/templates/configmap.yaml
@@ -24,13 +24,13 @@ data:
         },
         "domainBlocklist": ["google.com"],
         "profiles": {
-          "default": {
-            "description": "The profile you know and love",
-            "validityPeriod": 7776000
+          "123h": {
+            "description": "Certificates with duration 123h",
+            "validityPeriod": {{ mul 60 60 123 }}
           },
-          "shortlived": {
-            "description": "A short-lived cert profile, without actual enforcement",
-            "validityPeriod": 518400
+          "456h": {
+            "description": "Certificates with duration 456h",
+            "validityPeriod": {{ mul 60 60 456 }}
           }
         }
       }

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -114,6 +114,11 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+
+	// Profile allows requesting a certificate profile from the ACME server.
+	// Supported profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -82,6 +82,11 @@ type OrderSpec struct {
 	// this is set on order creation as pe the ACME spec.
 	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty"`
+
+	// Profile allows requesting a certificate profile from the ACME server.
+	// Supported profiles are listed by the server's ACME directory URL.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -188,12 +188,12 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 	ipBaseCR := gen.CertificateRequestFrom(baseCR, gen.SetCertificateRequestCSR(ipCSRPEM))
-	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR, baseIssuer.GetSpec().ACME.EnableDurationFeature)
+	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR, baseIssuer.GetSpec().ACME.EnableDurationFeature, "")
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}
 
-	baseOrder, err := buildOrder(baseCR, csr, baseIssuer.GetSpec().ACME.EnableDurationFeature)
+	baseOrder, err := buildOrder(baseCR, csr, baseIssuer.GetSpec().ACME.EnableDurationFeature, "")
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}
@@ -720,7 +720,7 @@ func Test_buildOrder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildOrder(tt.args.cr, tt.args.csr, tt.args.enableDurationFeature)
+			got, err := buildOrder(tt.args.cr, tt.args.csr, tt.args.enableDurationFeature, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildOrder() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -737,7 +737,7 @@ func Test_buildOrder(t *testing.T) {
 		"test-comparison-that-is-at-the-fifty-two-character-l",
 		gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour}),
 		gen.SetCertificateRequestCSR(csrPEM))
-	orderOne, err := buildOrder(longCrOne, csr, false)
+	orderOne, err := buildOrder(longCrOne, csr, false, "")
 	if err != nil {
 		t.Errorf("buildOrder() received error %v", err)
 		return
@@ -749,7 +749,7 @@ func Test_buildOrder(t *testing.T) {
 			gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour}),
 			gen.SetCertificateRequestCSR(csrPEM))
 
-		orderTwo, err := buildOrder(longCrTwo, csr, false)
+		orderTwo, err := buildOrder(longCrTwo, csr, false, "")
 		if err != nil {
 			t.Errorf("buildOrder() received error %v", err)
 			return
@@ -764,13 +764,13 @@ func Test_buildOrder(t *testing.T) {
 	})
 
 	t.Run("Builds two orders from the same long CRs to guarantee same name", func(t *testing.T) {
-		orderOne, err := buildOrder(longCrOne, csr, false)
+		orderOne, err := buildOrder(longCrOne, csr, false, "")
 		if err != nil {
 			t.Errorf("buildOrder() received error %v", err)
 			return
 		}
 
-		orderTwo, err := buildOrder(longCrOne, csr, false)
+		orderTwo, err := buildOrder(longCrOne, csr, false, "")
 		if err != nil {
 			t.Errorf("buildOrder() received error %v", err)
 			return

--- a/test/e2e/framework/helper/validation/certificaterequests/certificaterequests.go
+++ b/test/e2e/framework/helper/validation/certificaterequests/certificaterequests.go
@@ -40,7 +40,7 @@ func ExpectDuration(duration, fuzz time.Duration) func(certificaterequest *cmapi
 		}
 
 		certDuration := cert.NotAfter.Sub(cert.NotBefore)
-		if certDuration > (duration+fuzz) || certDuration < duration {
+		if certDuration > (duration+fuzz) || certDuration < (duration-fuzz) {
 			return fmt.Errorf("expected duration of %s, got %s (fuzz: %s) [NotBefore: %s, NotAfter: %s]", duration, certDuration,
 				fuzz, cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
 		}

--- a/test/e2e/suite/issuers/acme/certificaterequest/profiles.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/profiles.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// E2E tests for the ACME profiles extension
+
+package certificate
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cert-manager/cert-manager/e2e-tests/framework"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper"
+	"github.com/cert-manager/cert-manager/e2e-tests/framework/helper/validation/certificaterequests"
+	e2eutil "github.com/cert-manager/cert-manager/e2e-tests/util"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.CertManagerDescribe("ACME Profiles Extension", func() {
+	ctx := context.TODO()
+	f := framework.NewDefaultFramework("acme-profiles-extension")
+	h := f.Helper()
+
+	var acmeProfile string
+	var acmeIngressDomain string
+	issuerName := "test-acme-issuer"
+	certificateRequestName := "test-acme-certificate-request"
+	// fixedIngressName is the name of an ingress resource that is configured
+	// with a challenge solve.
+	// To utilise this solver, add the 'testing.cert-manager.io/fixed-ingress: "true"' label.
+	fixedIngressName := "testingress"
+
+	// JustBeforeEach is necessary here so that the `acmeProfile` variable can
+	// be mutated before we create the Issuer resource.
+	// https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach
+	JustBeforeEach(func() {
+		acmeIngressDomain = e2eutil.RandomSubdomain(f.Config.Addons.IngressController.Domain)
+
+		solvers := []cmacme.ACMEChallengeSolver{
+			{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Class: &f.Config.Addons.IngressController.IngressClass,
+					},
+				},
+			},
+			{
+				Selector: &cmacme.CertificateDNSNameSelector{
+					MatchLabels: map[string]string{
+						"testing.cert-manager.io/fixed-ingress": "true",
+					},
+				},
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Name: fixedIngressName,
+					},
+				},
+			},
+		}
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMESolvers(solvers),
+			gen.SetIssuerACMEProfile(acmeProfile),
+		)
+		By(fmt.Sprintf("Creating an Issuer with profile: %q", acmeProfile))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(ctx, acmeIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = e2eutil.WaitForIssuerCondition(ctx, f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Cleaning up")
+		err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(ctx, issuerName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, testingACMEPrivateKey, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("the Issuer has a profile which is supported by the ACME server", func() {
+		BeforeEach(func() {
+			// The supported profiles are defined in the Pebble configuration:
+			// <repository>/make/config/pebble/charts/templates/configmap.yaml
+			acmeProfile = "123h"
+		})
+
+		It("should obtain a signed certificate, with duration matching the profile", func() {
+			crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
+
+			By("Creating a CertificateRequest")
+			csr, key, err := gen.CSR(x509.RSA, gen.SetCSRDNSNames(acmeIngressDomain))
+			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestCSR(csr),
+			)
+
+			_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the Certificate is Ready")
+			_, err = h.WaitForCertificateRequestReady(ctx, f.Namespace.Name, certificateRequestName, time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the Certificate duration matches the profile")
+			err = h.ValidateCertificateRequest(
+				types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name},
+				key,
+				certificaterequests.ExpectDuration(time.Hour*123, time.Second),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+	When("the Issuer has a profile which is not supported by the ACME server", func() {
+		BeforeEach(func() {
+			acmeProfile = "unsupported-profile"
+		})
+
+		It("should set the CertificateRequest as failed, with an actionable error message", func() {
+			crClient := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name)
+
+			By("Creating a CertificateRequest")
+			csr, _, err := gen.CSR(x509.RSA, gen.SetCSRDNSNames(acmeIngressDomain))
+			Expect(err).NotTo(HaveOccurred())
+			cr := gen.CertificateRequest(certificateRequestName,
+				gen.SetCertificateRequestNamespace(f.Namespace.Name),
+				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Kind: v1.IssuerKind, Name: issuerName}),
+				gen.SetCertificateRequestCSR(csr),
+			)
+
+			_, err = crClient.Create(ctx, cr, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the Certificate is failed")
+			cr, err = h.WaitForCertificateRequestReady(ctx, f.Namespace.Name, certificateRequestName, time.Minute*5)
+			Expect(err).To(MatchError(helper.ErrCertificateRequestFailed))
+			readyCondition := apiutil.GetCertificateRequestCondition(cr, v1.CertificateRequestConditionReady)
+			Expect(readyCondition.Message).To(ContainSubstring(
+				"Failed to create Order: acme: certificate authority does not advertise a profile with name unsupported-profile",
+			))
+		})
+	})
+})

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -125,6 +125,17 @@ func SetIssuerACMEEmail(email string) IssuerModifier {
 		spec.ACME.Email = email
 	}
 }
+
+func SetIssuerACMEProfile(profile string) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		spec := iss.GetSpec()
+		if spec.ACME == nil {
+			spec.ACME = &cmacme.ACMEIssuer{}
+		}
+		spec.ACME.Profile = profile
+	}
+}
+
 func SetIssuerACMEPrivKeyRef(privateKeyName string) IssuerModifier {
 	return func(iss v1.GenericIssuer) {
 		spec := iss.GetSpec()


### PR DESCRIPTION
Adds support for the ACME Profiles extension by propagating a new Profile field through the controller, API types, client sync logic, and CRDs.

- Extends buildOrder to accept and set a certificate profile
- Updates ACME controller (Sign and createOrder) to pass and handle Profile
- Adds Profile to API types, CRDs, tests, and conversion logic

Stack:
1.  [x] #7752
2.  [x] #7776
3.  [ ] #7777

/kind feature

```release-note
Feature: Add support for [ACME profiles extension](https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/).
```
