### PR TITLE
acmechallenges: stabilize solver resource names

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -51,6 +52,8 @@ const (
 	// before giving up
 	authorizationTimeout = 2 * time.Minute
 )
+
+var solverResourceNamePattern = regexp.MustCompile(`cm-acme-http-solver-[a-z0-9]+`)
 
 // solver solves ACME challenges by presenting the given token and key in an
 // appropriate way given the config in the Issuer and Certificate.
@@ -264,6 +267,7 @@ func stabilizeSolverErrorMessage(err error) string {
 			)
 		}
 	}
+	fullMessage = solverResourceNamePattern.ReplaceAllString(fullMessage, "cm-acme-http-solver-<redacted>")
 	return fullMessage
 }
 

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -676,6 +676,11 @@ func Test_StabilizeSolverErrorMessage(t *testing.T) {
 
 			expectedMessage: "wrapper message: <redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
 		},
+		{
+			name:            "http01 solver resource name",
+			err:             errors.New("pods \"cm-acme-http-solver-22csz\" is forbidden: exceeded quota: default-resource-quota, requested: limits.ephemeral-storage=256Mi, used: limits.ephemeral-storage=100Mi, limited: limits.ephemeral-storage=200Mi"),
+			expectedMessage: "pods \"cm-acme-http-solver-<redacted>\" is forbidden: exceeded quota: default-resource-quota, requested: limits.ephemeral-storage=256Mi, used: limits.ephemeral-storage=100Mi, limited: limits.ephemeral-storage=200Mi",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Pull Request Motivation

- Fixes #5101.
- Stabilizes HTTP01 solver resource names in error messages so challenge retries rely on the controller rate limiter instead of immediate re-queues.

### Kind

/kind bug

### Release Note

```release-note
ACME HTTP-01 challenge retries now back off properly when solver resources fail to create.
```

### Testing

- `make unit-test` (timed out after 120s while running `gotestsum ./pkg/... ./internal/...`)
- `go test ./pkg/controller/acmechallenges/...`
