### PR TITLE
Handle ACME Accept asynchronously

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -3162,8 +3162,6 @@ spec:
                 - url
               type: object
             status:
-              required:
-                - accepted
               properties:
                 accepted:
                   description: |-
@@ -3206,6 +3204,8 @@ spec:
                     - expired
                     - errored
                   type: string
+              required:
+                - accepted
               type: object
           required:
             - metadata

--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -3162,7 +3162,14 @@ spec:
                 - url
               type: object
             status:
+              required:
+                - accepted
               properties:
+                accepted:
+                  description: |-
+                    ChallengeAccepted will be set to true after notifying the ACME server that the
+                    challenge is presented.
+                  type: boolean
                 presented:
                   description: |-
                     presented will be set to true if the challenge values for this challenge

--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -3359,6 +3359,11 @@ spec:
             type: object
           status:
             properties:
+              accepted:
+                description: |-
+                  ChallengeAccepted will be set to true after notifying the ACME server that the
+                  challenge is presented.
+                type: boolean
               presented:
                 description: |-
                   presented will be set to true if the challenge values for this challenge
@@ -3395,6 +3400,8 @@ spec:
                 - expired
                 - errored
                 type: string
+            required:
+            - accepted
             type: object
         required:
         - metadata

--- a/hack/openapi_reports/client.txt
+++ b/hack/openapi_reports/client.txt
@@ -18,6 +18,7 @@ API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/ac
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEIssuerDNS01ProviderRFC2136,TSIGSecret
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEIssuerDNS01ProviderRoute53,SecretAccessKey
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEIssuerDNS01ProviderRoute53,SecretAccessKeyID
+API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ChallengeStatus,ChallengeAccepted
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ServiceAccountRef,TokenAudiences
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1,CertificateKeystores,PKCS12
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1,CertificateSpec,URIs

--- a/internal/apis/acme/types_challenge.go
+++ b/internal/apis/acme/types_challenge.go
@@ -121,6 +121,10 @@ type ChallengeStatus struct {
 	// configured).
 	Presented bool
 
+	// ChallengeAccepted will be set to true after notifying the ACME server that the
+	// challenge is presented.
+	ChallengeAccepted bool `json:"accepted"`
+
 	// Reason contains human readable information on why the Challenge is in the
 	// current state.
 	Reason string

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1562,6 +1562,7 @@ func Convert_acme_ChallengeSpec_To_v1_ChallengeSpec(in *acme.ChallengeSpec, out 
 func autoConvert_v1_ChallengeStatus_To_acme_ChallengeStatus(in *acmev1.ChallengeStatus, out *acme.ChallengeStatus, s conversion.Scope) error {
 	out.Processing = in.Processing
 	out.Presented = in.Presented
+	out.ChallengeAccepted = in.ChallengeAccepted
 	out.Reason = in.Reason
 	out.State = acme.State(in.State)
 	return nil
@@ -1575,6 +1576,7 @@ func Convert_v1_ChallengeStatus_To_acme_ChallengeStatus(in *acmev1.ChallengeStat
 func autoConvert_acme_ChallengeStatus_To_v1_ChallengeStatus(in *acme.ChallengeStatus, out *acmev1.ChallengeStatus, s conversion.Scope) error {
 	out.Processing = in.Processing
 	out.Presented = in.Presented
+	out.ChallengeAccepted = in.ChallengeAccepted
 	out.Reason = in.Reason
 	out.State = acmev1.State(in.State)
 	return nil

--- a/internal/controller/challenges/apply_test.go
+++ b/internal/controller/challenges/apply_test.go
@@ -31,7 +31,7 @@ import (
 
 func Test_serializeApply(t *testing.T) {
 	const (
-		expReg  = `^{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{.*},"spec":{.*},"status":{"processing":false,"presented":false}}$`
+		expReg  = `^{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{.*},"spec":{.*},"status":{"processing":false,"presented":false,"accepted":false}}$`
 		numJobs = 10000
 	)
 
@@ -79,7 +79,7 @@ func Test_serializeApply(t *testing.T) {
 func Test_serializeApplyStatus(t *testing.T) {
 	const (
 		expReg   = `^{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar"},"spec":{"url":"","authorizationURL":"","dnsName":"","wildcard":false,"type":"","token":"","key":"","solver":{},"issuerRef":{"name":""}},"status":{.*}$`
-		expEmpty = `{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar"},"spec":{"url":"","authorizationURL":"","dnsName":"","wildcard":false,"type":"","token":"","key":"","solver":{},"issuerRef":{"name":""}},"status":{"processing":false,"presented":false}}`
+		expEmpty = `{"kind":"Challenge","apiVersion":"acme.cert-manager.io/v1","metadata":{"name":"foo","namespace":"bar"},"spec":{"url":"","authorizationURL":"","dnsName":"","wildcard":false,"type":"","token":"","key":"","solver":{},"issuerRef":{"name":""}},"status":{"processing":false,"presented":false,"accepted":false}}`
 		numJobs  = 10000
 	)
 

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -2070,6 +2070,14 @@ func schema_pkg_apis_acme_v1_ChallengeStatus(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"accepted": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ChallengeAccepted will be set to true after notifying the ACME server that the challenge is presented.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Contains human readable information on why the Challenge is in the current state.",
@@ -2085,6 +2093,7 @@ func schema_pkg_apis_acme_v1_ChallengeStatus(ref common.ReferenceCallback) commo
 						},
 					},
 				},
+				Required: []string{"accepted"},
 			},
 		},
 	}

--- a/pkg/apis/acme/v1/types_challenge.go
+++ b/pkg/apis/acme/v1/types_challenge.go
@@ -133,6 +133,10 @@ type ChallengeStatus struct {
 	// +optional
 	Presented bool `json:"presented"`
 
+	// ChallengeAccepted will be set to true after notifying the ACME server that the
+	// challenge is presented.
+	ChallengeAccepted bool `json:"accepted"`
+
 	// Contains human readable information on why the Challenge is in the
 	// current state.
 	// +optional

--- a/pkg/client/applyconfigurations/acme/v1/challengestatus.go
+++ b/pkg/client/applyconfigurations/acme/v1/challengestatus.go
@@ -25,10 +25,11 @@ import (
 // ChallengeStatusApplyConfiguration represents a declarative configuration of the ChallengeStatus type for use
 // with apply.
 type ChallengeStatusApplyConfiguration struct {
-	Processing *bool         `json:"processing,omitempty"`
-	Presented  *bool         `json:"presented,omitempty"`
-	Reason     *string       `json:"reason,omitempty"`
-	State      *acmev1.State `json:"state,omitempty"`
+	Processing        *bool         `json:"processing,omitempty"`
+	Presented         *bool         `json:"presented,omitempty"`
+	ChallengeAccepted *bool         `json:"accepted,omitempty"`
+	Reason            *string       `json:"reason,omitempty"`
+	State             *acmev1.State `json:"state,omitempty"`
 }
 
 // ChallengeStatusApplyConfiguration constructs a declarative configuration of the ChallengeStatus type for use with
@@ -50,6 +51,14 @@ func (b *ChallengeStatusApplyConfiguration) WithProcessing(value bool) *Challeng
 // If called multiple times, the Presented field is set to the value of the last call.
 func (b *ChallengeStatusApplyConfiguration) WithPresented(value bool) *ChallengeStatusApplyConfiguration {
 	b.Presented = &value
+	return b
+}
+
+// WithChallengeAccepted sets the ChallengeAccepted field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ChallengeAccepted field is set to the value of the last call.
+func (b *ChallengeStatusApplyConfiguration) WithChallengeAccepted(value bool) *ChallengeStatusApplyConfiguration {
+	b.ChallengeAccepted = &value
 	return b
 }
 

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -597,6 +597,10 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.cert-manager.cert-manager.pkg.apis.acme.v1.ChallengeStatus
   map:
     fields:
+    - name: accepted
+      type:
+        scalar: boolean
+      default: false
     - name: presented
       type:
         scalar: boolean

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -40,6 +40,8 @@ const (
 	reasonCleanUpError   = "CleanUpError"
 	reasonPresentError   = "PresentError"
 	reasonPresented      = "Presented"
+	reasonAcceptError    = "AcceptError"
+	reasonAccepted       = "Accepted"
 	reasonFailed         = "Failed"
 
 	// How long to wait for an authorization response from the ACME server in acceptChallenge()
@@ -184,10 +186,32 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 		return nil
 	}
 
-	err = c.acceptChallenge(ctx, cl, ch)
-	if err != nil {
-		return err
+	if !ch.Status.ChallengeAccepted {
+		err = c.acceptChallenge(ctx, cl, ch)
+		if err != nil {
+			return err
+		}
+
+		ch.Status.ChallengeAccepted = true
+		c.recorder.Eventf(ch, corev1.EventTypeNormal, reasonAccepted, "Accepted challenge")
 	}
+
+	err = c.syncChallengeStatus(ctx, cl, ch)
+	if err != nil {
+		return c.handleAuthorizationError(ctx, ch, err)
+	}
+	if ch.Status.State == acmeapi.StatusValid {
+		ch.Status.Reason = "Successfully authorized domain"
+		c.recorder.Eventf(ch, corev1.EventTypeNormal, reasonDomainVerified, "Domain %q verified with %q validation", ch.Spec.DNSName, ch.Spec.Type)
+		return nil
+	}
+	log.Error(err, "challenge not (yet) accepted")
+	ch.Status.Reason = fmt.Sprintf("Waiting for %s challenge acceptance", ch.Spec.Type)
+
+	c.queue.AddAfter(types.NamespacedName{
+		Namespace: ch.Namespace,
+		Name:      ch.Name,
+	}, c.DNS01CheckRetryPeriod)
 
 	return nil
 }
@@ -332,9 +356,12 @@ func (c *controller) syncChallengeStatus(ctx context.Context, cl acmecl.Interfac
 	return nil
 }
 
-// acceptChallenge will accept the challenge with the acme server and then wait
-// for the authorization to reach a 'final' state.
-// It will update the challenge's status to reflect the final state of the
+// acceptChallenge will accept the challenge with the acme server.
+// Next Step is to wait for the challenge to complete at ACME Server
+// by synching the status periodically in Sync method.
+// In previous versions of cert-manager WaitAuthorization has been called to
+// synchronously wait for the authorization to reach a 'final' state and
+// update the challenge's status to reflect the final state of the
 // challenge if it failed, or the final state of the challenge's authorization
 // if accepting the challenge succeeds.
 func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, ch *cmacme.Challenge) error {
@@ -356,25 +383,6 @@ func (c *controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 		ch.Status.Reason = fmt.Sprintf("Error accepting challenge: %v", err)
 		return handleError(ctx, ch, err)
 	}
-
-	log.V(logf.DebugLevel).Info("waiting for authorization for domain")
-	// The underlying ACME implementation from golang.org/x/crypto of WaitAuthorization retries on
-	// response parsing errors.  In the event that an ACME server is not returning expected JSON
-	// responses, the call to WaitAuthorization can and has been seen to not return and loop forever,
-	// blocking the challenge's processing. Here, we defensively add a timeout for this exchange
-	// with the ACME server and a "context deadline reached" error will be returned by WaitAuthorization
-	// in the err variable.
-	ctxTimeout, cancelAuthorization := context.WithTimeout(ctx, authorizationTimeout)
-	defer cancelAuthorization()
-	authorization, err := cl.WaitAuthorization(ctxTimeout, ch.Spec.AuthorizationURL)
-	if err != nil {
-		log.Error(err, "error waiting for authorization")
-		return c.handleAuthorizationError(ctxTimeout, ch, err)
-	}
-
-	ch.Status.State = cmacme.State(authorization.Status)
-	ch.Status.Reason = "Successfully authorized domain"
-	c.recorder.Eventf(ch, corev1.EventTypeNormal, reasonDomainVerified, "Domain %q verified with %q validation", ch.Spec.DNSName, ch.Spec.Type)
 
 	return nil
 }

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -368,10 +368,12 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.SetChallengeState(cmacme.Valid),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengePresented(true),
+							gen.SetChallengeAccepted(true),
 							gen.SetChallengeReason("Successfully authorized domain"),
 						))),
 				},
 				ExpectedEvents: []string{
+					"Normal Accepted Accepted challenge",
 					`Normal DomainVerified Domain "test.com" verified with "HTTP-01" validation`,
 				},
 			},
@@ -382,11 +384,19 @@ func TestSyncHappyPath(t *testing.T) {
 					// status and not the challenges
 					return &acmeapi.Challenge{Status: acmeapi.StatusPending}, nil
 				},
-				FakeWaitAuthorization: func(context.Context, string) (*acmeapi.Authorization, error) {
-					return &acmeapi.Authorization{Status: acmeapi.StatusValid}, nil
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return &acmeapi.Authorization{
+						Challenges: []*acmeapi.Challenge{
+							{URI: "testurl", Status: acmeapi.StatusValid},
+						},
+					}, nil
 				},
 			},
 		},
+		/*
+			the following test got obsolete, as we dont use the state of authorization anymore but rely
+			directly on the state of the challenger.
+		*
 		"mark certificate as failed if accepting the authorization fails": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
@@ -421,6 +431,7 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.SetChallengeState(cmacme.Invalid),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengePresented(true),
+							gen.SetChallengeAccepted(true),
 							gen.SetChallengeReason("Error accepting authorization: acme: authorization error for example.com: an error happened"),
 						))),
 				},
@@ -435,17 +446,19 @@ func TestSyncHappyPath(t *testing.T) {
 					// status and not the challenges
 					return &acmeapi.Challenge{Status: acmeapi.StatusPending}, nil
 				},
-				FakeWaitAuthorization: func(context.Context, string) (*acmeapi.Authorization, error) {
-					return nil, &acmeapi.AuthorizationError{
-						URI:        "http://testerroruri",
-						Identifier: "example.com",
-						Errors: []error{
-							fmt.Errorf("an error happened"),
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return &acmeapi.Authorization{
+						Challenges: []*acmeapi.Challenge{
+							{
+								URI: "testurl", Status: acmeapi.StatusInvalid,
+								Error: fmt.Errorf("an error happened"),
+							},
 						},
-					}
+					}, nil
 				},
 			},
 		},
+		*/
 		"correctly persist ACME authorization error details as Challenge failure reason": {
 			challenge: gen.ChallengeFrom(baseChallenge,
 				gen.SetChallengeProcessing(true),
@@ -480,11 +493,12 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.SetChallengeState(cmacme.Invalid),
 							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 							gen.SetChallengePresented(true),
-							gen.SetChallengeReason("Error accepting authorization: acme: authorization error for example.com: 400 fakeerror: this is a very detailed error"),
+							gen.SetChallengeAccepted(true),
+							gen.SetChallengeReason("Waiting for HTTP-01 challenge acceptance"),
 						))),
 				},
 				ExpectedEvents: []string{
-					"Warning Failed Accepting challenge authorization failed: acme: authorization error for example.com: 400 fakeerror: this is a very detailed error",
+					"Normal Accepted Accepted challenge",
 				},
 			},
 			acmeClient: &acmecl.FakeACME{
@@ -494,18 +508,18 @@ func TestSyncHappyPath(t *testing.T) {
 					// status and not the challenges
 					return &acmeapi.Challenge{Status: acmeapi.StatusPending}, nil
 				},
-				FakeWaitAuthorization: func(context.Context, string) (*acmeapi.Authorization, error) {
-					return nil, &acmeapi.AuthorizationError{
-						URI:        "http://testerroruri",
-						Identifier: "example.com",
-						Errors: []error{
-							&acmeapi.Error{
-								StatusCode:  400,
-								ProblemType: "fakeerror",
-								Detail:      "this is a very detailed error",
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return &acmeapi.Authorization{
+						Challenges: []*acmeapi.Challenge{
+							{URI: "testurl", Status: acmeapi.StatusInvalid, 
+								Error: &acmeapi.Error{
+									StatusCode:  400,
+									ProblemType: "fakeerror",
+									Detail:      "this is a very detailed error",
+								},
 							},
 						},
-					}
+					}, nil
 				},
 			},
 		},

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -89,6 +89,12 @@ func SetChallengePresented(p bool) ChallengeModifier {
 	}
 }
 
+func SetChallengeAccepted(p bool) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Status.ChallengeAccepted = p
+	}
+}
+
 func SetChallengeWildcard(p bool) ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Spec.Wildcard = p


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

In my Environment, Lets Encrypt staging takes a long time to accept the challenge.
Setting timeout to e.g. 2min lead to worries of @munnerz about a DoS vector. (see #7450) that suggested to make it asynchronous.

I´m not a go expert, so probably coding can be improved, I will be happy to receive your feedback.

See also other PR´s:
#7852 tries to add timeout configuration in CLI for timeout
#7450 (obsolete if this one is merged) tries to add timeout configuration in Issuer

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind 
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Don´t block while witting for ACME Server to accept challenge
```
