### PR TITLE
feat: implements `global.imageRegistry` and fixes #6160

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -79,6 +79,12 @@ delete the previously installed CustomResourceDefinition resources.
 
 ### Global
 
+#### **global.imageRegistry** ~ `string`
+> Default value:
+> ```yaml
+> quay.io
+> ```
+
 #### **global.imagePullSecrets** ~ `array`
 > Default value:
 > ```yaml
@@ -290,7 +296,7 @@ The container registry to pull the manager image from.
 #### **image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-controller
+> jetstack/cert-manager-controller
 > ```
 
 The container image for the cert-manager controller.
@@ -1226,7 +1232,7 @@ The container registry to pull the webhook image from.
 #### **webhook.image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-webhook
+> jetstack/cert-manager-webhook
 > ```
 
 The container image for the cert-manager webhook
@@ -1636,7 +1642,7 @@ The container registry to pull the cainjector image from.
 #### **cainjector.image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-cainjector
+> jetstack/cert-manager-cainjector
 > ```
 
 The container image for the cert-manager cainjector
@@ -1717,7 +1723,7 @@ The container registry to pull the acmesolver image from.
 #### **acmesolver.image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-acmesolver
+> jetstack/cert-manager-acmesolver
 > ```
 
 The container image for the cert-manager acmesolver.
@@ -1900,7 +1906,7 @@ The container registry to pull the startupapicheck image from.
 #### **startupapicheck.image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-startupapicheck
+> jetstack/cert-manager-startupapicheck
 > ```
 
 The container image for the cert-manager startupapicheck.

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -181,8 +181,13 @@ See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linke
 */}}
 {{- define "image" -}}
 {{- $defaultTag := index . 1 -}}
+{{- $global := index . 2 -}}
 {{- with index . 0 -}}
-{{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
+{{- if .registry -}}
+    {{- printf "%s/%s" .registry .repository -}}
+{{- else -}}
+    {{- printf "%s/%s" $global.imageRegistry .repository -}}
+{{- end -}}
 {{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
 {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-cainjector
-          image: "{{ template "image" (tuple .Values.cainjector.image $.Chart.AppVersion) }}"
+          image: "{{ template "image" (tuple .Values.cainjector.image $.Chart.AppVersion .Values.global) }}"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-controller
-          image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
+          image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion .Values.global) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
@@ -114,7 +114,7 @@ spec:
           - --leader-election-retry-period={{ .retryPeriod }}
           {{- end }}
           {{- end }}
-          - --acme-http01-solver-image={{ template "image" (tuple .Values.acmesolver.image $.Chart.AppVersion) }}
+          - --acme-http01-solver-image={{ template "image" (tuple .Values.acmesolver.image $.Chart.AppVersion .Values.global) }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -114,9 +114,7 @@ spec:
           - --leader-election-retry-period={{ .retryPeriod }}
           {{- end }}
           {{- end }}
-          {{- with .Values.acmesolver.image }}
-          - --acme-http01-solver-image={{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}
-          {{- end }}
+          - --acme-http01-solver-image={{ template "image" (tuple .Values.acmesolver.image $.Chart.AppVersion) }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-startupapicheck
-          image: "{{ template "image" (tuple .Values.startupapicheck.image $.Chart.AppVersion) }}"
+          image: "{{ template "image" (tuple .Values.startupapicheck.image $.Chart.AppVersion .Values.global) }}"
           imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
           args:
           - check

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -81,7 +81,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-webhook
-          image: "{{ template "image" (tuple .Values.webhook.image $.Chart.AppVersion) }}"
+          image: "{{ template "image" (tuple .Values.webhook.image $.Chart.AppVersion .Values.global) }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -218,7 +218,7 @@
       "type": "string"
     },
     "helm-values.acmesolver.image.repository": {
-      "default": "quay.io/jetstack/cert-manager-acmesolver",
+      "default": "jetstack/cert-manager-acmesolver",
       "description": "The container image for the cert-manager acmesolver.",
       "type": "string"
     },
@@ -421,7 +421,7 @@
       "type": "string"
     },
     "helm-values.cainjector.image.repository": {
-      "default": "quay.io/jetstack/cert-manager-cainjector",
+      "default": "jetstack/cert-manager-cainjector",
       "description": "The container image for the cert-manager cainjector",
       "type": "string"
     },
@@ -692,6 +692,9 @@
         "hostUsers": {
           "$ref": "#/$defs/helm-values.global.hostUsers"
         },
+        "imageRegistry": {
+          "$ref": "#/$defs/helm-values.global.imageRegistry"
+        },
         "imagePullSecrets": {
           "$ref": "#/$defs/helm-values.global.imagePullSecrets"
         },
@@ -727,6 +730,11 @@
     "helm-values.global.hostUsers": {
       "description": "Set all pods to run in a user namespace without host access. Experimental: may be removed once the Kubernetes User Namespaces feature is GA.\n\nRequirements:\n  - Kubernetes ≥ 1.33, or\n  - Kubernetes 1.27–1.32 with UserNamespacesSupport feature gate enabled.\n\nSet to false to run pods in a user namespace without host access.\n\nSee [limitations](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#limitations) for details.",
       "type": "boolean"
+    },
+    "helm-values.global.imageRegistry": {
+      "default": "quay.io",
+      "description": "Image registry default for all images",
+      "type": "string"
     },
     "helm-values.global.imagePullSecrets": {
       "default": [],
@@ -878,7 +886,7 @@
       "type": "string"
     },
     "helm-values.image.repository": {
-      "default": "quay.io/jetstack/cert-manager-controller",
+      "default": "jetstack/cert-manager-controller",
       "description": "The container image for the cert-manager controller.",
       "type": "string"
     },
@@ -1430,7 +1438,7 @@
       "type": "string"
     },
     "helm-values.startupapicheck.image.repository": {
-      "default": "quay.io/jetstack/cert-manager-startupapicheck",
+      "default": "jetstack/cert-manager-startupapicheck",
       "description": "The container image for the cert-manager startupapicheck.",
       "type": "string"
     },
@@ -1815,7 +1823,7 @@
       "type": "string"
     },
     "helm-values.webhook.image.repository": {
-      "default": "quay.io/jetstack/cert-manager-webhook",
+      "default": "jetstack/cert-manager-webhook",
       "description": "The container image for the cert-manager webhook",
       "type": "string"
     },

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -162,6 +162,10 @@ maxConcurrentChallenges: 60
 
 image:
   # The container registry to pull the manager image from.
+  # This value is prepended to the target image repository, if set.
+  # For example:
+  #   registry: quay.io
+  #   repository: jetstack/cert-manager-controller
   # +docs:property
   # registry: quay.io
 
@@ -897,6 +901,10 @@ webhook:
 
   image:
     # The container registry to pull the webhook image from.
+    # This value is prepended to the target image repository, if set.
+    # For example:
+    #   registry: quay.io
+    #   repository: jetstack/cert-manager-webhook
     # +docs:property
     # registry: quay.io
 
@@ -1210,6 +1218,10 @@ cainjector:
 
   image:
     # The container registry to pull the cainjector image from.
+    # This value is prepended to the target image repository, if set.
+    # For example:
+    #   registry: quay.io
+    #   repository: jetstack/cert-manager-cainjector
     # +docs:property
     # registry: quay.io
 
@@ -1269,6 +1281,10 @@ cainjector:
 acmesolver:
   image:
     # The container registry to pull the acmesolver image from.
+    # This value is prepended to the target image repository, if set.
+    # For example:
+    #   registry: quay.io
+    #   repository: jetstack/cert-manager-acmesolver
     # +docs:property
     # registry: quay.io
 
@@ -1402,6 +1418,10 @@ startupapicheck:
 
   image:
     # The container registry to pull the startupapicheck image from.
+    # This value is prepended to the target image repository, if set.
+    # For example:
+    #   registry: quay.io
+    #   repository: jetstack/cert-manager-startupapicheck
     # +docs:property
     # registry: quay.io
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -4,6 +4,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 global:
+  # Image registry default for all images
+  # +docs:property
+  imageRegistry: quay.io
+
   # Reference to one or more secrets to be used when pulling images.
   # For more information, see [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
   #
@@ -21,7 +25,7 @@ global:
   # If a component-specific nodeSelector is also set, it will take precedence.
   # +docs:property
   nodeSelector: {}
-  
+
   # Labels to apply to all resources.
   # Please note that this does not add labels to the resources created dynamically by the controllers.
   # For these resources, you have to add the labels in the template in the cert-manager custom resource:
@@ -171,7 +175,7 @@ image:
 
   # The container image for the cert-manager controller.
   # +docs:property
-  repository: quay.io/jetstack/cert-manager-controller
+  repository: jetstack/cert-manager-controller
 
   # Override the image tag to deploy by setting this variable.
   # If no value is set, the chart's appVersion is used.
@@ -910,7 +914,7 @@ webhook:
 
     # The container image for the cert-manager webhook
     # +docs:property
-    repository: quay.io/jetstack/cert-manager-webhook
+    repository: jetstack/cert-manager-webhook
 
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion will be used.
@@ -1227,7 +1231,7 @@ cainjector:
 
     # The container image for the cert-manager cainjector
     # +docs:property
-    repository: quay.io/jetstack/cert-manager-cainjector
+    repository: jetstack/cert-manager-cainjector
 
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion will be used.
@@ -1290,7 +1294,7 @@ acmesolver:
 
     # The container image for the cert-manager acmesolver.
     # +docs:property
-    repository: quay.io/jetstack/cert-manager-acmesolver
+    repository: jetstack/cert-manager-acmesolver
 
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion is used.
@@ -1427,7 +1431,7 @@ startupapicheck:
 
     # The container image for the cert-manager startupapicheck.
     # +docs:property
-    repository: quay.io/jetstack/cert-manager-startupapicheck
+    repository: jetstack/cert-manager-startupapicheck
 
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion is used.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR implements `global.imageRegistry` and fixes #6160. The implementation is inspired by the work in #7558 (https://github.com/cert-manager/cert-manager/pull/7558#issuecomment-3337394496).

Any change to the `template "image"` logic in `templates/_helpers.tpl` should also be applied to related repositories such as cert-manager, trust-manager, approver-policy, and others. See #6329 for a list of related pull requests.

This PR replaces and closes my earlier PR #8111, which addressed the handling of the `template "image"` for the `--acme-http01-solver-image` option that may have been missed in #6329.

Here are the test results for the `global.imageRegistry` option,

Case 1: set `global.imageRegistry`

All images use quay-registry.example.com registry

```shellsession
_bin/helm/cert-manager$ helm template cert-manager . --dry-run=client \
  --set global.imageRegistry=quay-registry.example.com | grep jetstack/
          image: "quay-registry.example.com/jetstack/cert-manager-cainjector:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-controller:v1.18.0-beta.0-351-gcc5deda68ebd39"
          - --acme-http01-solver-image=quay-registry.example.com/jetstack/cert-manager-acmesolver:v1.18.0-beta.0-351-gcc5deda68ebd39
          image: "quay-registry.example.com/jetstack/cert-manager-webhook:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-startupapicheck:v1.18.0-beta.0-351-gcc5deda68ebd39"
```

Case 2: set `global.imageRegistry`, `cainjector.image.registry`

cainjector uses quay-registry.example.net registry, all other images use quay-registry.example.com registry

```shellsession
_bin/helm/cert-manager$ helm template cert-manager . --dry-run=client \
  --set global.imageRegistry=quay-registry.example.com \
  --set cainjector.image.registry=quay-registry.example.net | grep jetstack/
          image: "quay-registry.example.net/jetstack/cert-manager-cainjector:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-controller:v1.18.0-beta.0-351-gcc5deda68ebd39"
          - --acme-http01-solver-image=quay-registry.example.com/jetstack/cert-manager-acmesolver:v1.18.0-beta.0-351-gcc5deda68ebd39
          image: "quay-registry.example.com/jetstack/cert-manager-webhook:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-startupapicheck:v1.18.0-beta.0-351-gcc5deda68ebd39"
```

Case 3: set `global.imageRegistry`, `cainjector.image.registry`, `acmesolver.image.registry`

cainjector uses quay-registry.example.net registry, acmesolver uses quay-registry.example.xyz registry, all other images use quay-registry.example.com registry

```shellsession
_bin/helm/cert-manager$ helm template cert-manager . --dry-run=client \
  --set global.imageRegistry=quay-registry.example.com \
  --set cainjector.image.registry=quay-registry.example.net \
  --set acmesolver.image.registry=quay-registry.example.xyz | grep jetstack/
          image: "quay-registry.example.net/jetstack/cert-manager-cainjector:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-controller:v1.18.0-beta.0-351-gcc5deda68ebd39"
          - --acme-http01-solver-image=quay-registry.example.xyz/jetstack/cert-manager-acmesolver:v1.18.0-beta.0-351-gcc5deda68ebd39
          image: "quay-registry.example.com/jetstack/cert-manager-webhook:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay-registry.example.com/jetstack/cert-manager-startupapicheck:v1.18.0-beta.0-351-gcc5deda68ebd39"
```

Case 4: set `cainjector.image.registry`, `acmesolver.image.registry`

cainjector uses quay-registry.example.net registry, acmesolver uses quay-registry.example.xyz registry, all other images remain quay.io registry

```shellsession
_bin/helm/cert-manager$ helm template cert-manager . --dry-run=client \
  --set cainjector.image.registry=quay-registry.example.net \
  --set acmesolver.image.registry=quay-registry.example.xyz | grep jetstack/
          image: "quay-registry.example.net/jetstack/cert-manager-cainjector:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay.io/jetstack/cert-manager-controller:v1.18.0-beta.0-351-gcc5deda68ebd39"
          - --acme-http01-solver-image=quay-registry.example.xyz/jetstack/cert-manager-acmesolver:v1.18.0-beta.0-351-gcc5deda68ebd39
          image: "quay.io/jetstack/cert-manager-webhook:v1.18.0-beta.0-351-gcc5deda68ebd39"
          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.18.0-beta.0-351-gcc5deda68ebd39"
```

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->

/kind feature

<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Helm: implements `global.imageRegistry` and fixes #6160
```
