### PR TITLE
Add global.nodeSelector to helm chart

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -93,6 +93,18 @@ For example:
 imagePullSecrets:
   - name: "image-pull-secret"
 ```
+#### **global.nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Global node selector  
+  
+The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).  
+  
+If a component-specific nodeSelector is also set, it will take precedence.
+
 #### **global.commonLabels** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -136,7 +136,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.cainjector.nodeSelector }}
+      {{- with (coalesce .Values.cainjector.nodeSelector .Values.global.nodeSelector) }}
       nodeSelector:
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -209,7 +209,7 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (coalesce .Values.nodeSelector .Values.global.nodeSelector) }}
       nodeSelector:
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -76,7 +76,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.startupapicheck.nodeSelector }}
+      {{- with (coalesce .Values.startupapicheck.nodeSelector .Values.global.nodeSelector) }}
       nodeSelector:
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -180,7 +180,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- with .Values.webhook.nodeSelector }}
+      {{- with (coalesce .Values.webhook.nodeSelector .Values.global.nodeSelector) }}
       nodeSelector:
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -698,6 +698,9 @@
         "logLevel": {
           "$ref": "#/$defs/helm-values.global.logLevel"
         },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.global.nodeSelector"
+        },
         "podSecurityPolicy": {
           "$ref": "#/$defs/helm-values.global.podSecurityPolicy"
         },
@@ -762,6 +765,11 @@
       "default": 2,
       "description": "Set the verbosity of cert-manager. A range of 0 - 6, with 6 being the most verbose.",
       "type": "number"
+    },
+    "helm-values.global.nodeSelector": {
+      "default": {},
+      "description": "Global node selector\n\nThe nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).\n\nIf a component-specific nodeSelector is also set, it will take precedence.",
+      "type": "object"
     },
     "helm-values.global.podSecurityPolicy": {
       "properties": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -12,6 +12,16 @@ global:
   #    - name: "image-pull-secret"
   imagePullSecrets: []
 
+  # Global node selector
+  #
+  # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
+  # matching labels.
+  # For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+  #
+  # If a component-specific nodeSelector is also set, it will take precedence.
+  # +docs:property
+  nodeSelector: {}
+  
   # Labels to apply to all resources.
   # Please note that this does not add labels to the resources created dynamically by the controllers.
   # For these resources, you have to add the labels in the template in the cert-manager custom resource:


### PR DESCRIPTION
Adds a `global.nodeSelector` option to be able to set `nodeSelector` for all services in a single location. This is overridable at an individual service level as before.


### Pull Request Motivation

Resolves issue #7817 

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add `global.nodeSelector` to helm chart to allow for a single `nodeSelector` to be set across all services.
```
