### PR TITLE
Try enabling Renovate for release branches again

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,11 @@
   extends: [
     'github>cert-manager/renovate-config:default.json5',
   ],
+  baseBranchPatterns: [
+    'master',
+    'release-1.19',
+    'release-1.18',
+  ],
   addLabels: [
     'kind/cleanup',
     'release-note-none',
@@ -51,6 +56,24 @@
           'hack/latest-kind-images.sh',
         ],
       },
+    },
+    {
+      matchBaseBranches: [
+        '/^release-.*/',
+      ],
+      enabled: false,
+    },
+    {
+      matchBaseBranches: [
+        '/^release-.*/',
+      ],
+      matchUpdateTypes: [
+        'patch',
+        'pin',
+        'pinDigest',
+        'digest',
+      ],
+      enabled: true,
     },
   ],
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I would really love to make Renovate suggest patches into our release branches. And I suspect that my last attempt didn't work because there was no Renovate config on the release branches. Now we have a Renovate config on the recent release-1.19 branch, so it's time to see if it works. If it does, we should backport a config to the release-1.18 branch.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
