### PR TITLE
fix(util): avoid returning address of loop variable in GetCertificateCondition and GetCertificateRequestCondition

### DIFF
--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -143,18 +143,18 @@ func CertificateHasConditionWithObservedGeneration(crt *cmapi.Certificate, c cma
 }
 
 func GetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.CertificateConditionType) *cmapi.CertificateCondition {
-	for _, cond := range crt.Status.Conditions {
+	for i, cond := range crt.Status.Conditions {
 		if cond.Type == conditionType {
-			return &cond
+			return &crt.Status.Conditions[i]
 		}
 	}
 	return nil
 }
 
 func GetCertificateRequestCondition(req *cmapi.CertificateRequest, conditionType cmapi.CertificateRequestConditionType) *cmapi.CertificateRequestCondition {
-	for _, cond := range req.Status.Conditions {
+	for i, cond := range req.Status.Conditions {
 		if cond.Type == conditionType {
-			return &cond
+			return &req.Status.Conditions[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
### Pull Request Motivation

The two functions was returning a pointer to the `for...range` loop's value variable.

This could lead to unpredictable behavior, data corruption, or panics when the caller attempts to dereference the returned pointer.

This commit refactors the loop to iterate by index. It now returns a pointer to the element directly from the slice, ensuring the pointer is stable and valid as it points to the slice's underlying data.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
