### PR TITLE
fix: Venafi call GetRefreshToken only when access token invalid for password/username authentication

### DIFF
--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -77,6 +77,8 @@ type Venafi struct {
 	tppClient   *tpp.Connector
 	cloudClient *cloud.Connector
 	config      *vcert.Config
+
+	tppAccessToken string
 }
 
 // connector exposes a subset of the vcert Connector interface to make stubbing
@@ -418,8 +420,12 @@ func (v *Venafi) VerifyCredentials() error {
 		}
 
 		if v.config.Credentials.AccessToken != "" {
+			v.tppAccessToken = v.config.Credentials.AccessToken
+		}
+
+		if v.tppAccessToken != "" {
 			_, err := v.tppClient.VerifyAccessToken(&endpoint.Authentication{
-				AccessToken: v.config.Credentials.AccessToken,
+				AccessToken: v.tppAccessToken,
 			})
 
 			if err != nil {
@@ -428,6 +434,10 @@ func (v *Venafi) VerifyCredentials() error {
 
 			return nil
 		}
+
+		// If VerifyAccessToken fail, reset tppAccessToken immediately
+		// So that GetRefreshToken get called again
+		v.tppAccessToken = ""
 
 		if v.config.Credentials.User != "" && v.config.Credentials.Password != "" {
 			// Use vcert library GetRefreshToken which brings back a token pair.
@@ -453,6 +463,8 @@ func (v *Venafi) VerifyCredentials() error {
 			if err != nil {
 				return fmt.Errorf("tppClient.Authenticate: %v", err)
 			}
+
+			v.tppAccessToken = resp.Access_token
 
 			return nil
 		}


### PR DESCRIPTION
### Pull Request Motivation
Close #7585

When using username/password authentication, **2 API calls: GetRefreshToken + Authenticate are invoked on all sync**. This is inefficient. 

This change optimize the flow by keeping an in-memory access token retrieved from the first successful GetRefreshToken.

Only use the original flow when the in-memory access token is invalid.

### Kind
/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Venafi: call GetRefreshToken only when access token invalid for password/username authentication
```
