### PR TITLE
fix(acme):  Use ImplementationSpecific pathType until next breaking-change release

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -378,7 +378,7 @@ func (s *Solver) cleanupIngresses(ctx context.Context, ch *cmacme.Challenge) err
 func ingressPath(token, serviceName string) networkingv1.HTTPIngressPath {
 	return networkingv1.HTTPIngressPath{
 		Path:     solverPathFn(token),
-		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeExact; return &s }(),
+		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeImplementationSpecific; return &s }(),
 		Backend: networkingv1.IngressBackend{
 			Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName,


### PR DESCRIPTION
This change introduced a breaking change for users of the `ingress-nginx` ingress controller. `cert-manager` will in an upcoming release introduce this breaking change alongside with an option to make the pathType configurable.

This reverts commit 0af46c43653518063a57e3771fc4df10bf6e290b.


```release-note
Reverting to ImplementationSpecific Ingress pathType for until an upcoming breaking change release.
```
