### PR TITLE
[release-1.17] Bump go to 1.24.6

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -161,8 +161,10 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-# NOTE: The version of Go here has been manually updated!
-VENDORED_GO_VERSION := 1.23.10
+# NOTE: The version of Go here has been manually updated.
+# cert-manager v1.17 was originally released using go 1.23.x but that Go version has now reached EOL
+
+VENDORED_GO_VERSION := 1.24.6
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -381,10 +383,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=535f9f81802499f2a7dbfa70abb8fda3793725fcc29460f719815f6e10b5fd60
-go_linux_arm64_SHA256SUM=bfb1f1df7173f44648ee070a39ab0481068632f595305a699d89cd56a33b8081
-go_darwin_amd64_SHA256SUM=1cbd7af6f07bc6fa1f8672f9b913c961986864100e467e0acdc942e0ae46fe68
-go_darwin_arm64_SHA256SUM=25c64bfa8a8fd8e7f62fb54afa4354af8409a4bb2358c2699a1003b733e6fce5
+go_linux_amd64_SHA256SUM=bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712
+go_linux_arm64_SHA256SUM=124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5
+go_darwin_amd64_SHA256SUM=4a8d7a32052f223e71faab424a69430455b27b3fff5f4e651f9d97c3e51a8746
+go_darwin_arm64_SHA256SUM=4e29202c49573b953be7cc3500e1f8d9e66ddd12faa8cf0939a4951411e09a2a
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
Note that this bumps the _minor_ version; go 1.23.x is EOL

### Kind

/kind bug

### Release Note

```release-note
Bump go to next minor version - 1.24.6
```
