### PR TITLE
[7883] - Fix uncontrolled cardinality for Prometheus metrics

### DIFF
--- a/pkg/acme/client/http.go
+++ b/pkg/acme/client/http.go
@@ -18,12 +18,11 @@ package client
 
 import (
 	"fmt"
-	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
 
 // This file implements a custom instrumented HTTP client round tripper that
@@ -95,15 +94,4 @@ func (it *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// return the response and error reported from the next RoundTripper.
 	return resp, err
-}
-
-// pathProcessor will trim the provided path to only include the first 2
-// segments in order to reduce the number of prometheus labels generated
-func pathProcessor(path string) string {
-	p := strings.Split(path, "/")
-	// only record the first two path segments as a prometheus label value
-	if len(p) > 3 {
-		p = p[:3]
-	}
-	return strings.Join(p, "/")
 }

--- a/pkg/acme/client/http.go
+++ b/pkg/acme/client/http.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 	"net/http"
 	"strings"
 	"time"
@@ -74,11 +75,17 @@ func (it *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if resp != nil {
 		statusCode = resp.StatusCode
 	}
-
+	var action string
+	if op, ok := req.Context().Value(acme.AcmeAction).(string); ok {
+		action = op
+	} else {
+		// Fallback for any requests where the context was not set.
+		action = "unnamed_action"
+	}
 	labels := []string{
 		req.URL.Scheme,
 		req.URL.Host,
-		pathProcessor(req.URL.Path),
+		action,
 		req.Method,
 		fmt.Sprintf("%d", statusCode),
 	}

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -125,7 +125,7 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 				t.Fatalf("Failed to parse server URL: %v", err)
 			}
 			expectedCounter := fmt.Sprintf(`
-				# HELP certmanager_http_acme_client_request_count The number of requests made by the ACME client.
+				# HELP certmanager_http_acme_client_request_count Total number of outbound ACME HTTP requests. Labels: scheme (http/https), host (ACME host), action (logical ACME operation), method (HTTP verb), status (HTTP status code).
 				# TYPE certmanager_http_acme_client_request_count counter
 				certmanager_http_acme_client_request_count{action="%s",host="%s",method="%s",scheme="%s",status="%d"} %d
 				`, tc.expectedAction, parsedURL.Host, tc.method, scheme, tc.statusToReturn, tc.requestsToMake)

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -26,12 +26,10 @@ import (
 	"testing"
 	"time"
 
+	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	fakeclock "k8s.io/utils/clock/testing"
-
-	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
-	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
 
 func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
@@ -46,7 +44,7 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 	}{
 		{
 			name:           "GET 200 OK with action",
-			ctx:            context.WithValue(context.Background(), acme.AcmeAction, "get_directory"),
+			ctx:            context.WithValue(context.Background(), AcmeActionLabel, "get_directory"),
 			method:         "GET",
 			statusToReturn: http.StatusOK,
 			useTLS:         false,
@@ -64,7 +62,7 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 		},
 		{
 			name:           "GET 200 OK over HTTPS",
-			ctx:            context.WithValue(context.Background(), acme.AcmeAction, "get_cert"),
+			ctx:            context.WithValue(context.Background(), AcmeActionLabel, "get_cert"),
 			method:         "GET",
 			statusToReturn: http.StatusOK,
 			useTLS:         true,
@@ -73,7 +71,7 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 		},
 		{
 			name:           "Multiple requests accumulate",
-			ctx:            context.WithValue(context.Background(), acme.AcmeAction, "finalize_order"),
+			ctx:            context.WithValue(context.Background(), AcmeActionLabel, "finalize_order"),
 			method:         "POST",
 			statusToReturn: http.StatusOK,
 			useTLS:         false,

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -108,14 +108,17 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 			}
 			httpClient.Transport = instrumentedTransport
 
-			for i := 0; i < tc.requestsToMake; i++ {
+			for range tc.requestsToMake {
 				req, err := http.NewRequestWithContext(tc.ctx, tc.method, server.URL, nil)
 				if err != nil {
 					t.Fatalf("Failed to create request: %v", err)
 				}
-				if _, err = httpClient.Do(req); err != nil {
-					t.Fatalf("client.Do failed: %v", err)
+
+				resp, err := httpClient.Do(req)
+				if err != nil {
+					t.Fatalf("failed to make request: %v", err)
 				}
+				resp.Body.Close()
 			}
 			parsedURL, err := url.Parse(server.URL)
 			if err != nil {

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -26,10 +26,11 @@ import (
 	"testing"
 	"time"
 
-	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	fakeclock "k8s.io/utils/clock/testing"
+
+	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
 )
 
 func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
-	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	fakeclock "k8s.io/utils/clock/testing"
+
+	metricspkg "github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
 
 func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -113,7 +113,7 @@ func (l *Logger) WaitAuthorization(ctx context.Context, url string) (*acme.Autho
 
 func (l *Logger) Register(ctx context.Context, a *acme.Account, prompt func(tosURL string) bool) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Register")
-	ctx = context.WithValue(ctx, client.AcmeActionLabel, "regiser_account")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "register_account")
 
 	return l.baseCl.Register(ctx, a, prompt)
 }

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -43,72 +43,84 @@ var _ client.Interface = &Logger{}
 
 func (l *Logger) AuthorizeOrder(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling AuthorizeOrder")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "authorize_order")
 
 	return l.baseCl.AuthorizeOrder(ctx, id, opt...)
 }
 
 func (l *Logger) GetOrder(ctx context.Context, url string) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetOrder")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "get_order")
 
 	return l.baseCl.GetOrder(ctx, url)
 }
 
 func (l *Logger) FetchCert(ctx context.Context, url string, bundle bool) ([][]byte, error) {
 	l.log.V(logf.TraceLevel).Info("Calling FetchCert")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "fetch_cert")
 
 	return l.baseCl.FetchCert(ctx, url, bundle)
 }
 
 func (l *Logger) ListCertAlternates(ctx context.Context, url string) ([]string, error) {
 	l.log.V(logf.TraceLevel).Info("Calling ListCertAlternates")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "list_cert_alternates")
 
 	return l.baseCl.ListCertAlternates(ctx, url)
 }
 
 func (l *Logger) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling WaitOrder")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "wait_order")
 
 	return l.baseCl.WaitOrder(ctx, url)
 }
 
 func (l *Logger) CreateOrderCert(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error) {
 	l.log.V(logf.TraceLevel).Info("Calling CreateOrderCert")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "create_order_cert")
 
 	return l.baseCl.CreateOrderCert(ctx, finalizeURL, csr, bundle)
 }
 
 func (l *Logger) Accept(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Accept")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "accept_challenge")
 
 	return l.baseCl.Accept(ctx, chal)
 }
 
 func (l *Logger) GetChallenge(ctx context.Context, url string) (*acme.Challenge, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetChallenge")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "get_challenge")
 
 	return l.baseCl.GetChallenge(ctx, url)
 }
 
 func (l *Logger) GetAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetAuthorization")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "get_authorization")
 
 	return l.baseCl.GetAuthorization(ctx, url)
 }
 
 func (l *Logger) WaitAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	l.log.V(logf.TraceLevel).Info("Calling WaitAuthorization")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "wait_authorization")
 
 	return l.baseCl.WaitAuthorization(ctx, url)
 }
 
 func (l *Logger) Register(ctx context.Context, a *acme.Account, prompt func(tosURL string) bool) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Register")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "regiser_account")
 
 	return l.baseCl.Register(ctx, a, prompt)
 }
 
 func (l *Logger) GetReg(ctx context.Context, url string) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling GetReg")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "get_registration")
 
 	return l.baseCl.GetReg(ctx, url)
 }
@@ -127,12 +139,14 @@ func (l *Logger) DNS01ChallengeRecord(token string) (string, error) {
 
 func (l *Logger) Discover(ctx context.Context) (acme.Directory, error) {
 	l.log.V(logf.TraceLevel).Info("Calling Discover")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "discover")
 
 	return l.baseCl.Discover(ctx)
 }
 
 func (l *Logger) UpdateReg(ctx context.Context, a *acme.Account) (*acme.Account, error) {
 	l.log.V(logf.TraceLevel).Info("Calling UpdateReg")
+	ctx = context.WithValue(ctx, client.AcmeActionLabel, "update_registration")
 
 	return l.baseCl.UpdateReg(ctx, a)
 }

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -33,7 +33,9 @@ func NewLogger(baseCl client.Interface) client.Interface {
 	}
 }
 
-// Logger is a glog based logging middleware for an ACME client
+// Logger is a glog based logging middleware for an ACME client.
+// Also used to attach an AcmeActionLabel to the request's context to be used downstream in as a metric label.
+// TODO: Maybe rename to something more generic like "ACMEObservabilityMiddleware" since it does more than just logging.
 type Logger struct {
 	baseCl client.Interface
 	log    logr.Logger

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -200,10 +200,6 @@ func (m *Metrics) ACMERequestCounter() *prometheus.CounterVec {
 	return m.acmeClientRequestCount
 }
 
-func (m *Metrics) ACMERequestDuration() *prometheus.SummaryVec {
-	return m.acmeClientRequestDurationSeconds
-}
-
 // NewServer registers Prometheus metrics and returns a new Prometheus metrics HTTP server.
 func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.clockTimeSeconds)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,14 +31,15 @@ import (
 	"net/http"
 	"time"
 
-	cmcollectors "github.com/cert-manager/cert-manager/internal/collectors"
-	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
-	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/utils/clock"
+
+	cmcollectors "github.com/cert-manager/cert-manager/internal/collectors"
+	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 )
 
 const (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,15 +31,14 @@ import (
 	"net/http"
 	"time"
 
+	cmcollectors "github.com/cert-manager/cert-manager/internal/collectors"
+	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/utils/clock"
-
-	cmcollectors "github.com/cert-manager/cert-manager/internal/collectors"
-	cmacmelisters "github.com/cert-manager/cert-manager/pkg/client/listers/acme/v1"
-	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 )
 
 const (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,8 +20,8 @@ limitations under the License.
 // certificate_renewal_timestamp_seconds{name, namespace, issuer_name, issuer_kind, issuer_group}
 // certificate_ready_status{name, namespace, condition, issuer_name, issuer_kind, issuer_group}
 // certificate_challenge_status{status, domain, reason, processing, id, type}
-// acme_client_request_count{"scheme", "host", "path", "method", "status"}
-// acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
+// acme_client_request_count{"scheme", "host", "action", "method", "status"}
+// acme_client_request_duration_seconds{"scheme", "host", "action", "method", "status"}
 // venafi_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
 // controller_sync_call_count{"controller"}
 package metrics
@@ -113,7 +113,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Help:      "The number of requests made by the ACME client.",
 				Subsystem: "http",
 			},
-			[]string{"scheme", "host", "path", "method", "status"},
+			[]string{"scheme", "host", "action", "method", "status"},
 		)
 
 		// acmeClientRequestDurationSeconds is a Prometheus summary to collect request
@@ -126,7 +126,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Subsystem:  "http",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
-			[]string{"scheme", "host", "path", "method", "status"},
+			[]string{"scheme", "host", "action", "method", "status"},
 		)
 
 		// venafiClientRequestDurationSeconds is a Prometheus summary to
@@ -194,6 +194,14 @@ func (m *Metrics) SetupACMECollector(acmeInformers cmacmelisters.ChallengeLister
 
 func (m *Metrics) SetupCertificateCollector(certLister cmlisters.CertificateLister) {
 	m.certificateCollector = cmcollectors.NewCertificateCollector(certLister)
+}
+
+func (m *Metrics) ACMERequestCounter() *prometheus.CounterVec {
+	return m.acmeClientRequestCount
+}
+
+func (m *Metrics) ACMERequestDuration() *prometheus.SummaryVec {
+	return m.acmeClientRequestDurationSeconds
 }
 
 // NewServer registers Prometheus metrics and returns a new Prometheus metrics HTTP server.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -96,7 +96,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "clock_time_seconds_gauge",
-				Help:      "The clock time given in seconds (from 1970/01/01 UTC).",
+				Help:      "The clock time given in seconds (from 1970/01/01 UTC). Gauge form of the deprecated clock_time_seconds counter. No labels.",
 			},
 			func() float64 {
 				return float64(c.Now().Unix())
@@ -110,7 +110,9 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "acme_client_request_count",
-				Help:      "The number of requests made by the ACME client.",
+				Help: "Total number of outbound ACME HTTP requests. " +
+					"Labels: scheme (http/https), host (ACME host), action (logical ACME operation), " +
+					"method (HTTP verb), status (HTTP status code).",
 				Subsystem: "http",
 			},
 			[]string{"scheme", "host", "action", "method", "status"},
@@ -120,9 +122,13 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		// times for the ACME client.
 		acmeClientRequestDurationSeconds = prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
-				Namespace:  namespace,
-				Name:       "acme_client_request_duration_seconds",
-				Help:       "The HTTP request latencies in seconds for the ACME client.",
+				Namespace: namespace,
+				Name:      "acme_client_request_duration_seconds",
+				Help: "Latency of outbound ACME HTTP requests in seconds. " +
+					"Summary quantiles approximate request distribution. " +
+					"Labels: scheme (http/https), host (ACME host), action (logical ACME operation), " +
+					"method (HTTP verb), status (HTTP status code). " +
+					"Use with acme_client_request_count for rate/error analysis.",
 				Subsystem:  "http",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
@@ -149,7 +155,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "controller_sync_call_count",
-				Help:      "The number of sync() calls made by a controller.",
+				Help:      "The number of sync() calls made by a controller. Label: controller (fixed small set of controller names).",
 			},
 			[]string{"controller"},
 		)
@@ -159,7 +165,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "controller_sync_error_count",
-				Help:      "The number of errors encountered during controller sync().",
+				Help:      "The number of errors encountered during controller sync(). Label: controller. Use with controller_sync_call_count to derive error rates.",
 			},
 			[]string{"controller"},
 		)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -57,7 +57,7 @@ certmanager_clock_time_seconds %f
 			metricName: "certmanager_clock_time_seconds_gauge",
 			metric:     m.clockTimeSecondsGauge,
 			expected: fmt.Sprintf(`
-# HELP certmanager_clock_time_seconds_gauge The clock time given in seconds (from 1970/01/01 UTC).
+# HELP certmanager_clock_time_seconds_gauge The clock time given in seconds (from 1970/01/01 UTC). Gauge form of the deprecated clock_time_seconds counter. No labels.
 # TYPE certmanager_clock_time_seconds_gauge gauge
 certmanager_clock_time_seconds_gauge %f
 	`, float64(fixedClock.Now().Unix())),

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -49,7 +49,7 @@ var (
 # TYPE certmanager_clock_time_seconds counter
 certmanager_clock_time_seconds %.9e`, float64(fixedClock.Now().Unix()))
 	clockGaugeMetric = fmt.Sprintf(`
-# HELP certmanager_clock_time_seconds_gauge The clock time given in seconds (from 1970/01/01 UTC).
+# HELP certmanager_clock_time_seconds_gauge The clock time given in seconds (from 1970/01/01 UTC). Gauge form of the deprecated clock_time_seconds counter. No labels.
 # TYPE certmanager_clock_time_seconds_gauge gauge
 certmanager_clock_time_seconds_gauge %.9e`, float64(fixedClock.Now().Unix()))
 )
@@ -60,7 +60,6 @@ certmanager_clock_time_seconds_gauge %.9e`, float64(fixedClock.Now().Unix()))
 func TestMetricsController(t *testing.T) {
 	config, stopFn := framework.RunControlPlane(t)
 	t.Cleanup(stopFn)
-
 	// Build, instantiate and run the issuing controller.
 	kubernetesCl, factory, cmClient, cmFactory, scheme := framework.NewClients(t, config)
 
@@ -241,7 +240,7 @@ certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issu
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
 certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 0
 ` + clockCounterMetric + clockGaugeMetric + `
-# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
+# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller. Label: controller (fixed small set of controller names).
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 1
 `)
@@ -304,7 +303,7 @@ certmanager_certificate_ready_status{condition="Unknown",issuer_group="test-issu
 # TYPE certmanager_certificate_renewal_timestamp_seconds gauge
 certmanager_certificate_renewal_timestamp_seconds{issuer_group="test-issuer-group",issuer_kind="Issuer",issuer_name="test-issuer",name="testcrt",namespace="testns"} 100
 ` + clockCounterMetric + clockGaugeMetric + `
-# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
+# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller. Label: controller (fixed small set of controller names).
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 2
 `)
@@ -320,7 +319,7 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 2
 
 	// Should expose no Certificates and only metrics sync count increase
 	waitForMetrics(clockCounterMetric + clockGaugeMetric + `
-# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
+# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller. Label: controller (fixed small set of controller names).
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 3
 `)

--- a/third_party/forked/acme/acme.go
+++ b/third_party/forked/acme/acme.go
@@ -134,13 +134,6 @@ type Client struct {
 	nonces   map[string]struct{} // nonces collected from previous responses
 }
 
-// MetricsContextKey is the type used for context keys in the metrics package.
-// Using a custom type prevents key collisions with other packages.
-type MetricsContextKey string
-
-// AcmeAction is the context key for storing the logical ACME operation name.
-const AcmeAction = MetricsContextKey("acme_action")
-
 // accountKID returns a key ID associated with c.Key, the account identity
 // provided by the CA during RFC based registration.
 // It assumes c.Discover has already been called.
@@ -247,7 +240,6 @@ func (c *Client) CreateCert(ctx context.Context, csr []byte, exp time.Duration, 
 // Callers are encouraged to parse the returned value to ensure the certificate is valid
 // and has expected features.
 func (c *Client) FetchCert(ctx context.Context, url string, bundle bool) ([][]byte, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "fetch_cert")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -261,7 +253,6 @@ func (c *Client) FetchCert(ctx context.Context, url string, bundle bool) ([][]by
 // For instance, the key pair of the certificate may be authorized.
 // If the key is nil, c.Key is used instead.
 func (c *Client) RevokeCert(ctx context.Context, key crypto.Signer, cert []byte, reason CRLReasonCode) error {
-	ctx = context.WithValue(ctx, AcmeAction, "revoke_cert")
 	if _, err := c.Discover(ctx); err != nil {
 		return err
 	}
@@ -288,7 +279,6 @@ func (c *Client) Register(ctx context.Context, acct *Account, prompt func(tosURL
 	if c.Key == nil {
 		return nil, errors.New("acme: client.Key must be set to Register")
 	}
-	ctx = context.WithValue(ctx, AcmeAction, "register")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -300,7 +290,6 @@ func (c *Client) Register(ctx context.Context, acct *Account, prompt func(tosURL
 // The url argument is a legacy artifact of the pre-RFC 8555 API
 // and is ignored.
 func (c *Client) GetReg(ctx context.Context, url string) (*Account, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "get_registration")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -313,7 +302,6 @@ func (c *Client) GetReg(ctx context.Context, url string) (*Account, error) {
 // The account's URI is ignored and the account URL associated with
 // c.Key is used instead.
 func (c *Client) UpdateReg(ctx context.Context, acct *Account) (*Account, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "update_registration")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -331,7 +319,6 @@ func (c *Client) UpdateReg(ctx context.Context, acct *Account) (*Account, error)
 // More about account key rollover can be found at
 // https://tools.ietf.org/html/rfc8555#section-7.3.5.
 func (c *Client) AccountKeyRollover(ctx context.Context, newKey crypto.Signer) error {
-	ctx = context.WithValue(ctx, AcmeAction, "account_key_rollover")
 	return c.accountKeyRollover(ctx, newKey)
 }
 
@@ -351,7 +338,6 @@ func (c *Client) AccountKeyRollover(ctx context.Context, newKey crypto.Signer) e
 // More about pre-authorization can be found at
 // https://tools.ietf.org/html/rfc8555#section-7.4.1.
 func (c *Client) Authorize(ctx context.Context, domain string) (*Authorization, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "authorize_dns")
 	return c.authorize(ctx, "dns", domain)
 }
 
@@ -362,7 +348,6 @@ func (c *Client) Authorize(ctx context.Context, domain string) (*Authorization, 
 // See the ACME spec extension for more details about IP address identifiers:
 // https://tools.ietf.org/html/draft-ietf-acme-ip.
 func (c *Client) AuthorizeIP(ctx context.Context, ipaddr string) (*Authorization, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "authorize_ip")
 	return c.authorize(ctx, "ip", ipaddr)
 }
 
@@ -407,7 +392,6 @@ func (c *Client) authorize(ctx context.Context, typ, val string) (*Authorization
 // If a caller needs to poll an authorization until its status is final,
 // see the WaitAuthorization method.
 func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorization, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "get_authorization")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -434,7 +418,6 @@ func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorizati
 //
 // It does not revoke existing certificates.
 func (c *Client) RevokeAuthorization(ctx context.Context, url string) error {
-	ctx = context.WithValue(ctx, AcmeAction, "revoke_authorization")
 	if _, err := c.Discover(ctx); err != nil {
 		return err
 	}
@@ -464,7 +447,6 @@ func (c *Client) RevokeAuthorization(ctx context.Context, url string) error {
 // In all other cases WaitAuthorization returns an error.
 // If the Status is StatusInvalid, the returned error is of type *AuthorizationError.
 func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorization, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "wait_authorization")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -512,7 +494,6 @@ func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorizat
 //
 // A client typically polls a challenge status using this method.
 func (c *Client) GetChallenge(ctx context.Context, url string) (*Challenge, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "get_challenge")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}
@@ -535,7 +516,6 @@ func (c *Client) GetChallenge(ctx context.Context, url string) (*Challenge, erro
 //
 // The server will then perform the validation asynchronously.
 func (c *Client) Accept(ctx context.Context, chal *Challenge) (*Challenge, error) {
-	ctx = context.WithValue(ctx, AcmeAction, "accept_challenge")
 	if _, err := c.Discover(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR addresses issue https://github.com/cert-manager/cert-manager/issues/7883 where the ACME client's Prometheus metrics could grow with unbounded cardinality, leading to performance degradation and high memory usage in Prometheus.

#### Rationale

The existing instrumentation for ACME client metrics used the request's URL `path` as a label. A `pathProcessor` function attempted to normalize this by taking the first two URL segments. While this heuristic worked for ACME CAs like Let's Encrypt (e.g., `/acme/orders/<id>`), it failed for others like Google Public CA, whose URL structures are different (e.g., `/orders/<id>`).

This divergence meant that for some CAs, unique order/challenge identifiers were still included in the `path` label, creating a new time series for nearly every step of the certificate issuance process.

This change fixes the issue by replacing the brittle, high-cardinality `path` label with a new, low-cardinality `action` label. The `action` is a string representing the logical ACME operation being performed (e.g., `get_challenge`, `authorize_order`), ensuring a stable and predictable number of metric series regardless of the CA's URL structure.

#### Implementation Details

1.  **Context Propagation via Middleware**: The logical ACME operation name is now added to the `context.Context` within the `Logger` middleware (`pkg/acme/client/middleware/logger.go`). This cleanly separates the instrumentation concern from the underlying ACME client logic.
2.  **Metric Instrumentation**: The instrumented HTTP `RoundTripper` in `pkg/acme/client/http.go` now reads the `action` value from the context using the `AcmeActionLabel` key.
3.  **Label Update**: If the `action` is present, it's used as a label. A fallback of `unnamed_action` is used for any requests where the context value is not set, ensuring robustness. The brittle `pathProcessor` function has been removed.
4.  **Testing**: New unit tests have been added in `pkg/acme/client/http_test.go` to validate the new labeling scheme, including context handling, the fallback mechanism, and counter accumulation, using the `prometheus/testutil` package for precise validation.

---

### **BREAKING CHANGE**

This change modifies the labels of core ACME client metrics and will require users to update their monitoring dashboards and alerting rules if using those metrics.

### Output from changed metrics test `pkg/acme/client/http_test.go`
from `github.com/prometheus/client_golang@v1.23.2/prometheus/testutil/testutil.go:303`
```
# HELP certmanager_http_acme_client_request_count The number of requests made by the ACME client.
# TYPE certmanager_http_acme_client_request_count counter
certmanager_http_acme_client_request_count{action="get_directory",host="127.0.0.1:34759",method="GET",scheme="http",status="200"} 1
```
```
# HELP certmanager_http_acme_client_request_count The number of requests made by the ACME client.
# TYPE certmanager_http_acme_client_request_count counter
certmanager_http_acme_client_request_count{action="finalize_order",host="127.0.0.1:34091",method="POST",scheme="http",status="200"} 3
```

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
This change removes the `path` label of core ACME client metrics and will require users to update their monitoring dashboards and alerting rules if using those metrics.
```
