### PR TITLE
fix: Enforce strict mutual exclusion for HTTP-01 ingress configuration fields

### DIFF
--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -197,7 +197,17 @@ func ValidateACMEIssuerChallengeSolverHTTP01Config(http01 *cmacme.ACMEChallengeS
 func ValidateACMEIssuerChallengeSolverHTTP01IngressConfig(ingress *cmacme.ACMEChallengeSolverHTTP01Ingress, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
-	if ingress.Class != nil && ingress.IngressClassName != nil && len(ingress.Name) > 0 {
+	numFieldsSpecified := 0
+	if ingress.Class != nil {
+		numFieldsSpecified++
+	}
+	if ingress.IngressClassName != nil {
+		numFieldsSpecified++
+	}
+	if len(ingress.Name) > 0 {
+		numFieldsSpecified++
+	}
+	if numFieldsSpecified > 1 {
 		el = append(el, field.Forbidden(fldPath, "only one of 'ingressClassName', 'name' or 'class' should be specified"))
 	}
 

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -835,7 +835,7 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 		cfg               *cmacme.ACMEChallengeSolverHTTP01
 		errs              []*field.Error
 	}{
-		"ingress field specified": {
+		"ingress name field specified": {
 			cfg: &cmacme.ACMEChallengeSolverHTTP01{
 				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{Name: "abc"},
 			},
@@ -859,6 +859,39 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 			cfg: &cmacme.ACMEChallengeSolverHTTP01{},
 			errs: []*field.Error{
 				field.Required(fldPath, "no HTTP01 solver type configured"),
+			},
+		},
+		"both ingress class and ingressClassName specified": {
+			cfg: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					Class:            ptr.To("abc"),
+					IngressClassName: ptr.To("abc"),
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(fldPath.Child("ingress"), "only one of 'ingressClassName', 'name' or 'class' should be specified"),
+			},
+		},
+		"both ingress class and ingress name specified": {
+			cfg: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					Class: ptr.To("abc"),
+					Name:  "abc",
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(fldPath.Child("ingress"), "only one of 'ingressClassName', 'name' or 'class' should be specified"),
+			},
+		},
+		"both ingressClassName and ingress name specified": {
+			cfg: &cmacme.ACMEChallengeSolverHTTP01{
+				Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+					IngressClassName: ptr.To("abc"),
+					Name:             "abc",
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(fldPath.Child("ingress"), "only one of 'ingressClassName', 'name' or 'class' should be specified"),
 			},
 		},
 		"all three fields specified": {


### PR DESCRIPTION
to reject configurations when multiple ingress options (class, ingressClassName, name) are specified simultaneously. This would help us catch errors at admission time rather than runtime.

### Pull Request Motivation

Addresses https://github.com/cert-manager/cert-manager/pull/5849#discussion_r2297621682

### E2E Verification

Invalid configurations that should be rejected by the webhook:
- Both `http01.ingress.class` and `http01.ingress.ingressClassName`
- Both `http01.ingress.class` and `http01.ingress.name`
- Both `http01.ingress.ingressClassName` and `http01.ingress.name`
- All three fields

Error message:
```
Error from server (Forbidden): error when creating "STDIN": admission webhook "webhook.cert-manager.io" denied the request: spec.acme.solvers[0].http01.ingress: Forbidden: only one of 'ingressClassName', 'name' or 'class' should be specified
```

### Kind

/kind bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Enforced ACME HTTP-01 solver validation to properly reject configurations when multiple ingress options (class, ingressClassName, name) are specified simultaneously
```
