### PR TITLE
feat: log version information when starting the cert-manager controller, webhook and ca-injector

### DIFF
--- a/cmd/cainjector/app/cainjector.go
+++ b/cmd/cainjector/app/cainjector.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/cainjector/validation"
 	cainjectorconfigfile "github.com/cert-manager/cert-manager/pkg/cainjector/configfile"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
@@ -39,6 +40,11 @@ func NewCAInjectorCommand(ctx context.Context) *cobra.Command {
 	return newCAInjectorCommand(
 		ctx,
 		func(ctx context.Context, cfg *config.CAInjectorConfiguration) error {
+			log := logf.FromContext(ctx, componentController)
+
+			versionInfo := util.VersionInfo()
+			log.Info("starting cert-manager ca-injector", "version", versionInfo.GitVersion, "git_commit", versionInfo.GitCommit, "go_version", versionInfo.GoVersion, "platform", versionInfo.Platform)
+
 			return Run(cfg, ctx)
 		},
 		os.Args[1:],

--- a/cmd/cainjector/app/cainjector.go
+++ b/cmd/cainjector/app/cainjector.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/cainjector/validation"
 	cainjectorconfigfile "github.com/cert-manager/cert-manager/pkg/cainjector/configfile"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
@@ -61,8 +60,7 @@ func newCAInjectorCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:   componentController,
-		Short: fmt.Sprintf("CA Injection Controller for Kubernetes (%s) (%s)", util.AppVersion, util.AppGitCommit),
+		Use: componentController,
 		Long: `
 cert-manager CA injector is a Kubernetes addon to automate the injection of CA data into
 webhooks and APIServices from cert-manager certificates.

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/server"
 	"github.com/cert-manager/cert-manager/pkg/server/tls"
 	"github.com/cert-manager/cert-manager/pkg/server/tls/authority"
+	"github.com/cert-manager/cert-manager/pkg/util"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
 )
@@ -68,6 +69,9 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 
 	log := logf.FromContext(rootCtx)
 	g, rootCtx := errgroup.WithContext(rootCtx)
+
+	versionInfo := util.VersionInfo()
+	log.Info("starting cert-manager controller", "version", versionInfo.GitVersion, "git_commit", versionInfo.GitCommit, "go_version", versionInfo.GoVersion, "platform", versionInfo.Platform)
 
 	ctxFactory, err := buildControllerContextFactory(rootCtx, opts)
 	if err != nil {

--- a/cmd/controller/app/start.go
+++ b/cmd/controller/app/start.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/controller/validation"
 	controllerconfigfile "github.com/cert-manager/cert-manager/pkg/controller/configfile"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 
@@ -72,8 +71,7 @@ func newServerCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:   componentController,
-		Short: fmt.Sprintf("Automated TLS controller for Kubernetes (%s) (%s)", util.AppVersion, util.AppGitCommit),
+		Use: componentController,
 		Long: `
 cert-manager is a Kubernetes addon to automate the management and issuance of
 TLS certificates from various issuing sources.

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/webhook/validation"
 	cmwebhook "github.com/cert-manager/cert-manager/internal/webhook"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	webhookconfigfile "github.com/cert-manager/cert-manager/pkg/webhook/configfile"
@@ -41,6 +42,9 @@ func NewServerCommand(ctx context.Context) *cobra.Command {
 		ctx,
 		func(ctx context.Context, webhookConfig *config.WebhookConfiguration) error {
 			log := logf.FromContext(ctx, componentWebhook)
+
+			versionInfo := util.VersionInfo()
+			log.Info("starting cert-manager webhook", "version", versionInfo.GitVersion, "git_commit", versionInfo.GitCommit, "go_version", versionInfo.GoVersion, "platform", versionInfo.Platform)
 
 			srv, err := cmwebhook.NewCertManagerWebhookServer(log, *webhookConfig)
 			if err != nil {

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cert-manager/cert-manager/internal/apis/config/webhook/validation"
 	cmwebhook "github.com/cert-manager/cert-manager/internal/webhook"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util"
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	webhookconfigfile "github.com/cert-manager/cert-manager/pkg/webhook/configfile"
@@ -69,8 +68,7 @@ func newServerCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:   componentWebhook,
-		Short: fmt.Sprintf("Webhook component providing API validation, mutation and conversion functionality for cert-manager (%s) (%s)", util.AppVersion, util.AppGitCommit),
+		Use: componentWebhook,
 		Long: `
 cert-manager is a Kubernetes addon to automate the management and issuance of
 TLS certificates from various issuing sources.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Print `util.AppVersion` and `util.AppGitCommit` when the controller, webhook and ca-injector starts.  
Previously, these values were present in `Short`, which never gets printed for the root command removed since they are standalone root commands with no subcommands.
resolves https://github.com/cert-manager/cert-manager/issues/8067

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The controller, webhook and ca-injector now logs its version and git commit on startup for easier debugging and support.
```
