### PR TITLE
feat(helm) add startupProbe and readinessProbe to cert-manager-controller

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       {{- if (hasKey .Values.global "hostUsers") }}
-      hostUsers: {{ .Values.global.hostUsers }}       
+      hostUsers: {{ .Values.global.hostUsers }}
       {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
@@ -76,8 +76,8 @@ spec:
       {{- if or .Values.volumes .Values.config}}
       volumes:
         {{- if .Values.config }}
-        - name: config 
-          configMap: 
+        - name: config
+          configMap:
             name: {{ include "cert-manager.fullname" . }}
         {{- end }}
         {{ with .Values.volumes }}
@@ -163,7 +163,7 @@ spec:
           {{- if or .Values.config .Values.volumeMounts }}
           volumeMounts:
             {{- if .Values.config }}
-            - name: config 
+            - name: config
               mountPath: /var/cert-manager/config
             {{- end }}
             {{- with .Values.volumeMounts }}
@@ -211,6 +211,13 @@ spec:
             successThreshold: {{ .successThreshold }}
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
+          startupProbe:
+            httpGet:
+              port: http-healthz
+              path: /livez
+              scheme: HTTP
+            failureThreshold: {{ .failureThreshold }}
+            periodSeconds: {{ .periodSeconds }}
           {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.nodeSelector | default dict) }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -93,6 +93,9 @@
         "livenessProbe": {
           "$ref": "#/$defs/helm-values.livenessProbe"
         },
+        "readinessProbe": {
+          "$ref": "#/$defs/helm-values.readinessProbe"
+        },
         "maxConcurrentChallenges": {
           "$ref": "#/$defs/helm-values.maxConcurrentChallenges"
         },
@@ -928,6 +931,14 @@
         "timeoutSeconds": 15
       },
       "description": "LivenessProbe settings for the controller container of the controller Pod.\n\nThis is enabled by default, in order to enable the clock-skew liveness probe that restarts the controller in case of a skew between the system clock and the monotonic clock. LivenessProbe durations and thresholds are based on those used for the Kubernetes controller-manager. For more information see the following on the\n[Kubernetes GitHub repository](https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245)",
+      "type": "object"
+    },
+    "helm-values.readinessProbe": {
+      "default": {
+        "initialDelaySeconds": 10,
+        "periodSeconds": 90
+      },
+      "description": "readinessProbe settings for the controller container of the controller Pod.",
       "type": "object"
     },
     "helm-values.maxConcurrentChallenges": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -21,7 +21,7 @@ global:
   # If a component-specific nodeSelector is also set, it will be merged and take precedence.
   # +docs:property
   nodeSelector: {}
-  
+
   # Labels to apply to all resources.
   # Please note that this does not add labels to the resources created dynamically by the controllers.
   # For these resources, you have to add the labels in the template in the cert-manager custom resource:
@@ -507,6 +507,11 @@ livenessProbe:
   timeoutSeconds: 15
   successThreshold: 1
   failureThreshold: 8
+
+# readinessProbe settings for the controller container of the controller Pod.
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 90
 
 # enableServiceLinks indicates whether information about services should be
 # injected into the pod's environment variables, matching the syntax of Docker


### PR DESCRIPTION
### Pull Request Motivation

The cert-manager-controller has an optional livenessProbe enabled by default. However, the startupProbe and readinessProbe keys were not defined. This PR adds those probes for completeness.

My text editor also trimmed trailing white space off the edited files.

### Kind

/kind feature

### Release Note

```release-note
NONE
```
