### PR TITLE
fix: add case for parsing key with ec parameters

### DIFF
--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -29,7 +29,7 @@ import (
 // It supports ECDSA, RSA and EdDSA private keys only. All other types will return err.
 func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	// decode the private key pem
-	block, _, err := pem.SafeDecodePrivateKey(keyBytes)
+	block, rest, err := pem.SafeDecodePrivateKey(keyBytes)
 	if err != nil {
 		return nil, errors.NewInvalidData("error decoding private key PEM block: %s", err.Error())
 	}
@@ -63,6 +63,13 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 		if err != nil {
 			return nil, errors.NewInvalidData("rsa private key failed validation: %s", err.Error())
 		}
+		return key, nil
+	case "EC PARAMETERS":
+		key, err := DecodePrivateKeyBytes(rest)
+		if err != nil {
+			return nil, err
+		}
+
 		return key, nil
 	default:
 		return nil, errors.NewInvalidData("unknown private key type: %s", block.Type)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
Fixes: #8058 

Skip the EC PARAMETERS block from private keys created with for example `openssl ecparam`.

Since Decode from https://go.dev/src/encoding/pem/pem.go only processes the first PEM Block(searches for the first end line and the begin line prior to that) we get err="unknown private key type: EC PARAMETERS" in DecodePrivateKeyBytes
https://github.com/cert-manager/cert-manager/blob/bc5faa3ac50d6a3b321ccaf0b0254679c58dd1b7/pkg/util/pki/parse.go#L30-L70

But as Decode returns the remaining bytes we can recursively call DecodePrivateKeyBytes with them to skip the block, if the block.type was EC PARAMETERS.

Like this
```

	case "EC PARAMETERS":
		// ignore the PEM Block and use the rest(the block which comes after EC PARAMETERS) returned from Decode
		key, err := DecodePrivateKeyBytes(rest)
		if err != nil {
			return nil, err
		}

		return key, nil
} 
```


<details>

<summary>Fulll output of the Error</summary>

   ```
I1017 06:33:17.807148       1 reflector.go:436] "Caches populated" type="*v1.CertificateRequest" reflector="k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290"
E1017 06:33:17.884854       1 setup.go:50] "error getting signing CA TLS certificate" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:17.885149       1 sync.go:62] "error setting up issuer" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:17.885408       1 controller.go:157] "re-queuing item due to error processing" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller"
E1017 06:33:22.886169       1 setup.go:50] "error getting signing CA TLS certificate" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:22.886237       1 sync.go:62] "error setting up issuer" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:22.886263       1 controller.go:157] "re-queuing item due to error processing" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller"
E1017 06:33:32.886986       1 setup.go:50] "error getting signing CA TLS certificate" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:32.887054       1 sync.go:62] "error setting up issuer" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:32.887080       1 controller.go:157] "re-queuing item due to error processing" err="secrets \"my-tls-secret\" not found" logger="cert-manager.controller"
E1017 06:33:39.355217       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:39.355253       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:39.366392       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
E1017 06:33:39.367883       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:39.367902       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:39.367915       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
E1017 06:33:52.890012       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:52.890042       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:33:52.890072       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
E1017 06:35:07.271291       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
I1017 06:35:07.271627       1 conditions.go:102] "Setting lastTransitionTime for Issuer condition" logger="cert-manager" issuer="issuer" condition="Ready" lastTransitionTime="2025-10-17 06:35:07.271316723 +0000 UTC m=+166.556423458"
E1017 06:35:07.271646       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:35:07.278784       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
E1017 06:35:07.280916       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:35:07.280932       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:35:07.280946       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
E1017 06:35:12.284845       1 setup.go:59] "error getting signing CA private key" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller.setup" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:35:12.284876       1 sync.go:62] "error setting up issuer" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller" resource_name="issuer" resource_namespace="" resource_kind="ClusterIssuer" resource_version="v1"
E1017 06:35:12.284898       1 controller.go:157] "re-queuing item due to error processing" err="unknown private key type: EC PARAMETERS" logger="cert-manager.controller"
```
</details>

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--
/

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
