### PR TITLE
Fix typo in Certificate.Spec.SignatureAlgorithm documentation

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -538,7 +538,7 @@ spec:
                         type: string
                 signatureAlgorithm:
                   description: |-
-                    Signature algorith to use.
+                    Signature algorithm to use.
                     Allowed values for RSA keys: SHA256WithRSA, SHA384WithRSA, SHA512WithRSA.
                     Allowed values for ECDSA keys: ECDSAWithSHA256, ECDSAWithSHA384, ECDSAWithSHA512.
                     Allowed values for Ed25519 keys: PureEd25519.

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -271,7 +271,7 @@ type CertificateSpec struct {
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
 
-	// Signature algorith to use.
+	// Signature algorithm to use.
 	// Allowed values for RSA keys: SHA256WithRSA, SHA384WithRSA, SHA512WithRSA.
 	// Allowed values for ECDSA keys: ECDSAWithSHA256, ECDSAWithSHA384, ECDSAWithSHA512.
 	// Allowed values for Ed25519 keys: PureEd25519.


### PR DESCRIPTION
Discovered by copilot in another PR:
 * https://github.com/cert-manager/website/pull/1710#discussion_r2137296005

/type cleanup

```release-note
NONE
```
