### PR TITLE
fix: typo in SecretTemplateMismatch's comment

### DIFF
--- a/internal/controller/certificates/policies/constants.go
+++ b/internal/controller/certificates/policies/constants.go
@@ -53,7 +53,7 @@ const (
 	// Expired is a policy violation reason for a scenario where Certificate has
 	// expired.
 	Expired string = "Expired"
-	// SecretTemplateMisMatch is a policy violation whereby the Certificate's
+	// SecretTemplateMismatch is a policy violation whereby the Certificate's
 	// SecretTemplate is not reflected on the target Secret, either by having
 	// extra, missing, or wrong Annotations or Labels.
 	SecretTemplateMismatch string = "SecretTemplateMismatch"


### PR DESCRIPTION
### Pull Request Motivation

fix typo comments form `SecretTemplateMisMatch` to `SecretTemplateMismatch`

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
