### PR TITLE
fix: schedule readiness re-evaluation at certificate expiry time

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -253,8 +253,17 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		log.V(logf.DebugLevel).Info("updating status fields", "notAfter",
 			crt.Status.NotAfter, "notBefore", crt.Status.NotBefore, "renewalTime",
 			crt.Status.RenewalTime)
-		return c.updateOrApplyStatus(ctx, crt)
+		if err := c.updateOrApplyStatus(ctx, crt); err != nil {
+			return err
+		}
 	}
+
+	// Schedule a re-queue at the certificate's expiry time so that the Ready
+	// condition is updated promptly when the certificate expires. Without this,
+	// a certificate that is Ready=True will remain in that state even after it
+	// has expired, because no event triggers a re-evaluation.
+	c.scheduleRequeueAtExpiry(log, key, crt)
+
 	return nil
 }
 
@@ -379,6 +388,37 @@ func (c *controller) getARIInfo(ctx context.Context, genericIssuer cmapi.Generic
 	}
 
 	return ri, nil
+}
+
+// scheduleRequeueAtExpiry schedules a delayed requeue of the Certificate at its
+// NotAfter time so the readiness condition is re-evaluated upon expiry.
+//
+// The requeue is scheduled on every reconcile regardless of the current Ready
+// status. The scheduled work queue lives in memory, so its pending entries are
+// lost on controller restart, and any reconcile that happens to skip scheduling
+// would leave the cert with no path back to a re-evaluation. Re-arming the delay
+// on every pass means any unrelated event (Secret change, CertificateRequest
+// change, informer resync) restores the schedule. The policy chain's
+// CurrentCertificateHasExpired check, evaluated on every ProcessItem, is what
+// actually flips Ready=False once we land past NotAfter, so this is just the
+// trigger that gets us there.
+func (c *controller) scheduleRequeueAtExpiry(log logr.Logger, key types.NamespacedName, crt *cmapi.Certificate) {
+	if crt.Status.NotAfter == nil {
+		return
+	}
+
+	now := c.clock.Now()
+	expiryTime := crt.Status.NotAfter.Time
+	if !now.Before(expiryTime) {
+		// Already past expiry. The current ProcessItem invocation will have
+		// run the policy chain and set Ready=False via CurrentCertificateHasExpired,
+		// so no further requeue is needed.
+		return
+	}
+
+	requeueAfter := expiryTime.Sub(now) + time.Second // 1s buffer so we land past expiry
+	log.V(logf.DebugLevel).Info("scheduling re-queue at certificate expiry time", "expiry", expiryTime, "requeueAfter", requeueAfter)
+	c.scheduledWorkQueue.Add(key, requeueAfter)
 }
 
 // updateOrApplyStatus will update the controller status. If the

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -92,6 +92,10 @@ type controller struct {
 	helper             issuer.Helper
 	clock              clock.Clock
 	scheduledWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
+	// queue is held on the controller so scheduleRequeueAtExpiry can re-arm
+	// a delayed requeue at certificate expiry without sharing the per-key
+	// timer slot used by ARI's scheduledWorkQueue.
+	queue workqueue.TypedRateLimitingInterface[types.NamespacedName]
 }
 
 // readyConditionFunc is custom function type that builds certificate's Ready condition
@@ -175,6 +179,7 @@ func NewController(
 		fieldManager:          ctx.FieldManager,
 		clock:                 ctx.Clock,
 		scheduledWorkQueue:    scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
+		queue:                 queue,
 	}, queue, mustSync, nil
 }
 
@@ -394,31 +399,36 @@ func (c *controller) getARIInfo(ctx context.Context, genericIssuer cmapi.Generic
 // NotAfter time so the readiness condition is re-evaluated upon expiry.
 //
 // The requeue is scheduled on every reconcile regardless of the current Ready
-// status. The scheduled work queue lives in memory, so its pending entries are
-// lost on controller restart, and any reconcile that happens to skip scheduling
-// would leave the cert with no path back to a re-evaluation. Re-arming the delay
-// on every pass means any unrelated event (Secret change, CertificateRequest
-// change, informer resync) restores the schedule. The policy chain's
-// CurrentCertificateHasExpired check, evaluated on every ProcessItem, is what
-// actually flips Ready=False once we land past NotAfter, so this is just the
-// trigger that gets us there.
+// status. The workqueue's delaying queue lives in memory, so its pending
+// AddAfter entries are lost on controller restart, and any reconcile that
+// happens to skip scheduling would leave the cert with no path back to a
+// re-evaluation. Re-arming the delay on every pass means any unrelated event
+// (Secret change, CertificateRequest change, informer resync) restores the
+// schedule. The policy chain's CurrentCertificateHasExpired check, evaluated
+// on every ProcessItem, is what actually flips Ready=False once we land past
+// NotAfter, so this is just the trigger that gets us there.
+//
+// We use the workqueue's AddAfter rather than scheduledWorkQueue so the
+// expiry timer doesn't share a per-key timer slot with ARI's poll schedule
+// (scheduledWorkQueue cancels any prior timer for the same key, which would
+// stomp ARI's much-shorter poll interval).
 func (c *controller) scheduleRequeueAtExpiry(log logr.Logger, key types.NamespacedName, crt *cmapi.Certificate) {
 	if crt.Status.NotAfter == nil {
 		return
 	}
 
-	// Only schedule requeue if the certificate has not yet expired and is currently Ready
 	now := c.clock.Now()
 	expiryTime := crt.Status.NotAfter.Time
-	if now.Before(expiryTime) {
-		// Check if the certificate is currently Ready
-		readyCondition := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady)
-		if readyCondition != nil && readyCondition.Status == cmmeta.ConditionTrue {
-			requeueAfter := expiryTime.Sub(now) + time.Second // add 1s buffer to ensure we're past expiry
-			log.V(logf.DebugLevel).Info("scheduling re-queue at certificate expiry time", "expiry", expiryTime, "requeueAfter", requeueAfter)
-			c.scheduledWorkQueue.Add(key, requeueAfter)
-		}
+	if !now.Before(expiryTime) {
+		// Already past expiry. The current ProcessItem invocation will have
+		// run the policy chain and set Ready=False via CurrentCertificateHasExpired,
+		// so no further requeue is needed.
+		return
 	}
+
+	requeueAfter := expiryTime.Sub(now) + time.Second // 1s buffer so we land past expiry
+	log.V(logf.DebugLevel).Info("scheduling re-queue at certificate expiry time", "expiry", expiryTime, "requeueAfter", requeueAfter)
+	c.queue.AddAfter(key, requeueAfter)
 }
 
 // updateOrApplyStatus will update the controller status. If the

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -407,18 +407,18 @@ func (c *controller) scheduleRequeueAtExpiry(log logr.Logger, key types.Namespac
 		return
 	}
 
+	// Only schedule requeue if the certificate has not yet expired and is currently Ready
 	now := c.clock.Now()
 	expiryTime := crt.Status.NotAfter.Time
-	if !now.Before(expiryTime) {
-		// Already past expiry. The current ProcessItem invocation will have
-		// run the policy chain and set Ready=False via CurrentCertificateHasExpired,
-		// so no further requeue is needed.
-		return
+	if now.Before(expiryTime) {
+		// Check if the certificate is currently Ready
+		readyCondition := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady)
+		if readyCondition != nil && readyCondition.Status == cmmeta.ConditionTrue {
+			requeueAfter := expiryTime.Sub(now) + time.Second // add 1s buffer to ensure we're past expiry
+			log.V(logf.DebugLevel).Info("scheduling re-queue at certificate expiry time", "expiry", expiryTime, "requeueAfter", requeueAfter)
+			c.scheduledWorkQueue.Add(key, requeueAfter)
+		}
 	}
-
-	requeueAfter := expiryTime.Sub(now) + time.Second // 1s buffer so we land past expiry
-	log.V(logf.DebugLevel).Info("scheduling re-queue at certificate expiry time", "expiry", expiryTime, "requeueAfter", requeueAfter)
-	c.scheduledWorkQueue.Add(key, requeueAfter)
 }
 
 // updateOrApplyStatus will update the controller status. If the

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -159,6 +159,14 @@ func NewController(
 		issuerInformer.Informer().HasSynced,
 	}
 
+	// ClusterIssuers are only watched when running cluster-wide.
+	var clusterIssuerLister cmlisters.ClusterIssuerLister
+	if ctx.Namespace == "" {
+		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
+		mustSync = append(mustSync, clusterIssuerInformer.Informer().HasSynced)
+		clusterIssuerLister = clusterIssuerInformer.Lister()
+	}
+
 	return &controller{
 		policyChain:              chain,
 		certificateLister:        certificateInformer.Lister(),
@@ -168,6 +176,8 @@ func NewController(
 		recorder:                 ctx.Recorder,
 		accountRegistry:          ctx.ACMEAccountRegistry,
 		issuerLister:             issuerInformer.Lister(),
+		clusterIssuerLister:      clusterIssuerLister,
+		helper:                   issuer.NewHelper(issuerInformer.Lister(), clusterIssuerLister),
 		gatherer: &policies.Gatherer{
 			CertificateRequestLister: certificateRequestInformer.Lister(),
 			SecretLister:             secretsInformer.Lister(),
@@ -511,14 +521,6 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Type
 		BuildReadyConditionFromChain,
 	)
 	c.controller = ctrl
-
-	if ctx.Namespace == "" {
-		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
-		mustSync = append(mustSync, clusterIssuerInformer.Informer().HasSynced)
-		c.clusterIssuerLister = clusterIssuerInformer.Lister()
-	}
-
-	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 
 	return queue, mustSync, err
 }

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -94,6 +94,11 @@ type controller struct {
 	helper             issuer.Helper
 	clock              clock.Clock
 	scheduledWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
+
+	// expiryWorkQueue re-checks a Certificate when it expires. It is separate
+	// from scheduledWorkQueue because each queue holds only one timer per key,
+	// so sharing would mean expiry and ARI checks cancelling each other.
+	expiryWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
 }
 
 // readyConditionFunc is custom function type that builds certificate's Ready condition
@@ -187,6 +192,7 @@ func NewController(
 		fieldManager:          ctx.FieldManager,
 		clock:                 ctx.Clock,
 		scheduledWorkQueue:    scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
+		expiryWorkQueue:       scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
 	}, queue, mustSync, nil
 }
 
@@ -205,6 +211,11 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 	if crt == nil || crt.DeletionTimestamp != nil {
 		// If the Certificate object was/ is being deleted, we don't want to update its status.
+		// Cancel any pending timers too. Each armed timer parks a goroutine
+		// until it fires, and the expiry timer could otherwise hold one for
+		// the remaining lifetime of a certificate that no longer exists.
+		c.scheduledWorkQueue.Forget(key)
+		c.expiryWorkQueue.Forget(key)
 		return nil
 	}
 
@@ -275,9 +286,42 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		log.V(logf.DebugLevel).Info("updating status fields", "notAfter",
 			klog.SafePtr(crt.Status.NotAfter), "notBefore", klog.SafePtr(crt.Status.NotBefore), "renewalTime",
 			klog.SafePtr(crt.Status.RenewalTime))
-		return c.updateOrApplyStatus(ctx, crt)
+		if err := c.updateOrApplyStatus(ctx, crt); err != nil {
+			return err
+		}
 	}
+
+	c.scheduleRecheckAtExpiry(log, key, crt.Status.NotAfter)
+
 	return nil
+}
+
+// scheduleRecheckAtExpiry re-processes the Certificate just after it expires.
+//
+// Readiness depends on the clock, but the controller only reconciles on watch
+// events. A Certificate whose renewal is stuck gets no events, so it keeps
+// reporting Ready=True long after expiry. We re-arm on every reconcile because
+// the timers are in memory and are lost on restart.
+func (c *controller) scheduleRecheckAtExpiry(log logr.Logger, key types.NamespacedName, notAfter *metav1.Time) {
+	if notAfter == nil {
+		c.expiryWorkQueue.Forget(key)
+		return
+	}
+
+	// Wake up just after NotAfter, so the clock has definitely passed it.
+	// Add the buffer to the time, not the duration: Sub saturates at
+	// math.MaxInt64 for a NotAfter centuries away (e.g. the RFC 5280
+	// "no well-defined expiration" date of 9999-12-31), and adding to a
+	// saturated duration would wrap negative and skip the re-check.
+	recheckIn := notAfter.Time.Add(time.Second).Sub(c.clock.Now())
+	if recheckIn <= 0 {
+		// Already expired, and this reconcile has just set the condition.
+		c.expiryWorkQueue.Forget(key)
+		return
+	}
+
+	log.V(logf.DebugLevel).Info("scheduling re-check at certificate expiry", "notAfter", notAfter.Time, "recheckIn", recheckIn)
+	c.expiryWorkQueue.Add(key, recheckIn)
 }
 
 func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) time.Time {

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -470,12 +470,9 @@ func TestScheduleRequeueAtExpiry(t *testing.T) {
 				t.Error(err)
 			}
 
-			// Check the queue length to verify requeue was scheduled
-			if test.expectRequeue {
-				// AddAfter with future duration won't immediately appear in Len(),
-				// but we can verify the call didn't panic and completed successfully
-				// The test passes if no panic occurred during ProcessItem
-			}
+			// When test.expectRequeue is true, we verify that ProcessItem completed
+			// successfully without panic. AddAfter with future duration won't immediately
+			// appear in Len(), so the test passes if no panic occurred during ProcessItem.
 		})
 	}
 }

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -383,9 +383,9 @@ func TestScheduleRequeueAtExpiry(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		notAfter       time.Time
-		expectRequeue  bool
-		condition      cmapi.CertificateCondition
+		notAfter      time.Time
+		expectRequeue bool
+		condition     cmapi.CertificateCondition
 	}{
 		"should schedule requeue when certificate is Ready and NotAfter is in the future": {
 			notAfter:      now.Add(2 * time.Hour),

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -474,6 +474,7 @@ func TestScheduleRequeueAtExpiry(t *testing.T) {
 			if test.expectRequeue {
 				// AddAfter with future duration won't immediately appear in Len(),
 				// but we can verify the call didn't panic and completed successfully
+				// The test passes if no panic occurred during ProcessItem
 			}
 		})
 	}

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -477,6 +477,122 @@ func TestScheduleRequeueAtExpiry(t *testing.T) {
 	}
 }
 
+// TestProcessItemFlipsReadyAfterExpiry covers the scenario reported on #8529
+// where a Certificate's underlying x509 was past notAfter but the Certificate
+// resource still showed Ready=True until the controller pod was re-rolled.
+//
+// The repro: 1h cert with 55m renewBefore, issuer deleted so renewal can't
+// succeed, wait past notAfter. The fix relies on the policy chain's
+// CurrentCertificateHasExpired check running on every ProcessItem invocation,
+// so any reconcile (informer resync, Secret event, AddAfter tick) flips Ready
+// to False with reason=Expired. This test asserts that contract by using the
+// real readiness policy chain (not the test-only policyEvaluator stub) and
+// feeding it a Secret whose x509 is already past notAfter.
+func TestProcessItemFlipsReadyAfterExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	privKey := testcrypto.MustCreatePEMPrivateKey(t)
+
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+		Spec: cmapi.CertificateSpec{
+			SecretName: "test-secret",
+			DNSNames:   []string{"example.com"},
+		},
+	}
+	// the cert resource starts out Ready=True - this mirrors hjoshi123's repro
+	// where the cert had been happily issued before the issuer was deleted.
+	certWithReadyTrue := gen.CertificateFrom(cert, gen.SetCertificateStatusCondition(
+		cmapi.CertificateCondition{
+			Type:    cmapi.CertificateConditionReady,
+			Status:  cmmeta.ConditionTrue,
+			Reason:  ReadyReason,
+			Message: "Certificate is up to date and has not expired",
+		}))
+
+	// Build an x509 cert whose notAfter is already in the past relative to
+	// the controller's clock. notBefore is set well before now so the cert
+	// was validly issued at some earlier point.
+	notBefore := now.Add(-2 * time.Hour).Truncate(time.Second)
+	notAfter := now.Add(-time.Minute).Truncate(time.Second)
+	x509Bytes := testcrypto.MustCreateCertWithNotBeforeAfter(t, privKey, cert, notBefore, notAfter)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "test-secret",
+		},
+	}
+
+	fc := fakeclock.NewFakeClock(now)
+	builder := &testpkg.Builder{
+		T:     t,
+		Clock: fc,
+	}
+	builder.CertManagerObjects = append(builder.CertManagerObjects, certWithReadyTrue)
+	builder.KubeObjects = append(builder.KubeObjects,
+		gen.SecretFrom(secret,
+			gen.SetSecretData(map[string][]byte{
+				corev1.TLSCertKey:       x509Bytes,
+				corev1.TLSPrivateKeyKey: privKey,
+			})))
+
+	// Status update should flip Ready to False with reason=Expired and stamp
+	// notBefore / notAfter onto the Certificate.
+	expectedNotBefore := metav1.NewTime(notBefore)
+	expectedNotAfter := metav1.NewTime(notAfter)
+	metaNow := metav1.NewTime(now)
+	expectedCondition := cmapi.CertificateCondition{
+		Type:               cmapi.CertificateConditionReady,
+		Status:             cmmeta.ConditionFalse,
+		Reason:             policies.Expired,
+		Message:            fmt.Sprintf("Certificate expired on %s", notAfter.Format(time.RFC1123)),
+		LastTransitionTime: &metaNow,
+	}
+	expectedCert := gen.CertificateFrom(certWithReadyTrue,
+		gen.SetCertificateStatusCondition(expectedCondition))
+	expectedCert.Status.NotBefore = &expectedNotBefore
+	expectedCert.Status.NotAfter = &expectedNotAfter
+	// renewal time is computed from the real RenewalTime func against the
+	// expired x509; record what the controller will calculate so we can
+	// compare against it.
+	renewalTime, err := pki.RenewalTime(notBefore, notAfter, cert.Spec.RenewBefore, cert.Spec.RenewBeforePercentage, cert.Spec.Renewal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCert.Status.RenewalTime = renewalTime
+
+	builder.ExpectedActions = append(builder.ExpectedActions,
+		testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+			cmapi.SchemeGroupVersion.WithResource("certificates"),
+			"status",
+			expectedCert.Namespace,
+			expectedCert)))
+
+	builder.Init()
+
+	w := &controllerWrapper{}
+	_, _, err = w.Register(builder.Context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Intentionally NOT overriding policyEvaluator - we want the real
+	// BuildReadyConditionFromChain + NewReadinessPolicyChain wiring so we
+	// exercise the CurrentCertificateHasExpired path on every reconcile.
+	w.controller.recorder = new(testpkg.FakeRecorder)
+
+	builder.Start()
+	defer builder.Stop()
+
+	key := types.NamespacedName{Namespace: cert.Namespace, Name: cert.Name}
+	if err := w.controller.ProcessItem(t.Context(), key); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := builder.AllActionsExecuted(); err != nil {
+		t.Error(err)
+	}
+}
+
 // Test the evaluation of the ordered policy chain as a whole.
 func TestNewReadinessPolicyChain(t *testing.T) {
 	clock := &fakeclock.FakeClock{}

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -363,6 +363,122 @@ func TestProcessItem(t *testing.T) {
 	}
 }
 
+func TestScheduleRequeueAtExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	metaNow := metav1.NewTime(now)
+	privKey := testcrypto.MustCreatePEMPrivateKey(t)
+
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+		Spec: cmapi.CertificateSpec{
+			SecretName: "test-secret",
+			DNSNames:   []string{"example.com"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "test-secret",
+		},
+	}
+
+	tests := map[string]struct {
+		notAfter       time.Time
+		expectRequeue  bool
+		condition      cmapi.CertificateCondition
+	}{
+		"should schedule requeue when certificate is Ready and NotAfter is in the future": {
+			notAfter:      now.Add(2 * time.Hour),
+			expectRequeue: true,
+			condition: cmapi.CertificateCondition{
+				Type:               cmapi.CertificateConditionReady,
+				Status:             cmmeta.ConditionTrue,
+				Reason:             ReadyReason,
+				Message:            "Certificate is up to date and has not expired",
+				LastTransitionTime: &metaNow,
+			},
+		},
+		"should not schedule requeue when certificate NotAfter is in the past": {
+			notAfter:      now.Add(-1 * time.Hour),
+			expectRequeue: false,
+			condition: cmapi.CertificateCondition{
+				Type:               cmapi.CertificateConditionReady,
+				Status:             cmmeta.ConditionFalse,
+				Reason:             "Expired",
+				Message:            "Certificate has expired",
+				LastTransitionTime: &metaNow,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fc := fakeclock.NewFakeClock(now)
+			builder := &testpkg.Builder{
+				T:     t,
+				Clock: fc,
+			}
+
+			notAfter := metav1.NewTime(test.notAfter.Truncate(time.Second))
+			notBefore := metav1.NewTime(now.Truncate(time.Second))
+			renewalTime := metav1.NewTime(now.Add(time.Hour))
+
+			x509Bytes := testcrypto.MustCreateCertWithNotBeforeAfter(t, privKey, cert, notBefore.Time, notAfter.Time)
+
+			builder.CertManagerObjects = append(builder.CertManagerObjects, gen.CertificateFrom(cert))
+			builder.KubeObjects = append(builder.KubeObjects,
+				gen.SecretFrom(secret,
+					gen.SetSecretData(map[string][]byte{
+						"tls.crt": x509Bytes,
+					})))
+
+			builder.Init()
+
+			w := &controllerWrapper{}
+			_, _, err := w.Register(builder.Context)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			w.controller.policyEvaluator = policyEvaluatorBuilder(test.condition)
+			w.controller.renewalTimeCalculator = renewalTimeBuilder(&renewalTime, nil)
+
+			// Build expected updated cert
+			c := gen.CertificateFrom(cert,
+				gen.SetCertificateStatusCondition(test.condition))
+			c.Status.NotAfter = &notAfter
+			c.Status.NotBefore = &notBefore
+			c.Status.RenewalTime = &renewalTime
+
+			builder.ExpectedActions = append(builder.ExpectedActions,
+				testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"status",
+					c.Namespace,
+					c)))
+
+			builder.Start()
+			defer builder.Stop()
+
+			key := types.NamespacedName{Namespace: cert.Namespace, Name: cert.Name}
+			err = w.controller.ProcessItem(t.Context(), key)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if err := builder.AllActionsExecuted(); err != nil {
+				t.Error(err)
+			}
+
+			// Check the queue length to verify requeue was scheduled
+			if test.expectRequeue {
+				// AddAfter with future duration won't immediately appear in Len(),
+				// but we can verify the call didn't panic and completed successfully
+			}
+		})
+	}
+}
+
 // Test the evaluation of the ordered policy chain as a whole.
 func TestNewReadinessPolicyChain(t *testing.T) {
 	clock := &fakeclock.FakeClock{}

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -24,9 +24,12 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/clock"
 	fakeclock "k8s.io/utils/clock/testing"
 
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
@@ -46,6 +50,7 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/cert-manager/cert-manager/pkg/scheduler"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
@@ -1427,6 +1432,90 @@ func TestProcessItemARIRenewalTimePersistence(t *testing.T) {
 			if err := builder.AllActionsExecuted(); err != nil {
 				t.Error(err)
 			}
+		})
+	}
+}
+
+// TestScheduleRecheckAtExpiry drives a real ScheduledWorkQueue inside a
+// synctest bubble, so the assertions are on when the re-check actually fires
+// rather than on the delay that was requested.
+func TestScheduleRecheckAtExpiry(t *testing.T) {
+	key := types.NamespacedName{Namespace: "testns", Name: "test"}
+
+	tests := map[string]struct {
+		notAfter func(now time.Time) *metav1.Time
+		// wantFireAfter is the offset from now at which the re-check must
+		// fire. Zero means it must not fire at all.
+		wantFireAfter time.Duration
+	}{
+		"fires one second after a future expiry": {
+			notAfter:      func(now time.Time) *metav1.Time { return &metav1.Time{Time: now.Add(time.Hour)} },
+			wantFireAfter: time.Hour + time.Second,
+		},
+		"does not fire for an already expired certificate": {
+			notAfter: func(now time.Time) *metav1.Time { return &metav1.Time{Time: now.Add(-time.Hour)} },
+		},
+		"does not fire when the expiry is unknown": {
+			notAfter: func(time.Time) *metav1.Time { return nil },
+		},
+		// time.Time.Sub saturates at math.MaxInt64 for a NotAfter this far
+		// away. Whatever the arithmetic does with that, the re-check must
+		// not fire early.
+		"does not fire early for an expiry centuries away": {
+			notAfter: func(time.Time) *metav1.Time {
+				return &metav1.Time{Time: time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+
+				// The timer goroutine writes and the test goroutine reads, and
+				// synctest.Wait does not order the two for the race detector.
+				var mu sync.Mutex
+				var fired []time.Duration
+				firedAt := func() []time.Duration {
+					mu.Lock()
+					defer mu.Unlock()
+					return append([]time.Duration(nil), fired...)
+				}
+
+				c := &controller{
+					clock: clock.RealClock{},
+					expiryWorkQueue: scheduler.NewScheduledWorkQueue(clock.RealClock{}, func(types.NamespacedName) {
+						mu.Lock()
+						defer mu.Unlock()
+						fired = append(fired, time.Since(start))
+					}),
+				}
+				defer c.expiryWorkQueue.Forget(key)
+
+				c.scheduleRecheckAtExpiry(logr.Discard(), key, test.notAfter(start))
+
+				if test.wantFireAfter == 0 {
+					time.Sleep(100 * 365 * 24 * time.Hour)
+					synctest.Wait()
+					if got := firedAt(); len(got) != 0 {
+						t.Fatalf("expected no re-check, but it fired at %v", got)
+					}
+					return
+				}
+
+				time.Sleep(test.wantFireAfter - time.Nanosecond)
+				synctest.Wait()
+				if got := firedAt(); len(got) != 0 {
+					t.Fatalf("re-check fired early at %v", got)
+				}
+
+				time.Sleep(time.Nanosecond)
+				synctest.Wait()
+				if got := firedAt(); len(got) != 1 || got[0] != test.wantFireAfter {
+					t.Fatalf("expected one re-check at %v, got %v", test.wantFireAfter, got)
+				}
+			})
 		})
 	}
 }

--- a/test/integration/certificates/readiness_controller_test.go
+++ b/test/integration/certificates/readiness_controller_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/readiness"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/cert-manager/cert-manager/integration-tests/framework"
+)
+
+// TestReadinessController_ExpiryWithoutEvents checks that a Certificate stops
+// reporting Ready=True once it expires, even when nothing else changes.
+//
+// This is the case reported in issue #7895: renewal is stuck, so the readiness
+// controller never sees a watch event and the Certificate looks healthy long
+// after it expired.
+func TestReadinessController_ExpiryWithoutEvents(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	t.Cleanup(stopFn)
+
+	fakeClock := &fakeclock.FakeClock{}
+	fakeClock.SetTime(time.Now())
+
+	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
+
+	namespace := "testns-readiness-expiry"
+	secretName := "example"
+	certName := "testcrt"
+
+	now := fakeClock.Now()
+	notBefore := now
+	notAfter := now.Add(3 * time.Hour)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	if _, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: certName, Namespace: namespace},
+		Spec: cmapi.CertificateSpec{
+			SecretName: secretName,
+			CommonName: "example.com",
+			IssuerRef:  cmmeta.IssuerReference{Name: "testissuer"}, // doesn't need to exist
+		},
+	}
+
+	sk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skBytes := pki.EncodePKCS1PrivateKey(sk)
+	x509CertBytes := selfSignCertificateWithNotBeforeAfter(t, skBytes, cert, notBefore, notAfter)
+
+	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: skBytes,
+			corev1.TLSCertKey:       x509CertBytes,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controllerContext := &controllerpkg.Context{
+		Scheme:                    scheme,
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		Clock:                     fakeClock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-readiness-test",
+	}
+	ctrl, queue, mustSync, err := readiness.NewController(
+		logf.Log,
+		controllerContext,
+		policies.NewReadinessPolicyChain(fakeClock),
+		pki.RenewalTime,
+		readiness.BuildReadyConditionFromChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := controllerpkg.NewController(
+		"readiness_test",
+		metrics.New(logf.Log, clock.RealClock{}),
+		ctrl.ProcessItem,
+		mustSync,
+		nil,
+		queue,
+	)
+	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopController()
+
+	if _, err := cmCl.CertmanagerV1().Certificates(namespace).Create(t.Context(), cert, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Waiting for the Certificate to become Ready")
+	waitForReadyCondition(t, t.Context(), cmCl, namespace, certName, cmmeta.ConditionTrue, readiness.ReadyReason)
+
+	// Nothing else changes here: no Secret update, no CertificateRequest, no
+	// edit to the Certificate. Only a re-check the controller scheduled for
+	// itself can wake it up.
+	t.Log("Advancing the clock past the certificate's expiry")
+	fakeClock.SetTime(notAfter.Add(2 * time.Second))
+
+	t.Log("Waiting for the Certificate to report that it has expired")
+	waitForReadyCondition(t, t.Context(), cmCl, namespace, certName, cmmeta.ConditionFalse, policies.Expired)
+}
+
+// waitForReadyCondition polls until the Ready condition matches status and reason.
+func waitForReadyCondition(t *testing.T, ctx context.Context, cmCl cmclient.Interface, namespace, name string, status cmmeta.ConditionStatus, reason string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	var last *cmapi.CertificateCondition
+	err := wait.PollUntilContextCancel(ctx, 200*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		crt, err := cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		last = apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady)
+		if last == nil {
+			return false, nil
+		}
+		return last.Status == status && last.Reason == reason, nil
+	})
+	if err != nil {
+		t.Fatalf("expected Ready condition with status %q and reason %q, last seen %+v: %v", status, reason, last, err)
+	}
+}


### PR DESCRIPTION
### Pull Request Motivation

Fixes #7895

Certificates that expire while cert-manager is running remain in `Ready=True` state because the readiness controller never re-evaluates them after the initial reconciliation. The `CurrentCertificateHasExpired` policy check exists in the readiness chain but is never invoked again once the certificate passes its `notAfter` time, since no event triggers a new reconciliation.

This was confirmed by a maintainer as a bug in the bi-weekly review: the certificate needs to be re-queued at expiry time.

### Approach

After each `ProcessItem`, the controller schedules a re-check one second after the certificate's `NotAfter`, re-armed on every reconcile because the timers are in memory and lost on restart. When it fires, the existing `CurrentCertificateHasExpired` policy sets `Ready=False` with reason `Expired`. When a Certificate is deleted, the controller cancels both of its timers, so a deleted Certificate does not hold a parked goroutine until its `NotAfter`.

The re-check uses a second `ScheduledWorkQueue` rather than the existing one, which holds one timer per key and is already used for ARI polling, and rather than `queue.AddAfter`, which runs on a real clock and cannot be driven by the fake clock the integration tests use.

Two commits:

1. **Build the issuer helper in NewController.** `helper` was only set in `controllerWrapper.Register`, so any caller of the exported constructor panicked on the first Certificate with a decodable certificate. This is why there was no readiness integration test before. Cherry-picked from #9260.
2. **Re-check certificate readiness at expiry time.** The fix, plus a `synctest`-driven unit test that asserts when the re-check fires, and an integration test that reproduces #7895 by advancing the fake clock past `NotAfter` with no watch events. The integration test fails without the fix.

Co-authored with @DinethShakya23, whose #9260 contributed the helper fix, the `ScheduledWorkQueue` approach and the integration test.

*Description updated by @wallrj on rebase.* [Claude Fable 5]

### Kind

/kind bug

### Release Note

```release-note
Fixed a bug where Certificate resources remained in Ready=True state after the certificate expired, because the readiness controller did not re-evaluate certificates at their expiry time. The controller now schedules a re-evaluation at the NotAfter time of each certificate.
```

