### PR TITLE
Clarify code around DNS01 Self Check

### DIFF
--- a/pkg/issuer/acme/dns/util/cache.go
+++ b/pkg/issuer/acme/dns/util/cache.go
@@ -198,18 +198,18 @@ func (c *CachingResolver) LookupAuthoritativeNameservers(ctx context.Context, fq
 
 		// Cache hit, return from cache
 		if entry, exists := c.getCache(key, now); exists {
-			var authoritativeNss []string
+			var authoritativeNSs []string
 
 			logf.FromContext(ctx).V(logf.DebugLevel).Info("Returning cached DNS response", "type", "ns", "fqdn", fqdn, "nameserver", nameserver)
 			for _, rr := range entry.Response.Answer {
 				if ns, ok := rr.(*dns.NS); ok {
-					authoritativeNss = append(authoritativeNss, strings.ToLower(ns.Ns))
+					authoritativeNSs = append(authoritativeNSs, strings.ToLower(ns.Ns))
 				}
 			}
 
-			if len(authoritativeNss) != 0 {
-				logf.FromContext(ctx).V(logf.DebugLevel).Info("Returning authoritative nameservers", "authoritativeNameservers", authoritativeNss)
-				return authoritativeNss, nil
+			if len(authoritativeNSs) != 0 {
+				logf.FromContext(ctx).V(logf.DebugLevel).Info("Returning authoritative nameservers", "authoritativeNameservers", authoritativeNSs)
+				return authoritativeNSs, nil
 			}
 
 			logf.FromContext(ctx).V(logf.WarnLevel).Info("Cached response has no NS records, retrying DNS query", "fqdn", fqdn, "nameserver", nameserver)
@@ -218,7 +218,7 @@ func (c *CachingResolver) LookupAuthoritativeNameservers(ctx context.Context, fq
 
 	// Cache miss, query DNS
 	return tryAllNameservers(nameservers, func(nameserver string) ([]string, error) {
-		var authoritativeNss []string
+		var authoritativeNSs []string
 
 		// The cache key for this nameserver/fqdn combo
 		key := cacheKey{
@@ -245,7 +245,7 @@ func (c *CachingResolver) LookupAuthoritativeNameservers(ctx context.Context, fq
 		ttl := time.Duration(0)
 		for _, rr := range r.Answer {
 			if ns, ok := rr.(*dns.NS); ok {
-				authoritativeNss = append(authoritativeNss, strings.ToLower(ns.Ns))
+				authoritativeNSs = append(authoritativeNSs, strings.ToLower(ns.Ns))
 				if newTTL := time.Second * time.Duration(ns.Hdr.Ttl); newTTL < ttl || ttl == 0 {
 					ttl = newTTL
 				}
@@ -253,7 +253,7 @@ func (c *CachingResolver) LookupAuthoritativeNameservers(ctx context.Context, fq
 		}
 
 		// If we did not find any NS records, continue
-		if len(authoritativeNss) == 0 {
+		if len(authoritativeNSs) == 0 {
 			return nil, fmt.Errorf("Could not determine authoritative nameservers for %q", fqdn)
 		}
 
@@ -263,48 +263,48 @@ func (c *CachingResolver) LookupAuthoritativeNameservers(ctx context.Context, fq
 			Expiry:   now.Add(ttl),
 		})
 
-		logf.FromContext(ctx).V(logf.DebugLevel).Info("Returning authoritative nameservers", "authoritativeNameservers", authoritativeNss)
-		return authoritativeNss, nil
+		logf.FromContext(ctx).V(logf.DebugLevel).Info("Returning authoritative nameservers", "authoritativeNameservers", authoritativeNSs)
+		return authoritativeNSs, nil
 	})
 }
 
 // CheckTXTRecordPropagation follows any CNAME chain for fqdn, then verifies
-// that value is present in the TXT records returned by the given nameservers.
+// that value is present in the TXT records returned by the configured nameservers.
 // When useAuthoritative is true, the authoritative nameservers for the zone are
 // resolved via LookupAuthoritativeNameservers and queried instead.
 func (c *CachingResolver) CheckTXTRecordPropagation(
 	ctx context.Context,
 	fqdn, value string,
-	nameservers []string,
+	configuredNSs []string,
 	useAuthoritative UseAuthoritative,
 ) (bool, error) {
 
 	// Follow CNAME records to find the real FQDN
 	var err error
-	fqdn, err = followCNAMEs(ctx, fqdn, nameservers)
+	fqdn, err = followCNAMEs(ctx, fqdn, configuredNSs)
 	if err != nil {
 		return false, err
 	}
 
 	// If we are not using the authoritative servers just directly check the
-	// provided nameservers
+	// configured nameservers
 	if !useAuthoritative {
-		return checkAuthoritativeNss(ctx, fqdn, value, nameservers)
+		return checkTXTRecord(ctx, fqdn, value, configuredNSs)
 	}
 
 	// Find the authoritative nameservers
-	authoritativeNss, err := c.LookupAuthoritativeNameservers(ctx, fqdn, nameservers)
+	authoritativeNSs, err := c.LookupAuthoritativeNameservers(ctx, fqdn, configuredNSs)
 	if err != nil {
 		return false, err
 	}
 
 	// Convert the return nameservers to the correct format <ip>:<port>
-	for i, ans := range authoritativeNss {
-		authoritativeNss[i] = net.JoinHostPort(ans, "53")
+	for i, ans := range authoritativeNSs {
+		authoritativeNSs[i] = net.JoinHostPort(ans, "53")
 	}
 
 	// Check for the TXT record using the authoritative nameservers
-	return checkAuthoritativeNss(ctx, fqdn, value, authoritativeNss)
+	return checkTXTRecord(ctx, fqdn, value, authoritativeNSs)
 }
 
 func (c *CachingResolver) putCache(key cacheKey, value cacheEntry) {

--- a/pkg/issuer/acme/dns/util/cache_test.go
+++ b/pkg/issuer/acme/dns/util/cache_test.go
@@ -581,7 +581,7 @@ func TestCachingResolver_CheckTXTRecordPropagation(t *testing.T) {
 						&dns.NS{Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300}, Ns: "ns1.example.com."},
 					},
 				}},
-				// checkAuthoritativeNss querying the resolved authoritative server
+				// checkTXTRecord querying the resolved authoritative server
 				{"TXT example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{

--- a/pkg/issuer/acme/dns/util/livedns_test.go
+++ b/pkg/issuer/acme/dns/util/livedns_test.go
@@ -89,8 +89,8 @@ func TestPreCheckDNSNonAuthoritative(t *testing.T) {
 	}
 }
 
-func TestCheckAuthoritativeNss(t *testing.T) {
-	checkAuthoritativeNssTests := []struct {
+func TestCheckTXTRecord(t *testing.T) {
+	checkTXTRecordTests := []struct {
 		fqdn, value string
 		ns          []string
 		ok          bool
@@ -109,12 +109,12 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 		},
 	}
 
-	for i, tt := range checkAuthoritativeNssTests {
+	for i, tt := range checkTXTRecordTests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), standardTimeout)
 			defer cancel()
 
-			ok, _ := checkAuthoritativeNss(ctx, tt.fqdn, tt.value, tt.ns)
+			ok, _ := checkTXTRecord(ctx, tt.fqdn, tt.value, tt.ns)
 			if ok != tt.ok {
 				t.Errorf("%s: got %t; want %t", tt.fqdn, ok, tt.ok)
 			}

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -124,16 +124,16 @@ func followCNAMEs(ctx context.Context, fqdn string, nameservers []string, fqdnCh
 	return fqdn, nil
 }
 
-// checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
-func checkDNSPropagation(ctx context.Context, fqdn, value string, nameservers []string,
+// checkDNSPropagation is a wrapper around [CachingResolver.CheckTXTRecordPropagation].
+func checkDNSPropagation(ctx context.Context, fqdn, value string, configuredNSs []string,
 	useAuthoritative bool) (bool, error) {
 
 	return LegacyCachedResolver().
-		CheckTXTRecordPropagation(ctx, fqdn, value, nameservers, UseAuthoritative(useAuthoritative))
+		CheckTXTRecordPropagation(ctx, fqdn, value, configuredNSs, UseAuthoritative(useAuthoritative))
 }
 
-// checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
-func checkAuthoritativeNss(ctx context.Context, fqdn, value string, nameservers []string) (bool, error) {
+// checkTXTRecord queries each of the given nameservers for the expected TXT record.
+func checkTXTRecord(ctx context.Context, fqdn, value string, nameservers []string) (bool, error) {
 	for _, ns := range nameservers {
 		r, err := dnsQuery(ctx, fqdn, dns.TypeTXT, []string{ns}, true)
 		if err != nil {

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -139,7 +139,7 @@ func TestFindZoneByFqdn(t *testing.T) {
 	}
 }
 
-func TestCheckAuthoritativeNss(t *testing.T) {
+func TestCheckTXTRecord(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		withMockDNSQuery(t, []interaction{
 			{"TXT 8.8.8.8.asn.routeviews.org.", &dns.Msg{
@@ -149,7 +149,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 				},
 			}},
 		})
-		ok, err := checkAuthoritativeNss(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
+		ok, err := checkTXTRecord(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -160,7 +160,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 				MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
 			}},
 		})
-		ok, err := checkAuthoritativeNss(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
+		ok, err := checkTXTRecord(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -168,7 +168,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 	t.Run("errors out when DnsQuery fails", func(t *testing.T) {
 		withMockDNSQueryErr(t, fmt.Errorf("some error coming from DnsQuery"))
 
-		_, err := checkAuthoritativeNss(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
+		_, err := checkTXTRecord(t.Context(), "8.8.8.8.asn.routeviews.org.", "fe01=", []string{"1.1.1.1:53"})
 		assert.EqualError(t, err, "some error coming from DnsQuery")
 	})
 }


### PR DESCRIPTION
### Pull Request Motivation

Some identifiers around DNS01 Self Check don't have the right names. For example, `checkAuthoritativeNss` not always checks authoritative nameservers. 

### Kind

/kind cleanup 

### Release Note

```release-note
NONE
```

### Note

Changes are untested.