### PR TITLE
Change ACMEHTTP01IngressPathTypeExact feature to beta

### DIFF
--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -212,7 +212,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	OtherNames:                                       {Default: false, PreRelease: featuregate.Alpha},
 	UseDomainQualifiedFinalizer:                      {Default: true, PreRelease: featuregate.GA},
 	DefaultPrivateKeyRotationPolicyAlways:            {Default: true, PreRelease: featuregate.Beta},
-	ACMEHTTP01IngressPathTypeExact:                   {Default: true, PreRelease: featuregate.GA},
+	ACMEHTTP01IngressPathTypeExact:                   {Default: true, PreRelease: featuregate.Beta},
 
 	// NB: Deprecated + removed feature gates are kept here.
 	// `featuregate.Deprecated` exists, but will cause the featuregate library


### PR DESCRIPTION
This new featuregate was supposed to be introduced at maturity level Beta, exactly like the DefaultPrivateKeyRotationPolicyAlways feature. Instead it has been set to GA.

The consequence of setting it to GA, is that when you disable it, you get a warning in the cert-manager logs:

```
$ kubectl  -n cert-manager logs deployments/cert-manager --follow
W0617 15:42:25.514056       1 feature_gate.go:354] Setting GA feature gate ACMEHTTP01IngressPathTypeExact=false. It will be removed in a future release.
```

I overlooked this when reviewing https://github.com/cert-manager/cert-manager/pull/7795
* https://github.com/cert-manager/cert-manager/pull/7795

/kind cleanup

```release-note
NONE
```

## Testing


```
make e2e-setup FEATURE_GATES=AllAlpha=false,AllBeta=false
```


