### PR TITLE
Let x509.CreateCertificate set Version and SerialNumber

### DIFF
--- a/internal/cainjector/bundle/bundle_test.go
+++ b/internal/cainjector/bundle/bundle_test.go
@@ -19,10 +19,8 @@ package bundle
 import (
 	"bytes"
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math/big"
 	"testing"
 	"time"
 
@@ -95,23 +93,14 @@ func TestAppendCertificatesToBundle(t *testing.T) {
 	}
 }
 
-var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
-
 func mustCreateCertificate(t *testing.T, name string, notBefore, notAfter time.Time) []byte {
 	pk, err := pki.GenerateECPrivateKey(256)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	template := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
-		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,
 		PublicKey:             pk.Public(),
 		IsCA:                  true,

--- a/internal/controller/certificates/secrets_test.go
+++ b/internal/controller/certificates/secrets_test.go
@@ -40,7 +40,6 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 	}{
 		"if pass non-nil certificate, expect all Annotations to be present": {
 			certificate: &x509.Certificate{
-				Version: 3,
 				Subject: pkix.Name{
 					CommonName:         "cert-manager",
 					Organization:       []string{"Example Organization 1", "Example Organization 2"},
@@ -75,7 +74,6 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 		},
 		"if pass non-nil certificate with only CommonName, expect all Annotations to be present": {
 			certificate: &x509.Certificate{
-				Version: 3,
 				Subject: pkix.Name{
 					CommonName: "cert-manager",
 				},
@@ -89,7 +87,6 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 		},
 		"if pass non-nil certificate with only IP Addresses, expect all Annotations to be present": {
 			certificate: &x509.Certificate{
-				Version:     3,
 				IPAddresses: []net.IP{{1, 1, 1, 1}, {1, 2, 3, 4}},
 			},
 			expAnnotations: map[string]string{
@@ -101,8 +98,7 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 		},
 		"if pass non-nil certificate with only URI SANs, expect all Annotations to be present": {
 			certificate: &x509.Certificate{
-				Version: 3,
-				URIs:    urls,
+				URIs: urls,
 			},
 			expAnnotations: map[string]string{
 				"cert-manager.io/common-name": "",
@@ -113,7 +109,6 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 		},
 		"if pass non-nil certificate with only DNS names, expect all Annotations to be present": {
 			certificate: &x509.Certificate{
-				Version:  3,
 				DNSNames: []string{"example.com", "cert-manager.io"},
 			},
 			expAnnotations: map[string]string{

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -91,7 +91,6 @@ func TestSign(t *testing.T) {
 	}
 
 	rootTmpl := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -68,7 +68,6 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -18,11 +18,9 @@ package venafi
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
-	"math/big"
 	"testing"
 	"time"
 
@@ -76,15 +74,8 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	rootTmpl := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
-		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,
 		PublicKey:             rootPK.Public(),
 		IsCA:                  true,

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -71,7 +71,6 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -188,12 +188,8 @@ func Test__caRequiresRegeneration(t *testing.T) {
 		assert.NoError(t, err)
 		pkBytes, err := pki.EncodePrivateKey(pk, cmapi.PKCS8)
 		assert.NoError(t, err)
-		serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-		assert.NoError(t, err)
 		cert := &x509.Certificate{
-			Version:               3,
 			BasicConstraintsValid: true,
-			SerialNumber:          serialNumber,
 			PublicKeyAlgorithm:    x509.ECDSA,
 			Subject: pkix.Name{
 				CommonName: "cert-manager-webhook-ca",

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -237,7 +237,6 @@ func (f *DynamicSource) regenerateCertificate(ctx context.Context, nextRenew cha
 
 	// create the certificate template to be signed
 	template := &x509.Certificate{
-		Version:            3,
 		PublicKeyAlgorithm: x509.ECDSA,
 		PublicKey:          pk.Public(),
 		DNSNames:           f.DNSNames,

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -140,7 +140,6 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 						return nil, fmt.Errorf("mock error")
 					}
 
-					template.Version = 3
 					template.SerialNumber = big.NewInt(10)
 					template.NotBefore = time.Now()
 					template.NotAfter = template.NotBefore.Add(time.Minute)
@@ -162,7 +161,6 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 		{
 			name: "don't rotate root",
 			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
-				template.Version = 3
 				template.SerialNumber = big.NewInt(10)
 				template.NotBefore = time.Now()
 				template.NotAfter = template.NotBefore.Add(time.Minute)
@@ -194,7 +192,6 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 		{
 			name: "rotate root",
 			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
-				template.Version = 3
 				template.SerialNumber = big.NewInt(10)
 				template.NotBefore = time.Now()
 				template.NotAfter = template.NotBefore.Add(time.Minute)
@@ -230,7 +227,6 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 		{
 			name: "expire leaf",
 			signFunc: func(template *x509.Certificate) (*x509.Certificate, error) {
-				template.Version = 3
 				template.SerialNumber = big.NewInt(10)
 				template.NotBefore = time.Now()
 				template.NotAfter = template.NotBefore.Add(150 * time.Millisecond)

--- a/pkg/server/tls/file_source_test.go
+++ b/pkg/server/tls/file_source_test.go
@@ -18,10 +18,8 @@ package tls
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -141,8 +139,6 @@ func TestFileSource_UpdatesFile(t *testing.T) {
 	}
 }
 
-var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
-
 func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []byte) {
 	pk, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
@@ -153,14 +149,8 @@ func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []by
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		t.Fatal(err)
-	}
 	cert := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
-		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.RSA,
 		Subject: pkix.Name{
 			SerialNumber: serial,

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -908,7 +908,6 @@ func TestSignCSRTemplate(t *testing.T) {
 			permittedIPRanges = nameConstraints.PermittedIPRanges
 		}
 		tmpl := &x509.Certificate{
-			Version:               3,
 			BasicConstraintsValid: true,
 			SerialNumber:          big.NewInt(0),
 			Subject: pkix.Name{
@@ -1189,14 +1188,7 @@ func Test_SignCertificate_Signatures(t *testing.T) {
 			signerKey := spec.SignerKey
 			pub := signerKey.Public()
 
-			serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-			if err != nil {
-				t.Fatalf("failed to generate serial number for certificate: %s", err)
-			}
-
 			tmpl := &x509.Certificate{
-				SerialNumber: serialNumber,
-
 				PublicKey: pub,
 				Subject:   pkix.Name{CommonName: "abc123"},
 

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -254,15 +254,8 @@ func TestGeneratePrivateKeyForCertificate(t *testing.T) {
 func signTestCert(key crypto.Signer) *x509.Certificate {
 	commonName := "testingcert"
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		panic(fmt.Errorf("failed to generate serial number: %s", err.Error()))
-	}
-
 	template := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
-		SerialNumber:          serialNumber,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		Subject: pkix.Name{
 			Organization: []string{"cert-manager"},

--- a/pkg/util/pki/parse_certificate_chain_test.go
+++ b/pkg/util/pki/parse_certificate_chain_test.go
@@ -18,7 +18,6 @@ package pki
 
 import (
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
@@ -40,15 +39,8 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 		t.Fatal(err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	template := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
-		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,
 		PublicKey:             pk.Public(),
 		IsCA:                  true,

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -453,7 +453,6 @@ func generateVaultServingCert(vaultCA []byte, vaultCAPrivateKey []byte, dnsName 
 	}
 
 	cert := &x509.Certificate{
-		Version:      3,
 		SerialNumber: big.NewInt(1658),
 		Subject: pkix.Name{
 			CommonName:   dnsName,
@@ -498,7 +497,6 @@ func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, 
 	}
 
 	cert := &x509.Certificate{
-		Version:      3,
 		SerialNumber: big.NewInt(1658),
 		Subject: pkix.Name{
 			CommonName:   "cert-manager vault client",
@@ -531,7 +529,6 @@ func generateVaultClientCert(vaultCA []byte, vaultCAPrivateKey []byte) ([]byte, 
 
 func GenerateCA() ([]byte, []byte, error) {
 	ca := &x509.Certificate{
-		Version:      3,
 		SerialNumber: big.NewInt(1653),
 		Subject: pkix.Name{
 			Organization: []string{"cert-manager test"},

--- a/test/e2e/suite/conformance/certificatesigningrequests/ca/ca.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/ca/ca.go
@@ -132,7 +132,6 @@ func newSigningKeypairSecret(name string) *corev1.Secret {
 	Expect(err).NotTo(HaveOccurred())
 
 	tmpl := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -152,7 +152,6 @@ func generateTLSAssets() (caPEM, certificatePEM, privateKeyPEM []byte, err error
 		return nil, nil, nil, err
 	}
 	rootCA := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(1658),
 		PublicKeyAlgorithm:    x509.RSA,
@@ -173,7 +172,6 @@ func generateTLSAssets() (caPEM, certificatePEM, privateKeyPEM []byte, err error
 		return nil, nil, nil, err
 	}
 	servingCert := &x509.Certificate{
-		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(1659),
 		PublicKeyAlgorithm:    x509.RSA,


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While working on another cert-manager project, I noticed that the `x509.CreateCertificate` function hard-codes the version to 2 (v3), as ref. https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1. Thus, ignoring our `Version: 3` set in templates in a lot of places. I am also questioning the value 3 used, as I think it should be 2 (v3), but this needs to be investigated more. 

The `x509.CreateCertificate` function also contains code for generating a proper serial number, if one is not set in the template. So instead of maintaining code to generate a serial number ourselves, I propose to make the Go stdlib generate a serial number when the template is only used to create a certificate.

I left the hardcoded `Version: 3` and custom serial number generation in [`pki.CertificateTemplateFromCSR`](https://github.com/cert-manager/cert-manager/blob/6836b366e091b8c380751b9fc964938381dae7af/pkg/util/pki/certificatetemplate.go#L147-L156), since it was asserted in tests, but I don't really understand why. 🤔 

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
