### PR TITLE
WIP: Graduate ServerSideApply feature gates to Beta

### DIFF
--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -43,6 +43,7 @@ const (
 
 	// Owner: @inteon
 	// Alpha: v1.12
+	// Beta: v1.20
 	//
 	// ServerSideApply enables the use of ServerSideApply in all API calls.
 	ServerSideApply featuregate.Feature = "ServerSideApply"
@@ -69,6 +70,6 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	ServerSideApply:   {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideApply:   {Default: true, PreRelease: featuregate.Beta},
 	CAInjectorMerging: {Default: true, PreRelease: featuregate.GA},
 }

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -66,6 +66,7 @@ const (
 
 	// Owner: @joshvanl
 	// Alpha: v1.8
+	// Beta: v1.20
 	//
 	// ServerSideApply enables the use of ServerSideApply in all API calls.
 	ServerSideApply featuregate.Feature = "ServerSideApply"
@@ -216,7 +217,7 @@ var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.Feature
 	ExperimentalGatewayAPISupport:                    {Default: true, PreRelease: featuregate.Beta},
 	ListenerSets:                                     {Default: false, PreRelease: featuregate.Alpha},
 	AdditionalCertificateOutputFormats:               {Default: true, PreRelease: featuregate.GA},
-	ServerSideApply:                                  {Default: false, PreRelease: featuregate.Alpha},
+	ServerSideApply:                                  {Default: true, PreRelease: featuregate.Beta},
 	LiteralCertificateSubject:                        {Default: true, PreRelease: featuregate.Beta},
 	UseCertificateRequestBasicConstraints:            {Default: false, PreRelease: featuregate.Alpha},
 	NameConstraints:                                  {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/controller/acmechallenges/update_test.go
+++ b/pkg/controller/acmechallenges/update_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestUpdateStatusStandard(t *testing.T) {
+	featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, false)
 	runUpdateStatusTests(t, "update")
 }
 

--- a/pkg/controller/issuers/sync_test.go
+++ b/pkg/controller/issuers/sync_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	clientgotesting "k8s.io/client-go/testing"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -86,20 +86,20 @@ func TestUpdateIssuerStatus(t *testing.T) {
 	assertNumberOfActions(t, fatalf, actions, 2)
 
 	action := actions[1]
-	updateAction := assertIsUpdateAction(t, errorf, action)
+	patchAction := assertIsPatchAction(t, errorf, action)
 
-	obj := updateAction.GetObject()
-	issuer = assertIsIssuer(t, errorf, obj)
+	err = json.Unmarshal(patchAction.GetPatch(), issuer)
+	assertErrIsNil(t, fatalf, err)
 
 	assertDeepEqual(t, errorf, newStatus, issuer.Status)
 }
 
-func assertIsUpdateAction(t *testing.T, f failfFunc, action clientgotesting.Action) clientgotesting.UpdateAction {
-	updateAction, ok := action.(clientgotesting.UpdateAction)
+func assertIsPatchAction(t *testing.T, f failfFunc, action clientgotesting.Action) clientgotesting.PatchAction {
+	patchAction, ok := action.(clientgotesting.PatchAction)
 	if !ok {
-		f(t, "action %#v does not implement interface UpdateAction")
+		f(t, "action %#v does not implement interface PatchAction")
 	}
-	return updateAction
+	return patchAction
 }
 
 func assertNumberOfActions(t *testing.T, f failfFunc, actions []clientgotesting.Action, number int) {
@@ -112,14 +112,6 @@ func assertErrIsNil(t *testing.T, f failfFunc, err error) {
 	if err != nil {
 		f(t, err.Error())
 	}
-}
-
-func assertIsIssuer(t *testing.T, f failfFunc, obj runtime.Object) *v1.Issuer {
-	issuer, ok := obj.(*v1.Issuer)
-	if !ok {
-		f(t, "expected runtime.Object to be of type *v1.Issuer, but it was %#v", obj)
-	}
-	return issuer
 }
 
 func assertDeepEqual(t *testing.T, f failfFunc, left, right any) {

--- a/pkg/controller/test/actions.go
+++ b/pkg/controller/test/actions.go
@@ -107,6 +107,10 @@ func (a *action) Matches(act coretesting.Action) error {
 
 		return testutil.Diff(expObj, gotObj,
 			cmp.FilterPath(func(p cmp.Path) bool {
+				if p.String() == "Spec" {
+					// Filter out spec if this action is for the status sub-resource
+					return a.action.GetSubresource() == "status"
+				}
 				if p.String() == "TypeMeta.APIVersion" {
 					return true
 				}

--- a/test/e2e/suite/certificates/additionaloutputformats.go
+++ b/test/e2e/suite/certificates/additionaloutputformats.go
@@ -22,11 +22,9 @@ import (
 	"encoding/pem"
 	"time"
 
-	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -328,9 +326,6 @@ var _ = framework.CertManagerDescribe("Certificate additionalOutputFormats", fun
 	})
 
 	It("if a third party set additional output formats, they then get added to the Certificate, when they are removed again they should persist as they are still owned by a third party", func(testingCtx context.Context) {
-		// This e2e test requires that the ServerSideApply feature gate is enabled.
-		framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ServerSideApply)
-
 		crtName, crt := createCertificate(testingCtx, f, nil)
 
 		By("add additional output formats manually to the secret")


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Enable the use of ServerSideApply in all API calls by default.
```

CyberArk tracker: [VC-45578](https://venafi.atlassian.net/browse/VC-45578) <!-- do not edit this line, will be re-added automatically -->