### PR TITLE
add dns issuer secrets validation before marking it as ready

### DIFF
--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -162,7 +162,8 @@ func ValidateACMEIssuerChallengeSolverConfig(sol *cmacme.ACMEChallengeSolver, fl
 			el = append(el, field.Forbidden(fldPath, "may not specify more than one solver type in a single solver"))
 		} else {
 			numProviders++
-			el = append(el, ValidateACMEChallengeSolverDNS01(sol.DNS01, fldPath.Child("dns01"))...)
+			solverErrs, _ := ValidateACMEChallengeSolverDNS01(sol.DNS01, fldPath.Child("dns01"))
+			el = append(el, solverErrs...)
 		}
 	}
 	if numProviders == 0 {
@@ -461,8 +462,9 @@ var supportedTSIGAlgorithms = []string{
 	"HMACSHA512",
 }
 
-func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPath *field.Path) field.ErrorList {
+func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPath *field.Path) (field.ErrorList, []*cmmeta.SecretKeySelector) {
 	el := field.ErrorList{}
+	requiredSecrets := []*cmmeta.SecretKeySelector{}
 
 	// allow empty values for now, until we have a MutatingWebhook to apply
 	// default values to fields.
@@ -478,8 +480,14 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 	if p.Akamai != nil {
 		numProviders++
 		el = append(el, ValidateSecretKeySelector(&p.Akamai.AccessToken, fldPath.Child("akamai", "accessToken"))...)
+		requiredSecrets = append(requiredSecrets, &p.Akamai.AccessToken)
+
 		el = append(el, ValidateSecretKeySelector(&p.Akamai.ClientSecret, fldPath.Child("akamai", "clientSecret"))...)
+		requiredSecrets = append(requiredSecrets, &p.Akamai.ClientSecret)
+
 		el = append(el, ValidateSecretKeySelector(&p.Akamai.ClientToken, fldPath.Child("akamai", "clientToken"))...)
+		requiredSecrets = append(requiredSecrets, &p.Akamai.ClientToken)
+
 		if len(p.Akamai.ServiceConsumerDomain) == 0 {
 			el = append(el, field.Required(fldPath.Child("akamai", "serviceConsumerDomain"), ""))
 		}
@@ -499,6 +507,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 					el = append(el, field.Required(fldPath.Child("azureDNS", "clientSecretSecretRef"), ""))
 				} else {
 					el = append(el, ValidateSecretKeySelector(p.AzureDNS.ClientSecret, fldPath.Child("azureDNS", "clientSecretSecretRef"))...)
+					requiredSecrets = append(requiredSecrets, p.AzureDNS.ClientSecret)
 				}
 				if len(p.AzureDNS.TenantID) == 0 {
 					el = append(el, field.Required(fldPath.Child("azureDNS", "tenantID"), ""))
@@ -543,6 +552,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			// selector
 			if p.CloudDNS.ServiceAccount != nil {
 				el = append(el, ValidateSecretKeySelector(p.CloudDNS.ServiceAccount, fldPath.Child("cloudDNS", "serviceAccountSecretRef"))...)
+				requiredSecrets = append(requiredSecrets, p.CloudDNS.ServiceAccount)
 			}
 			if len(p.CloudDNS.Project) == 0 {
 				el = append(el, field.Required(fldPath.Child("cloudDNS", "project"), ""))
@@ -556,9 +566,11 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			numProviders++
 			if p.Cloudflare.APIKey != nil {
 				el = append(el, ValidateSecretKeySelector(p.Cloudflare.APIKey, fldPath.Child("cloudflare", "apiKeySecretRef"))...)
+				requiredSecrets = append(requiredSecrets, p.Cloudflare.APIKey)
 			}
 			if p.Cloudflare.APIToken != nil {
 				el = append(el, ValidateSecretKeySelector(p.Cloudflare.APIToken, fldPath.Child("cloudflare", "apiTokenSecretRef"))...)
+				requiredSecrets = append(requiredSecrets, p.Cloudflare.APIToken)
 			}
 			if p.Cloudflare.APIKey != nil && p.Cloudflare.APIToken != nil {
 				el = append(el, field.Forbidden(fldPath.Child("cloudflare"), "apiKeySecretRef and apiTokenSecretRef cannot both be specified"))
@@ -582,15 +594,20 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			if len(p.Route53.AccessKeyID) > 0 && p.Route53.SecretAccessKeyID != nil {
 				el = append(el, field.Required(fldPath.Child("route53"), "accessKeyID and accessKeyIDSecretRef cannot both be specified"))
 			}
+			if len(p.Route53.SecretAccessKey.Name) > 0 {
+				requiredSecrets = append(requiredSecrets, &p.Route53.SecretAccessKey)
+			}
 			// if an accessKeyIDSecretRef is given, validate that it resolves to an actual secret
 			if p.Route53.SecretAccessKeyID != nil {
 				el = append(el, ValidateSecretKeySelector(p.Route53.SecretAccessKeyID, fldPath.Child("route53", "accessKeyIDSecretRef"))...)
+				requiredSecrets = append(requiredSecrets, p.Route53.SecretAccessKeyID)
 			}
 		}
 	}
 	if p.AcmeDNS != nil {
 		numProviders++
 		el = append(el, ValidateSecretKeySelector(&p.AcmeDNS.AccountSecret, fldPath.Child("acmeDNS", "accountSecretRef"))...)
+		requiredSecrets = append(requiredSecrets, &p.AcmeDNS.AccountSecret)
 		if len(p.AcmeDNS.Host) == 0 {
 			el = append(el, field.Required(fldPath.Child("acmeDNS", "host"), ""))
 		}
@@ -602,6 +619,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		} else {
 			numProviders++
 			el = append(el, ValidateSecretKeySelector(&p.DigitalOcean.Token, fldPath.Child("digitalocean", "tokenSecretRef"))...)
+			requiredSecrets = append(requiredSecrets, &p.DigitalOcean.Token)
 		}
 	}
 	if p.RFC2136 != nil {
@@ -628,6 +646,10 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 					el = append(el, field.NotSupported(fldPath.Child("rfc2136", "tsigAlgorithm"), "", supportedTSIGAlgorithms))
 				}
 			}
+			if len(p.RFC2136.TSIGSecret.Name) > 0 {
+				requiredSecrets = append(requiredSecrets, &p.RFC2136.TSIGSecret)
+			}
+
 			if len(p.RFC2136.TSIGKeyName) > 0 {
 				el = append(el, ValidateSecretKeySelector(&p.RFC2136.TSIGSecret, fldPath.Child("rfc2136", "tsigSecretSecretRef"))...)
 			}
@@ -636,7 +658,6 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 				if len(p.RFC2136.TSIGKeyName) == 0 {
 					el = append(el, field.Required(fldPath.Child("rfc2136", "tsigKeyName"), ""))
 				}
-
 			}
 		}
 	}
@@ -654,7 +675,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		el = append(el, field.Required(fldPath, "no DNS01 provider configured"))
 	}
 
-	return el
+	return el, requiredSecrets
 }
 
 func ValidateSecretKeySelector(sks *cmmeta.SecretKeySelector, fldPath *field.Path) field.ErrorList {

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1731,7 +1731,7 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateACMEChallengeSolverDNS01(s.cfg, fldPath)
+			errs, _ := ValidateACMEChallengeSolverDNS01(s.cfg, fldPath)
 			if len(errs) != len(s.errs) {
 				t.Errorf("Expected %v but got %v", s.errs, errs)
 				return

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -585,7 +585,7 @@ func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) 
 	}
 
 	for _, s := range secrets {
-		res, err := a.secretsClient.Secrets(issuer.GetNamespace()).Get(ctx, s.Name, metav1.GetOptions{})
+		res, err := a.secretsClient.Secrets(a.resourceNamespace(issuer)).Get(ctx, s.Name, metav1.GetOptions{})
 		if err != nil {
 			warning = append(warning, fmt.Sprintf("failed to get secret %q: %v", s.Name, err))
 			continue
@@ -603,57 +603,63 @@ func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) 
 func extractSecrets(issuer v1.GenericIssuer) []*cmmeta.SecretKeySelector {
 	var secrets []*cmmeta.SecretKeySelector
 	spec := issuer.GetSpec()
-	if spec.ACME != nil {
-		solvers := spec.ACME.Solvers
+	if spec.ACME == nil {
+		return secrets
+	}
+	solvers := spec.ACME.Solvers
 
-		for _, s := range solvers {
-			if s.DNS01 == nil {
-				continue
-			}
-			dnsSolver := s.DNS01
-			if dnsSolver.AcmeDNS != nil {
-				// required
-				secrets = append(secrets, &dnsSolver.AcmeDNS.AccountSecret)
-			}
-			if dnsSolver.Akamai != nil {
-				// required
-				secrets = append(secrets, &dnsSolver.Akamai.ClientSecret)
-				secrets = append(secrets, &dnsSolver.Akamai.ClientToken)
-				secrets = append(secrets, &dnsSolver.Akamai.AccessToken)
-			}
-			if dnsSolver.AzureDNS != nil {
-				if dnsSolver.AzureDNS.ClientSecret != nil {
-					secrets = append(secrets, dnsSolver.AzureDNS.ClientSecret)
-				}
-			}
-			if dnsSolver.Cloudflare != nil {
-				if dnsSolver.Cloudflare.APIKey != nil {
-					secrets = append(secrets, dnsSolver.Cloudflare.APIKey)
-				}
-				if dnsSolver.Cloudflare.APIToken != nil {
-					secrets = append(secrets, dnsSolver.Cloudflare.APIToken)
-				}
-			}
-			if dnsSolver.DigitalOcean != nil {
-				// required
-				secrets = append(secrets, &dnsSolver.DigitalOcean.Token)
-			}
-			if dnsSolver.RFC2136 != nil {
-				if len(dnsSolver.RFC2136.TSIGSecret.Name) > 0 {
-					secrets = append(secrets, &dnsSolver.RFC2136.TSIGSecret)
-				}
-			}
-			if dnsSolver.Route53 != nil {
-				// because of the ambient credential both can be missing
-				if len(dnsSolver.Route53.SecretAccessKey.Name) > 0 {
-					secrets = append(secrets, &dnsSolver.Route53.SecretAccessKey)
-				}
-				if dnsSolver.Route53.SecretAccessKeyID != nil {
-					secrets = append(secrets, dnsSolver.Route53.SecretAccessKeyID)
-				}
-			}
-
+	for _, s := range solvers {
+		if s.DNS01 == nil {
+			continue
 		}
+		dnsSolver := s.DNS01
+		if dnsSolver.AcmeDNS != nil {
+			// required
+			secrets = append(secrets, &dnsSolver.AcmeDNS.AccountSecret)
+		}
+		if dnsSolver.Akamai != nil {
+			// required
+			secrets = append(secrets, &dnsSolver.Akamai.ClientSecret)
+			secrets = append(secrets, &dnsSolver.Akamai.ClientToken)
+			secrets = append(secrets, &dnsSolver.Akamai.AccessToken)
+		}
+		if dnsSolver.AzureDNS != nil {
+			if dnsSolver.AzureDNS.ClientSecret != nil {
+				secrets = append(secrets, dnsSolver.AzureDNS.ClientSecret)
+			}
+		}
+
+		if dnsSolver.CloudDNS != nil {
+			secrets = append(secrets, dnsSolver.CloudDNS.ServiceAccount)
+		}
+
+		if dnsSolver.Cloudflare != nil {
+			if dnsSolver.Cloudflare.APIKey != nil {
+				secrets = append(secrets, dnsSolver.Cloudflare.APIKey)
+			}
+			if dnsSolver.Cloudflare.APIToken != nil {
+				secrets = append(secrets, dnsSolver.Cloudflare.APIToken)
+			}
+		}
+		if dnsSolver.DigitalOcean != nil {
+			// required
+			secrets = append(secrets, &dnsSolver.DigitalOcean.Token)
+		}
+		if dnsSolver.RFC2136 != nil {
+			if len(dnsSolver.RFC2136.TSIGSecret.Name) > 0 {
+				secrets = append(secrets, &dnsSolver.RFC2136.TSIGSecret)
+			}
+		}
+		if dnsSolver.Route53 != nil {
+			// because of the ambient credential both can be missing
+			if len(dnsSolver.Route53.SecretAccessKey.Name) > 0 {
+				secrets = append(secrets, &dnsSolver.Route53.SecretAccessKey)
+			}
+			if dnsSolver.Route53.SecretAccessKeyID != nil {
+				secrets = append(secrets, dnsSolver.Route53.SecretAccessKeyID)
+			}
+		}
+
 	}
 
 	return secrets

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -29,10 +29,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
+	"github.com/cert-manager/cert-manager/internal/apis/meta"
 	"github.com/cert-manager/cert-manager/pkg/acme"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/acme/client"
+	"github.com/cert-manager/cert-manager/pkg/api"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -579,7 +584,12 @@ var acmev1ToV2Mappings = map[string]string{
 func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) []string {
 	var warning []string
 
-	secrets := extractSecrets(issuer)
+	secrets, err := extractSecrets(issuer)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "error extracting secrets")
+		warning = append(warning, "unable to verify dns solvers")
+		return warning
+	}
 	if len(secrets) == 0 {
 		return warning
 	}
@@ -600,67 +610,31 @@ func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) 
 	return warning
 }
 
-func extractSecrets(issuer v1.GenericIssuer) []*cmmeta.SecretKeySelector {
-	var secrets []*cmmeta.SecretKeySelector
+func extractSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
+	var secrets []*meta.SecretKeySelector
 	spec := issuer.GetSpec()
 	if spec.ACME == nil {
-		return secrets
+		return secrets, nil
 	}
-	solvers := spec.ACME.Solvers
 
-	for _, s := range solvers {
-		if s.DNS01 == nil {
+	solvers := spec.ACME.Solvers
+	for i := range solvers {
+		sol := solvers[i]
+		if sol.DNS01 == nil {
 			continue
 		}
-		dnsSolver := s.DNS01
-		if dnsSolver.AcmeDNS != nil {
-			// required
-			secrets = append(secrets, &dnsSolver.AcmeDNS.AccountSecret)
-		}
-		if dnsSolver.Akamai != nil {
-			// required
-			secrets = append(secrets, &dnsSolver.Akamai.ClientSecret)
-			secrets = append(secrets, &dnsSolver.Akamai.ClientToken)
-			secrets = append(secrets, &dnsSolver.Akamai.AccessToken)
-		}
-		if dnsSolver.AzureDNS != nil {
-			if dnsSolver.AzureDNS.ClientSecret != nil {
-				secrets = append(secrets, dnsSolver.AzureDNS.ClientSecret)
-			}
+
+		var out cmacme.ACMEChallengeSolver
+		if err := api.Scheme.Convert(&sol, &out, nil); err != nil {
+			return nil, fmt.Errorf("unable to convert ACME challenge solver to internal challenge type: %w", err)
 		}
 
-		if dnsSolver.CloudDNS != nil {
-			secrets = append(secrets, dnsSolver.CloudDNS.ServiceAccount)
+		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
+		if len(requiredSecrets) == 0 {
+			continue
 		}
-
-		if dnsSolver.Cloudflare != nil {
-			if dnsSolver.Cloudflare.APIKey != nil {
-				secrets = append(secrets, dnsSolver.Cloudflare.APIKey)
-			}
-			if dnsSolver.Cloudflare.APIToken != nil {
-				secrets = append(secrets, dnsSolver.Cloudflare.APIToken)
-			}
-		}
-		if dnsSolver.DigitalOcean != nil {
-			// required
-			secrets = append(secrets, &dnsSolver.DigitalOcean.Token)
-		}
-		if dnsSolver.RFC2136 != nil {
-			if len(dnsSolver.RFC2136.TSIGSecret.Name) > 0 {
-				secrets = append(secrets, &dnsSolver.RFC2136.TSIGSecret)
-			}
-		}
-		if dnsSolver.Route53 != nil {
-			// because of the ambient credential both can be missing
-			if len(dnsSolver.Route53.SecretAccessKey.Name) > 0 {
-				secrets = append(secrets, &dnsSolver.Route53.SecretAccessKey)
-			}
-			if dnsSolver.Route53.SecretAccessKeyID != nil {
-				secrets = append(secrets, dnsSolver.Route53.SecretAccessKeyID)
-			}
-		}
-
+		secrets = append(secrets, requiredSecrets...)
 	}
 
-	return secrets
+	return secrets, nil
 }

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -44,6 +44,7 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/errors"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -664,23 +665,23 @@ func mustGenerateRSAKey(t *testing.T) crypto.Signer {
 func TestValidateDNSSolvers(t *testing.T) {
 	tests := []struct {
 		name             string
-		issuer           cmapi.GenericIssuer
+		objectMeta       metav1.ObjectMeta
+		spec             cmapi.IssuerSpec
 		secrets          []*corev1.Secret
 		wantWarnings     []string
 		wantWarningCount int
 	}{
+		// Edge cases - no DNS solvers
 		{
 			name: "no DNS solvers configured",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{},
-						},
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{},
 					},
 				},
 			},
@@ -688,19 +689,27 @@ func TestValidateDNSSolvers(t *testing.T) {
 			wantWarnings: nil,
 		},
 		{
-			name: "HTTP01 solver only, no warnings",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									HTTP01: &cmacme.ACMEChallengeSolverHTTP01{},
-								},
+			name: "issuer with no ACME spec generates no warnings",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec:         cmapi.IssuerSpec{},
+			secrets:      []*corev1.Secret{},
+			wantWarnings: nil,
+		},
+		{
+			name: "HTTP01 solver only generates no warnings",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								HTTP01: &cmacme.ACMEChallengeSolverHTTP01{},
 							},
 						},
 					},
@@ -709,26 +718,26 @@ func TestValidateDNSSolvers(t *testing.T) {
 			secrets:      []*corev1.Secret{},
 			wantWarnings: nil,
 		},
+
+		// AcmeDNS solver
 		{
 			name: "AcmeDNS solver with existing secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
-											AccountSecret: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "acme-dns-secret",
-												},
-												Key: "account",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+										AccountSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "acme-dns-secret",
 											},
+											Key: "account",
 										},
 									},
 								},
@@ -752,24 +761,22 @@ func TestValidateDNSSolvers(t *testing.T) {
 		},
 		{
 			name: "AcmeDNS solver with missing secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
-											AccountSecret: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "missing-secret",
-												},
-												Key: "account",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+										AccountSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
 											},
+											Key: "account",
 										},
 									},
 								},
@@ -781,32 +788,261 @@ func TestValidateDNSSolvers(t *testing.T) {
 			secrets:          []*corev1.Secret{},
 			wantWarningCount: 1,
 		},
+
+		// Akamai solver
 		{
-			name: "Cloudflare solver with existing secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
+			name: "Akamai solver with all required secrets",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{
+										ClientSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "akamai-secret",
+											},
+											Key: "client-secret",
+										},
+										ClientToken: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "akamai-secret",
+											},
+											Key: "client-token",
+										},
+										AccessToken: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "akamai-secret",
+											},
+											Key: "access-token",
+										},
+									},
+								},
+							},
+						},
+					},
 				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
-											APIKey: &cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "cloudflare-api-key",
-												},
-												Key: "api-key",
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "akamai-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"client-secret": []byte("test-client-secret"),
+						"client-token":  []byte("test-client-token"),
+						"access-token":  []byte("test-access-token"),
+					},
+				},
+			},
+			wantWarnings: nil,
+		},
+		{
+			name: "Akamai solver with missing secrets",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{
+										ClientSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
 											},
-											APIToken: &cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "cloudflare-api-token",
-												},
-												Key: "api-token",
+											Key: "client-secret",
+										},
+										ClientToken: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
 											},
+											Key: "client-token",
+										},
+										AccessToken: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
+											},
+											Key: "access-token",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:          []*corev1.Secret{},
+			wantWarningCount: 3,
+		},
+
+		// AzureDNS solver
+		{
+			name: "AzureDNS solver with client secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+										ClientSecret: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "azure-secret",
+											},
+											Key: "client-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "azure-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"client-secret": []byte("test-client-secret"),
+					},
+				},
+			},
+			wantWarnings: nil,
+		},
+		{
+			name: "AzureDNS solver without client secret (e.g. using managed identity)",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:      []*corev1.Secret{},
+			wantWarnings: nil,
+		},
+
+		// CloudDNS solver
+		{
+			name: "CloudDNS solver with existing secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+										ServiceAccount: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "clouddns-sa",
+											},
+											Key: "service-account-key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "clouddns-sa",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"service-account-key": []byte("test-sa-key"),
+					},
+				},
+			},
+			wantWarnings: nil,
+		},
+		{
+			name: "CloudDNS solver with missing secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+										ServiceAccount: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
+											},
+											Key: "service-account-key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:          []*corev1.Secret{},
+			wantWarningCount: 1,
+		},
+
+		// Cloudflare solver
+		{
+			name: "Cloudflare solver with both APIKey and APIToken",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
+										APIKey: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "cloudflare-api-key",
+											},
+											Key: "api-key",
+										},
+										APIToken: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "cloudflare-api-token",
+											},
+											Key: "api-token",
 										},
 									},
 								},
@@ -838,25 +1074,23 @@ func TestValidateDNSSolvers(t *testing.T) {
 			wantWarnings: nil,
 		},
 		{
-			name: "Route53 solver with missing secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-											SecretAccessKey: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "route53-secret",
-												},
-												Key: "secret-access-key",
+			name: "Cloudflare solver with only APIToken",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
+										APIToken: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "cloudflare-api-token",
 											},
+											Key: "api-token",
 										},
 									},
 								},
@@ -865,41 +1099,39 @@ func TestValidateDNSSolvers(t *testing.T) {
 					},
 				},
 			},
-			secrets:          []*corev1.Secret{},
-			wantWarningCount: 1,
-		},
-		{
-			name: "multiple DNS solvers with mixed results",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloudflare-api-token",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"api-token": []byte("test-api-token"),
+					},
 				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
-											Token: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "do-token",
-												},
-												Key: "token",
+			},
+			wantWarnings: nil,
+		},
+
+		// DigitalOcean solver
+		{
+			name: "DigitalOcean solver with existing secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+										Token: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "do-token",
 											},
-										},
-									},
-								},
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
-											AccountSecret: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "missing-secret",
-												},
-												Key: "account",
-											},
+											Key: "token",
 										},
 									},
 								},
@@ -919,40 +1151,26 @@ func TestValidateDNSSolvers(t *testing.T) {
 					},
 				},
 			},
-			wantWarningCount: 1,
+			wantWarnings: nil,
 		},
 		{
-			name: "Akamai solver with all required secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{
-											ClientSecret: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "akamai-secret",
-												},
-												Key: "client-secret",
+			name: "DigitalOcean solver with missing secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+										Token: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
 											},
-											ClientToken: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "akamai-secret",
-												},
-												Key: "client-token",
-											},
-											AccessToken: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "akamai-secret",
-												},
-												Key: "access-token",
-											},
+											Key: "token",
 										},
 									},
 								},
@@ -961,41 +1179,29 @@ func TestValidateDNSSolvers(t *testing.T) {
 					},
 				},
 			},
-			secrets: []*corev1.Secret{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "akamai-secret",
-						Namespace: "default",
-					},
-					Data: map[string][]byte{
-						"client-secret": []byte("test-client-secret"),
-						"client-token":  []byte("test-client-token"),
-						"access-token":  []byte("test-access-token"),
-					},
-				},
-			},
-			wantWarnings: nil,
+			secrets:          []*corev1.Secret{},
+			wantWarningCount: 1,
 		},
+
+		// RFC2136 solver
 		{
 			name: "RFC2136 solver with TSIG secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
-											TSIGSecret: cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "tsig-secret",
-												},
-												Key: "tsig-key",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
+										TSIGSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "tsig-secret",
 											},
+											Key: "tsig-key",
 										},
 									},
 								},
@@ -1018,25 +1224,89 @@ func TestValidateDNSSolvers(t *testing.T) {
 			wantWarnings: nil,
 		},
 		{
-			name: "AzureDNS solver with client secret",
-			issuer: &cmapi.Issuer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-issuer",
-					Namespace: "default",
-				},
-				Spec: cmapi.IssuerSpec{
-					IssuerConfig: cmapi.IssuerConfig{
-						ACME: &cmacme.ACMEIssuer{
-							Solvers: []cmacme.ACMEChallengeSolver{
-								{
-									DNS01: &cmacme.ACMEChallengeSolverDNS01{
-										AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
-											ClientSecret: &cmmeta.SecretKeySelector{
-												LocalObjectReference: cmmeta.LocalObjectReference{
-													Name: "azure-secret",
-												},
-												Key: "client-secret",
+			name: "RFC2136 solver with missing TSIG secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
+										TSIGSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
 											},
+											Key: "tsig-key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:          []*corev1.Secret{},
+			wantWarningCount: 1,
+		},
+		{
+			name: "RFC2136 solver without TSIGSecret (empty Name)",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
+										TSIGSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "",
+											},
+											Key: "tsig-key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:      []*corev1.Secret{},
+			wantWarnings: nil,
+		},
+
+		// Route53 solver
+		{
+			name: "Route53 solver with both SecretAccessKey and SecretAccessKeyID",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+										SecretAccessKey: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "route53-secret",
+											},
+											Key: "secret-access-key",
+										},
+										SecretAccessKeyID: &cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "route53-access-key-id",
+											},
+											Key: "access-key-id",
 										},
 									},
 								},
@@ -1048,48 +1318,165 @@ func TestValidateDNSSolvers(t *testing.T) {
 			secrets: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "azure-secret",
+						Name:      "route53-secret",
 						Namespace: "default",
 					},
 					Data: map[string][]byte{
-						"client-secret": []byte("test-client-secret"),
+						"secret-access-key": []byte("test-secret-access-key"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route53-access-key-id",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"access-key-id": []byte("test-access-key-id"),
 					},
 				},
 			},
 			wantWarnings: nil,
 		},
+		{
+			name: "Route53 solver with missing secret",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+										SecretAccessKey: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
+											},
+											Key: "secret-access-key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:          []*corev1.Secret{},
+			wantWarningCount: 1,
+		},
+
+		// Multiple solvers with mixed results
+		{
+			name: "multiple DNS solvers with mixed results",
+			objectMeta: metav1.ObjectMeta{
+				Name:      "test-issuer",
+				Namespace: "default",
+			},
+			spec: cmapi.IssuerSpec{
+				IssuerConfig: cmapi.IssuerConfig{
+					ACME: &cmacme.ACMEIssuer{
+						Solvers: []cmacme.ACMEChallengeSolver{
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+										Token: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "do-token",
+											},
+											Key: "token",
+										},
+									},
+								},
+							},
+							{
+								DNS01: &cmacme.ACMEChallengeSolverDNS01{
+									AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+										AccountSecret: cmmeta.SecretKeySelector{
+											LocalObjectReference: cmmeta.LocalObjectReference{
+												Name: "missing-secret",
+											},
+											Key: "account",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "do-token",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"token": []byte("test-token"),
+					},
+				},
+			},
+			wantWarningCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		issOpt := controller.IssuerOptions{
+			ClusterResourceNamespace: "default",
+		}
+		a := &Acme{
+			secretsClient:     &fakeSecretGetter{secrets: tt.secrets},
+			resourceNamespace: issOpt.ResourceNamespace,
+		}
+		t.Run("Issuer-"+tt.name, func(t *testing.T) {
+			t.Parallel()
 
-			a := &Acme{
-				secretsClient: &fakeSecretGetter{secrets: tt.secrets},
+			issuer := &cmapi.Issuer{
+				ObjectMeta: tt.objectMeta,
+				Spec:       tt.spec,
 			}
 
-			warnings := a.validateDNSSolvers(context.Background(), tt.issuer)
-
-			if tt.wantWarnings != nil {
-				if len(warnings) != len(tt.wantWarnings) {
-					t.Errorf("validateDNSSolvers() returned %d warnings, want %d", len(warnings), len(tt.wantWarnings))
-				}
-				for i, wantWarning := range tt.wantWarnings {
-					if i < len(warnings) && warnings[i] != wantWarning {
-						t.Errorf("validateDNSSolvers() warning[%d] = %v, want %v", i, warnings[i], wantWarning)
-					}
-				}
-			}
-
-			if tt.wantWarningCount > 0 {
-				if len(warnings) != tt.wantWarningCount {
-					t.Errorf("validateDNSSolvers() returned %d warnings, want %d. Warnings: %v", len(warnings), tt.wantWarningCount, warnings)
-				}
-			}
-
-			if tt.wantWarnings == nil && tt.wantWarningCount == 0 && len(warnings) > 0 {
-				t.Errorf("validateDNSSolvers() returned unexpected warnings: %v", warnings)
-			}
+			runValidateDNSSolversTest(t, a, issuer, tt.wantWarnings, tt.wantWarningCount)
 		})
+
+		t.Run("ClusterIssuer-"+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterIssuer := &cmapi.ClusterIssuer{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.objectMeta.Name},
+				Spec:       tt.spec,
+			}
+
+			runValidateDNSSolversTest(t, a, clusterIssuer, tt.wantWarnings, tt.wantWarningCount)
+		})
+	}
+}
+
+func runValidateDNSSolversTest(t *testing.T, a *Acme, issuer cmapi.GenericIssuer, wantWarnings []string, wantWarningCount int) {
+	t.Helper()
+
+	warnings := a.validateDNSSolvers(context.Background(), issuer)
+
+	if wantWarnings != nil {
+		if len(warnings) != len(wantWarnings) {
+			t.Errorf("validateDNSSolvers() returned %d warnings, want %d", len(warnings), len(wantWarnings))
+		}
+		for i, wantWarning := range wantWarnings {
+			if i < len(warnings) && warnings[i] != wantWarning {
+				t.Errorf("validateDNSSolvers() warning[%d] = %v, want %v", i, warnings[i], wantWarning)
+			}
+		}
+	}
+
+	if wantWarningCount > 0 {
+		if len(warnings) != wantWarningCount {
+			t.Errorf("validateDNSSolvers() returned %d warnings, want %d. Warnings: %v", len(warnings), wantWarningCount, warnings)
+		}
+	}
+
+	if wantWarnings == nil && wantWarningCount == 0 && len(warnings) > 0 {
+		t.Errorf("validateDNSSolvers() returned unexpected warnings: %v", warnings)
 	}
 }
 

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -357,6 +357,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
 			gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
 				{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{
@@ -386,7 +387,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should mark as not ready if ACME issuer secret does nat have specified key", func(testingCtx context.Context) {
+	It("should mark as not ready if ACME issuer secret does nost have specified key", func(testingCtx context.Context) {
 		secretName := "test-secret"
 
 		keyBytes := []byte("")
@@ -403,6 +404,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
 			gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
 				{
 					DNS01: &cmacme.ACMEChallengeSolverDNS01{


### PR DESCRIPTION
### Pull Request Motivation

The ACME DNS issuer is marked as ready, although the solver's secret is missing or the secret key does not exist. This is misleading because without a valid solver's secret, the issuer's challenges would never be processed.  To avoid this, this PR adds validation and error messages that indicate that there is missing info to complete the whole flow of issuing a certificate

```yaml
  status:
    conditions:
    - lastTransitionTime: "2025-11-16T14:48:17Z"
      message: the secret "acme-dns" does not have key "acmedns.json"
      observedGeneration: 1
      reason: InvalidSolver
      status: "False"
      type: Ready

```

```yaml
  status:
    acme: {}
    conditions:
    - lastTransitionTime: "2025-11-16T14:44:54Z"
      message: 'failed to get secret "acme-dns": secrets "acme-dns" not found'
      observedGeneration: 1
      reason: InvalidSolver
      status: "False"
      type: Ready

```

Fix: https://github.com/cert-manager/cert-manager/issues/7826


### Kind

/bug

### Release Note


```release-note
add dns issuer secrets validation before marking it as ready
```

### Steps for testing. 

Scenario: 1 - missing secret

```yaml
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: example-issuer123
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt123.org/directory
    privateKeySecretRef:
      name: example-issuer-account-key
    solvers:
    - dns01:
        acmeDNS:
          host: test1.example.com
          accountSecretRef:
            name: missing-secret
            key: "key"

```

Scenation 2  - missing key

```yaml
apiVersion: v1
data:
  secret: c2VjZXJ0
kind: Secret
metadata:
  creationTimestamp: null
  name: acme-secret

---


apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: example-issuer1234
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt123.org/directory
    privateKeySecretRef:
      name: example-issuer-account-key
    solvers:
    - dns01:
        acmeDNS:
          host: test2.example.com
          accountSecretRef:
            name: acme-secret
            key: "key"

```

