### PR TITLE
Use generics to make predicates typed

### DIFF
--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -212,7 +212,6 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -260,9 +259,9 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 		// certificate request revision when the certificate's revision is nil,
 		// hence the above if revision != nil.
 
-		reqs, err := certificates.ListCertificateRequestsMatchingPredicates(g.CertificateRequestLister.CertificateRequests(crt.Namespace),
-			labels.Everything(),
-			predicate.ResourceOwnedBy(crt),
+		reqs, err := certificates.ListCertificateRequestsMatchingPredicates(
+			g.CertificateRequestLister.CertificateRequests(crt.Namespace),
+			predicate.ResourceOwnedBy[*cmapi.CertificateRequest](crt),
 			predicate.CertificateRequestRevision(*crt.Status.Revision),
 		)
 		if err != nil {
@@ -287,9 +286,9 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 		// nil.
 		nextCRRevision = *crt.Status.Revision + 1
 	}
-	reqs, err := certificates.ListCertificateRequestsMatchingPredicates(g.CertificateRequestLister.CertificateRequests(crt.Namespace),
-		labels.Everything(),
-		predicate.ResourceOwnedBy(crt),
+	reqs, err := certificates.ListCertificateRequestsMatchingPredicates(
+		g.CertificateRequestLister.CertificateRequests(crt.Namespace),
+		predicate.ResourceOwnedBy[*cmapi.CertificateRequest](crt),
 		predicate.CertificateRequestRevision(nextCRRevision),
 	)
 	if err != nil {

--- a/pkg/controller/certificates/listers.go
+++ b/pkg/controller/certificates/listers.go
@@ -29,12 +29,12 @@ import (
 // ListCertificateRequestsMatchingPredicates will list CertificateRequest
 // resources using the provided lister, optionally applying the given predicate
 // functions to filter the CertificateRequest resources returned.
-func ListCertificateRequestsMatchingPredicates(lister cmlisters.CertificateRequestNamespaceLister, selector labels.Selector, predicates ...predicate.Func) ([]*cmapi.CertificateRequest, error) {
-	reqs, err := lister.List(selector)
+func ListCertificateRequestsMatchingPredicates(lister cmlisters.CertificateRequestNamespaceLister, predicates ...predicate.Func[*cmapi.CertificateRequest]) ([]*cmapi.CertificateRequest, error) {
+	reqs, err := lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
-	funcs := predicate.Funcs(predicates)
+	funcs := predicate.Funcs[*cmapi.CertificateRequest](predicates)
 	out := make([]*cmapi.CertificateRequest, 0)
 	for _, req := range reqs {
 		if funcs.Evaluate(req) {
@@ -48,12 +48,12 @@ func ListCertificateRequestsMatchingPredicates(lister cmlisters.CertificateReque
 // ListCertificatesMatchingPredicates will list Certificate resources using
 // the provided lister, optionally applying the given predicate functions to
 // filter the Certificate resources returned.
-func ListCertificatesMatchingPredicates(lister cmlisters.CertificateNamespaceLister, selector labels.Selector, predicates ...predicate.Func) ([]*cmapi.Certificate, error) {
+func ListCertificatesMatchingPredicates(lister cmlisters.CertificateNamespaceLister, selector labels.Selector, predicates ...predicate.Func[*cmapi.Certificate]) ([]*cmapi.Certificate, error) {
 	reqs, err := lister.List(selector)
 	if err != nil {
 		return nil, err
 	}
-	funcs := predicate.Funcs(predicates)
+	funcs := predicate.Funcs[*cmapi.Certificate](predicates)
 	out := make([]*cmapi.Certificate, 0)
 	for _, req := range reqs {
 		if funcs.Evaluate(req) {
@@ -67,12 +67,12 @@ func ListCertificatesMatchingPredicates(lister cmlisters.CertificateNamespaceLis
 // ListSecretsMatchingPredicates will list Secret resources using
 // the provided lister, optionally applying the given predicate functions to
 // filter the Secret resources returned.
-func ListSecretsMatchingPredicates(lister corelisters.SecretNamespaceLister, selector labels.Selector, predicates ...predicate.Func) ([]*corev1.Secret, error) {
+func ListSecretsMatchingPredicates(lister corelisters.SecretNamespaceLister, selector labels.Selector, predicates ...predicate.Func[*corev1.Secret]) ([]*corev1.Secret, error) {
 	reqs, err := lister.List(selector)
 	if err != nil {
 		return nil, err
 	}
-	funcs := predicate.Funcs(predicates)
+	funcs := predicate.Funcs[*corev1.Secret](predicates)
 	out := make([]*corev1.Secret, 0)
 	for _, req := range reqs {
 		if funcs.Evaluate(req) {

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -107,17 +106,26 @@ func NewController(
 	}
 
 	// When a CertificateRequest resource changes, enqueue the Certificate resource that owns it.
-	if _, err := certificateRequestInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(
-		certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(), predicate.ResourceOwnerOf),
-	)); err != nil {
+	if _, err := certificateRequestInformer.Informer().AddEventHandler(
+		controllerpkg.BlockingEventHandler(
+			certificates.EnqueueCertificatesForResourceUsingPredicates[*cmapi.CertificateRequest](
+				log, queue, certificateInformer.Lister(),
+				predicate.ResourceOwnerOf,
+			),
+		),
+	); err != nil {
 		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
 	// When a Secret resource changes, enqueue any Certificate resources that name it as spec.secretName.
-	if _, err := secretsInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(
-		// Trigger reconciles on changes to the Secret named `spec.secretName`
-		certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
-			predicate.ExtractResourceName(predicate.CertificateSecretName)),
-	)); err != nil {
+	if _, err := secretsInformer.Informer().AddEventHandler(
+		controllerpkg.BlockingEventHandler(
+			// Trigger reconciles on changes to the Secret named `spec.secretName`
+			certificates.EnqueueCertificatesForResourceUsingPredicates(
+				log, queue, certificateInformer.Lister(),
+				predicate.ExtractResourceName[*corev1.Secret](predicate.CertificateSecretName),
+			),
+		),
+	); err != nil {
 		return nil, nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
 

--- a/pkg/util/predicate/certificate.go
+++ b/pkg/util/predicate/certificate.go
@@ -17,16 +17,13 @@ limitations under the License.
 package predicate
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 // CertificateSecretName returns a predicate that used to filter Certificates
 // to only those with the given 'spec.secretName'.
-func CertificateSecretName(name string) Func {
-	return func(obj runtime.Object) bool {
-		crt := obj.(*cmapi.Certificate)
+func CertificateSecretName(name string) Func[*cmapi.Certificate] {
+	return func(crt *cmapi.Certificate) bool {
 		return crt.Spec.SecretName == name
 	}
 }
@@ -35,9 +32,8 @@ func CertificateSecretName(name string) Func {
 // to only those with the given 'status.nextPrivateKeySecretName'.
 // It is not possible to select Certificates with a 'nil' secret name using
 // this predicate function.
-func CertificateNextPrivateKeySecretName(name string) Func {
-	return func(obj runtime.Object) bool {
-		crt := obj.(*cmapi.Certificate)
+func CertificateNextPrivateKeySecretName(name string) Func[*cmapi.Certificate] {
+	return func(crt *cmapi.Certificate) bool {
 		if crt.Status.NextPrivateKeySecretName == nil {
 			return false
 		}

--- a/pkg/util/predicate/certificaterequest.go
+++ b/pkg/util/predicate/certificaterequest.go
@@ -19,16 +19,13 @@ package predicate
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 // CertificateRequestRevision returns a predicate that used to filter
 // CertificateRequest to only those with a given 'revision' number.
-func CertificateRequestRevision(revision int) Func {
-	return func(obj runtime.Object) bool {
-		req := obj.(*cmapi.CertificateRequest)
+func CertificateRequestRevision(revision int) Func[*cmapi.CertificateRequest] {
+	return func(req *cmapi.CertificateRequest) bool {
 		if req.Annotations == nil {
 			return false
 		}

--- a/pkg/util/predicate/generic.go
+++ b/pkg/util/predicate/generic.go
@@ -18,21 +18,20 @@ package predicate
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ResourceOwnedBy will filter returned results to only those with the
 // given resource as an owner.
-func ResourceOwnedBy(owner runtime.Object) Func {
-	return func(obj runtime.Object) bool {
-		return metav1.IsControlledBy(obj.(metav1.Object), owner.(metav1.Object))
+func ResourceOwnedBy[T, U metav1.Object](ownerObj U) Func[T] {
+	return func(obj T) bool {
+		return metav1.IsControlledBy(obj, ownerObj)
 	}
 }
 
 // ResourceOwnerOf will filter returned results to only those that own the given
 // resource.
-func ResourceOwnerOf(obj runtime.Object) Func {
-	return func(ownerObj runtime.Object) bool {
-		return metav1.IsControlledBy(obj.(metav1.Object), ownerObj.(metav1.Object))
+func ResourceOwnerOf[T, U metav1.Object](owned U) Func[T] {
+	return func(ownerObj T) bool {
+		return metav1.IsControlledBy(owned, ownerObj)
 	}
 }

--- a/pkg/util/predicate/generic_test.go
+++ b/pkg/util/predicate/generic_test.go
@@ -57,7 +57,7 @@ func TestResourceOwnedBy(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ResourceOwnedBy(test.owner)(test.obj)
+			got := ResourceOwnedBy[*cmapi.CertificateRequest](test.owner.(metav1.Object))(test.obj.(*cmapi.CertificateRequest))
 			if got != test.expected {
 				t.Errorf("unexpected response: got=%t, exp=%t", got, test.expected)
 			}
@@ -95,7 +95,7 @@ func TestResourceOwnerOf(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ResourceOwnerOf(test.ownee)(test.obj)
+			got := ResourceOwnerOf[*cmapi.CertificateRequest](test.ownee.(metav1.Object))(test.obj.(*cmapi.CertificateRequest))
 			if got != test.expected {
 				t.Errorf("unexpected response: got=%t, exp=%t", got, test.expected)
 			}

--- a/pkg/util/predicate/predicate_test.go
+++ b/pkg/util/predicate/predicate_test.go
@@ -20,36 +20,35 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
 func TestFuncs_Evaluate(t *testing.T) {
-	falseFunc := func(_ runtime.Object) bool {
+	falseFunc := func(_ *cmapi.Certificate) bool {
 		return false
 	}
-	trueFunc := func(_ runtime.Object) bool {
+	trueFunc := func(_ *cmapi.Certificate) bool {
 		return true
 	}
 	tests := map[string]struct {
-		funcs    Funcs
+		funcs    Funcs[*cmapi.Certificate]
 		expected bool
 	}{
 		"returns false if one returns false": {
-			funcs:    Funcs{falseFunc},
+			funcs:    Funcs[*cmapi.Certificate]{falseFunc},
 			expected: false,
 		},
 		"returns false if at least one returns false": {
-			funcs:    Funcs{falseFunc, trueFunc},
+			funcs:    Funcs[*cmapi.Certificate]{falseFunc, trueFunc},
 			expected: false,
 		},
 		"returns false if at least one returns false (reversed)": {
-			funcs:    Funcs{trueFunc, falseFunc},
+			funcs:    Funcs[*cmapi.Certificate]{trueFunc, falseFunc},
 			expected: false,
 		},
 		"returns true if all return true": {
-			funcs:    Funcs{trueFunc, trueFunc},
+			funcs:    Funcs[*cmapi.Certificate]{trueFunc, trueFunc},
 			expected: true,
 		},
 	}
@@ -67,7 +66,7 @@ func TestExtractResourceName(t *testing.T) {
 	expectedValue := "expected-value"
 	called := false
 
-	fn := ExtractResourceName(func(s string) Func {
+	fn := ExtractResourceName[metav1.Object](func(s string) Func[*cmapi.Certificate] {
 		called = true
 		if s != expectedValue {
 			t.Errorf("function called with unexpected value: got=%s, exp=%s", s, expectedValue)

--- a/test/e2e/suite/certificates/duplicatesecretname.go
+++ b/test/e2e/suite/certificates/duplicatesecretname.go
@@ -129,7 +129,7 @@ var _ = framework.CertManagerDescribe("Certificate Duplicate Secret Name", func(
 				Expect(err).NotTo(HaveOccurred())
 				var ownedReqs int
 				for _, req := range reqs.Items {
-					if predicate.ResourceOwnedBy(crt)(&req) {
+					if predicate.ResourceOwnedBy[*cmapi.CertificateRequest](crt)(&req) {
 						ownedReqs++
 					}
 				}

--- a/test/e2e/suite/certificates/foregrounddeletion.go
+++ b/test/e2e/suite/certificates/foregrounddeletion.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
@@ -142,7 +141,7 @@ var _ = framework.CertManagerDescribe("Certificate Foreground Deletion", func() 
 			WithContext(testingCtx).
 			WithArguments(
 				f.CRClient,
-				predicate.ResourceOwnedBy(crt),
+				predicate.ResourceOwnedBy[*cmapi.CertificateRequest](crt),
 			).
 			WithTimeout(time.Second * 10).
 			MustPassRepeatedly(10).
@@ -155,8 +154,7 @@ var _ = framework.CertManagerDescribe("Certificate Foreground Deletion", func() 
 			WithContext(testingCtx).
 			WithArguments(
 				f.CRClient,
-				func(obj runtime.Object) bool {
-					secret := obj.(*corev1.Secret)
+				func(secret *corev1.Secret) bool {
 					return secret.Annotations != nil &&
 						secret.Annotations["cert-manager.io/certificate-name"] == crt.Name &&
 						secret.Namespace == crt.Namespace

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -408,16 +408,17 @@ type ObjectListPtrConstraint[T any] interface {
 }
 
 // ListMatchingPredicates will list the objects that match a set of predicates
-func ListMatchingPredicates[O any, OL any, P ObjectPtrConstraint[O], PL ObjectListPtrConstraint[OL]](g Gomega, ctx context.Context, cli client.Client, predicates ...predicate.Func) []O {
+func ListMatchingPredicates[O any, OL any, P ObjectPtrConstraint[O], PL ObjectListPtrConstraint[OL]](g Gomega, ctx context.Context, cli client.Client, predicates ...predicate.Func[P]) []O {
 	list := PL(new(OL))
 	g.Expect(cli.List(ctx, list)).ToNot(HaveOccurred(), "failed to list objects")
 
 	// Evaluate predicates
-	funcs := predicate.Funcs(predicates)
+	funcs := predicate.Funcs[P](predicates)
 	out := make([]O, 0)
 	err := meta.EachListItem(list, func(o runtime.Object) error {
-		if funcs.Evaluate(o) {
-			out = append(out, *(o.(P)))
+		typedObj := o.(P)
+		if funcs.Evaluate(typedObj) {
+			out = append(out, *typedObj)
 		}
 		return nil
 	})


### PR DESCRIPTION
Makes predicates strictly typed using generics.

### [Claude] Commit Review: 64baed9789 - use generics to make predicates typed                                                                                      
                                             
This commit refactors the predicate system to use Go generics for improved type safety.                                                                
                                                                                                                                                       
Summary                                                                                                                                                
                                                                                                                                                       
Changes: 18 files, +173/-135 lines                                                                                                                     
Core change: Converted predicate functions from using runtime.Object with type assertions to using generic type parameters constrained by
metav1.Object.                                                                                                                                         
                
Key Improvements                                                                                                                                       

1. Type-safe predicate definitions
```
pkg/util/predicate/predicate.go:24
// Before: type Func func(obj runtime.Object) bool
// After:  type Func[T metav1.Object] func(obj T) bool
```

3. Generic predicate builders
```
pkg/util/predicate/generic.go:25-28
func ResourceOwnedBy[T, U metav1.Object](ownerObj U) Func[T] {
    return func(obj T) bool {
        return metav1.IsControlledBy(obj, ownerObj)
    }
}
```

4. Eliminates unsafe type assertions                                                                                                                   
Before calls used: `obj.(*cmapi.Certificate)`, `obj.(runtime.Object)`, etc.                                                                                
After: Types are known at compile time via generics                                                                                                    
                                                                                                                                                       
Controller Updates                                                                                                                                     
                                                                                                                                                       
All certificate controllers updated to specify explicit types at call sites:                                                                           
- `predicate.ResourceOwnedBy[*cmapi.CertificateRequest](crt)`
- `predicate.ResourceOwnerOf[*cmapi.CertificateRequest]`
- `predicate.ExtractResourceName[*corev1.Secret](predicate.CertificateSecretName)`
                                                                                                                                                       
Benefits                                                                                                                                               
                                                                                                                                                       
✅ Type safety - Compile-time type checking instead of runtime panics                                                                                  
✅ Better tooling - IDEs can provide better autocomplete and type hints                                                                                
✅ Clearer intent - Type parameters make data flow explicit                                                                                            
✅ Removed imports - No longer need runtime package in many files                                                                                      
                                                                                                                                                       
Code Quality                                                                                                                                           
                                                                                                                                                       
- Clean, consistent formatting improvements                                                                                                            
- Removed redundant labels.Everything() calls in some places
- All tests updated and passing                                                                                                                        
- No behavioral changes, pure refactoring                                                                                                              
                                                                                                                                                       
This is a well-executed modernization that leverages Go 1.18+ generics effectively. The refactoring is complete and consistent across the codebase. 

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
