### PR TITLE
[release-1.17] Bump Go to 1.23.10 to fix GO-2025-3749, GO-2025-3750, and GO-2025-3751

### DIFF
--- a/cmd/acmesolver/go.mod
+++ b/cmd/acmesolver/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/acmesolver-binary
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cainjector-binary
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/controller-binary
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/startupapicheck/go.mod
+++ b/cmd/startupapicheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/startupapicheck-binary
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/webhook-binary
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -162,7 +162,7 @@ tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
 # NOTE: The version of Go here has been manually updated!
-VENDORED_GO_VERSION := 1.23.8
+VENDORED_GO_VERSION := 1.23.10
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -381,10 +381,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f
-go_linux_arm64_SHA256SUM=9d6d938422724a954832d6f806d397cf85ccfde8c581c201673e50e634fdc992
-go_darwin_amd64_SHA256SUM=4a0f0a5eb539013c1f4d989e0864aed45973c0a9d4b655ff9fd56013e74c1303
-go_darwin_arm64_SHA256SUM=d4f53dcaecd67d9d2926eab7c3d674030111c2491e68025848f6839e04a4d3d1
+go_linux_amd64_SHA256SUM=535f9f81802499f2a7dbfa70abb8fda3793725fcc29460f719815f6e10b5fd60
+go_linux_arm64_SHA256SUM=bfb1f1df7173f44648ee070a39ab0481068632f595305a699d89cd56a33b8081
+go_darwin_amd64_SHA256SUM=1cbd7af6f07bc6fa1f8672f9b913c961986864100e467e0acdc942e0ae46fe68
+go_darwin_arm64_SHA256SUM=25c64bfa8a8fd8e7f62fb54afa4354af8409a4bb2358c2699a1003b733e6fce5
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/e2e-tests
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/integration-tests
 
-go 1.23.8
+go 1.23.10
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a


### PR DESCRIPTION
govulncheck and trivy are reporting three vulnerabilities in the release-1.17 branch:
- https://testgrid.k8s.io/cert-manager-periodics-release-1.17
- https://github.com/cert-manager/cert-manager/actions/runs/15633164071/job/44041966423



The vulnerabilities are:
- https://pkg.go.dev/vuln/GO-2025-3749

```
Vulnerability #3: GO-2025-3749
    Usage of ExtKeyUsageAny disables policy validation in crypto/x[50](https://github.com/cert-manager/cert-manager/actions/runs/15633164071/job/44041966423#step:5:51)9
  More info: https://pkg.go.dev/vuln/GO-2025-3749
  Standard library
    Found in: crypto/x509@go1.23.8
    Fixed in: crypto/x509@go1.23.10
    Example traces found:
Error:       #1: pkg/check/api/api.go:130:14: api.Options.Run calls fmt.Fprintln, which eventually calls x509.Certificate.Verify
```

* https://pkg.go.dev/vuln/GO-2025-3750
```
Vulnerability #2: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.[23](https://github.com/cert-manager/cert-manager/actions/runs/15633164071/job/44041966423#step:5:24).8
    Fixed in: os@go1.23.10
    Platforms: windows
    Example traces found:
Error:       #1: pkg/factory/factory.go:[25](https://github.com/cert-manager/cert-manager/actions/runs/15633164071/job/44041966423#step:5:26):2: factory.init calls auth.init, which eventually calls os.Create
...
```

- https://pkg.go.dev/vuln/GO-2025-3751

```
Vulnerability #1: GO-2025-3751
    Sensitive headers not cleared on cross-origin redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3751
  Standard library
    Found in: net/http@go1.23.8
    Fixed in: net/http@go1.23.10
    Example traces found:
Error:       #1: pkg/check/api/api.go:99:40: api.Options.Run calls wait.PollUntilContextCancel, which eventually calls http.Client.Do
```

Fixed in Go 1.23.10:
 * https://go.dev/doc/devel/release#go1.23.minor

> go1.23.10 (released 2025-06-05) includes security fixes to the net/http and os packages, as well as bug fixes to the linker. See the [Go 1.23.10 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.10+label%3ACherryPickApproved) on our issue tracker for details.

/kind bug

```release-note
Bump Go to 1.23.10 to fix GO-2025-3749, GO-2025-3750, and GO-2025-3751
```

## Testing

```
$ make verify-govulncheck
mkdir -p _bin/scratch
Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory '.'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './cmd/startupapicheck'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './cmd/webhook'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './cmd/acmesolver'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './cmd/cainjector'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './cmd/controller'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './test/e2e'
No vulnerabilities found.

Running 'GOTOOLCHAIN=go1.23.10 _bin/tools/govulncheck ./...' in directory './test/integration'
No vulnerabilities found.
```