### PR TITLE
[release-1.17] increase maximum PEM sizes for leaf certificates and chains

### DIFF
--- a/internal/pem/decode.go
+++ b/internal/pem/decode.go
@@ -41,14 +41,30 @@ import (
 
 // See https://fm4dd.com/openssl/certexamples.shtm for examples of large RSA certs / keys
 
+// A further factor more usually for leaf certificates is the number of identities contained within the certificate - usually, DNS names.
+// Adding one DNS name to a certificate experimentally adds the length of the DNS name itself, plus about 20 bytes of overhead.
+// We've seen[0] some certificates with 250+ DNS names, which could add up to about 30kB of extra size to a certificate given very long DNS names.
+
+// Generally, issuer certificates will not contain vast amounts of identities, so we can assume a difference in the size of leaf and issuer certificates,
+// with issuer certificates being dominated by the size of the public key and signature, while leaf certificates can vary greatly but may be significantly larger
+// than issuer certificates due to the number of identities they contain.
+
+// [0]: https://github.com/cert-manager/cert-manager/pull/7642#issuecomment-3129868718
+
 const (
-	// maxCertificatePEMSize is the maximum size, in bytes, of a single PEM-encoded X.509 certificate which SafeDecodeSingleCertificate will accept.
-	// The value is based on how large a "realistic" (but still very large) self-signed 16k-bit RSA certificate might be.
+	// maxCACertificatePEMSize is the maximum size in bytes expected for a single PEM-encoded X.509 CA certificate. In practice, this is smaller than the
+	// maximum size which will be accepted by SafeDecodeSingleCertificate, because CA certificates generally won't contain large numbers of identities.
+	// The value is based on how large a "realistic" (but still very large) 16k-bit RSA CA certificate might be, plus about a kilobyte of extra data.
 	// 16k-bit RSA keys are impractical on most on modern hardware due to how slow they can be,
-	// so we can reasonably assume that no real-world PEM-encoded X.509 cert will be this large.
-	// Note that X.509 certificates can contain extra arbitrary data (e.g. DNS names, policy names, etc) whose size is hard to predict.
-	// So we guess at how much of that data we'll allow in very large certs and allow about 1kB of such data.
-	maxCertificatePEMSize = 6500
+	// so we can reasonably assume that no real-world PEM-encoded X.509 cert will be larger than this because of the key size.
+	maxCACertificatePEMSize = 6500
+
+	// maxLeafCertificatePEMSize is the maximum size in bytes expected for a single PEM-encoded X.509 certificate which SafeDecodeSingleCertificate will accept.
+	// The value is based on how large a "realistic" (but still very large) self-signed 16k-bit RSA certificate might be, plus
+	// a significant amount of extra data for potentially hundreds of DNS names, policy names, etc.
+	// See the comment for maxCACertificatePEMSize for more details on why we use a 16k-bit RSA key.
+	// 30000 is a rounded-up estimate for about 250 large DNS names.
+	maxLeafCertificatePEMSize = 30000 + maxCACertificatePEMSize
 
 	// maxPrivateKeyPEMSize is the maximum size, in bytes, of PEM-encoded private keys which SafeDecodePrivateKey will accept.
 	// cert-manager supports RSA, ECDSA and Ed25519 keys, of which RSA is by far the largest.
@@ -57,10 +73,15 @@ const (
 	// we can reasonably assume that no real-world PEM-encoded key will be this large.
 	maxPrivateKeyPEMSize = 13000
 
-	// maxChainSize is the maximum number of 16k-bit RSA certificates signed by 16k-bit RSA CAs we'll allow in a given call to SafeDecodeCertificateChain.
+	// maxCertsInChain is the maximum number of 16k-bit RSA certificates signed by 16k-bit RSA CAs we'll allow in a given call to SafeDecodeCertificateChain.
 	// This is _not_ the maximum number of certificates cert-manager will process in a given chain, which could be much larger.
-	// This is simply the maximum number of worst-case certificates we'll accept in a chain.
-	maxChainSize = 10
+	// This is simply the maximum number of worst-case certificates we'll accept in a chain when parsing PEM data.
+	maxCertsInChain = 10
+
+	// maxCertificateChainSize assumes a chain of CA certificates - which we expect to be smaller, generally -
+	// plus one leaf certificate which can be much larger due to the number of identities it contains.
+	// See comments for individual constants for more details on the sizes of the certificates.
+	maxCertificateChainSize = (maxCertsInChain-1)*maxCACertificatePEMSize + maxLeafCertificatePEMSize
 
 	// maxCertsInTrustBundle is an estimated upper-bound for how many large certs might appear in a PEM-encoded trust bundle,
 	// based on the cert-manager `cert-manager-package-debian` bundle [1] which contains 129 certificates.
@@ -71,10 +92,10 @@ const (
 	// [1] quay.io/jetstack/cert-manager-package-debian:20210119.0@sha256:116133f68938ef568aca17a0c691d5b1ef73a9a207029c9a068cf4230053fed5
 	maxCertsInTrustBundle = 150
 
-	// estimatedCACertSize is a guess of how many bytes a large realistic trust bundle cert might be. This is slightly larger
+	// estimatedCACertSize is a guess of how many bytes a large realistic CA cert in a trust bundle cert might be. This is slightly larger
 	// than a typical self-signed 4096-bit RSA cert (which is just under 2kB).
-	// For other estimates (such as maxCertificatePEMSize) we use a much larger RSA key, but using such a large RSA key would make
-	// maxBundleSize's estimate unrealistically large.
+	// For other estimates (i.e. maxCACertificatePEMSize and maxLeafCertificatePEMSize) we use a much larger RSA key, but using such a large RSA key would make
+	// maxBundleSize's estimate unrealistically large when compared to real-world trust bundles (such as the widely used Mozilla CA trust store)
 	estimatedCACertSize = 2200
 
 	// maxBundleSize is an estimate for the max reasonable size for a PEM-encoded TLS trust bundle.
@@ -119,34 +140,31 @@ func SafeDecodePrivateKey(b []byte) (*stdpem.Block, []byte, error) {
 
 // SafeDecodeCSR calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
 // how large we expect a single PEM-encoded PKCS#10 CSR to be.
-// We assume that a PKCS#12 CSR is smaller than a single certificate because our assumptions are that
-// a certificate has a large public key and a large signature, which is roughly the case for a CSR.
-// We also assume that we'd only ever decode one CSR which is the case in practice.
+// We assume that a PKCS#12 CSR can be about as large as a leaf certificate, which grows with the size of its public key, signature
+// and the number of identities it contains.
 func SafeDecodeCSR(b []byte) (*stdpem.Block, []byte, error) {
-	return safeDecodeInternal(b, maxCertificatePEMSize)
+	return safeDecodeInternal(b, maxLeafCertificatePEMSize)
 }
 
 // SafeDecodeSingleCertificate calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
-// how large we expect a single PEM-encoded X.509 certificate to be.
-// The baseline is a 16k-bit RSA certificate signed by a different 16k-bit RSA CA, which is larger than the maximum
-// supported by cert-manager for key generation.
+// how large we expect a single PEM-encoded X.509 _leaf_ certificate to be.
+// The baseline is a 16k-bit RSA certificate signed by a different 16k-bit RSA CA, with a very large number of long DNS names.
+// The maximum size allowed by this function is significantly larger than the size of most CA certificates, which will usually
+// not have a large amount of DNS names or other identities in them.
 func SafeDecodeSingleCertificate(b []byte) (*stdpem.Block, []byte, error) {
-	return safeDecodeInternal(b, maxCertificatePEMSize)
+	return safeDecodeInternal(b, maxLeafCertificatePEMSize)
 }
 
 // SafeDecodeCertificateChain calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
 // how large we expect a reasonable-length PEM-encoded X.509 certificate chain to be.
-// The baseline is several 16k-bit RSA certificates, all signed by 16k-bit RSA keys, which is larger than the maximum
-// supported by cert-manager for key generation.
-// The maximum number of chains supported by this function is not reflective of the maximum chain length supported by
-// cert-manager; a larger chain of smaller certificate should be supported.
+// The baseline is many average sized CA certificates, plus one potentially much larger leaf certificate.
 func SafeDecodeCertificateChain(b []byte) (*stdpem.Block, []byte, error) {
-	return safeDecodeInternal(b, maxCertificatePEMSize*maxChainSize)
+	return safeDecodeInternal(b, maxCertificateChainSize)
 }
 
 // SafeDecodeCertificateBundle calls [encoding/pem.Decode] on the given input as long as it's within a sensible range for
 // how large we expect a reasonable-length PEM-encoded X.509 certificate bundle (such as a TLS trust store) to be.
-// The baseline is a bundle of 4k-bit RSA certificates, all self signed. This is smaller than the 16k-bit RSA keys
+// The baseline is a bundle of 4k-bit RSA certificates, all self-signed. This is smaller than the 16k-bit RSA keys
 // we use in other functions, because using such large keys would make our estimate several times
 // too large for a realistic bundle which would be used in practice.
 func SafeDecodeCertificateBundle(b []byte) (*stdpem.Block, []byte, error) {

--- a/internal/pem/decode_test.go
+++ b/internal/pem/decode_test.go
@@ -33,6 +33,10 @@ var fuzzFile []byte
 // pathologicalFuzzFile is a copy of fuzzFile trimmed to fit inside our max allowable size
 var pathologicalFuzzFile []byte
 
+// largestLimit is set to maxBundleSize as the maximum size that any of our SafeDecode* functions accepts; we use this
+// as an upper bound for the size of pathologicalFuzzFile.
+const largestLimit = maxBundleSize
+
 func init() {
 	fuzzFilename := "./testdata/issue-ghsa-r4pg-vg54-wxx4.bin"
 
@@ -42,20 +46,21 @@ func init() {
 		panic(fmt.Errorf("failed to read fuzz file %q: %s", fuzzFilename, err))
 	}
 
-	// Assert that SafeDecodeCertificateBundle has the largest max size so we're definitely
-	// testing the worst case with pathologicalFuzzFile
-	if maxBundleSize < maxPrivateKeyPEMSize || maxBundleSize < maxChainSize {
-		panic(fmt.Errorf("invalid test: expected max cert bundle size %d to be larger than maxPrivateKeyPEMSize %d", maxChainSize, maxPrivateKeyPEMSize))
+	// Assert that largestLimit is actually the largest limit so we're definitely
+	// testing the worst case with pathologicalFuzzFile. This guards against future changes making these tests invalid;
+	// e.g. if, maxCertificateChainSize actually became the largest we accept, we'd want to test against that instead.
+	if largestLimit < maxPrivateKeyPEMSize || largestLimit < maxCertificateChainSize {
+		panic(fmt.Errorf("invalid test: expected max cert bundle size %d to be larger than maxPrivateKeyPEMSize %d and maxCertificateChainSize %d", maxBundleSize, maxPrivateKeyPEMSize, maxCertificateChainSize))
 	}
 
-	pathologicalFuzzFile = fuzzFile[:maxBundleSize-1]
+	pathologicalFuzzFile = fuzzFile[:largestLimit-1]
 }
 
 func TestFuzzData(t *testing.T) {
 	// The fuzz test data should be rejected by all Safe* functions
 
 	// Ensure fuzz test data is larger than the max we allow
-	if len(fuzzFile) < maxCertificatePEMSize*maxChainSize {
+	if len(fuzzFile) < maxCertificateChainSize {
 		t.Fatalf("invalid test; fuzz file data is smaller than the maximum allowed input")
 	}
 
@@ -64,9 +69,9 @@ func TestFuzzData(t *testing.T) {
 	var err error
 
 	expPrivateKeyError := ErrPEMDataTooLarge(maxPrivateKeyPEMSize)
-	expCSRError := ErrPEMDataTooLarge(maxCertificatePEMSize)
-	expSingleCertError := ErrPEMDataTooLarge(maxCertificatePEMSize)
-	expCertChainError := ErrPEMDataTooLarge(maxCertificatePEMSize * maxChainSize)
+	expCSRError := ErrPEMDataTooLarge(maxLeafCertificatePEMSize)
+	expSingleCertError := ErrPEMDataTooLarge(maxLeafCertificatePEMSize)
+	expCertChainError := ErrPEMDataTooLarge(maxCertificateChainSize)
 	expCertBundleError := ErrPEMDataTooLarge(maxBundleSize)
 
 	block, rest, err = SafeDecodePrivateKey(fuzzFile)
@@ -166,7 +171,7 @@ func TestPathologicalInput(t *testing.T) {
 }
 
 func BenchmarkPathologicalInput(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		testPathologicalInternal(b)
 	}
 }

--- a/pkg/util/pki/parse_certificate_chain_test.go
+++ b/pkg/util/pki/parse_certificate_chain_test.go
@@ -232,7 +232,7 @@ func TestParseSingleCertificateChainPEM(t *testing.T) {
 			}(),
 			expPEMBundle: PEMBundle{},
 			expErr:       true,
-			expErrString: "provided PEM data was larger than the maximum 65000B",
+			expErrString: "provided PEM data was larger than the maximum 95000B",
 		},
 	}
 


### PR DESCRIPTION
This commit manually checks out the internal/pem/decode* files from b8ade82a7997148c570e2181b6ae863b78070cb4 as merged to master in #7961

I chose to just check out the files (rather than cherry-picking) because these files are security-relevant and I want the review to be as simple as possible.

The diff on this PR is pretty much irrelevant, since this files are now identical to those on master which have already been reviewed.

### Kind

/kind bug

### Release Note

```release-note
Increase maximum sizes of PEM certificates and chains which can be parsed in cert-manager, to handle leaf certificates with large numbers of DNS names or other identities
```
