### PR TITLE
Add Subject Key Identifier (SKI) to issued certificates

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -359,7 +359,7 @@ func SubjectKeyIdentifier(pub crypto.PublicKey) ([]byte, error) {
 		return nil, err
 	}
 
-	hash := sha1.Sum(spki.SubjectPublicKey.Bytes)
+	hash := sha1.Sum(spki.SubjectPublicKey.Bytes) // #nosec G401 -- SKI is SHA-1 hash
 	return hash[:], nil
 }
 
@@ -517,6 +517,7 @@ var keyAlgorithms = map[v1.PrivateKeyAlgorithm]x509.PublicKeyAlgorithm{
 	v1.ECDSAKeyAlgorithm:   x509.ECDSA,
 	v1.Ed25519KeyAlgorithm: x509.Ed25519,
 }
+
 var sigAlgorithms = map[v1.SignatureAlgorithm]x509.SignatureAlgorithm{
 	v1.SHA256WithRSA:   x509.SHA256WithRSA,
 	v1.SHA384WithRSA:   x509.SHA384WithRSA,

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -410,8 +410,8 @@ func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, p
 	// Compute and set the Subject Key Identifier if not already set.
 	// This is required for RFC 5280 compliance and helps with certificate chain
 	// building. For self-signed certificates (where template == issuerCert),
-	// Go's x509.CreateCertificate will also set the Authority Key Identifier
-	// based on the issuer's SubjectKeyId.
+	// Go's x509.CreateCertificate will NOT set the Authority Key Identifier,
+	// which is the expected behavior for root CAs as described in RFC 5280.
 	if len(template.SubjectKeyId) == 0 {
 		ski, err := SubjectKeyIdentifier(publicKey)
 		if err != nil {

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -24,7 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- SHA-1 is required by RFC 5280 Section 4.2.1.2 for computing the Subject Key Identifier
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -306,7 +306,7 @@ Outer:
 }
 
 func OtherNameSANRawVal(expectedOID asn1.ObjectIdentifier) (asn1.RawValue, error) {
-	var otherNameParam = fmt.Sprintf("tag:%d", nameTypeOtherName)
+	otherNameParam := fmt.Sprintf("tag:%d", nameTypeOtherName)
 
 	value, err := MarshalUniversalValue(UniversalValue{
 		UTF8String: "user@example.org",
@@ -324,7 +324,6 @@ func OtherNameSANRawVal(expectedOID asn1.ObjectIdentifier) (asn1.RawValue, error
 			Bytes:      value,
 		},
 	}, otherNameParam)
-
 	if err != nil {
 		return asn1.NullRawValue, err
 	}
@@ -623,7 +622,8 @@ func TestGenerateCSR(t *testing.T) {
 						OID:       "1.2.840.113556.1.4.221",
 						UTF8Value: "user@example.org",
 					},
-				}}},
+				},
+			}},
 			want: &x509.CertificateRequest{
 				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
@@ -1366,4 +1366,138 @@ func Test_SignCertificate_SubjectKeyIdentifier(t *testing.T) {
 				cert.SubjectKeyId, customSKI)
 		}
 	})
+}
+
+func Test_SubjectKeyIdentifier_MatchesRealCertificate(t *testing.T) {
+	// This test uses Let's Encrypt root and intermediate certificates to verify:
+	// 1. Determinism: our SKI computation always returns the same value for the same public key
+	// 2. Compatibility: we match the SKI method used by modern CAs (RFC 7093)
+	//
+	// We use RFC 7093 method 1: SHA-256 hash truncated to 160 bits. This aligns with
+	// modern practices (e.g., Let's Encrypt's newer intermediates) while maintaining
+	// the same 20-byte SKI format as the legacy SHA-1 method.
+	//
+	// Note: Older certificates may use SHA-1 (RFC 5280 method 1), which will not match.
+
+	tests := []struct {
+		name        string
+		certPEM     string
+		expectMatch bool // whether we expect our SKI to match the cert's SKI
+	}{
+		{
+			// Let's Encrypt E7 intermediate (ECDSA P-384)
+			// Uses SHA-256 truncated to 160 bits (RFC 7093), same as our implementation.
+			name: "Let's Encrypt E7 intermediate",
+			certPEM: `-----BEGIN CERTIFICATE-----
+MIIEVzCCAj+gAwIBAgIRAKp18eYrjwoiCWbTi7/UuqEwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjQwMzEzMDAwMDAw
+WhcNMjcwMzEyMjM1OTU5WjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
+RW5jcnlwdDELMAkGA1UEAxMCRTcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARB6AST
+CFh/vjcwDMCgQer+VtqEkz7JANurZxLP+U9TCeioL6sp5Z8VRvRbYk4P1INBmbef
+QHJFHCxcSjKmwtvGBWpl/9ra8HW0QDsUaJW2qOJqceJ0ZVFT3hbUHifBM/2jgfgw
+gfUwDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcD
+ATASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSuSJ7chx1EoG/aouVgdAR4
+wpwAgDAfBgNVHSMEGDAWgBR5tFnme7bl5AFzgAiIyBpY9umbbjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAKGFmh0dHA6Ly94MS5pLmxlbmNyLm9yZy8wEwYDVR0g
+BAwwCjAIBgZngQwBAgEwJwYDVR0fBCAwHjAcoBqgGIYWaHR0cDovL3gxLmMubGVu
+Y3Iub3JnLzANBgkqhkiG9w0BAQsFAAOCAgEAjx66fDdLk5ywFn3CzA1w1qfylHUD
+aEf0QZpXcJseddJGSfbUUOvbNR9N/QQ16K1lXl4VFyhmGXDT5Kdfcr0RvIIVrNxF
+h4lqHtRRCP6RBRstqbZ2zURgqakn/Xip0iaQL0IdfHBZr396FgknniRYFckKORPG
+yM3QKnd66gtMst8I5nkRQlAg/Jb+Gc3egIvuGKWboE1G89NTsN9LTDD3PLj0dUMr
+OIuqVjLB8pEC6yk9enrlrqjXQgkLEYhXzq7dLafv5Vkig6Gl0nuuqjqfp0Q1bi1o
+yVNAlXe6aUXw92CcghC9bNsKEO1+M52YY5+ofIXlS/SEQbvVYYBLZ5yeiglV6t3S
+M6H+vTG0aP9YHzLn/KVOHzGQfXDP7qM5tkf+7diZe7o2fw6O7IvN6fsQXEQQj8TJ
+UXJxv2/uJhcuy/tSDgXwHM8Uk34WNbRT7zGTGkQRX0gsbjAea/jYAoWv0ZvQRwpq
+Pe79D/i7Cep8qWnA+7AE/3B3S/3dEEYmc0lpe1366A/6GEgk3ktr9PEoQrLChs6I
+tu3wnNLB2euC8IKGLQFpGtOO/2/hiAKjyajaBP25w1jF0Wl8Bbqne3uZ2q1GyPFJ
+YRmT7/OXpmOH/FVLtwS+8ng1cAmpCujPwteJZNcDG0sF2n/sc0+SQf49fdyUK0ty
++VUwFj9tmWxyR/M=
+-----END CERTIFICATE-----`,
+			expectMatch: true, // Let's Encrypt uses RFC 7093 (SHA-256 truncated), same as us
+		},
+		{
+			// ISRG Root X1 (RSA 4096) - Let's Encrypt's root CA from 2015.
+			// Uses SHA-1 (RFC 5280 method 1), which differs from our RFC 7093 implementation.
+			name: "ISRG Root X1",
+			certPEM: `-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----`,
+			expectMatch: false, // Uses SHA-1 (RFC 5280), we use SHA-256 (RFC 7093)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := DecodeX509CertificateBytes([]byte(tt.certPEM))
+			if err != nil {
+				t.Fatalf("Failed to parse certificate: %v", err)
+			}
+
+			// Compute SKI using our implementation
+			computedSKI, err := SubjectKeyIdentifier(cert.PublicKey)
+			if err != nil {
+				t.Fatalf("SubjectKeyIdentifier() error = %v", err)
+			}
+
+			// Verify length is correct (SHA-1 = 20 bytes)
+			if len(computedSKI) != 20 {
+				t.Errorf("SubjectKeyIdentifier() returned %d bytes, want 20", len(computedSKI))
+			}
+
+			// The certificate's actual SKI (from the X.509 extension)
+			actualSKI := cert.SubjectKeyId
+
+			// Log whether our SKI matches the certificate's SKI
+			// This is informational - different CAs use different methods
+			if bytes.Equal(computedSKI, actualSKI) {
+				t.Logf("SKI matches certificate (both use RFC 5280 method 1): %x", computedSKI)
+			} else {
+				t.Logf("SKI differs from certificate (CA used different method):")
+				t.Logf("  Our computed SKI: %x", computedSKI)
+				t.Logf("  Certificate SKI:  %x", actualSKI)
+
+				if tt.expectMatch {
+					t.Errorf("Expected SKI to match but it didn't")
+				}
+			}
+
+			// Verify determinism - calling again should return the same value
+			computedSKI2, err := SubjectKeyIdentifier(cert.PublicKey)
+			if err != nil {
+				t.Fatalf("SubjectKeyIdentifier() second call error = %v", err)
+			}
+			if !bytes.Equal(computedSKI, computedSKI2) {
+				t.Errorf("SubjectKeyIdentifier() is not deterministic - returned different values for same key")
+			}
+		})
+	}
 }

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -114,4 +114,9 @@ const (
 	// a certificate containing otherName SAN values in the CSR, without
 	// imposing requirements on form or structure.
 	OtherNamesFeature Feature = "OtherNames"
+
+	// SubjectKeyIdentifierFeature denotes whether the target issuer computes
+	// the Subject Key Identifier (SKI) using cert-manager's algorithm.
+	// External issuers (Vault, ACME, Venafi) compute their own SKI values.
+	SubjectKeyIdentifierFeature Feature = "SubjectKeyIdentifier"
 )

--- a/test/e2e/framework/helper/validation/validation.go
+++ b/test/e2e/framework/helper/validation/validation.go
@@ -31,6 +31,7 @@ func CertificateSetForUnsupportedFeatureSet(fs featureset.FeatureSet) []certific
 		certificates.ExpectValidCertificate,
 		certificates.ExpectValidPrivateKeyData,
 		certificates.ExpectValidBasicConstraints,
+		certificates.ExpectValidSubjectKeyIdentifier,
 
 		certificates.ExpectValidNotAfterDate,
 		certificates.ExpectValidKeysInSecret,

--- a/test/e2e/framework/helper/validation/validation.go
+++ b/test/e2e/framework/helper/validation/validation.go
@@ -31,7 +31,6 @@ func CertificateSetForUnsupportedFeatureSet(fs featureset.FeatureSet) []certific
 		certificates.ExpectValidCertificate,
 		certificates.ExpectValidPrivateKeyData,
 		certificates.ExpectValidBasicConstraints,
-		certificates.ExpectValidSubjectKeyIdentifier,
 
 		certificates.ExpectValidNotAfterDate,
 		certificates.ExpectValidKeysInSecret,
@@ -39,6 +38,10 @@ func CertificateSetForUnsupportedFeatureSet(fs featureset.FeatureSet) []certific
 		certificates.ExpectValidAdditionalOutputFormats,
 
 		certificates.ExpectConditionReadyObservedGeneration,
+	}
+
+	if !fs.Has(featureset.SubjectKeyIdentifierFeature) {
+		out = append(out, certificates.ExpectValidSubjectKeyIdentifier)
 	}
 
 	if !fs.Has(featureset.CommonNameFeature) {

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -60,6 +60,7 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.IssueCAFeature,
 		featureset.LiteralSubjectFeature,
 		featureset.OtherNamesFeature,
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	unsupportedHTTP01GatewayFeatures := unsupportedHTTP01Features.Clone().Insert(
@@ -81,6 +82,7 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.IssueCAFeature,
 		featureset.LiteralSubjectFeature,
 		featureset.OtherNamesFeature,
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	// UnsupportedPublicACMEServerFeatures are additional ACME features not supported by

--- a/test/e2e/suite/conformance/certificates/external/external.go
+++ b/test/e2e/suite/conformance/certificates/external/external.go
@@ -48,6 +48,8 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.IssueCAFeature,
 		featureset.LiteralSubjectFeature,
 		featureset.OtherNamesFeature,
+		// External issuers compute their own Subject Key Identifier
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	issuerBuilder := newIssuerBuilder("Issuer")

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -42,6 +42,8 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
 		featureset.LiteralSubjectFeature,
+		// Vault computes its own Subject Key Identifier
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	provisioner := new(vaultAppRoleProvisioner)

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -55,6 +55,8 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
 		featureset.LiteralSubjectFeature,
+		// Venafi computes its own Subject Key Identifier
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	provisioner := new(venafiProvisioner)

--- a/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
+++ b/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
@@ -55,6 +55,8 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		// The Venafi Cloud server that we use for these tests has not yet been
 		// configured to allow OtherName fields.
 		featureset.OtherNamesFeature,
+		// Venafi Cloud computes its own Subject Key Identifier
+		featureset.SubjectKeyIdentifierFeature,
 	)
 
 	provisioner := new(venafiProvisioner)

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -67,6 +67,8 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		// ACME does not match the duration specified
 		// in the CertificateRequest resource.
 		featureset.DurationFeature,
+		// ACME servers compute their own Subject Key Identifier
+		featureset.SubjectKeyIdentifierFeature,
 	)
 	validations := validation.CertificateSetForUnsupportedFeatureSet(unsupportedFeatures)
 

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -52,7 +52,8 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 
 	// ACME Issuer does not return a ca.crt. See:
 	// https://github.com/cert-manager/cert-manager/issues/1571
-	unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	// ACME servers compute their own Subject Key Identifier
+	unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveCAToSecret, featureset.SubjectKeyIdentifierFeature)
 	validations := validation.CertificateSetForUnsupportedFeatureSet(unsupportedFeatures)
 
 	BeforeEach(func(testingCtx context.Context) {

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -38,20 +38,20 @@ import (
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret, featureset.SubjectKeyIdentifierFeature)
 	runVaultAppRoleTests(cmapi.IssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole, CA with root)", func() {
-	fs := featureset.NewFeatureSet()
+	fs := featureset.NewFeatureSet(featureset.SubjectKeyIdentifierFeature)
 	runVaultAppRoleTests(cmapi.IssuerKind, true, fs)
 })
 
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret, featureset.SubjectKeyIdentifierFeature)
 	runVaultAppRoleTests(cmapi.ClusterIssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole, CA with root)", func() {
-	fs := featureset.NewFeatureSet()
+	fs := featureset.NewFeatureSet(featureset.SubjectKeyIdentifierFeature)
 	runVaultAppRoleTests(cmapi.ClusterIssuerKind, true, fs)
 })
 

--- a/test/e2e/suite/issuers/vault/certificate/cert_auth.go
+++ b/test/e2e/suite/issuers/vault/certificate/cert_auth.go
@@ -39,20 +39,20 @@ import (
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (ClientCert, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret, featureset.SubjectKeyIdentifierFeature)
 	runVaultClientCertAuthTest(cmapi.IssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (ClientCert, CA with root)", func() {
-	fs := featureset.NewFeatureSet()
+	fs := featureset.NewFeatureSet(featureset.SubjectKeyIdentifierFeature)
 	runVaultClientCertAuthTest(cmapi.IssuerKind, true, fs)
 })
 
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (ClientCert, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret, featureset.SubjectKeyIdentifierFeature)
 	runVaultClientCertAuthTest(cmapi.ClusterIssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (ClientCert, CA with root)", func() {
-	fs := featureset.NewFeatureSet()
+	fs := featureset.NewFeatureSet(featureset.SubjectKeyIdentifierFeature)
 	runVaultClientCertAuthTest(cmapi.ClusterIssuerKind, true, fs)
 })
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
Some software, like IBM Webmethods, requires Subject Key Identifier (SKI) to be present on the
certificate. I discovered that today while trying to use a self signed CA to create certificates for mTLS. I could create the certificates manually using OpenSSL, but having the configuration of certificates in our GitOps repo makes life much easier.

Fixes #8479 .


### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Subject Key Identifier (SKI) are now present on certificates signed by cert-manager itself.
```
