### PR TITLE
Migrate away from deprecated fake NewSimpleClientset func

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -306,7 +306,7 @@ func TestScheduleN(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cl := fake.NewSimpleClientset()
+			cl := fake.NewClientset()
 			factory := cminformers.NewSharedInformerFactory(cl, 0)
 			challengesInformer := factory.Acme().V1().Challenges()
 			for _, ch := range test.challenges {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -485,7 +485,7 @@ func TestProcessItem(t *testing.T) {
 			},
 			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "test-1"`},
 			expectedActions: []testpkg.Action{
-				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "test")),
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "test-1")),
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
 					gen.CertificateRequestFrom(bundle1.certificateRequest,
 						gen.SetCertificateRequestName("test-1"),

--- a/pkg/controller/test/actions.go
+++ b/pkg/controller/test/actions.go
@@ -18,8 +18,8 @@ package test
 
 import (
 	"fmt"
-	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kr/pretty"
 	coretesting "k8s.io/client-go/testing"
 )
@@ -79,19 +79,16 @@ func (a *action) Action() coretesting.Action {
 
 // Matches compares action.action with another Action.
 func (a *action) Matches(act coretesting.Action) error {
-	matches := reflect.DeepEqual(a.action, act)
-	if matches {
-		return nil
+	diff := cmp.Diff(a.action, act,
+		// We ignore differences in .ManagedFields since the expected object does not have them.
+		// FIXME: don't ignore this field
+		cmp.FilterPath(func(p cmp.Path) bool {
+			// FIXME: Must ignore managed fields as newer fake clients are tracking them
+			return p.Last().String() == ".ManagedFields"
+		}, cmp.Ignore()),
+	)
+	if diff != "" {
+		return fmt.Errorf("unexpected difference between actions (-want +got):\n%s", pretty.Diff(a.action, act))
 	}
-
-	objAct, ok := act.(coretesting.CreateAction)
-	if !ok {
-		return nil
-	}
-	objExp, ok := a.action.(coretesting.CreateAction)
-	if !ok {
-		return nil
-	}
-
-	return fmt.Errorf("unexpected difference between actions: %s", pretty.Diff(objExp.GetObject(), objAct.GetObject()))
+	return nil
 }

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -126,8 +126,9 @@ func (b *Builder) Init() {
 		b.T.Fatalf("error adding meta to scheme: %v", err)
 	}
 	b.ACMEOptions.ACMEHTTP01SolverRunAsNonRoot = true // default from cmd/controller/app/options/options.go
-	b.Client = kubefake.NewSimpleClientset(b.KubeObjects...)
-	b.CMClient = cmfake.NewSimpleClientset(b.CertManagerObjects...)
+	b.Client = kubefake.NewClientset(b.KubeObjects...)
+	b.CMClient = cmfake.NewClientset(b.CertManagerObjects...)
+	// FIXME: It seems like the gateway-api fake.NewClientset is misbehaving and is not usable per July 2025
 	b.GWClient = gwfake.NewSimpleClientset(b.GWObjects...)
 	b.MetadataClient = metadatafake.NewSimpleMetadataClient(scheme, b.PartialMetadataObjects...)
 	b.DiscoveryClient = discoveryfake.NewDiscovery().WithServerResourcesForGroupVersion(func(groupVersion string) (*metav1.APIResourceList, error) {

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -470,6 +470,8 @@ func TestCleanupIngresses(t *testing.T) {
 					t.Errorf("error getting ingress resource: %v", err)
 				}
 
+				expectedIng.ManagedFields = actualIng.ManagedFields
+
 				if diff := cmp.Diff(expectedIng, actualIng); diff != "" {
 					t.Errorf("expected did not match actual (-want +got):\n%s", diff)
 				}
@@ -657,11 +659,14 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 					return
 				}
 
+				expectedIngress.APIVersion = resp.APIVersion
+				expectedIngress.Kind = resp.Kind
 				expectedIngress.OwnerReferences = resp.OwnerReferences
+				expectedIngress.ManagedFields = resp.ManagedFields
 				expectedIngress.Name = resp.Name
 
-				if !reflect.DeepEqual(resp, expectedIngress) {
-					t.Errorf("unexpected ingress generated from merge\nexp=%+v\ngot=%+v", expectedIngress, resp)
+				if diff := cmp.Diff(expectedIngress, resp); diff != "" {
+					t.Errorf("unexpected ingress generated from merge (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -735,11 +740,14 @@ func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
 					return
 				}
 
+				expectedIngress.APIVersion = resp.APIVersion
+				expectedIngress.Kind = resp.Kind
 				expectedIngress.OwnerReferences = resp.OwnerReferences
+				expectedIngress.ManagedFields = resp.ManagedFields
 				expectedIngress.Name = resp.Name
 
-				if !reflect.DeepEqual(resp, expectedIngress) {
-					t.Errorf("unexpected ingress generated from merge\nexp=%+v\ngot=%+v", expectedIngress, resp)
+				if diff := cmp.Diff(expectedIngress, resp); diff != "" {
+					t.Errorf("unexpected ingress generated from merge (-want +got):\n%s", diff)
 				}
 			},
 		},

--- a/pkg/issuer/vault/setup_test.go
+++ b/pkg/issuer/vault/setup_test.go
@@ -430,7 +430,7 @@ func TestVault_Setup(t *testing.T) {
 					IssuerConfig: tt.givenIssuer,
 				},
 			}
-			cmclient := cmfake.NewSimpleClientset(givenIssuer)
+			cmclient := cmfake.NewClientset(givenIssuer)
 
 			v := &Vault{
 				Context: &controller.Context{CMClient: cmclient},

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -92,7 +92,7 @@ func Test_ACMEChallenges(t *testing.T) {
 		gen.SetChallengeNamespace("test-challenge"),
 	))
 
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	factory := externalversions.NewSharedInformerFactory(fakeClient, 0)
 	challengesInformer := factory.Acme().V1().Challenges()
 	for _, ch := range challenges {

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -74,7 +74,7 @@ func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAu
 }
 
 func TestDynamicAuthority(t *testing.T) {
-	fake := kubefake.NewSimpleClientset()
+	fake := kubefake.NewClientset()
 
 	da := testAuthority(t, "authority", fake)
 
@@ -135,7 +135,7 @@ func TestDynamicAuthority(t *testing.T) {
 }
 
 func TestDynamicAuthorityMulti(t *testing.T) {
-	fake := kubefake.NewSimpleClientset()
+	fake := kubefake.NewClientset()
 
 	authorities := make([]*DynamicAuthority, 0)
 	for i := range 200 {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This is a follow-up after https://github.com/cert-manager/cert-manager/pull/7866. Using deprecated APIs is something we should avoid when we can.

It seems like the generated `fake.NewClientSet` func in Gateway API isn't usable, so I have left it for now, as this must be fixed upstream.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
