### PR TITLE
adds cli option configure ACME challange authorization timeout

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -340,6 +340,8 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.ACMEDNS01Config.RecursiveNameserversOnly,
+
+			ChallengeAuthorizationTimeout: opts.ChallengeAuthorizationTimeout,
 		},
 
 		SchedulerOptions: controller.SchedulerOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -245,6 +245,10 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 		"Duration of the initial certificate request backoff when a certificate request fails. "+
 		"The backoff duration is exponentially increased based on consecutive failures, up to a maximum of 32 hours.")
 
+	fs.DurationVar(&c.ChallengeAuthorizationTimeout, "challenge-authorization-timeout", c.ChallengeAuthorizationTimeout, ""+
+		"Defines the timeout a challenge authorization can take before the request will be "+
+		"canceled.")
+
 	logf.AddFlags(&c.Logging, fs)
 }
 

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -147,6 +147,10 @@ type ControllerConfiguration struct {
 	// a maximum of 32 hours) based on the number of consecutive failures and represents
 	// the minimum backoff applied.
 	CertificateRequestMinimumBackoffDuration time.Duration
+
+	// Defines the timeout a challenge authorization can take before the request will be
+	// canceled.
+	ChallengeAuthorizationTimeout time.Duration
 }
 
 type LeaderElectionConfig struct {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -81,6 +81,8 @@ var (
 	defaultNumberOfConcurrentWorkers int32 = 5
 	defaultMaxConcurrentChallenges   int32 = 60
 
+	defaultChallengeAuthorizationTimeout = 2 * time.Minute
+
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
 	defaultHealthzServerAddress = "0.0.0.0:9403"
@@ -267,6 +269,10 @@ func SetDefaults_ControllerConfiguration(obj *v1alpha1.ControllerConfiguration) 
 
 	if obj.CertificateRequestMinimumBackoffDuration.IsZero() {
 		obj.CertificateRequestMinimumBackoffDuration = sharedv1alpha1.DurationFromTime(defaultCertificateRequestMinimumBackoffDuration)
+	}
+
+	if obj.ChallengeAuthorizationTimeout == nil || obj.ChallengeAuthorizationTimeout.IsZero() {
+		obj.ChallengeAuthorizationTimeout = sharedv1alpha1.DurationFromTime(defaultChallengeAuthorizationTimeout)
 	}
 
 	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)

--- a/internal/apis/config/controller/v1alpha1/testdata/defaults.json
+++ b/internal/apis/config/controller/v1alpha1/testdata/defaults.json
@@ -73,5 +73,6 @@
 		"maxChainLength": 95000,
 		"maxBundleSize": 330000
 	},
-	"certificateRequestMinimumBackoffDuration": "1h0m0s"
+	"certificateRequestMinimumBackoffDuration": "1h0m0s",
+	"challengeAuthorizationTimeout": "2m0s"
 }

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -233,6 +233,9 @@ func autoConvert_v1alpha1_ControllerConfiguration_To_controller_ControllerConfig
 	if err := sharedv1alpha1.Convert_Pointer_v1alpha1_Duration_To_time_Duration(&in.CertificateRequestMinimumBackoffDuration, &out.CertificateRequestMinimumBackoffDuration, s); err != nil {
 		return err
 	}
+	if err := sharedv1alpha1.Convert_Pointer_v1alpha1_Duration_To_time_Duration(&in.ChallengeAuthorizationTimeout, &out.ChallengeAuthorizationTimeout, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -302,6 +305,9 @@ func autoConvert_controller_ControllerConfiguration_To_v1alpha1_ControllerConfig
 		return err
 	}
 	if err := sharedv1alpha1.Convert_time_Duration_To_Pointer_v1alpha1_Duration(&in.CertificateRequestMinimumBackoffDuration, &out.CertificateRequestMinimumBackoffDuration, s); err != nil {
+		return err
+	}
+	if err := sharedv1alpha1.Convert_time_Duration_To_Pointer_v1alpha1_Duration(&in.ChallengeAuthorizationTimeout, &out.ChallengeAuthorizationTimeout, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -149,6 +149,10 @@ type ControllerConfiguration struct {
 	// when a certificate request fails. This duration is exponentially increased
 	// (up to a maximum of 32 hours) based on the number of consecutive failures.
 	CertificateRequestMinimumBackoffDuration *sharedv1alpha1.Duration `json:"certificateRequestMinimumBackoffDuration,omitempty"`
+
+	// Defines the timeout a challenge authorization can take before the request will be
+	// canceled.
+	ChallengeAuthorizationTimeout *sharedv1alpha1.Duration `json:"challengeAuthorizationTimeout,omitempty"`
 }
 
 type LeaderElectionConfig struct {

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *ControllerConfiguration) DeepCopyInto(out *ControllerConfiguration) {
 		*out = new(sharedv1alpha1.Duration)
 		**out = **in
 	}
+	if in.ChallengeAuthorizationTimeout != nil {
+		in, out := &in.ChallengeAuthorizationTimeout, &out.ChallengeAuthorizationTimeout
+		*out = new(sharedv1alpha1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -78,6 +78,8 @@ type controller struct {
 
 	DNS01CheckRetryPeriod time.Duration
 
+	ChallengeAuthorizationTimeout time.Duration
+
 	// objectUpdater implements the updateObject function which is used to save
 	// changes to the Challenge.Status and Challenge.Finalizers
 	objectUpdater
@@ -157,6 +159,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	// read options from context
 	c.dns01Nameservers = ctx.ACMEOptions.DNS01Nameservers
 	c.DNS01CheckRetryPeriod = ctx.ACMEOptions.DNS01CheckRetryPeriod
+	c.ChallengeAuthorizationTimeout = ctx.ACMEOptions.ChallengeAuthorizationTimeout
 
 	// Construct an objectUpdater which is used to save changes to the Challenge
 	// object, either using Update or using Patch + Server Side Apply.

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -46,10 +45,6 @@ const (
 	reasonPresentError   = "PresentError"
 	reasonPresented      = "Presented"
 	reasonFailed         = "Failed"
-
-	// How long to wait for an authorization response from the ACME server in acceptChallenge()
-	// before giving up
-	authorizationTimeout = 2 * time.Minute
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -416,7 +411,8 @@ func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 	// blocking the challenge's processing. Here, we defensively add a timeout for this exchange
 	// with the ACME server and a "context deadline reached" error will be returned by WaitAuthorization
 	// in the err variable.
-	ctxTimeout, cancelAuthorization := context.WithTimeout(ctx, authorizationTimeout)
+
+	ctxTimeout, cancelAuthorization := context.WithTimeout(ctx, c.ChallengeAuthorizationTimeout)
 	defer cancelAuthorization()
 	authorization, err := cl.WaitAuthorization(ctxTimeout, ch.Spec.AuthorizationURL)
 	if err != nil {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -211,6 +211,9 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// Defines the timeout a challenge authorization can take before the request will be canceled
+	ChallengeAuthorizationTimeout time.Duration
 }
 
 // IngressShimOptions contain default Issuer GVK config for the certificate-shim controllers.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation
This PR introduces a cli controller config option to define a timeout for ACME challenge authorisation.

This was introduced with #7202.

This then caused issues with the timeout of 20 seconds being to short:
* #7330
* #7444 
* #7685 

Then the value has been increased from 20 seconds to 2 minutes with #7801

In our case, even two minutes is not enough to complete the challenge.

There is another PR #7450 which proposes a new config option for the solver.
This then raised the valid concern of abusing this config option: https://github.com/cert-manager/cert-manager/pull/7450#discussion_r1874390939

There I propose this solution in order to give cert-manager administrators the option to define the timeout themselves.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
controller:
- A new flag was added to the controller binary. The `--challenge-authorization-timeout` defines how long the controller waits for the ACME server to validate a challenge. It defaults to 2 minutes.
```
