### PR TITLE
fix(helm): Align targetPorts in metrics endpoints for webhook and cainjector services

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-service.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-service.yaml
@@ -24,6 +24,7 @@ spec:
   - protocol: TCP
     port: 9402
     name: http-metrics
+    targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
   selector:
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -36,7 +36,7 @@ spec:
   - name: metrics
     port: 9402
     protocol: TCP
-    targetPort: "http-metrics"
+    targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
 {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "webhook.name" . }}


### PR DESCRIPTION
This change aligns the `targetPort` configuration for metrics endpoints in `webhook` and `cainjector` services with the `controller` service by using the same template variable reference.

Previously:
- `webhook-service`: Used hardcoded "http-metrics" string
- `cainjector-service`: Was missing the `targetPort` field entirely

Now both services use` {{ .Values.prometheus.servicemonitor.targetPort }}` which defaults to `"http-metrics"`, matching the controller service implementation and ensuring consistency across all three services.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
