### PR TITLE
feat(rfc2136): new protocol field for dns update

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -405,6 +405,9 @@ spec:
                                 enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                 This field is required.
                               type: string
+                            protocol:
+                              description: Protocol to use for DNS queries. Valid values are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+                              type: string
                             tsigAlgorithm:
                               description: |-
                                 The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -522,6 +522,9 @@ spec:
                                       enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                       This field is required.
                                     type: string
+                                  protocol:
+                                    description: Protocol to use for DNS queries. Valid values are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+                                    type: string
                                   tsigAlgorithm:
                                     description: |-
                                       The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -521,6 +521,9 @@ spec:
                                       enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                       This field is required.
                                     type: string
+                                  protocol:
+                                    description: Protocol to use for DNS queries. Valid values are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+                                    type: string
                                   tsigAlgorithm:
                                     description: |-
                                       The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -413,6 +413,10 @@ spec:
                               enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                               This field is required.
                             type: string
+                          protocol:
+                            description: Protocol to use for DNS queries. Valid values
+                              are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+                            type: string
                           tsigAlgorithm:
                             description: |-
                               The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -534,6 +534,11 @@ spec:
                                     enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                     This field is required.
                                   type: string
+                                protocol:
+                                  description: Protocol to use for DNS queries. Valid
+                                    values are (case-sensitive) ``tcp`` and ``udp``;
+                                    ``udp`` (default).
+                                  type: string
                                 tsigAlgorithm:
                                   description: |-
                                     The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -533,6 +533,11 @@ spec:
                                     enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                     This field is required.
                                   type: string
+                                protocol:
+                                  description: Protocol to use for DNS queries. Valid
+                                    values are (case-sensitive) ``tcp`` and ``udp``;
+                                    ``udp`` (default).
+                                  type: string
                                 tsigAlgorithm:
                                   description: |-
                                     The TSIG Algorithm configured in the DNS supporting RFC2136. Used only

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -641,6 +641,10 @@ type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// Supported values are (case-insensitive): ``HMACMD5`` (default),
 	// ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
 	TSIGAlgorithm string
+
+	// Protocol to use for DNS queries. Valid values are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+	// +optional
+	Protocol string `json:"protocol,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderWebhook specifies configuration for a webhook DNS01

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1268,6 +1268,7 @@ func autoConvert_v1_ACMEIssuerDNS01ProviderRFC2136_To_acme_ACMEIssuerDNS01Provid
 	}
 	out.TSIGKeyName = in.TSIGKeyName
 	out.TSIGAlgorithm = in.TSIGAlgorithm
+	out.Protocol = in.Protocol
 	return nil
 }
 
@@ -1283,6 +1284,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderRFC2136_To_v1_ACMEIssuerDNS01Provid
 	}
 	out.TSIGKeyName = in.TSIGKeyName
 	out.TSIGAlgorithm = in.TSIGAlgorithm
+	out.Protocol = in.Protocol
 	return nil
 }
 

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -764,6 +764,10 @@ type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
 	// +optional
 	TSIGAlgorithm string `json:"tsigAlgorithm,omitempty"`
+
+	// Protocol to use for DNS queries. Valid values are (case-sensitive) ``tcp`` and ``udp``; ``udp`` (default).
+	// +optional
+	Protocol string `json:"protocol,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderWebhook specifies configuration for a webhook DNS01

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerrfc2136.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerrfc2136.go
@@ -29,6 +29,7 @@ type ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration struct {
 	TSIGSecret    *metav1.SecretKeySelector `json:"tsigSecretSecretRef,omitempty"`
 	TSIGKeyName   *string                   `json:"tsigKeyName,omitempty"`
 	TSIGAlgorithm *string                   `json:"tsigAlgorithm,omitempty"`
+	Protocol      *string                   `json:"protocol,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration constructs a declarative configuration of the ACMEIssuerDNS01ProviderRFC2136 type for use with
@@ -66,5 +67,13 @@ func (b *ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration) WithTSIGKeyName(value
 // If called multiple times, the TSIGAlgorithm field is set to the value of the last call.
 func (b *ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration) WithTSIGAlgorithm(value string) *ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration {
 	b.TSIGAlgorithm = &value
+	return b
+}
+
+// WithProtocol sets the Protocol field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Protocol field is set to the value of the last call.
+func (b *ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration) WithProtocol(value string) *ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration {
+	b.Protocol = &value
 	return b
 }

--- a/pkg/issuer/acme/dns/rfc2136/provider.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider.go
@@ -190,5 +190,5 @@ func (s *Solver) buildDNSProvider(ch *whapi.ChallengeRequest) (*DNSProvider, err
 		key = string(secret)
 	}
 
-	return NewDNSProviderCredentials(cfg.Nameserver, cfg.TSIGAlgorithm, cfg.TSIGKeyName, key)
+	return NewDNSProviderCredentials(cfg.Nameserver, cfg.TSIGAlgorithm, cfg.TSIGKeyName, key, cfg.Protocol)
 }

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -45,6 +45,7 @@ var supportedAlgorithms = map[string]string{
 type DNSProvider struct {
 	nameserver    string
 	tsigAlgorithm string
+	protocol      string
 	tsigKeyName   string
 	tsigSecret    string
 }
@@ -53,7 +54,7 @@ type DNSProvider struct {
 // DNSProvider instance configured for rfc2136 dynamic update. To disable TSIG
 // authentication, leave the TSIG parameters as empty strings.
 // nameserver must be a network address in the form "IP" or "IP:port".
-func NewDNSProviderCredentials(nameserver, tsigAlgorithm, tsigKeyName, tsigSecret string) (*DNSProvider, error) {
+func NewDNSProviderCredentials(nameserver, tsigAlgorithm, tsigKeyName, tsigSecret, protocol string) (*DNSProvider, error) {
 	logf.Log.V(logf.DebugLevel).Info("Creating RFC2136 Provider")
 
 	d := &DNSProvider{}
@@ -76,7 +77,6 @@ func NewDNSProviderCredentials(nameserver, tsigAlgorithm, tsigKeyName, tsigSecre
 			tsigAlgorithm = value
 		} else {
 			return nil, fmt.Errorf("algorithm '%v' is not supported", tsigAlgorithm)
-
 		}
 	}
 	d.tsigAlgorithm = tsigAlgorithm
@@ -128,6 +128,9 @@ func (r *DNSProvider) changeRecord(action, fqdn, zone, value string, ttl uint32)
 
 	// Setup client
 	c := new(dns.Client)
+	if r.protocol == "tcp" {
+		c.Net = "tcp"
+	}
 	c.TsigProvider = tsigHMACProvider(r.tsigSecret)
 	// TSIG authentication / msg signing
 	if len(r.tsigKeyName) > 0 && len(r.tsigSecret) > 0 {

--- a/test/integration/rfc2136_dns01/rfc2136_test.go
+++ b/test/integration/rfc2136_dns01/rfc2136_test.go
@@ -93,7 +93,7 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 		}
 	}()
 
-	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "")
+	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "", "")
 	if err != nil {
 		t.Fatalf("Expected rfc2136.NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
@@ -118,7 +118,7 @@ func TestRFC2136ServerError(t *testing.T) {
 		}
 	}()
 
-	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "")
+	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "", "")
 	if err != nil {
 		t.Fatalf("Expected rfc2136.NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
@@ -149,7 +149,7 @@ func TestRFC2136TsigClient(t *testing.T) {
 		}
 	}()
 
-	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	if err != nil {
 		t.Fatalf("Expected rfc2136.NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
@@ -159,34 +159,33 @@ func TestRFC2136TsigClient(t *testing.T) {
 }
 
 func TestRFC2136NameserverEmpty(t *testing.T) {
-	_, err := rfc2136.NewDNSProviderCredentials("", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials("", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
 func TestRFC2136NameserverWithoutHost(t *testing.T) {
-	_, err := rfc2136.NewDNSProviderCredentials(":53", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials(":53", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
 func TestRFC2136NameserverWithoutHostNorPort(t *testing.T) {
-	_, err := rfc2136.NewDNSProviderCredentials(":", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials(":", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
 func TestRFC2136NameserverIPv4WithoutPort(t *testing.T) {
 	nameserver := "127.0.0.1"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+":"+defaultPort {
 		t.Errorf("dnsProvider.Nameserver() to be %v:%v, but it is %v", nameserver, defaultPort, dnsProvider.Nameserver())
 	}
-
 }
 
 func TestRFC2136NameserverIPv4WithEmptyPort(t *testing.T) {
 	nameserver := "127.0.0.1:"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+defaultPort {
@@ -196,7 +195,7 @@ func TestRFC2136NameserverIPv4WithEmptyPort(t *testing.T) {
 
 func TestRFC2136NameserverIPv4WithPort(t *testing.T) {
 	nameserver := "127.0.0.1:12345"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver {
@@ -206,19 +205,19 @@ func TestRFC2136NameserverIPv4WithPort(t *testing.T) {
 
 func TestRFC2136NameserverIPv6NotEnclosed(t *testing.T) {
 	nameserver := "2001:db8::1"
-	_, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
 func TestRFC2136NameserverIPv6Empty(t *testing.T) {
 	nameserver := "[]:53"
-	_, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
 func TestRFC2136NameserverIPv6WithoutPort(t *testing.T) {
 	nameserver := "[2001:db8::1]"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+":"+defaultPort {
@@ -228,7 +227,7 @@ func TestRFC2136NameserverIPv6WithoutPort(t *testing.T) {
 
 func TestRFC2136NameserverIPv6WithEmptyPort(t *testing.T) {
 	nameserver := "[2001:db8::1]:"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+defaultPort {
@@ -238,7 +237,7 @@ func TestRFC2136NameserverIPv6WithEmptyPort(t *testing.T) {
 
 func TestRFC2136NameserverIPv6WithPort(t *testing.T) {
 	nameserver := "[2001:db8::1]:12345"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver {
@@ -248,7 +247,7 @@ func TestRFC2136NameserverIPv6WithPort(t *testing.T) {
 
 func TestRFC2136NameserverFQDNWithoutPort(t *testing.T) {
 	nameserver := "dns.example.net"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+":"+defaultPort {
@@ -258,7 +257,7 @@ func TestRFC2136NameserverFQDNWithoutPort(t *testing.T) {
 
 func TestRFC2136NameserverFQDNWithEmptyPort(t *testing.T) {
 	nameserver := "dns.example.com:"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+defaultPort {
@@ -268,7 +267,7 @@ func TestRFC2136NameserverFQDNWithEmptyPort(t *testing.T) {
 
 func TestRFC2136NameserverFQDNWithPort(t *testing.T) {
 	nameserver := "dns.example.net:12345"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver {
@@ -278,7 +277,7 @@ func TestRFC2136NameserverFQDNWithPort(t *testing.T) {
 
 func TestRFC2136NameserverHostnameWithoutPort(t *testing.T) {
 	nameserver := "dns"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+":"+defaultPort {
@@ -288,7 +287,7 @@ func TestRFC2136NameserverHostnameWithoutPort(t *testing.T) {
 
 func TestRFC2136NameserverHostnameWithEmptyPort(t *testing.T) {
 	nameserver := "dns:"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver+defaultPort {
@@ -298,7 +297,7 @@ func TestRFC2136NameserverHostnameWithEmptyPort(t *testing.T) {
 
 func TestRFC2136NameserverHostnameWithPort(t *testing.T) {
 	nameserver := "dns:12345"
-	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	dnsProvider, err := rfc2136.NewDNSProviderCredentials(nameserver, "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.NoError(t, err)
 
 	if dnsProvider.Nameserver() != nameserver {
@@ -307,14 +306,14 @@ func TestRFC2136NameserverHostnameWithPort(t *testing.T) {
 }
 
 func TestRFC2136DefaultTSIGAlgorithm(t *testing.T) {
-	provider, err := rfc2136.NewDNSProviderCredentials("127.0.0.1:0", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	provider, err := rfc2136.NewDNSProviderCredentials("127.0.0.1:0", "", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	if err != nil {
 		assert.Equal(t, provider.TSIGAlgorithm(), dns.HmacMD5, "Default TSIG must match")
 	}
 }
 
 func TestRFC2136InvalidTSIGAlgorithm(t *testing.T) {
-	_, err := rfc2136.NewDNSProviderCredentials("127.0.0.1:0", "HAMMOCK", rfc2136TestTsigKeyName, rfc2136TestTsigSecret)
+	_, err := rfc2136.NewDNSProviderCredentials("127.0.0.1:0", "HAMMOCK", rfc2136TestTsigKeyName, rfc2136TestTsigSecret, "")
 	assert.Error(t, err)
 }
 
@@ -340,7 +339,41 @@ func TestRFC2136ValidUpdatePacket(t *testing.T) {
 	m.RemoveRRset(rrs)
 	m.Insert(rrs)
 
-	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "")
+	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "", "")
+	if err != nil {
+		t.Fatalf("Expected rfc2136.NewDNSProviderCredentials() to return no error but the error was -> %v", err)
+	}
+
+	if err := provider.Present(rfc2136TestDomain, "_acme-challenge."+rfc2136TestDomain+".", rfc2136TestDomain+".", rfc2136TestValue); err != nil {
+		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
+	}
+
+	assert.NoError(t, err)
+}
+
+func TestRFC2136TCPUpdate(t *testing.T) {
+	ctx := logf.NewContext(t.Context(), testr.New(t), t.Name())
+	server := &testserver.BasicServer{
+		T:     t,
+		Zones: []string{rfc2136TestZone},
+	}
+	if err := server.Run(ctx); err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			t.Errorf("failed to gracefully shut down test server: %v", err)
+		}
+	}()
+
+	txtRR, _ := dns.NewRR(fmt.Sprintf("%s %d IN TXT %s", rfc2136TestFqdn, rfc2136TestTTL, rfc2136TestValue))
+	rrs := []dns.RR{txtRR}
+	m := new(dns.Msg)
+	m.SetUpdate(rfc2136TestZone)
+	m.RemoveRRset(rrs)
+	m.Insert(rrs)
+
+	provider, err := rfc2136.NewDNSProviderCredentials(server.ListenAddr(), "", "", "", "tcp")
 	if err != nil {
 		t.Fatalf("Expected rfc2136.NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes https://github.com/cert-manager/cert-manager/issues/7849

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
added `protocol` field for `rfc2136` DNS01 provider
```
