### PR TITLE
Don't set x509.CreateCertificate Version and SerialNumber

### DIFF
--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pki
 
 import (
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -144,16 +143,7 @@ func (k printKeyUsage) String() string {
 // CertificateTemplateFromCSR will create a x509.Certificate for the
 // given *x509.CertificateRequest.
 func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators ...CertificateTemplateValidatorMutator) (*x509.Certificate, error) {
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate serial number: %s", err.Error())
-	}
-
 	cert := &x509.Certificate{
-		// Version must be 3 according to RFC5280.
-		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1
-		Version:            3,
-		SerialNumber:       serialNumber,
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
 		Subject:            csr.Subject,
@@ -257,6 +247,7 @@ func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators 
 	{
 		// If the certificate has an empty Subject, we set any SAN extensions to be critical
 		var asn1Subject []byte
+		var err error
 		if cert.RawSubject != nil {
 			asn1Subject = cert.RawSubject
 		} else {

--- a/pkg/util/pki/certificatetemplate_test.go
+++ b/pkg/util/pki/certificatetemplate_test.go
@@ -62,7 +62,6 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 				},
 			},
 			expected: &x509.Certificate{
-				Version: 3,
 				Subject: pkix.Name{
 					Country:            []string{"US"},
 					Organization:       []string{"cert-manager"},
@@ -82,7 +81,6 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 				DNSNames: []string{"test.example.com"},
 			},
 			expected: &x509.Certificate{
-				Version: 3,
 				RawSubject: subjectGenerator(t, pkix.Name{
 					Country:            []string{"US"},
 					Organization:       []string{"cert-manager"},
@@ -101,9 +99,7 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 					},
 				},
 			},
-			expected: &x509.Certificate{
-				Version: 3,
-			},
+			expected: &x509.Certificate{},
 		},
 		{
 			name: "should copy SANs and not fix critical flag subject is set",
@@ -119,7 +115,6 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 				},
 			},
 			expected: &x509.Certificate{
-				Version: 3,
 				Subject: pkix.Name{
 					Country:      []string{"US"},
 					Organization: []string{"cert-manager"},
@@ -141,7 +136,6 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 				},
 			},
 			expected: &x509.Certificate{
-				Version: 3,
 				ExtraExtensions: []pkix.Extension{
 					sansGenerator(t, []asn1.RawValue{
 						{Tag: 2, Class: 2, Bytes: []byte("test.example.com")},
@@ -157,13 +151,6 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-
-			if result.SerialNumber == nil {
-				t.Errorf("expected serial number to be set")
-			}
-
-			// Set serial number to nil to avoid comparing it
-			result.SerialNumber = nil
 
 			if !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf("unexpected result: %v", result)

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -30,7 +30,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"net/netip"
 	"net/url"
@@ -86,8 +85,6 @@ func SubjectForCertificate(crt *v1.Certificate) v1.X509Subject {
 
 	return *crt.Spec.Subject
 }
-
-var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 func KeyUsagesForCertificateOrCertificateRequest(usages []v1.KeyUsage, isCA bool) (ku x509.KeyUsage, eku []x509.ExtKeyUsage, err error) {
 	var unk []v1.KeyUsage

--- a/pkg/util/pki/kube_test.go
+++ b/pkg/util/pki/kube_test.go
@@ -95,9 +95,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               3,
 				BasicConstraintsValid: true,
-				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
 				PublicKey:             pk.Public(),
 				IsCA:                  true,
@@ -140,9 +138,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               3,
 				BasicConstraintsValid: true,
-				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
 				PublicKey:             pk.Public(),
 				IsCA:                  false,
@@ -185,9 +181,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               3,
 				BasicConstraintsValid: true,
-				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
 				PublicKey:             pk.Public(),
 				IsCA:                  false,
@@ -231,9 +225,7 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               3,
 				BasicConstraintsValid: true,
-				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
 				PublicKey:             pk.Public(),
 				IsCA:                  false,
@@ -282,7 +274,6 @@ func TestCertificateTemplateFromCertificateSigningRequest(t *testing.T) {
 				test.expCertificate.NotBefore = time.Time{}
 				templ.NotAfter = time.Time{}
 				templ.NotBefore = time.Time{}
-				templ.SerialNumber = nil
 				templ.Subject.Names = nil
 				templ.RawSubject = nil
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This is a follow-up to https://github.com/cert-manager/cert-manager/pull/7844, removing the last traces of setting `x509.Certificate` Version and SerialNumber in production code. Since this PR also changes the unit test, I wanted this cleanup to go in a separate PR.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
