### PR TITLE
Event handling: use typed handlers

### DIFF
--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -32,14 +32,8 @@ import (
 func handleGenericIssuerFunc(
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	orderLister cmacmelisters.OrderLister,
-) func(interface{}) {
-	return func(obj interface{}) {
-		iss, ok := obj.(cmapi.GenericIssuer)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("object does not implement GenericIssuer %#v", obj))
-			return
-		}
-
+) func(cmapi.GenericIssuer) {
+	return func(iss cmapi.GenericIssuer) {
 		certs, err := ordersForGenericIssuer(iss, orderLister)
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetNamespace(), iss.GetName()))

--- a/pkg/controller/certificate-shim/gateways/controller.go
+++ b/pkg/controller/certificate-shim/gateways/controller.go
@@ -23,7 +23,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	gwlisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
@@ -112,14 +111,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 //	    name: gateway-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
-	return func(obj interface{}) {
-		crt, ok := obj.(*cmapi.Certificate)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("not a Certificate object: %#v", obj))
-			return
-		}
-
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(*cmapi.Certificate) {
+	return func(crt *cmapi.Certificate) {
 		ref := metav1.GetControllerOf(crt)
 		if ref == nil {
 			// No controller should care about orphans being deleted or

--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -23,7 +23,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -122,14 +121,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 //	    name: ingress-1
 //	    blockOwnerDeletion: true
 //	    uid: 7d3897c2-ce27-4144-883a-e1b5f89bd65a
-func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(obj interface{}) {
-	return func(obj interface{}) {
-		cert, ok := obj.(*cmapi.Certificate)
-		if !ok {
-			runtime.HandleError(fmt.Errorf("not a Certificate object: %#v", obj))
-			return
-		}
-
+func certificateHandler(queue workqueue.TypedRateLimitingInterface[types.NamespacedName]) func(*cmapi.Certificate) {
+	return func(cert *cmapi.Certificate) {
 		ingress := metav1.GetControllerOf(cert)
 		if ingress == nil {
 			// No controller should care about orphans being deleted or

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -26,14 +26,8 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-func (c *Controller) handleGenericIssuer(obj interface{}) {
+func (c *Controller) handleGenericIssuer(iss cmapi.GenericIssuer) {
 	log := c.log.WithName("handleGenericIssuer")
-
-	iss, ok := obj.(cmapi.GenericIssuer)
-	if !ok {
-		log.Error(nil, "object does not implement GenericIssuer")
-		return
-	}
 
 	log = logf.WithResource(log, iss)
 	crs, err := c.certificatesRequestsForGenericIssuer(iss)

--- a/pkg/controller/certificaterequests/selfsigned/checks.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -43,8 +44,8 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 	lister clientv1.CertificateRequestLister,
 	helper issuer.Helper,
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
-) func(obj any) {
-	return func(obj any) {
+) func(metav1.Object) {
+	return func(obj metav1.Object) {
 		log := log.WithName("handleSecretReference")
 		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {

--- a/pkg/controller/certificaterequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/checks_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -35,7 +36,7 @@ import (
 
 func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 	tests := map[string]struct {
-		secret          runtime.Object
+		secret          metav1.Object
 		existingCRs     []runtime.Object
 		existingIssuers []runtime.Object
 		expectedQueue   []types.NamespacedName

--- a/pkg/controller/certificates/informers.go
+++ b/pkg/controller/certificates/informers.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
-	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
 )
 
@@ -37,14 +36,8 @@ import (
 // call when enqueuing Certificate resources.
 // If no predicate constructors are given, all Certificate resources will be
 // enqueued on every invocation.
-func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[types.NamespacedName], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(obj interface{}) {
-	return func(obj interface{}) {
-		s, ok := obj.(metav1.Object)
-		if !ok {
-			log.V(logf.ErrorLevel).Info("Non-Object type resource passed to EnqueueCertificatesForSecretUsingPredicates")
-			return
-		}
-
+func EnqueueCertificatesForResourceUsingPredicates(log logr.Logger, queue workqueue.TypedInterface[types.NamespacedName], lister cmlisters.CertificateLister, selector labels.Selector, predicateBuilders ...predicate.ExtractorFunc) func(metav1.Object) {
+	return func(s metav1.Object) {
 		// 'Construct' the predicate functions using the given Secret
 		predicates := make(predicate.Funcs, len(predicateBuilders))
 		for i, b := range predicateBuilders {

--- a/pkg/controller/certificatesigningrequests/checks.go
+++ b/pkg/controller/certificatesigningrequests/checks.go
@@ -29,16 +29,10 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
-func (c *Controller) handleGenericIssuer(obj interface{}) {
+func (c *Controller) handleGenericIssuer(iss cmapi.GenericIssuer) {
 	log := c.log.WithName("handleGenericIssuer")
-
-	iss, ok := obj.(cmapi.GenericIssuer)
-	if !ok {
-		log.Error(nil, "object does not implement GenericIssuer")
-		return
-	}
-
 	log = logf.WithResource(log, iss)
+
 	crs, err := c.certificateSigningRequestsForGenericIssuer(iss)
 	if err != nil {
 		log.Error(err, "error looking up certificate signing requests observing issuer or clusterissuer")

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks.go
@@ -23,6 +23,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	clientv1 "k8s.io/client-go/listers/certificates/v1"
@@ -46,8 +47,8 @@ func handleSecretReferenceWorkFunc(log logr.Logger,
 	helper issuer.Helper,
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	issuerOptions controllerpkg.IssuerOptions,
-) func(obj any) {
-	return func(obj any) {
+) func(metav1.Object) {
+	return func(obj metav1.Object) {
 		log := log.WithName("handleSecretReference")
 		secret, ok := controllerpkg.ToSecret(obj)
 		if !ok {

--- a/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/checks_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -36,7 +37,7 @@ import (
 
 func Test_handleSecretReferenceWorkFunc(t *testing.T) {
 	tests := map[string]struct {
-		secret          runtime.Object
+		secret          metav1.Object
 		existingCSRs    []runtime.Object
 		existingIssuers []runtime.Object
 		expectedQueue   []types.NamespacedName

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -112,7 +113,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 }
 
 // TODO: replace with generic handleObject function (like Navigator)
-func (c *controller) secretEvent(obj interface{}) {
+func (c *controller) secretEvent(obj metav1.Object) {
 	log := c.log.WithName("secretEvent")
 
 	secret, ok := controllerpkg.ToSecret(obj)

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -107,7 +108,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 }
 
 // TODO: replace with generic handleObject function (like Navigator)
-func (c *controller) secretEvent(obj interface{}) {
+func (c *controller) secretEvent(obj metav1.Object) {
 	log := c.log.WithName("secretEvent")
 	secret, ok := controllerpkg.ToSecret(obj)
 	if !ok {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -63,15 +62,9 @@ func HandleOwnedResourceNamespacedFunc[T metav1.Object](
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 	ownerGVK schema.GroupVersionKind,
 	get func(namespace, name string) (T, error),
-) func(obj interface{}) {
-	return func(obj interface{}) {
+) func(metav1.Object) {
+	return func(metaobj metav1.Object) {
 		log := log.WithName("handleOwnedResource")
-
-		metaobj, ok := obj.(metav1.Object)
-		if !ok {
-			log.Error(nil, "item passed to handleOwnedResource does not implement metav1.Object")
-			return
-		}
 		log = logf.WithResource(log, metaobj)
 
 		ownerRefs := metaobj.GetOwnerReferences()
@@ -118,21 +111,13 @@ func HandleOwnedResourceNamespacedFunc[T metav1.Object](
 func QueuingEventHandler(
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 ) cache.ResourceEventHandler {
-	return filteredEventHandler{
-		handler: blockingEventHandler{workFunc: func(obj interface{}) {
-			objectName, err := cache.ObjectToName(obj)
-			if err != nil {
-				runtime.HandleError(err)
-				return
-			}
-			queue.Add(types.NamespacedName{
-				Name:      objectName.Name,
-				Namespace: objectName.Namespace,
-			})
+	return filteredEventHandler[metav1.Object]{
+		handler: blockingEventHandler[metav1.Object]{workFunc: func(obj metav1.Object) {
+			queue.Add(cache.MetaObjectToName(obj).AsNamespacedName())
 		}},
 		predicates: []predicate.TypedPredicate[metav1.Object]{
 			// prevent unnecessary reconciliations in case the resource did not update
-			onlyUpdateWhenResourceChanged{},
+			onlyUpdateWhenResourceChanged[metav1.Object]{},
 		},
 	}
 }
@@ -141,44 +126,54 @@ func QueuingEventHandler(
 // simply synchronously calls its workFunc upon calls to OnAdd, OnUpdate or
 // OnDelete.
 // It skips update events in case the resource has not changed.
-type blockingEventHandler struct {
-	workFunc func(obj interface{})
+type blockingEventHandler[T any] struct {
+	workFunc func(obj T)
 }
 
-var _ cache.ResourceEventHandler = blockingEventHandler{}
+var _ cache.ResourceEventHandler = blockingEventHandler[metav1.Object]{}
 
 // BlockingEventHandler returns a cache.ResourceEventHandler that
 // simply synchronously calls the workFunc upon calls to OnAdd, OnUpdate or
 // OnDelete. It skips update events in case the resource has not changed.
-func BlockingEventHandler(
-	workFunc func(obj any),
+func BlockingEventHandler[T metav1.Object](
+	workFunc func(obj T),
 ) cache.ResourceEventHandler {
-	return filteredEventHandler{
-		handler: blockingEventHandler{workFunc: workFunc},
-		predicates: []predicate.TypedPredicate[metav1.Object]{
+	return filteredEventHandler[T]{
+		handler: blockingEventHandler[T]{workFunc: workFunc},
+		predicates: []predicate.TypedPredicate[T]{
 			// prevent unnecessary reconciliations in case the resource did not update
-			onlyUpdateWhenResourceChanged{},
+			onlyUpdateWhenResourceChanged[T]{},
 		},
 	}
 }
 
+func (b blockingEventHandler[T]) run(obj interface{}) {
+	tObj, ok := obj.(T)
+	if !ok {
+		logf.Log.Error(nil, "Object could not be casted to type", "object", obj, "type", fmt.Sprintf("%T", obj), "expected_type", fmt.Sprintf("%T", *new(T)))
+		return
+	}
+
+	b.workFunc(tObj)
+}
+
 // OnAdd synchronously adds a newly created object to the workqueue.
-func (b blockingEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
-	b.workFunc(obj)
+func (b blockingEventHandler[T]) OnAdd(obj interface{}, isInInitialList bool) {
+	b.run(obj)
 }
 
 // OnUpdate synchronously adds an updated object to the workqueue.
-func (b blockingEventHandler) OnUpdate(oldObj, newObj interface{}) {
-	b.workFunc(newObj)
+func (b blockingEventHandler[T]) OnUpdate(oldObj, newObj interface{}) {
+	b.run(newObj)
 }
 
 // OnDelete synchronously adds a deleted object to the workqueue.
-func (b blockingEventHandler) OnDelete(obj interface{}) {
+func (b blockingEventHandler[T]) OnDelete(obj interface{}) {
 	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if ok {
 		obj = tombstone.Obj
 	}
-	b.workFunc(obj)
+	b.run(obj)
 }
 
 // onlyUpdateWhenResourceChanged implements a predicate function only
@@ -192,17 +187,17 @@ func (b blockingEventHandler) OnDelete(obj interface{}) {
 //
 // This predicate is similar to the predicate in controller-runtime but with fallback
 // see https://github.com/kubernetes-sigs/controller-runtime/blob/4b46eb04d57ff3bec4c3c05206c46af9aa647a24/pkg/predicate/predicate.go#L154
-type onlyUpdateWhenResourceChanged struct {
-	predicate.TypedFuncs[metav1.Object]
+type onlyUpdateWhenResourceChanged[T metav1.Object] struct {
+	predicate.TypedFuncs[T]
 }
 
 // Update implements default UpdateEvent filter for validating resource version change.
-func (onlyUpdateWhenResourceChanged) Update(e event.TypedUpdateEvent[metav1.Object]) bool {
-	if e.ObjectOld == nil {
+func (onlyUpdateWhenResourceChanged[T]) Update(e event.TypedUpdateEvent[T]) bool {
+	if isNil(e.ObjectOld) {
 		logf.Log.Error(nil, "Update event has no old object to update", "event", e)
 		return false
 	}
-	if e.ObjectNew == nil {
+	if isNil(e.ObjectNew) {
 		logf.Log.Error(nil, "Update event has no new object to update", "event", e)
 		return false
 	}
@@ -217,40 +212,52 @@ func (onlyUpdateWhenResourceChanged) Update(e event.TypedUpdateEvent[metav1.Obje
 	return e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion()
 }
 
+func isNil(arg any) bool {
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+		v.Kind() == reflect.Interface ||
+		v.Kind() == reflect.Slice ||
+		v.Kind() == reflect.Map ||
+		v.Kind() == reflect.Chan ||
+		v.Kind() == reflect.Func) && v.IsNil()) {
+		return true
+	}
+	return false
+}
+
 // filteredEventHandler is an implementation of cache.ResourceEventHandler that
 // only passes the event to the handler when all predicates return true
-type filteredEventHandler struct {
+type filteredEventHandler[T metav1.Object] struct {
 	handler cache.ResourceEventHandler
 	// predicates is a list of predicates that must all pass
 	// for the object to be enqueued.
-	predicates []predicate.TypedPredicate[metav1.Object]
+	predicates []predicate.TypedPredicate[T]
 }
 
-var _ cache.ResourceEventHandler = filteredEventHandler{}
+var _ cache.ResourceEventHandler = filteredEventHandler[metav1.Object]{}
 
 // FilterEventHandler returns a cache.ResourceEventHandler that
 // skips events based on the passed predicates and passes all other
 // events to the provided handler.
-func FilterEventHandler(
+func FilterEventHandler[T metav1.Object](
 	handler cache.ResourceEventHandler,
-	predicates ...predicate.TypedPredicate[metav1.Object],
+	predicates ...predicate.TypedPredicate[T],
 ) cache.ResourceEventHandler {
-	return filteredEventHandler{
+	return filteredEventHandler[T]{
 		handler:    handler,
 		predicates: predicates,
 	}
 }
 
 // OnAdd adds a newly created object to the workqueue.
-func (q filteredEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
+func (q filteredEventHandler[T]) OnAdd(obj interface{}, isInInitialList bool) {
 	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnAdd")
 
-	c := event.TypedCreateEvent[metav1.Object]{
+	c := event.TypedCreateEvent[T]{
 		IsInInitialList: isInInitialList,
 	}
 
 	// Pull Object out of the object
-	if o, ok := obj.(metav1.Object); ok {
+	if o, ok := obj.(T); ok {
 		c.Object = o
 	} else {
 		log.Error(nil, "OnAdd missing Object", "object", obj, "type", fmt.Sprintf("%T", obj))
@@ -267,12 +274,12 @@ func (q filteredEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 // OnUpdate adds an updated object to the workqueue.
-func (q filteredEventHandler) OnUpdate(oldObj, newObj interface{}) {
+func (q filteredEventHandler[T]) OnUpdate(oldObj, newObj interface{}) {
 	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnUpdate")
 
-	u := event.TypedUpdateEvent[metav1.Object]{}
+	u := event.TypedUpdateEvent[T]{}
 
-	if o, ok := oldObj.(metav1.Object); ok {
+	if o, ok := oldObj.(T); ok {
 		u.ObjectOld = o
 	} else {
 		log.Error(nil, "OnUpdate missing ObjectOld", "object", oldObj, "type", fmt.Sprintf("%T", oldObj))
@@ -280,7 +287,7 @@ func (q filteredEventHandler) OnUpdate(oldObj, newObj interface{}) {
 	}
 
 	// Pull Object out of the object
-	if o, ok := newObj.(metav1.Object); ok {
+	if o, ok := newObj.(T); ok {
 		u.ObjectNew = o
 	} else {
 		log.Error(nil, "OnUpdate missing ObjectNew", "object", newObj, "type", fmt.Sprintf("%T", newObj))
@@ -297,10 +304,10 @@ func (q filteredEventHandler) OnUpdate(oldObj, newObj interface{}) {
 }
 
 // OnDelete adds a deleted object to the workqueue for processing.
-func (q filteredEventHandler) OnDelete(obj interface{}) {
+func (q filteredEventHandler[T]) OnDelete(obj interface{}) {
 	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnDelete")
 
-	d := event.TypedDeleteEvent[metav1.Object]{}
+	d := event.TypedDeleteEvent[T]{}
 
 	unwrappedObj := obj
 
@@ -314,7 +321,7 @@ func (q filteredEventHandler) OnDelete(obj interface{}) {
 	}
 
 	// Pull Object out of the object
-	if o, ok := unwrappedObj.(metav1.Object); ok {
+	if o, ok := unwrappedObj.(T); ok {
 		d.Object = o
 	} else {
 		log.Error(nil, "OnDelete missing Object", "object", unwrappedObj, "type", fmt.Sprintf("%T", unwrappedObj))
@@ -359,7 +366,7 @@ func BuildAnnotationsToCopy(allAnnotations map[string]string, prefixes []string)
 	return filteredAnnotations
 }
 
-func ToSecret(obj interface{}) (*corev1.Secret, bool) {
+func ToSecret(obj metav1.Object) (*corev1.Secret, bool) {
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		meta, ok := obj.(*metav1.PartialObjectMetadata)

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -212,6 +212,7 @@ func (onlyUpdateWhenResourceChanged[T]) Update(e event.TypedUpdateEvent[T]) bool
 	return e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion()
 }
 
+// copied from https://github.com/kubernetes-sigs/controller-runtime/blob/5de4c4f5997c4b9469c7cfe003eff06bfdbd7f87/pkg/handler/enqueue.go#L110-L120
 func isNil(arg any) bool {
 	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
 		v.Kind() == reflect.Interface ||

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -106,7 +106,7 @@ func TestOnlyUpdateWhenResourceChanged(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			predicate := onlyUpdateWhenResourceChanged{}
+			predicate := onlyUpdateWhenResourceChanged[metav1.Object]{}
 			e := event.TypedUpdateEvent[metav1.Object]{
 				ObjectOld: tt.oldObj,
 				ObjectNew: tt.newObj,
@@ -182,7 +182,7 @@ func TestBlockingEventHandler(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			callCount := 0
-			handler := BlockingEventHandler(func(obj interface{}) {
+			handler := BlockingEventHandler(func(obj metav1.Object) {
 				require.Equal(t, obj, obj1)
 				callCount++
 			})
@@ -363,7 +363,7 @@ func TestFilterEventHandler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			callCount := 0
 			handler := FilterEventHandler(
-				BlockingEventHandler(func(obj interface{}) { callCount++ }),
+				BlockingEventHandler(func(obj metav1.Object) { callCount++ }),
 				test.predicate,
 			)
 


### PR DESCRIPTION
Introduce generics to make event handling typed.
Reduces the amount of type castings in our code base.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```

CyberArk tracker: [VC-47742](https://venafi.atlassian.net/browse/VC-47742) <!-- do not edit this line, will be re-added automatically -->