### PR TITLE
Improve script generating applyconfigurations

### DIFF
--- a/hack/k8s-codegen.sh
+++ b/hack/k8s-codegen.sh
@@ -155,15 +155,14 @@ gen-applyconfigurations() {
   # This is a temporary hack to generate the schema YAMLs
   # required to generate fake clientsets that actually works.
   # Upstream issue: https://github.com/kubernetes/kubernetes/issues/126850
-  GOPROXY=off go install \
-    "${module_name}/internal/generated/openapi/cmd/models-schema"
+  models_schema=( "${module_name}/internal/generated/openapi/cmd/models-schema" )
 
   clean "${client_subpackage}"/applyconfigurations '*.go'
   echo "+++ Generating applyconfigurations..." >&2
   prefixed_inputs=( "${api_inputs[@]/#/$module_name/}" )
  "$applyconfigurationgen" \
     --go-header-file hack/boilerplate-go.txt \
-    --openapi-schema <($(go env GOPATH)/bin/models-schema) \
+    --openapi-schema <(go run "$models_schema") \
     --output-dir "${client_subpackage}"/applyconfigurations \
     --output-pkg "${client_package}"/applyconfigurations \
     "${prefixed_inputs[@]}"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While working on bootstrapping Renovate, we detected some issues related to running `make generate`. Maybe `GOBIN` is set in the Renovate environment? Which will make the current script fail. Anyway this appears like a simplification to me. Kudos to @ThatsMrTalbot!

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
