### PR TITLE
Add predicate filtering to queuing handler

### DIFF
--- a/cmd/controller/LICENSES
+++ b/cmd/controller/LICENSES
@@ -85,6 +85,7 @@ github.com/davecgh/go-spew/spew,ISC
 github.com/digitalocean/godo,MIT
 github.com/digitalocean/godo,BSD-3-Clause
 github.com/emicklei/go-restful/v3,MIT
+github.com/evanphx/json-patch/v5,BSD-3-Clause
 github.com/felixge/httpsnoop,MIT
 github.com/fxamacker/cbor/v2,MIT
 github.com/go-asn1-ber/asn1-ber,MIT
@@ -213,6 +214,7 @@ k8s.io/kube-openapi/pkg/validation/spec,Apache-2.0
 k8s.io/utils,Apache-2.0
 k8s.io/utils/internal/third_party/forked/golang,BSD-3-Clause
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client,Apache-2.0
+sigs.k8s.io/controller-runtime/pkg,Apache-2.0
 sigs.k8s.io/gateway-api,Apache-2.0
 sigs.k8s.io/json,Apache-2.0
 sigs.k8s.io/json,BSD-3-Clause

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitalocean/godo v1.169.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
@@ -112,8 +113,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nrdcg/goacmedns v0.2.0 // indirect
-	github.com/onsi/ginkgo/v2 v2.22.0 // indirect
-	github.com/onsi/gomega v1.36.1 // indirect
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -173,6 +172,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 // indirect
+	sigs.k8s.io/controller-runtime v0.22.4 // indirect
 	sigs.k8s.io/gateway-api v1.4.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/cmd/controller/go.sum
+++ b/cmd/controller/go.sum
@@ -92,7 +92,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -20,16 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/smithy-go"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/digitalocean/godo"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
@@ -627,59 +619,4 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	test.builder.CheckAndFinish(err)
-}
-
-func Test_StabilizeSolverErrorMessage(t *testing.T) {
-	newResponseError := func() *smithyhttp.ResponseError {
-		return &smithyhttp.ResponseError{
-			Err: errors.New("foo"),
-			Response: &smithyhttp.Response{
-				Response: &http.Response{},
-			},
-		}
-	}
-
-	tests := []struct {
-		name            string
-		err             error
-		expectedMessage string
-	}{
-		{
-			name:            "aws response error",
-			err:             &smithy.OperationError{OperationName: "test", Err: &awshttp.ResponseError{RequestID: "SOMEREQUESTID", ResponseError: newResponseError()}},
-			expectedMessage: "operation error : test, <redacted AWS SDK error: http.ResponseError: see events and logs for details>",
-		},
-		{
-			name: "azure sdk azidentity.AuthenticationFailed error",
-			err: &azidentity.AuthenticationFailedError{
-				RawResponse: &http.Response{},
-			},
-			expectedMessage: "<redacted Azure SDK error: azidentity.AuthenticationFailedError: see events and logs for details>",
-		},
-		{
-			name: "azure sdk azcore.ResponseError other error",
-			err: fmt.Errorf("wrapper message: %w", &azcore.ResponseError{
-				StatusCode: 500,
-				ErrorCode:  "SomeOtherError",
-			}),
-			expectedMessage: "wrapper message: <redacted Azure SDK error: azcore.ResponseError: see events and logs for details>",
-		},
-		{
-			name: "DigitalOcean SDK error",
-			err: fmt.Errorf("wrapper message: %w", &godo.ErrorResponse{
-				Response: &http.Response{
-					Request: &http.Request{},
-				},
-				Message:   "some detailed error message",
-				RequestID: "SOMEREQUESTID",
-			}),
-
-			expectedMessage: "wrapper message: <redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedMessage, stabilizeSolverErrorMessage(tt.err))
-		})
-	}
 }

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -32,14 +32,8 @@ import (
 func handleGenericIssuerFunc(
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	orderLister cmacmelisters.OrderLister,
-) func(interface{}) {
-	return func(obj interface{}) {
-		iss, ok := obj.(cmapi.GenericIssuer)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("object does not implement GenericIssuer %#v", obj))
-			return
-		}
-
+) func(cmapi.GenericIssuer) {
+	return func(iss cmapi.GenericIssuer) {
 		certs, err := ordersForGenericIssuer(iss, orderLister)
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetNamespace(), iss.GetName()))

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -23,7 +23,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	gwlisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
@@ -112,14 +111,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 //	    name: gateway-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
-	return func(obj interface{}) {
-		crt, ok := obj.(*cmapi.Certificate)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("not a Certificate object: %#v", obj))
-			return
-		}
-
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(*cmapi.Certificate) {
+	return func(crt *cmapi.Certificate) {
 		ref := metav1.GetControllerOf(crt)
 		if ref == nil {
 			// No controller should care about orphans being deleted or

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -23,7 +23,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -122,14 +121,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 //	    name: ingress-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
-	return func(obj interface{}) {
-		cert, ok := obj.(*cmapi.Certificate)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("not a Certificate object: %#v", obj))
-			return
-		}
-
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(*cmapi.Certificate) {
+	return func(cert *cmapi.Certificate) {
 		ingress := metav1.GetControllerOf(cert)
 		if ingress == nil {
 			// No controller should care about orphans being deleted or

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -26,14 +26,8 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-func (c *Controller) handleGenericIssuer(obj interface{}) {
+func (c *Controller) handleGenericIssuer(iss cmapi.GenericIssuer) {
 	log := c.log.WithName("handleGenericIssuer")
-
-	iss, ok := obj.(cmapi.GenericIssuer)
-	if !ok {
-		log.Error(nil, "object does not implement GenericIssuer")
-		return
-	}
 
 	log = logf.WithResource(log, iss)
 	crs, err := c.certificatesRequestsForGenericIssuer(iss)

--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -43,8 +44,8 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateRequestLister,
 	helper issuer.Helper,
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
-) func(obj any) {
-	return func(obj any) {
+) func(metav1.Object) {
+	return func(obj metav1.Object) {
 		log := log.WithName("handleSecretReference")
 		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {

--- a/pkg/controller/certificaterequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -35,7 +36,7 @@ import (
 
 func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 	tests := map[string]struct {
-		secret          runtime.Object
+		secret          metav1.Object
 		existingCRs     []runtime.Object
 		existingIssuers []runtime.Object
 		expectedQueue   []types.NamespacedName

--- a/pkg/controller/certificates/informers.go
+++ b/pkg/controller/certificates/informers.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
-	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
 )
 
@@ -37,14 +36,8 @@ import (
 // call when enqueuing Certificate resources.
 // If no predicate constructors are given, all Certificate resources will be
 // enqueued on every invocation.
-func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[types.NamespacedName], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
-	return func(obj interface{}) {
-		s, ok := obj.(metav1.Object)
-		if !ok {
-			log.V(logf.ErrorLevel).Info("Non-Object type resource passed to EnqueueCertificatesForSecretUsingPredicates")
-			return
-		}
-
+func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[types.NamespacedName], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(metav1.Object) {
+	return func(s metav1.Object) {
 		// 'Construct' the predicate functions using the given Secret
 		predicates := make(predicate.Funcs, len(predicateBuilders))
 		for i, b := range predicateBuilders {

--- a/pkg/controller/certificatesigningrequests/checks.go
+++ b/pkg/controller/certificatesigningrequests/checks.go
@@ -29,16 +29,10 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-func (c *Controller) handleGenericIssuer(obj interface{}) {
+func (c *Controller) handleGenericIssuer(iss cmapi.GenericIssuer) {
 	log := c.log.WithName("handleGenericIssuer")
-
-	iss, ok := obj.(cmapi.GenericIssuer)
-	if !ok {
-		log.Error(nil, "object does not implement GenericIssuer")
-		return
-	}
-
 	log = logf.WithResource(log, iss)
+
 	crs, err := c.certificateSigningRequestsForGenericIssuer(iss)
 	if err != nil {
 		log.Error(err, "error looking up certificate signing requests observing issuer or clusterissuer")

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks.go
@@ -23,6 +23,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	clientv1 "k8s.io/client-go/listers/certificates/v1"
@@ -46,8 +47,8 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 	helper issuer.Helper,
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	issuerOptions controllerpkg.IssuerOptions,
-) func(obj any) {
-	return func(obj any) {
+) func(metav1.Object) {
+	return func(obj metav1.Object) {
 		log := log.WithName("handleSecretReference")
 		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -36,7 +37,7 @@ import (
 
 func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 	tests := map[string]struct {
-		secret          runtime.Object
+		secret          metav1.Object
 		existingCSRs    []runtime.Object
 		existingIssuers []runtime.Object
 		expectedQueue   []types.NamespacedName

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -112,7 +113,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 }
 
 // TODO: replace with generic handleObject function (like Navigator)
-func (c *controller) secretEvent(obj interface{}) {
+func (c *controller) secretEvent(obj metav1.Object) {
 	log := c.log.WithName("secretEvent")
 
 	secret, ok := controllerpkg.ToSecret(obj)

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -107,7 +108,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 }
 
 // TODO: replace with generic handleObject function (like Navigator)
-func (c *controller) secretEvent(obj interface{}) {
+func (c *controller) secretEvent(obj metav1.Object) {
 	log := c.log.WithName("secretEvent")
 	secret, ok := controllerpkg.ToSecret(obj)
 	if !ok {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"time"
@@ -30,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
@@ -109,57 +112,29 @@ func HandleOwnedResourceNamespacedFunc[T metav1.Object](
 	}
 }
 
-// queuingEventHandler is an implementation of cache.ResourceEventHandler that
-// simply queues objects that are added/updated/deleted.
-// It skips update events in case the resource has not changed.
-type queuingEventHandler struct {
-	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
-}
-
 // QueuingEventHandler returns a cache.ResourceEventHandler that
 // simply queues objects that are added/updated/deleted. It skips
 // update events in case the resource has not changed.
 func QueuingEventHandler(
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 ) cache.ResourceEventHandler {
-	return queuingEventHandler{
-		queue: queue,
+	return filteredEventHandler{
+		handler: blockingEventHandler{workFunc: func(obj interface{}) {
+			objectName, err := cache.ObjectToName(obj)
+			if err != nil {
+				runtime.HandleError(err)
+				return
+			}
+			queue.Add(types.NamespacedName{
+				Name:      objectName.Name,
+				Namespace: objectName.Namespace,
+			})
+		}},
+		predicates: []predicate.TypedPredicate[metav1.Object]{
+			// prevent unnecessary reconciliations in case the resource did not update
+			onlyUpdateWhenResourceChanged{},
+		},
 	}
-}
-
-// enqueue adds a key for an object to the workqueue.
-func (q queuingEventHandler) enqueue(obj interface{}) {
-	objectName, err := cache.DeletionHandlingObjectToName(obj)
-	if err != nil {
-		runtime.HandleError(err)
-		return
-	}
-	q.queue.Add(types.NamespacedName{
-		Name:      objectName.Name,
-		Namespace: objectName.Namespace,
-	})
-}
-
-// OnAdd adds a newly created object to the workqueue.
-func (q queuingEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
-	q.enqueue(obj)
-}
-
-// OnUpdate adds an updated object to the workqueue.
-func (q queuingEventHandler) OnUpdate(oldObj, newObj interface{}) {
-	if reflect.DeepEqual(oldObj, newObj) {
-		return
-	}
-	q.enqueue(newObj)
-}
-
-// OnDelete adds a deleted object to the workqueue for processing.
-func (q queuingEventHandler) OnDelete(obj interface{}) {
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		obj = tombstone.Obj
-	}
-	q.enqueue(obj)
 }
 
 // blockingEventHandler is an implementation of cache.ResourceEventHandler that
@@ -170,14 +145,20 @@ type blockingEventHandler struct {
 	workFunc func(obj interface{})
 }
 
+var _ cache.ResourceEventHandler = blockingEventHandler{}
+
 // BlockingEventHandler returns a cache.ResourceEventHandler that
 // simply synchronously calls the workFunc upon calls to OnAdd, OnUpdate or
 // OnDelete. It skips update events in case the resource has not changed.
 func BlockingEventHandler(
-	workFunc func(obj interface{}),
+	workFunc func(obj any),
 ) cache.ResourceEventHandler {
-	return blockingEventHandler{
-		workFunc: workFunc,
+	return filteredEventHandler{
+		handler: blockingEventHandler{workFunc: workFunc},
+		predicates: []predicate.TypedPredicate[metav1.Object]{
+			// prevent unnecessary reconciliations in case the resource did not update
+			onlyUpdateWhenResourceChanged{},
+		},
 	}
 }
 
@@ -188,9 +169,6 @@ func (b blockingEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 
 // OnUpdate synchronously adds an updated object to the workqueue.
 func (b blockingEventHandler) OnUpdate(oldObj, newObj interface{}) {
-	if reflect.DeepEqual(oldObj, newObj) {
-		return
-	}
 	b.workFunc(newObj)
 }
 
@@ -201,6 +179,139 @@ func (b blockingEventHandler) OnDelete(obj interface{}) {
 		obj = tombstone.Obj
 	}
 	b.workFunc(obj)
+}
+
+// onlyUpdateWhenResourceChanged implements a predicate function only
+// keeping update events when the resources does not deepequal
+type onlyUpdateWhenResourceChanged struct {
+	predicate.TypedFuncs[metav1.Object]
+}
+
+// Update implements default UpdateEvent filter for validating resource version change.
+func (onlyUpdateWhenResourceChanged) Update(e event.TypedUpdateEvent[metav1.Object]) bool {
+	if e.ObjectOld == nil {
+		logf.Log.Error(nil, "Update event has no old object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		logf.Log.Error(nil, "Update event has no new object to update", "event", e)
+		return false
+	}
+
+	return !reflect.DeepEqual(e.ObjectOld, e.ObjectNew)
+}
+
+// filteredEventHandler is an implementation of cache.ResourceEventHandler that
+// only passes the event to the handler when all predicates return true
+type filteredEventHandler struct {
+	handler cache.ResourceEventHandler
+	// predicates is a list of predicates that must all pass
+	// for the object to be enqueued.
+	predicates []predicate.TypedPredicate[metav1.Object]
+}
+
+var _ cache.ResourceEventHandler = filteredEventHandler{}
+
+// FilterEventHandler returns a cache.ResourceEventHandler that
+// skips events based on the passed predicates and passes all other
+// events to the provided handler.
+func FilterEventHandler(
+	handler cache.ResourceEventHandler,
+	predicates ...predicate.TypedPredicate[metav1.Object],
+) cache.ResourceEventHandler {
+	return filteredEventHandler{
+		handler:    handler,
+		predicates: predicates,
+	}
+}
+
+// OnAdd adds a newly created object to the workqueue.
+func (q filteredEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
+	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnAdd")
+
+	c := event.TypedCreateEvent[metav1.Object]{
+		IsInInitialList: isInInitialList,
+	}
+
+	// Pull Object out of the object
+	if o, ok := obj.(metav1.Object); ok {
+		c.Object = o
+	} else {
+		log.Error(nil, "OnAdd missing Object", "object", obj, "type", fmt.Sprintf("%T", obj))
+		return
+	}
+
+	for _, p := range q.predicates {
+		if !p.Create(c) {
+			return
+		}
+	}
+
+	q.handler.OnAdd(obj, isInInitialList)
+}
+
+// OnUpdate adds an updated object to the workqueue.
+func (q filteredEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnUpdate")
+
+	u := event.TypedUpdateEvent[metav1.Object]{}
+
+	if o, ok := oldObj.(metav1.Object); ok {
+		u.ObjectOld = o
+	} else {
+		log.Error(nil, "OnUpdate missing ObjectOld", "object", oldObj, "type", fmt.Sprintf("%T", oldObj))
+		return
+	}
+
+	// Pull Object out of the object
+	if o, ok := newObj.(metav1.Object); ok {
+		u.ObjectNew = o
+	} else {
+		log.Error(nil, "OnUpdate missing ObjectNew", "object", newObj, "type", fmt.Sprintf("%T", newObj))
+		return
+	}
+
+	for _, p := range q.predicates {
+		if !p.Update(u) {
+			return
+		}
+	}
+
+	q.handler.OnUpdate(oldObj, newObj)
+}
+
+// OnDelete adds a deleted object to the workqueue for processing.
+func (q filteredEventHandler) OnDelete(obj interface{}) {
+	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnDelete")
+
+	d := event.TypedDeleteEvent[metav1.Object]{}
+
+	unwrappedObj := obj
+
+	// If the object doesn't have Metadata, assume it is a tombstone object of type DeletedFinalStateUnknown
+	tombstone, ok := unwrappedObj.(cache.DeletedFinalStateUnknown)
+	if ok {
+		// Set DeleteStateUnknown to true
+		d.DeleteStateUnknown = true
+
+		unwrappedObj = tombstone.Obj
+	}
+
+	// Pull Object out of the object
+	if o, ok := unwrappedObj.(metav1.Object); ok {
+		d.Object = o
+	} else {
+		log.Error(nil, "OnDelete missing Object", "object", unwrappedObj, "type", fmt.Sprintf("%T", unwrappedObj))
+		return
+	}
+
+	for _, p := range q.predicates {
+		if !p.Delete(d) {
+			return
+		}
+	}
+
+	q.handler.OnDelete(obj)
 }
 
 // BuildAnnotationsToCopy takes a map of annotations and a list of prefix


### PR DESCRIPTION
- Register GenerationChangedPredicate for ACME challenge informer
- Make queuing handler generic and accept typed predicates
- Evaluate predicates on create/update/delete before enqueueing objects
- Add typed event handling, tombstone delete support, and logging

```release-note
NONE
```
