### PR TITLE
feat(helm): add opt-in ttlSecondsAfterFinished for startupapicheck Job

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -2008,6 +2008,11 @@ Timeout for 'kubectl check api' command.
 > ```
 
 Job backoffLimit
+#### **startupapicheck.ttlSecondsAfterFinished** ~ `integer`
+
+Limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, once the Job finishes, it will be automatically cleaned up after ttlSecondsAfterFinished seconds. This is disabled by default (field is not set) to preserve backward compatibility and avoid issues with GitOps tools (e.g. Argo CD) that may attempt to reconcile or recreate Jobs after they are automatically deleted. For more information, see [Automatic Cleanup for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
+
+
 #### **startupapicheck.jobAnnotations** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  {{- if hasKey .Values.startupapicheck "ttlSecondsAfterFinished" }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1540,6 +1540,9 @@
         "tolerations": {
           "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
         },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        },
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.startupapicheck.volumeMounts"
         },
@@ -1767,6 +1770,9 @@
       "description": "A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
       "items": {},
       "type": "array"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "description": "Limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, once the Job finishes, it will be automatically cleaned up after ttlSecondsAfterFinished seconds. This is disabled by default (field is not set) to preserve backward compatibility and avoid issues with GitOps tools (e.g. Argo CD) that may attempt to reconcile or recreate Jobs after they are automatically deleted. For more information, see [Automatic Cleanup for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)."
     },
     "helm-values.startupapicheck.volumeMounts": {
       "default": [],

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1529,6 +1529,17 @@ startupapicheck:
   # Job backoffLimit
   backoffLimit: 4
 
+  # Limits the lifetime of a Job that has finished execution (either Complete
+  # or Failed). If this field is set, once the Job finishes, it will be
+  # automatically cleaned up after ttlSecondsAfterFinished seconds. This is
+  # disabled by default (field is not set) to preserve backward compatibility
+  # and avoid issues with GitOps tools (e.g. Argo CD) that may attempt to
+  # reconcile or recreate Jobs after they are automatically deleted.
+  # For more information, see [Automatic Cleanup for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
+  # +docs:property
+  # +docs:type=integer
+  # ttlSecondsAfterFinished:
+
   # Optional additional annotations to add to the startupapicheck Job.
   # +docs:property
   jobAnnotations:


### PR DESCRIPTION
## Summary

Fixes #8363.

Adds a new optional Helm value `startupapicheck.ttlSecondsAfterFinished` that, when set, configures the Kubernetes [TTL-after-finished controller](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) to automatically clean up the `cert-manager-startupapicheck` Job once it has finished (either `Complete` or `Failed`).

## Changes

- `deploy/charts/cert-manager/templates/startupapicheck-job.yaml` — conditionally renders `ttlSecondsAfterFinished` in the Job spec when the value is set
- `deploy/charts/cert-manager/values.yaml` — adds `startupapicheck.ttlSecondsAfterFinished` as a commented-out opt-in value with documentation
- `deploy/charts/cert-manager/values.schema.json` — adds the corresponding JSON schema definition

## Design

The field is **disabled by default** (commented out in `values.yaml`) to preserve backward compatibility and avoid issues with GitOps tools such as Argo CD that may attempt to reconcile or recreate Jobs after they are garbage-collected by the TTL controller, as discussed in #8363.

Users who want automatic Job cleanup can opt in by setting:

```yaml
startupapicheck:
  ttlSecondsAfterFinished: 600
```

## Test plan

- [x] `helm lint` passes (with a generated `Chart.yaml`)
- [x] `helm template` with `--set startupapicheck.ttlSecondsAfterFinished=300` renders `ttlSecondsAfterFinished: 300` in the Job spec
- [x] `helm template` without the value set produces no `ttlSecondsAfterFinished` field (opt-in behaviour confirmed)

```release-note
Add opt-in `startupapicheck.ttlSecondsAfterFinished` Helm value to enable automatic cleanup of the startupapicheck Job via the Kubernetes TTL-after-finished controller.
```