### PR TITLE
feat(acme): Add default feature gate for ACME HTTP01 Ingress pathType Exact

### DIFF
--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -172,6 +172,22 @@ const (
 	// feature, because it is thought be low-risk feature and because we want to
 	// accelerate the adoption of this important security feature.
 	DefaultPrivateKeyRotationPolicyAlways featuregate.Feature = "DefaultPrivateKeyRotationPolicyAlways"
+
+	// Owner: @sspreitzer, @wallrj
+	// Alpha: v1.18.1
+	// Beta: v1.18.1
+	//
+	// ACMEHTTP01IngressPathTypeExact will use Ingress pathType `Exact`.
+	// `ACMEHTTP01IngressPathTypeExact` changes the default `pathType`` for ACME
+	// HTTP01 Ingress based challenges to `Exact`. This security feature ensures
+	// that the challenge path (which is an exact path) is not misinterpreted as
+	// a regular expression or some other Ingress specific (ImplementationSpecific)
+	// parsing. This allows HTTP01 challenges to be solved when using standards
+	// compliant Ingress controllers such as Cilium. The old default
+	// `ImplementationSpecific`` can be reinstated by disabling this feature gate.
+	// You may need to disable the feature for compatibility with ingress-nginx.
+	// See: https://cert-manager.io/docs/releases/release-notes/release-notes-1.18
+	ACMEHTTP01IngressPathTypeExact featuregate.Feature = "ACMEHTTP01IngressPathTypeExact"
 )
 
 func init() {
@@ -196,6 +212,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	OtherNames:                                       {Default: false, PreRelease: featuregate.Alpha},
 	UseDomainQualifiedFinalizer:                      {Default: true, PreRelease: featuregate.GA},
 	DefaultPrivateKeyRotationPolicyAlways:            {Default: true, PreRelease: featuregate.Beta},
+	ACMEHTTP01IngressPathTypeExact:                   {Default: true, PreRelease: featuregate.GA},
 
 	// NB: Deprecated + removed feature gates are kept here.
 	// `featuregate.Deprecated` exists, but will cause the featuregate library

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -382,6 +382,7 @@ e2e-setup-ingressnginx: $(call image-tar,ingressnginx) load-$(call image-tar,ing
 		--set controller.service.clusterIP=${SERVICE_IP_PREFIX}.15 \
 		--set controller.service.type=ClusterIP \
 		--set controller.config.no-tls-redirect-locations= \
+		--set-string controller.config.strict-validate-path-type=false \
 		--set admissionWebhooks.enabled=true \
 		--set controller.admissionWebhooks.enabled=true \
 		--set controller.watchIngressWithoutClass=true \

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/http/solver"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 const (
@@ -377,8 +379,16 @@ func (s *Solver) cleanupIngresses(ctx context.Context, ch *cmacme.Challenge) err
 // challenge.
 func ingressPath(token, serviceName string) networkingv1.HTTPIngressPath {
 	return networkingv1.HTTPIngressPath{
-		Path:     solverPathFn(token),
-		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeImplementationSpecific; return &s }(),
+		Path: solverPathFn(token),
+		PathType: func() *networkingv1.PathType {
+			var s networkingv1.PathType
+			if utilfeature.DefaultFeatureGate.Enabled(feature.ACMEHTTP01IngressPathTypeExact) {
+				s = networkingv1.PathTypeExact
+			} else {
+				s = networkingv1.PathTypeImplementationSpecific
+			}
+			return &s
+		}(),
 		Backend: networkingv1.IngressBackend{
 			Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName,


### PR DESCRIPTION
### Pull Request Motivation

With the release of cert-manager version `1.18.1` the pathType changes from `ImplementationSpecific` to `Exact`. This PR implements the feature gate `ACMEHTTP01IngressPathTypeExact`.

`ACMEHTTP01IngressPathTypeExact` changes the default `pathType` for ACME HTTP01 Ingress based challenges to `Exact`. This security feature ensures that the challenge path (which is an exact path) is not misinterpreted as a regular expression or some other Ingress specific (ImplementationSpecific) parsing. This allows HTTP01 challenges to be solved when using standards compliant Ingress controllers such as Cilium. The old default `ImplementationSpecific` can be reinstated by disabling this feature gate. You may need to disable the feature for compatibility with `ingress-nginx`. See [version 1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-are-rejected-by-the-ingress-nginx-validating-webhook).

### Kind

/kind feature

### Release Note

```release-note
Add a feature gate to default to Ingress pathType `Exact` in ACME HTTP01 Ingress challenge solvers.
```
