### PR TITLE
Refactor ACME client registry (part 1)

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -35,18 +35,15 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/cert-manager/controller-binary/app/options"
 	config "github.com/cert-manager/cert-manager/internal/apis/config/controller"
 	"github.com/cert-manager/cert-manager/internal/apis/config/shared"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
-	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/healthz"
 	dnsutil "github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/server"
 	"github.com/cert-manager/cert-manager/pkg/server/tls"
 	"github.com/cert-manager/cert-manager/pkg/server/tls/authority"
@@ -306,7 +303,6 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 	}
 
 	ACMEHTTP01SolverRunAsNonRoot := opts.ACMEHTTP01Config.SolverRunAsNonRoot
-	acmeAccountRegistry := accounts.NewDefaultRegistry()
 
 	ctxFactory, err := controller.NewContextFactory(ctx, controller.ContextOptions{
 		Kubeconfig:         opts.KubeConfig,
@@ -315,9 +311,6 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 		APIServerHost:      opts.APIServerHost,
 
 		Namespace: opts.Namespace,
-
-		Clock:   clock.RealClock{},
-		Metrics: metrics.New(log, clock.RealClock{}),
 
 		ACMEOptions: controller.ACMEOptions{
 			HTTP01SolverResourceRequestCPU:    http01SolverResourceRequestCPU,
@@ -332,8 +325,6 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.ACMEDNS01Config.RecursiveNameserversOnly,
-
-			AccountRegistry: acmeAccountRegistry,
 		},
 
 		SchedulerOptions: controller.SchedulerOptions{

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -17,7 +17,6 @@ require (
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 	k8s.io/component-base v0.33.1
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
 require (
@@ -165,6 +164,7 @@ require (
 	k8s.io/apiserver v0.33.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/gateway-api v1.3.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -37,6 +37,8 @@ include make/scan.mk
 include make/ko.mk
 include make/third_party.mk
 
+generate-licenses: generate-go-licenses
+
 .PHONY: tidy
 tidy: generate-go-mod-tidy
 

--- a/pkg/acme/accounts/registry.go
+++ b/pkg/acme/accounts/registry.go
@@ -22,11 +22,9 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	"net/http"
 	"sync"
 
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
-	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
 
 // ErrNotFound is returned by GetClient if there is no ACME client registered.
@@ -38,7 +36,7 @@ var ErrNotFound = errors.New("ACME client for issuer not initialised/available")
 type Registry interface {
 	// AddClient will ensure the registry has a stored ACME client for the Issuer
 	// object with the given UID, configuration and private key.
-	AddClient(httpClient *http.Client, uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey, userAgent string)
+	AddClient(uid string, options NewClientOptions)
 
 	// RemoveClient will remove a registered client using the UID of the Issuer
 	// resource that constructed it.
@@ -66,15 +64,18 @@ type Getter interface {
 }
 
 // NewDefaultRegistry returns a new default instantiation of a client registry.
-func NewDefaultRegistry() Registry {
+func NewDefaultRegistry(newClientFunc NewClientFunc) Registry {
 	return &registry{
-		clients: make(map[string]clientWithMeta),
+		newClientFunc: newClientFunc,
+		clients:       make(map[string]clientWithMeta),
 	}
 }
 
 // Implementation of the Registry interface
 type registry struct {
 	lock sync.RWMutex
+
+	newClientFunc NewClientFunc
 
 	// a map of an issuer's 'uid' to an ACME client with metadata
 	clients map[string]clientWithMeta
@@ -97,18 +98,18 @@ func (c stableOptions) equalTo(c2 stableOptions) bool {
 	return c == c2
 }
 
-func newStableOptions(uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey) stableOptions {
+func newStableOptions(uid string, options NewClientOptions) stableOptions {
 	// Encoding a big.Int cannot fail
-	publicNBytes, _ := privateKey.PublicKey.N.GobEncode()
-	checksum := sha256.Sum256(x509.MarshalPKCS1PrivateKey(privateKey))
+	publicNBytes, _ := options.PrivateKey.PublicKey.N.GobEncode()
+	checksum := sha256.Sum256(x509.MarshalPKCS1PrivateKey(options.PrivateKey))
 
 	return stableOptions{
-		serverURL:     config.Server,
-		skipVerifyTLS: config.SkipTLSVerify,
+		serverURL:     options.Server,
+		skipVerifyTLS: options.SkipTLSVerify,
 		issuerUID:     uid,
 		publicKey:     string(publicNBytes),
-		exponent:      privateKey.PublicKey.E,
-		caBundle:      string(config.CABundle),
+		exponent:      options.PrivateKey.PublicKey.E,
+		caBundle:      string(options.CABundle),
 		keyChecksum:   checksum,
 	}
 }
@@ -123,9 +124,9 @@ type clientWithMeta struct {
 
 // AddClient will ensure the registry has a stored ACME client for the Issuer
 // object with the given UID, configuration and private key.
-func (r *registry) AddClient(httpClient *http.Client, uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey, userAgent string) {
+func (r *registry) AddClient(uid string, options NewClientOptions) {
 	// ensure the client is up to date for the current configuration
-	r.ensureClient(httpClient, uid, config, privateKey, userAgent)
+	r.ensureClient(uid, options)
 }
 
 // ensureClient will ensure an ACME client with the given parameters is registered.
@@ -133,14 +134,14 @@ func (r *registry) AddClient(httpClient *http.Client, uid string, config cmacme.
 // the client will NOT be mutated or replaced, allowing this method to be called
 // even if the client does not need replacing/updating without causing issues for
 // consumers of the registry.
-func (r *registry) ensureClient(httpClient *http.Client, uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey, userAgent string) {
+func (r *registry) ensureClient(uid string, options NewClientOptions) {
 	// acquire a read-write lock even if we hit the fast-path where the client
 	// is already present to avoid having to RLock, RUnlock and Lock again,
 	// which could itself cause a race
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	newOpts := newStableOptions(uid, config, privateKey)
+	newOpts := newStableOptions(uid, options)
 	// fast-path if there is nothing to do
 	if meta, ok := r.clients[uid]; ok && meta.equalTo(newOpts) {
 		return
@@ -149,7 +150,7 @@ func (r *registry) ensureClient(httpClient *http.Client, uid string, config cmac
 	// create a new client if one is not registered or if the
 	// 'metadata' does not match
 	r.clients[uid] = clientWithMeta{
-		Interface:     NewClient(httpClient, config, privateKey, userAgent),
+		Interface:     r.newClientFunc(options),
 		stableOptions: newOpts,
 	}
 }

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -18,26 +18,24 @@ package test
 
 import (
 	"crypto/rsa"
-	"net/http"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
-	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
 
 var _ accounts.Registry = &FakeRegistry{}
 
 // FakeRegistry implements the accounts.Registry interface using stub functions
 type FakeRegistry struct {
-	AddClientFunc           func(uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey, userAgent string)
+	AddClientFunc           func(uid string, options accounts.NewClientOptions)
 	RemoveClientFunc        func(uid string)
 	GetClientFunc           func(uid string) (acmecl.Interface, error)
 	ListClientsFunc         func() map[string]acmecl.Interface
 	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
 }
 
-func (f *FakeRegistry) AddClient(client *http.Client, uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey, userAgent string) {
-	f.AddClientFunc(uid, config, privateKey, userAgent)
+func (f *FakeRegistry) AddClient(uid string, options accounts.NewClientOptions) {
+	f.AddClientFunc(uid, options)
 }
 
 func (f *FakeRegistry) RemoveClient(uid string) {

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -142,7 +142,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 	c.scheduler = scheduler.New(logf.NewContext(ctx.RootContext, c.log), c.challengeLister, ctx.SchedulerOptions.MaxConcurrentChallenges)
 	c.recorder = ctx.Recorder
-	c.accountRegistry = ctx.ACMEOptions.AccountRegistry
+	c.accountRegistry = ctx.ACMEAccountRegistry
 
 	var err error
 	c.httpSolver, err = http.NewSolver(ctx)

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -155,7 +155,7 @@ func NewController(
 		helper:              issuer.NewHelper(issuerLister, clusterIssuerLister),
 		recorder:            ctx.Recorder,
 		cmClient:            ctx.CMClient,
-		accountRegistry:     ctx.AccountRegistry,
+		accountRegistry:     ctx.ACMEAccountRegistry,
 		fieldManager:        ctx.FieldManager,
 	}, queue, mustSync, nil
 

--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -29,7 +29,6 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
-	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/kube"
 )
 
@@ -51,12 +50,6 @@ type Acme struct {
 	resourceNamespace func(iss cmapi.GenericIssuer) string
 	// used as a cache for ACME clients
 	accountRegistry accounts.Registry
-
-	// metrics is used to create instrumented ACME clients
-	metrics *metrics.Metrics
-
-	// userAgent is the string used as the UserAgent when making HTTP calls.
-	userAgent string
 }
 
 // New returns a new ACME issuer interface for the given issuer.
@@ -65,13 +58,11 @@ func New(ctx *controller.Context) (issuer.Interface, error) {
 
 	a := &Acme{
 		keyFromSecret:     newKeyFromSecret(secretsLister),
-		clientBuilder:     accounts.NewClient,
+		clientBuilder:     accounts.NewClient(ctx.Metrics, ctx.RESTConfig.UserAgent),
 		secretsClient:     ctx.Client.CoreV1(),
 		recorder:          ctx.Recorder,
 		resourceNamespace: ctx.IssuerOptions.ResourceNamespace,
-		accountRegistry:   ctx.ACMEOptions.AccountRegistry,
-		metrics:           ctx.Metrics,
-		userAgent:         ctx.RESTConfig.UserAgent,
+		accountRegistry:   ctx.ACMEAccountRegistry,
 	}
 
 	return a, nil

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -157,9 +157,12 @@ func (a *Acme) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 	// this function.
 	a.accountRegistry.RemoveClient(string(issuer.GetUID()))
 
-	httpClient := accounts.BuildHTTPClientWithCABundle(a.metrics, issuer.GetSpec().ACME.SkipTLSVerify, issuer.GetSpec().ACME.CABundle)
-
-	cl := a.clientBuilder(httpClient, *issuer.GetSpec().ACME, rsaPk, a.userAgent)
+	cl := a.clientBuilder(accounts.NewClientOptions{
+		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
+		CABundle:      issuer.GetSpec().ACME.CABundle,
+		Server:        issuer.GetSpec().ACME.Server,
+		PrivateKey:    rsaPk,
+	})
 
 	// TODO: perform a complex check to determine whether we need to verify
 	// the existing registration with the ACME server.
@@ -214,7 +217,12 @@ func (a *Acme) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 		status = cmmeta.ConditionTrue
 
 		// ensure the cached client in the account registry is up to date
-		a.accountRegistry.AddClient(httpClient, string(issuer.GetUID()), *issuer.GetSpec().ACME, rsaPk, a.userAgent)
+		a.accountRegistry.AddClient(string(issuer.GetUID()), accounts.NewClientOptions{
+			SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
+			CABundle:      issuer.GetSpec().ACME.CABundle,
+			Server:        issuer.GetSpec().ACME.Server,
+			PrivateKey:    rsaPk,
+		})
 		return nil
 	}
 
@@ -320,7 +328,12 @@ func (a *Acme) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 	issuer.GetStatus().ACMEStatus().LastRegisteredEmail = registeredEmail
 	issuer.GetStatus().ACMEStatus().LastPrivateKeyHash = checksumString
 	// ensure the cached client in the account registry is up to date
-	a.accountRegistry.AddClient(httpClient, string(issuer.GetUID()), *issuer.GetSpec().ACME, rsaPk, a.userAgent)
+	a.accountRegistry.AddClient(string(issuer.GetUID()), accounts.NewClientOptions{
+		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
+		CABundle:      issuer.GetSpec().ACME.CABundle,
+		Server:        issuer.GetSpec().ACME.Server,
+		PrivateKey:    rsaPk,
+	})
 
 	return nil
 }

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"fmt"
-	"net/http"
 	"net/url"
 	"reflect"
 	"slices"
@@ -536,7 +535,7 @@ func TestAcme_Setup(t *testing.T) {
 				RemoveClientFunc: func(string) {
 					removeClientWasCalled = true
 				},
-				AddClientFunc: func(string, cmacme.ACMEIssuer, *rsa.PrivateKey, string) {
+				AddClientFunc: func(string, accounts.NewClientOptions) {
 					addClientWasCalled = true
 				},
 				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
@@ -631,7 +630,7 @@ func keyFromSecretMockBuilder(wasCalled *bool, key crypto.Signer, err error) key
 }
 
 func clientBuilderMock(cl acmecl.Interface) accounts.NewClientFunc {
-	return func(*http.Client, cmacme.ACMEIssuer, *rsa.PrivateKey, string) acmecl.Interface {
+	return func(_ accounts.NewClientOptions) acmecl.Interface {
 		return cl
 	}
 }

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -121,12 +121,9 @@ func TestAcmeOrdersController(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Clock: clock.RealClock{},
-			ACMEOptions: controllerpkg.ACMEOptions{
-				AccountRegistry: accountRegistry,
-			},
-		},
+		ACMEAccountRegistry:       accountRegistry,
+		Clock:                     clock.RealClock{},
+		ContextOptions:            controllerpkg.ContextOptions{},
 
 		Recorder:     framework.NewEventRecorder(t, scheme),
 		FieldManager: "cert-manager-orders-test",

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -348,12 +348,11 @@ func runAllControllers(t *testing.T, config *rest.Config) framework.StopFunc {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Metrics: metrics,
-			Clock:   clock,
-		},
-		Recorder:     framework.NewEventRecorder(t, scheme),
-		FieldManager: "cert-manager-certificates-issuing-test",
+		Metrics:                   metrics,
+		Clock:                     clock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-issuing-test",
 	}
 
 	// TODO: set field manager before calling each of those - is that what we do in actual code?

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -69,8 +69,8 @@ func TestIssuingController(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),
@@ -271,8 +271,8 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),
@@ -482,8 +482,8 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),
@@ -715,8 +715,8 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),
@@ -940,8 +940,8 @@ func Test_IssuingController_OwnerReference(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmClient,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),
@@ -1038,8 +1038,8 @@ func Test_IssuingController_OwnerReference(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmClient,
 		SharedInformerFactory:     cmFactory,
+		Clock:                     clock.RealClock{},
 		ContextOptions: controllerpkg.ContextOptions{
-			Clock:              clock.RealClock{},
 			CertificateOptions: controllerOptions,
 		},
 		Recorder:     framework.NewEventRecorder(t, scheme),

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -99,9 +99,8 @@ func TestMetricsController(t *testing.T) {
 		Scheme:                    scheme,
 		KubeSharedInformerFactory: factory,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Metrics: metricsHandler,
-		},
+		Metrics:                   metricsHandler,
+		ContextOptions:            controllerpkg.ContextOptions{},
 	}
 	ctrl, queue, mustSync, err := controllermetrics.NewController(&controllerContext)
 	if err != nil {

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -72,11 +72,10 @@ func TestTriggerController(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Clock: fakeClock,
-		},
-		Recorder:     framework.NewEventRecorder(t, scheme),
-		FieldManager: "cert-manager-certificates-trigger-test",
+		Clock:                     fakeClock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-trigger-test",
 	}
 	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shouldReissue)
 	if err != nil {
@@ -177,11 +176,10 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Clock: fakeClock,
-		},
-		Recorder:     framework.NewEventRecorder(t, scheme),
-		FieldManager: "cert-manager-certificates-trigger-test",
+		Clock:                     fakeClock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-trigger-test",
 	}
 	// Start the trigger controller
 	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shouldReissue)
@@ -273,11 +271,10 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 		KubeSharedInformerFactory: factory,
 		CMClient:                  cmCl,
 		SharedInformerFactory:     cmFactory,
-		ContextOptions: controllerpkg.ContextOptions{
-			Clock: fakeClock,
-		},
-		Recorder:     framework.NewEventRecorder(t, scheme),
-		FieldManager: "cert-manager-certificates-trigger-test",
+		Clock:                     fakeClock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-trigger-test",
 	}
 
 	// Start the trigger controller


### PR DESCRIPTION
Refactored the `Registry interface`, such that its `AddClient` function takes a `NewClientOptions` object that we can check against in the `GetClient` calls (future PR).

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
