### PR TITLE
wip:  add retry mechanism for challenge solver whenever we detect unauthorized error 

### DIFF
--- a/pkg/controller/acmechallenges/retry.go
+++ b/pkg/controller/acmechallenges/retry.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acmechallenges
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/aws/smithy-go"
+	"github.com/digitalocean/godo"
+	v2 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	v3 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
+	controller2 "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/issuer"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/util/solverpicker"
+)
+
+func newRetrySolver(solver solver, orderLister v1.OrderLister, issuerHelper issuer.Helper, issuerOptions controller2.IssuerOptions) solver {
+	return &retrySolver{
+		solver:        solver,
+		orderLister:   orderLister,
+		issuerHelper:  issuerHelper,
+		issuerOptions: issuerOptions,
+	}
+}
+
+type retrySolver struct {
+	solver        solver
+	orderLister   v1.OrderLister
+	issuerHelper  issuer.Helper
+	issuerOptions controller2.IssuerOptions
+}
+
+func (r *retrySolver) Present(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error {
+	return r.withRetry(ctx, ch, issuer, func(newCtx context.Context, newIssuer cmapi.GenericIssuer, newCh *cmacme.Challenge) error {
+		return r.solver.Present(newCtx, newIssuer, newCh)
+	})
+}
+
+func (r *retrySolver) Check(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error {
+	return r.withRetry(ctx, ch, issuer, func(newCtx context.Context, newIssuer cmapi.GenericIssuer, newCh *cmacme.Challenge) error {
+		return r.solver.Check(newCtx, newIssuer, newCh)
+	})
+}
+
+func (r *retrySolver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
+	return r.withRetry(ctx, ch, nil, func(newCtx context.Context, _ cmapi.GenericIssuer, newCh *cmacme.Challenge) error {
+		return r.solver.CleanUp(newCtx, newCh)
+	})
+}
+
+func (r *retrySolver) withRetry(
+	ctx context.Context,
+	ch *cmacme.Challenge,
+	issuer cmapi.GenericIssuer,
+	f func(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmacme.Challenge) error) error {
+	err := f(ctx, issuer, ch)
+	if err == nil || !r.needsRetry(err) {
+		return err
+	}
+
+	log := logf.WithResource(logf.FromContext(ctx, "Retry"), ch).WithValues("domain", ch.Spec.DNSName)
+	newCh, retryErr := r.getChallengeWithFreshSolver(ctx, ch)
+	if retryErr != nil {
+		log.V(logf.InfoLevel).Info("failed to get fresh solver", "challenge", ch.Name, "err", retryErr)
+		return err
+	}
+	retryErr = f(ctx, issuer, newCh)
+	if retryErr != nil {
+		log.V(logf.InfoLevel).Info("withRetry request failed", "challenge", ch.Name, "err", retryErr)
+		return err
+
+	}
+	return nil
+}
+
+func (r *retrySolver) needsRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var awsError smithy.APIError
+	var digitalOceanError *godo.ErrorResponse
+	// route53
+	if errors.As(err, &awsError) {
+		return awsError.ErrorCode() == strconv.Itoa(http.StatusForbidden)
+	}
+	// digitalocean
+	if errors.As(err, &digitalOceanError) {
+		return digitalOceanError.Response.StatusCode == http.StatusForbidden
+	}
+
+	return false
+}
+
+func (r *retrySolver) getChallengeWithFreshSolver(ctx context.Context, ch *cmacme.Challenge) (*cmacme.Challenge, error) {
+	newSolver, err := r.getFreshSolver(ctx, ch)
+	if err != nil {
+		return nil, err
+	}
+	if !r.shouldRetry(ch.Spec.IssuerRef, ch.Spec.Solver, *newSolver) {
+		return nil, fmt.Errorf("solver has not changed")
+	}
+	newCh := ch.DeepCopy()
+	newCh.Spec.Solver = *newSolver
+	return newCh, nil
+}
+
+func (r *retrySolver) getFreshSolver(ctx context.Context, ch *cmacme.Challenge) (*cmacme.ACMEChallengeSolver, error) {
+	orderRef := v2.GetControllerOf(ch)
+	if orderRef == nil {
+		return nil, fmt.Errorf("challenge %s does not have a owner", ch.Name)
+	}
+	o, err := r.orderLister.Orders(ch.ObjectMeta.Namespace).Get(orderRef.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get order %s: %w", orderRef.Name, err)
+	}
+	genericIssuer, err := r.issuerHelper.GetGenericIssuer(ch.Spec.IssuerRef, ch.ObjectMeta.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get issuer %s: %w", ch.Spec.IssuerRef.Name, err)
+	}
+
+	chType := strings.ToLower(string(ch.Spec.Type))
+	challenges := []cmacme.ACMEChallenge{
+		{Type: chType},
+	}
+	issuerSolvers := genericIssuer.GetSpec().IssuerConfig.ACME.Solvers
+	solvers := r.filterIncompatibleSolvers(ch.Spec.Solver, issuerSolvers)
+	if len(solvers) == 0 {
+		return nil, fmt.Errorf("no compatible solvers found for challenge %s", ch.Spec.DNSName)
+	}
+	newSolver, _ := solverpicker.Pick(ctx, ch.Spec.DNSName, challenges, solvers, o)
+	if newSolver == nil {
+		return nil, fmt.Errorf("no compatible solvers found for challenge %s", ch.Spec.DNSName)
+	}
+	return newSolver, nil
+}
+
+// filterIncompatibleSolvers filter out the solvers that have different type from the original one.
+func (r *retrySolver) filterIncompatibleSolvers(origSolver cmacme.ACMEChallengeSolver, newSolvers []cmacme.ACMEChallengeSolver) []cmacme.ACMEChallengeSolver {
+	result := make([]cmacme.ACMEChallengeSolver, 0, cap(newSolvers))
+
+	for _, s := range newSolvers {
+		if origSolver.DNS01 != nil && s.DNS01 == nil {
+			continue
+		}
+		if origSolver.HTTP01 != nil && s.HTTP01 == nil {
+			continue
+		}
+
+		if origSolver.DNS01 != nil && s.DNS01 != nil {
+			if origSolver.DNS01.DigitalOcean != nil && s.DNS01.DigitalOcean == nil {
+				continue
+			}
+
+			if origSolver.DNS01.Route53 != nil && s.DNS01.Route53 == nil {
+				continue
+			}
+		}
+
+		result = append(result, s)
+	}
+
+	return result
+}
+
+func (r *retrySolver) shouldRetry(issueRef v3.IssuerReference, origSolver, newSolver cmacme.ACMEChallengeSolver) bool {
+	if origSolver.DNS01.DigitalOcean != nil && newSolver.DNS01.DigitalOcean != nil {
+		return !reflect.DeepEqual(origSolver.DNS01.DigitalOcean.Token, newSolver.DNS01.DigitalOcean.Token)
+	}
+
+	if origSolver.DNS01.Route53 != nil && newSolver.DNS01.Route53 != nil {
+		return !reflect.DeepEqual(origSolver.DNS01.Route53, newSolver.DNS01.Route53) || r.issuerOptions.CanUseAmbientCredentialsFromRef(issueRef)
+	}
+
+	return false
+}

--- a/pkg/controller/acmechallenges/retry_test.go
+++ b/pkg/controller/acmechallenges/retry_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acmechallenges
+
+import (
+	"testing"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestShouldReattemptRequest_Table(t *testing.T) {
+	r := &retrySolver{}
+
+	tests := []struct {
+		name string
+		orig cmacme.ACMEChallengeSolver
+		newS cmacme.ACMEChallengeSolver
+		want bool
+	}{
+		{
+			name: "DigitalOcean token ref changed (name) -> true",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret-a"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret-b"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "DigitalOcean token ref changed (key) -> true",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "tokenA",
+						},
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "tokenB",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "DigitalOcean token ref same -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "DigitalOcean present only on orig -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			want: false,
+		},
+		{
+			name: "DigitalOcean present only on new -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Route53 equal -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Route53 different -> true",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "eu-west-1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Route53 present only on orig -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			want: false,
+		},
+		{
+			name: "Route53 present only on new -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Both providers absent (DNS01 present) -> false",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{},
+			},
+			want: false,
+		},
+		{
+			name: "Both providers present; DO token ref same; Route53 different -> false (DO branch short-circuits)",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret"},
+							Key:                  "token",
+						},
+					},
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "eu-west-1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Both providers present; DO token ref different; Route53 equal -> true (DO branch decides)",
+			orig: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret-a"},
+							Key:                  "token",
+						},
+					},
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			newS: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmetav1.SecretKeySelector{
+							LocalObjectReference: cmmetav1.LocalObjectReference{Name: "do-secret-b"},
+							Key:                  "token",
+						},
+					},
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						Region: "us-east-1",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Keep DNS01 non-nil to match function preconditions
+			if tc.orig.DNS01 == nil || tc.newS.DNS01 == nil {
+				t.Fatalf("test %q must set DNS01 to non-nil", tc.name)
+			}
+			got := r.shouldRetry(cmmetav1.IssuerReference{}, tc.orig, tc.newS)
+			if got != tc.want {
+				t.Fatalf("shouldRetry() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
 
@@ -39,6 +40,8 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
+	controller2 "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -680,6 +683,227 @@ func Test_StabilizeSolverErrorMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expectedMessage, stabilizeSolverErrorMessage(tt.err))
+		})
+	}
+}
+
+type DummySolver struct {
+	results []error
+	index   int
+}
+
+func (d *DummySolver) Present(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+	defer func() {
+		d.index++
+	}()
+	return d.results[d.index]
+}
+
+func (d *DummySolver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+	defer func() {
+		d.index++
+	}()
+	return d.results[d.index]
+}
+
+func (d *DummySolver) CleanUp(ctx context.Context, ch *cmacme.Challenge) error {
+	defer func() {
+		d.index++
+	}()
+	return d.results[d.index]
+}
+
+type fakeOrder struct {
+	orders []*cmacme.Order
+}
+
+func (f fakeOrder) List(selector labels.Selector) (ret []*cmacme.Order, err error) {
+	panic("implement me")
+}
+
+func (f fakeOrder) Orders(namespace string) cmacmelisters.OrderNamespaceLister {
+	return &fakeOrderNamespaceLister{f.orders}
+}
+
+type fakeOrderNamespaceLister struct {
+	orders []*cmacme.Order
+}
+
+func (f fakeOrderNamespaceLister) List(selector labels.Selector) (ret []*cmacme.Order, err error) {
+	panic("implement me")
+}
+
+func (f fakeOrderNamespaceLister) Get(name string) (*cmacme.Order, error) {
+	for _, order := range f.orders {
+		if order.Name == name {
+			return order, nil
+		}
+	}
+	return nil, fmt.Errorf("order %s not found", name)
+}
+
+type testScenario struct {
+	challenge       *cmacme.Challenge
+	solverResponses []error
+	builder         *testpkg.Builder
+	acmeClient      *acmecl.FakeACME
+}
+
+func TestSyncSolverPickerPath(t *testing.T) {
+	baseOrder := gen.Order("testorder")
+	baseChallenge := gen.Challenge("testchal",
+		gen.SetChallengeIssuer(cmmeta.ObjectReference{
+			Name: "testissuer",
+		}),
+		gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+			DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					AccessKeyID: "oldkey",
+				},
+			},
+		}),
+		gen.SetChallengeOwner(baseOrder, cmacme.SchemeGroupVersion.WithKind("Order")),
+		gen.SetChallengeFinalizers([]string{cmacme.ACMEDomainQualifiedFinalizer}),
+	)
+
+	testIssuerHTTP01Enabled := gen.Issuer("testissuer", gen.SetIssuerACME(cmacme.ACMEIssuer{
+		Solvers: []cmacme.ACMEChallengeSolver{
+			{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						AccessKeyID: "newkey",
+					},
+				},
+			},
+		},
+	}))
+
+	accessDeniedError := &smithy.GenericAPIError{
+		Code: "403",
+	}
+
+	scenarios := map[string]testScenario{
+		"challenge with expired credentials": {
+			challenge: gen.ChallengeFrom(baseChallenge,
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengeURL("testurl"),
+				gen.SetChallengeDNSName("test.com"),
+				gen.SetChallengePresented(false),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+				gen.SetChallengeState(cmacme.Processing),
+			),
+			solverResponses: []error{
+				accessDeniedError, // Present
+				nil,
+				accessDeniedError, // Check
+				nil,
+			},
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
+					gen.SetChallengeProcessing(true),
+					gen.SetChallengeURL("testurl"),
+				), testIssuerHTTP01Enabled},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.ChallengeFrom(baseChallenge,
+							gen.SetChallengeProcessing(true),
+							gen.SetChallengeURL("testurl"),
+							gen.SetChallengeDNSName("test.com"),
+							gen.SetChallengeState(cmacme.Valid),
+							gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+							gen.SetChallengePresented(true),
+							gen.SetChallengeReason("Successfully authorized domain"),
+						))),
+				},
+				ExpectedEvents: []string{
+					"Normal Presented" + " Presented challenge using DNS-01 challenge mechanism",
+					"Normal DomainVerified Domain \"test.com\" verified with \"DNS-01\" validation",
+				},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeAccept: func(context.Context, *acmeapi.Challenge) (*acmeapi.Challenge, error) {
+					return &acmeapi.Challenge{URI: "testurl", Status: acmeapi.StatusReady}, nil
+				},
+				FakeWaitAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return &acmeapi.Authorization{Status: acmeapi.StatusValid}, nil
+				},
+			},
+		},
+		"valid challenge with residual resources": {
+			challenge: gen.ChallengeFrom(baseChallenge,
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengeURL("testurl"),
+				gen.SetChallengeDNSName("test.com"),
+				gen.SetChallengeState(cmacme.Valid),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+				gen.SetChallengePresented(true),
+				gen.SetChallengeReason("Successfully authorized domain"),
+			),
+			solverResponses: []error{
+				accessDeniedError,
+				nil,
+			},
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
+					gen.SetChallengeProcessing(true),
+					gen.SetChallengeURL("testurl"),
+				), testIssuerHTTP01Enabled},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.ChallengeFrom(baseChallenge,
+							gen.SetChallengeProcessing(false),
+							gen.SetChallengePresented(false),
+							gen.SetChallengeURL("testurl"),
+							gen.SetChallengeDNSName("test.com"),
+							gen.SetChallengeState(cmacme.Valid),
+							gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+							gen.SetChallengeReason("Successfully authorized domain"),
+						))),
+				},
+				ExpectedEvents: []string{},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeAccept: func(context.Context, *acmeapi.Challenge) (*acmeapi.Challenge, error) {
+					return &acmeapi.Challenge{URI: "testurl", Status: acmeapi.StatusReady}, nil
+				},
+				FakeWaitAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return &acmeapi.Authorization{Status: acmeapi.StatusValid}, nil
+				},
+			},
+		}}
+
+	for name, test := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			test.builder.T = t
+			test.builder.Init()
+			defer test.builder.Stop()
+
+			c := &controller{}
+			if _, _, err := c.Register(test.builder.Context); err != nil {
+				t.Fatal(err)
+			}
+			c.helper = issuer.NewHelper(
+				test.builder.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+				test.builder.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
+			)
+			c.accountRegistry = &accountstest.FakeRegistry{
+				GetClientFunc: func(_ string) (acmecl.Interface, error) {
+					return test.acmeClient, nil
+				},
+			}
+			dummySolver := DummySolver{results: test.solverResponses}
+			retrySolverIml := newRetrySolver(&dummySolver, fakeOrder{[]*cmacme.Order{baseOrder}}, c.helper, controller2.IssuerOptions{})
+			c.dnsSolver = retrySolverIml
+
+			test.builder.Start()
+
+			err := c.Sync(t.Context(), test.challenge)
+
+			test.builder.CheckAndFinish(err)
 		})
 	}
 }

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -18,6 +18,7 @@ package gen
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	internalv1 "github.com/cert-manager/cert-manager/internal/apis/acme/v1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -74,6 +75,18 @@ func SetChallengeKey(k string) ChallengeModifier {
 func SetChallengeIssuer(o cmmeta.IssuerReference) ChallengeModifier {
 	return func(c *cmacme.Challenge) {
 		c.Spec.IssuerRef = o
+	}
+}
+
+func SetChallengeOwner(o *cmacme.Order, gvk schema.GroupVersionKind) ChallengeModifier {
+	return func(c *cmacme.Challenge) {
+		c.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(o, gvk)}
+	}
+}
+
+func SetChallengeSolver(s cmacme.ACMEChallengeSolver) ChallengeModifier {
+	return func(c *cmacme.Challenge) {
+		c.Spec.Solver = s
 	}
 }
 


### PR DESCRIPTION
### Pull Request Motivation

Fix: https://github.com/cert-manager/cert-manager/issues/7234

---

This PR aims to fix two issues related to how the challenges are processed by cert-manager. 

First is the challenges created with credentials that are no longer valid. Those challenges will never be completed and an administrator needs to remove them manually.  https://github.com/cert-manager/cert-manager/issues/7234

Second, challenges that were able to create corresponding resources in the cloud provider, but were unable to remove them due to expired credentials.  This will result in challenges being marked as completed, but the resource created in the process will be left behind.  https://github.com/cert-manager/cert-manager/issues/3640

The idea of this PR is to wrap the [DNS solver](https://github.com/cert-manager/cert-manager/blob/8f2779cc6adba81a1638b5720dd7658bbd526c38/pkg/issuer/acme/dns/dns.go#L74) around another solver implementation that would intercept any error messages with status 403 returned by the cloud provider and re-attempt the request with freshly picked credentials from the issuer.  

This will fix the first issue by allowing challenges to be processed successfully once the issuer is updated with new credentials and greatly reduce the amount of residual resources. 

Even more, I believe this fix, combined with [this one](https://github.com/cert-manager/cert-manager/issues/7234), will enable cert-manager to clean up what it creates as effectively as possible, leaving only temporary issues (such as network errors and server errors) to prevent the cleaning phase from stopping.


### Kind

/feature

wip

```release-note
NONE
```
