### PR TITLE
Bugfix #7388 kid missing issue with Infisical ACME server or any other ACME that requires EAB

### DIFF
--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -43,6 +43,7 @@ type NewClientOptions struct {
 	CABundle      []byte
 	Server        string
 	PrivateKey    *rsa.PrivateKey
+	AccountUri    string
 }
 
 // NewClientFunc is a function type for building a new ACME client.
@@ -66,6 +67,7 @@ func newClientFromHTTPClient(httpClient *http.Client, userAgent string, options 
 		DirectoryURL: options.Server,
 		UserAgent:    userAgent,
 		RetryBackoff: acmeutil.RetryBackoff,
+		KID:          acmeapi.KeyID(options.AccountUri),
 	})
 }
 

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -260,6 +260,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 			CABundle:      issuer.GetSpec().ACME.CABundle,
 			Server:        issuer.GetSpec().ACME.Server,
+			AccountUri:    issuer.GetStatus().ACMEStatus().URI,
 			PrivateKey:    rsaPk,
 		})
 
@@ -419,6 +420,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
+		AccountUri:    account.URI,
 		PrivateKey:    rsaPk,
 	})
 

--- a/third_party/forked/acme/acme.go
+++ b/third_party/forked/acme/acme.go
@@ -143,18 +143,18 @@ type Client struct {
 //
 // When in pre-RFC mode or when c.getRegRFC responds with an error, accountKID
 // returns noKeyID.
-func (c *Client) accountKID(ctx context.Context) KeyID {
+func (c *Client) accountKID(ctx context.Context) (KeyID, error) {
 	c.cacheMu.Lock()
 	defer c.cacheMu.Unlock()
 	if c.KID != noKeyID {
-		return c.KID
+		return c.KID, nil
 	}
 	a, err := c.getRegRFC(ctx)
 	if err != nil {
-		return noKeyID
+		return noKeyID, err
 	}
 	c.KID = KeyID(a.URI)
-	return c.KID
+	return c.KID, nil
 }
 
 var errPreRFC = errors.New("acme: server does not support the RFC 8555 version of ACME")
@@ -371,7 +371,7 @@ func (c *Client) authorize(ctx context.Context, typ, val string) (*Authorization
 		Resource:   "new-authz",
 		Identifier: authzID{Type: typ, Value: val},
 	}
-	res, err := c.post(ctx, nil, c.dir.AuthzURL, req, wantStatus(http.StatusCreated))
+	res, err := c.post(ctx, nil, true, c.dir.AuthzURL, req, wantStatus(http.StatusCreated))
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (c *Client) RevokeAuthorization(ctx context.Context, url string) error {
 		Status:   "deactivated",
 		Delete:   true,
 	}
-	res, err := c.post(ctx, nil, url, req, wantStatus(http.StatusOK))
+	res, err := c.post(ctx, nil, true, url, req, wantStatus(http.StatusOK))
 	if err != nil {
 		return err
 	}
@@ -524,7 +524,7 @@ func (c *Client) Accept(ctx context.Context, chal *Challenge) (*Challenge, error
 	if len(chal.Payload) != 0 {
 		payload = chal.Payload
 	}
-	res, err := c.post(ctx, nil, chal.URI, payload, wantStatus(
+	res, err := c.post(ctx, nil, true, chal.URI, payload, wantStatus(
 		http.StatusOK,       // according to the spec
 		http.StatusAccepted, // Let's Encrypt: see https://goo.gl/WsJ7VT (acme-divergences.md)
 	))

--- a/third_party/forked/acme/http.go
+++ b/third_party/forked/acme/http.go
@@ -159,7 +159,8 @@ func (c *Client) get(ctx context.Context, url string, ok resOkay) (*http.Respons
 // It makes a POST request in KID form with zero JWS payload.
 // See nopayload doc comments in jws.go.
 func (c *Client) postAsGet(ctx context.Context, url string, ok resOkay) (*http.Response, error) {
-	return c.post(ctx, nil, url, noPayload, ok)
+	// All POST-as-GET requests required KID
+	return c.post(ctx, nil, true, url, noPayload, ok)
 }
 
 // post issues a signed POST request in JWS format using the provided key
@@ -169,10 +170,10 @@ func (c *Client) postAsGet(ctx context.Context, url string, ok resOkay) (*http.R
 // post retries unsuccessful attempts according to c.RetryBackoff
 // until the context is done or a non-retriable error is received.
 // It uses postNoRetry to make individual requests.
-func (c *Client) post(ctx context.Context, key crypto.Signer, url string, body interface{}, ok resOkay) (*http.Response, error) {
+func (c *Client) post(ctx context.Context, key crypto.Signer, requireKid bool, url string, body interface{}, ok resOkay) (*http.Response, error) {
 	retry := c.retryTimer()
 	for {
-		res, req, err := c.postNoRetry(ctx, key, url, body)
+		res, req, err := c.postNoRetry(ctx, key, requireKid, url, body)
 		if err != nil {
 			return nil, err
 		}
@@ -211,14 +212,18 @@ func (c *Client) post(ctx context.Context, key crypto.Signer, url string, body i
 // and JWK is used only when KID is unavailable: new account endpoint and certificate
 // revocation requests authenticated by a cert key.
 // See jwsEncodeJSON for other details.
-func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, url string, body interface{}) (*http.Response, *http.Request, error) {
+func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, requiresKid bool, url string, body interface{}) (*http.Response, *http.Request, error) {
 	kid := noKeyID
+	var err error
 	if key == nil {
 		if c.Key == nil {
 			return nil, nil, errors.New("acme: Client.Key must be populated to make POST requests")
 		}
 		key = c.Key
-		kid = c.accountKID(ctx)
+		kid, err = c.accountKID(ctx)
+		if requiresKid && kid == noKeyID {
+			return nil, nil, fmt.Errorf("acme: the operation requires account KID but the value is not provided and failed to obtain it from the server: %w", err)
+		}
 	}
 	nonce, err := c.popNonce(ctx, url)
 	if err != nil {

--- a/third_party/forked/acme/http.go
+++ b/third_party/forked/acme/http.go
@@ -222,7 +222,7 @@ func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, requiresKid
 		key = c.Key
 		kid, err = c.accountKID(ctx)
 		if requiresKid && kid == noKeyID {
-			return nil, nil, fmt.Errorf("acme: the operation requires account KID but the value is not provided and failed to obtain it from the server: %w", err)
+			return nil, nil, fmt.Errorf("acme: the operation requires account KID but the value is not provided and encountered error while retrieving it from the server: %w", err)
 		}
 	}
 	nonce, err := c.popNonce(ctx, url)

--- a/third_party/forked/acme/http.go
+++ b/third_party/forked/acme/http.go
@@ -212,7 +212,7 @@ func (c *Client) post(ctx context.Context, key crypto.Signer, requireKid bool, u
 // and JWK is used only when KID is unavailable: new account endpoint and certificate
 // revocation requests authenticated by a cert key.
 // See jwsEncodeJSON for other details.
-func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, requiresKid bool, url string, body interface{}) (*http.Response, *http.Request, error) {
+func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, requireKid bool, url string, body interface{}) (*http.Response, *http.Request, error) {
 	kid := noKeyID
 	var err error
 	if key == nil {
@@ -221,7 +221,7 @@ func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, requiresKid
 		}
 		key = c.Key
 		kid, err = c.accountKID(ctx)
-		if requiresKid && kid == noKeyID {
+		if requireKid && (kid == noKeyID || err != nil) {
 			return nil, nil, fmt.Errorf("acme: the operation requires account KID but the value is not provided and encountered error while retrieving it from the server: %w", err)
 		}
 	}

--- a/third_party/forked/acme/http_test.go
+++ b/third_party/forked/acme/http_test.go
@@ -244,7 +244,7 @@ func TestAccountKidLoop(t *testing.T) {
 	// then Client.Key must be set, otherwise we fall into an
 	// infinite loop (which also causes a deadlock).
 	client := &Client{dir: &Directory{OrderURL: ":)"}}
-	_, _, err := client.postNoRetry(context.Background(), nil, "", nil)
+	_, _, err := client.postNoRetry(context.Background(), nil, false, "", nil)
 	if err == nil {
 		t.Fatal("Client.postNoRetry didn't fail with a nil key")
 	}

--- a/third_party/forked/acme/rfc8555_test.go
+++ b/third_party/forked/acme/rfc8555_test.go
@@ -1119,6 +1119,11 @@ func TestRFC_AlreadyRevokedCert(t *testing.T) {
 
 func TestRFC_ListCertAlternates(t *testing.T) {
 	s := newACMEServer()
+	s.handle("/acme/new-account", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", s.url("/accounts/1"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status": "valid"}`))
+	})
 	s.handle("/crt", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/pem-certificate-chain")
 		w.Header().Add("Link", `<https://example.com/crt/2>;rel="alternate"`)

--- a/third_party/forked/acme/rfc8555_test.go
+++ b/third_party/forked/acme/rfc8555_test.go
@@ -243,7 +243,7 @@ func TestRFC_postKID(t *testing.T) {
 		},
 	}
 	req := json.RawMessage(`{"msg":"ping"}`)
-	res, err := cl.post(ctx, nil /* use kid */, ts.URL+"/post", req, wantStatus(http.StatusOK))
+	res, err := cl.post(ctx, nil /* use kid */, false, ts.URL+"/post", req, wantStatus(http.StatusOK))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,8 +422,12 @@ func TestRFC_Register(t *testing.T) {
 	if !didPrompt {
 		t.Error("tos prompt wasn't called")
 	}
-	if v := cl.accountKID(ctx); v != KeyID(okAccount.URI) {
+	v, err := cl.accountKID(ctx)
+	if v != KeyID(okAccount.URI) {
 		t.Errorf("account kid = %q; want %q", v, okAccount.URI)
+	}
+	if err != nil {
+		t.Errorf("account kid error %+v", err)
 	}
 }
 
@@ -559,8 +563,12 @@ func TestRFC_RegisterExternalAccountBinding(t *testing.T) {
 	if !didPrompt {
 		t.Error("tos prompt wasn't called")
 	}
-	if v := cl.accountKID(ctx); v != KeyID(okAccount.URI) {
+	v, err := cl.accountKID(ctx)
+	if v != KeyID(okAccount.URI) {
 		t.Errorf("account kid = %q; want %q", v, okAccount.URI)
+	}
+	if err != nil {
+		t.Errorf("account kid error %+v", err)
 	}
 }
 
@@ -580,7 +588,11 @@ func TestRFC_RegisterExisting(t *testing.T) {
 		t.Errorf("err = %v; want %v", err, ErrAccountAlreadyExists)
 	}
 	kid := KeyID(s.url("/accounts/1"))
-	if v := cl.accountKID(context.Background()); v != kid {
+	v, err := cl.accountKID(context.Background())
+	if err != nil {
+		t.Errorf("account kid error %+v", err)
+	}
+	if v != kid {
 		t.Errorf("account kid = %q; want %q", v, kid)
 	}
 }

--- a/third_party/forked/acme/rfc8555_test.go
+++ b/third_party/forked/acme/rfc8555_test.go
@@ -1201,12 +1201,40 @@ func TestRFC_RequireKidEndpoints(t *testing.T) {
 			_, err := cl.ListCertAlternates(context.Background(), s.url("/crt"))
 			return err
 		}},
+		{"Authorize", func(cl *Client) error {
+			_, err := cl.Authorize(context.Background(), s.url("example.com"))
+			return err
+		}},
+		{"AuthorizeIP", func(cl *Client) error {
+			_, err := cl.AuthorizeIP(context.Background(), s.url("1.1.1.1"))
+			return err
+		}},
+		{"GetAuthorization", func(cl *Client) error {
+			_, err := cl.GetAuthorization(context.Background(), s.url("/authz/1"))
+			return err
+		}},
+		{"RevokeAuthorization", func(cl *Client) error {
+			err := cl.RevokeAuthorization(context.Background(), s.url("/authz/1"))
+			return err
+		}},
+		{"WaitAuthorization", func(cl *Client) error {
+			_, err := cl.WaitAuthorization(context.Background(), s.url("/authz/1"))
+			return err
+		}},
+		{"GetChallenge", func(cl *Client) error {
+			_, err := cl.GetChallenge(context.Background(), s.url("/chall/1"))
+			return err
+		}},
+		{"Accept", func(cl *Client) error {
+			_, err := cl.Accept(context.Background(), &Challenge{Type: "http-01", URI: "/chall/1", Token: "test"})
+			return err
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := &Client{Key: testKeyEC, DirectoryURL: s.url("/")}
 			err := tt.op(cl)
-			expected := "acme: the operation requires account KID but the value is not provided and failed to obtain it from the server: 400 : 400 Bad Request"
+			expected := "acme: the operation requires account KID but the value is not provided and encountered error while retrieving it from the server: 400 : 400 Bad Request"
 			if err == nil || err.Error() != expected {
 				t.Errorf("err: %v; want %v", err, expected)
 			}

--- a/third_party/forked/acme/rfc8555_test.go
+++ b/third_party/forked/acme/rfc8555_test.go
@@ -1173,8 +1173,32 @@ func TestRFC_RequireKidEndpoints(t *testing.T) {
 		name string
 		op   func(client *Client) error
 	}{
-		{"new-order", func(cl *Client) error {
+		{"AuthorizeOrder", func(cl *Client) error {
 			_, err := cl.AuthorizeOrder(context.Background(), DomainIDs("example.org"))
+			return err
+		}},
+		{"GetOrder", func(cl *Client) error {
+			_, err := cl.GetOrder(context.Background(), s.url("/orders/1"))
+			return err
+		}},
+		{"WaitOrder", func(cl *Client) error {
+			_, err := cl.WaitOrder(context.Background(), s.url("/orders/1"))
+			return err
+		}},
+		{"CreateOrderCert", func(cl *Client) error {
+			q := &x509.CertificateRequest{
+				Subject: pkix.Name{CommonName: "example.org"},
+			}
+			csr, err := x509.CreateCertificateRequest(rand.Reader, q, testKeyEC)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, _, err = cl.CreateOrderCert(context.Background(), s.url("/pleaseissue"), csr, true)
+			return err
+		}},
+		{"ListCertAlternates", func(cl *Client) error {
+			_, err := cl.ListCertAlternates(context.Background(), s.url("/crt"))
 			return err
 		}},
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

We are testing our [Infisical's ACME server](https://infisical.com/docs/documentation/platform/pki/enrollment-methods/acme#certificate-enrollment-via-acme) against all ACME clients. So far, most of the clients work fine. But somehow we kept running into issue with cert-manager. After looking into the issue, we realized that many people have experienced the same issue: #7388. There are also other similar issues reported:

https://github.com/cert-manager/cert-manager/issues/5987
https://github.com/cert-manager/cert-manager/issues/7830

We looked into the issue deeper and reported our findings here:

https://github.com/cert-manager/cert-manager/issues/7388#issuecomment-3535630925

While it's possible that this bug can be addressed by a workaround in the ACME server implementation, still, the cert-manager's ACME client doesn't comply fully with [RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555) and causing issues like those mentioned above. A few issues we saw from the current implementation:

1. KID value is not used while it's available, the cert-manager ACME client always try to retrieve the KID by making a `{"onlyReturnExisting": true}` request to the `new-account` endpoint.
2. The account KID retrieve request doesn't include the EAB information. Which I think is fine because we've already checked the EAB credentials while creating the account. And it's not particularly clear in RFC 8555, should EAB included in this case or not.
3. Error from retrieving account KID is discarded silently and the client will send JWK to endpoints suppose to expect KID

If we look at the RFC 8555, [here's](https://datatracker.ietf.org/doc/html/rfc8555#section-6.2) what it says:
 
>   For all other requests, the request is signed using an existing
>   account, and there MUST be a "kid" field.  This field MUST contain
>   the account URL received by POSTing to the newAccount resource.

The only special case I know so far is the revoke cert request endpoint should [allow JWK signed with the key from cert](https://datatracker.ietf.org/doc/html/rfc8555#section-7.6) as well as KID:

>   Revocation requests are different from other ACME requests in that
>   they can be signed with either an account key pair or the key pair in
>   the certificate.

And as for getting the account with key signature instead of KID, [here's what the RFC said](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.1):

>  If the server receives a newAccount request signed with a key for
>  which it already has an account registered with the provided account
>  key, then it MUST return a response with status code 200 (OK) and
>  provide the URL of that account in the Location header field.  The
>
>  body of this response represents the account object as it existed on
>  the server before this request; any fields in the request object MUST
>  be ignored.  This allows a client that has an account key but not the
>  corresponding account URL to recover the account URL.

It seems like this statement implies `EAB` should also be ignored. However, [the RFC also said this](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4):

> If the CA receives a newAccount request without an
> "externalAccountBinding" field, then it SHOULD reply with an error of
> type "externalAccountRequired".

While this seems a bit like conflicting itself, but I would like to see the `newAccount request` here means "new account" instead of finding existing one.

Considering all the above, we are proposing fixing the issue 1 and 3 only. For the 1, is very simple, we use add the KID after registered an account or retrieved it from the resource status. For the 3, we return correct error message when the KID is required but it's not available.

Now, 1 and 3 can actually be different PR. And for the 3, the fix is in the forked upstream golang acme library in the repository. I will also open a PR in the https://github.com/golang/crypto repository addressing the problem. Please let me know if it makes more sense to breaking down issue fixing 1 and 3 into different PRs 🙏 

### Kind

kind/bug

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fix #7388 issue by using KID value and avoid retrieving KID all the time, also provide better error message when KID is not available.
```
