### PR TITLE
feat: add --dns01-timeout flag to make DNS01 provider API timeout configurable

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -340,6 +340,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.ACMEDNS01Config.RecursiveNameserversOnly,
+			DNS01Timeout:            opts.ACMEDNS01Config.Timeout,
 		},
 
 		SchedulerOptions: controller.SchedulerOptions{

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -349,6 +349,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.ACMEDNS01Config.RecursiveNameserversOnly,
+			DNS01Timeout:            opts.ACMEDNS01Config.Timeout,
 		},
 
 		SchedulerOptions: controller.SchedulerOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -167,6 +167,11 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.DurationVar(&c.ACMEDNS01Config.CheckRetryPeriod, "dns01-check-retry-period", c.ACMEDNS01Config.CheckRetryPeriod, ""+
 		"The duration the controller should wait between a propagation check. Despite the name, this flag is used to configure the wait period for both DNS01 and HTTP01 challenge propagation checks. For DNS01 challenges the propagation check verifies that a TXT record with the challenge token has been created. For HTTP01 challenges the propagation check verifies that the challenge token is served at the challenge URL."+
 		"This should be a valid duration string, for example 180s or 1h")
+	fs.DurationVar(&c.ACMEDNS01Config.Timeout, "dns01-timeout", c.ACMEDNS01Config.Timeout, ""+
+		"The maximum time allowed for DNS01 provider API calls to complete. "+
+		"This is the timeout applied to HTTP requests made to DNS provider APIs (e.g., Cloudflare, DigitalOcean). "+
+		"Increase this value in environments with slow or restricted internet connectivity. "+
+		"This should be a valid duration string, for example 30s or 1m")
 
 	fs.BoolVar(&c.EnableCertificateOwnerRef, "enable-certificate-owner-ref", c.EnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -177,6 +177,11 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.DurationVar(&c.ACMEDNS01Config.CheckRetryPeriod, "dns01-check-retry-period", c.ACMEDNS01Config.CheckRetryPeriod, ""+
 		"The duration the controller should wait between a propagation check. Despite the name, this flag is used to configure the wait period for both DNS01 and HTTP01 challenge propagation checks. For DNS01 challenges the propagation check verifies that a TXT record with the challenge token has been created. For HTTP01 challenges the propagation check verifies that the challenge token is served at the challenge URL."+
 		"This should be a valid duration string, for example 180s or 1h")
+	fs.DurationVar(&c.ACMEDNS01Config.Timeout, "dns01-timeout", c.ACMEDNS01Config.Timeout, ""+
+		"The maximum time allowed for DNS01 provider API calls to complete. "+
+		"This is the timeout applied to HTTP requests made to DNS provider APIs (e.g., Cloudflare, DigitalOcean). "+
+		"Increase this value in environments with slow or restricted internet connectivity. "+
+		"This should be a valid duration string, for example 30s or 1m")
 
 	fs.BoolVar(&c.EnableCertificateOwnerRef, "enable-certificate-owner-ref", c.EnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+

--- a/internal/apis/config/controller/fuzzer/fuzzer.go
+++ b/internal/apis/config/controller/fuzzer/fuzzer.go
@@ -115,6 +115,10 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []any {
 				s.ACMEDNS01Config.CheckRetryPeriod = time.Second * 8875
 			}
 
+			if s.ACMEDNS01Config.Timeout == time.Duration(0) {
+				s.ACMEDNS01Config.Timeout = time.Second * 8875
+			}
+
 			// The deprecated top-level fields are always overwritten by the defaulter
 			// to mirror the canonical GatewayAPIConfig fields, so keep them in sync here
 			// to ensure the round-trip produces an identical object.

--- a/internal/apis/config/controller/fuzzer/fuzzer.go
+++ b/internal/apis/config/controller/fuzzer/fuzzer.go
@@ -119,6 +119,10 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []any {
 				s.ACMEDNS01Config.CheckRetryPeriod = time.Second * 8875
 			}
 
+			if s.ACMEDNS01Config.Timeout == time.Duration(0) {
+				s.ACMEDNS01Config.Timeout = time.Second * 8875
+			}
+
 			// The deprecated top-level fields are always overwritten by the defaulter
 			// to mirror the canonical GatewayAPIConfig fields, so keep them in sync here
 			// to ensure the round-trip produces an identical object.

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -243,6 +243,13 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod time.Duration
+
+	// The maximum time allowed for DNS01 provider API calls to complete.
+	// This is the timeout applied to HTTP requests made to DNS provider APIs
+	// (e.g., Cloudflare, DigitalOcean). Increase this value in environments
+	// with slow or restricted internet connectivity. This should be a valid
+	// duration string, for example 30s or 1m
+	Timeout time.Duration
 }
 
 type GatewayAPIConfig struct {

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -260,6 +260,13 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod time.Duration
+
+	// The maximum time allowed for DNS01 provider API calls to complete.
+	// This is the timeout applied to HTTP requests made to DNS provider APIs
+	// (e.g., Cloudflare, DigitalOcean). Increase this value in environments
+	// with slow or restricted internet connectivity. This should be a valid
+	// duration string, for example 30s or 1m
+	Timeout time.Duration
 }
 
 type GatewayAPIConfig struct {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -78,6 +78,7 @@ var (
 	defaultDNS01RecursiveNameserversOnly = false
 	defaultDNS01RecursiveNameservers     = []string{}
 	defaultDNS01CheckRetryPeriod         = 10 * time.Second
+	defaultDNS01Timeout                  = 30 * time.Second
 
 	defaultNumberOfConcurrentWorkers int32 = 5
 	defaultMaxConcurrentChallenges   int32 = 60
@@ -362,6 +363,10 @@ func SetDefaults_ACMEDNS01Config(obj *v1alpha1.ACMEDNS01Config) {
 
 	if obj.CheckRetryPeriod.IsZero() {
 		obj.CheckRetryPeriod = sharedv1alpha1.DurationFromTime(defaultDNS01CheckRetryPeriod)
+	}
+
+	if obj.Timeout.IsZero() {
+		obj.Timeout = sharedv1alpha1.DurationFromTime(defaultDNS01Timeout)
 	}
 }
 

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -78,6 +78,7 @@ var (
 	defaultDNS01RecursiveNameserversOnly = false
 	defaultDNS01RecursiveNameservers     = []string{}
 	defaultDNS01CheckRetryPeriod         = 10 * time.Second
+	defaultDNS01Timeout                  = 30 * time.Second
 
 	defaultNumberOfConcurrentWorkers int32 = 5
 	defaultMaxConcurrentChallenges   int32 = 60
@@ -372,6 +373,10 @@ func SetDefaults_ACMEDNS01Config(obj *v1alpha1.ACMEDNS01Config) {
 
 	if obj.CheckRetryPeriod.IsZero() {
 		obj.CheckRetryPeriod = sharedv1alpha1.DurationFromTime(defaultDNS01CheckRetryPeriod)
+	}
+
+	if obj.Timeout.IsZero() {
+		obj.Timeout = sharedv1alpha1.DurationFromTime(defaultDNS01Timeout)
 	}
 }
 

--- a/internal/apis/config/controller/v1alpha1/testdata/defaults.json
+++ b/internal/apis/config/controller/v1alpha1/testdata/defaults.json
@@ -66,7 +66,8 @@
 	},
 	"acmeDNS01Config": {
 		"recursiveNameserversOnly": false,
-		"checkRetryPeriod": "10s"
+		"checkRetryPeriod": "10s",
+		"timeout": "30s"
 	},
 	"pemSizeLimitsConfig": {
 		"maxCertificateSize": 36500,

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -120,6 +120,9 @@ func autoConvert_v1alpha1_ACMEDNS01Config_To_controller_ACMEDNS01Config(in *cont
 	if err := sharedv1alpha1.Convert_Pointer_v1alpha1_Duration_To_time_Duration(&in.CheckRetryPeriod, &out.CheckRetryPeriod, s); err != nil {
 		return err
 	}
+	if err := sharedv1alpha1.Convert_Pointer_v1alpha1_Duration_To_time_Duration(&in.Timeout, &out.Timeout, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -134,6 +137,9 @@ func autoConvert_controller_ACMEDNS01Config_To_v1alpha1_ACMEDNS01Config(in *cont
 		return err
 	}
 	if err := sharedv1alpha1.Convert_time_Duration_To_Pointer_v1alpha1_Duration(&in.CheckRetryPeriod, &out.CheckRetryPeriod, s); err != nil {
+		return err
+	}
+	if err := sharedv1alpha1.Convert_time_Duration_To_Pointer_v1alpha1_Duration(&in.Timeout, &out.Timeout, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -245,6 +245,13 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod *sharedv1alpha1.Duration `json:"checkRetryPeriod,omitempty"`
+
+	// The maximum time allowed for DNS01 provider API calls to complete.
+	// This is the timeout applied to HTTP requests made to DNS provider APIs
+	// (e.g., Cloudflare, DigitalOcean). Increase this value in environments
+	// with slow or restricted internet connectivity. This should be a valid
+	// duration string, for example 30s or 1m
+	Timeout *sharedv1alpha1.Duration `json:"timeout,omitempty"`
 }
 
 type GatewayAPIConfig struct {

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -264,6 +264,13 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod *sharedv1alpha1.Duration `json:"checkRetryPeriod,omitempty"`
+
+	// The maximum time allowed for DNS01 provider API calls to complete.
+	// This is the timeout applied to HTTP requests made to DNS provider APIs
+	// (e.g., Cloudflare, DigitalOcean). Increase this value in environments
+	// with slow or restricted internet connectivity. This should be a valid
+	// duration string, for example 30s or 1m
+	Timeout *sharedv1alpha1.Duration `json:"timeout,omitempty"`
 }
 
 type GatewayAPIConfig struct {

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -44,6 +44,11 @@ func (in *ACMEDNS01Config) DeepCopyInto(out *ACMEDNS01Config) {
 		*out = new(sharedv1alpha1.Duration)
 		**out = **in
 	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(sharedv1alpha1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -211,6 +211,9 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// DNS01Timeout is the maximum time allowed for DNS01 provider API calls to complete.
+	DNS01Timeout time.Duration
 }
 
 // IngressShimOptions contain default Issuer GVK config for the certificate-shim controllers.

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -228,6 +228,9 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// DNS01Timeout is the maximum time allowed for DNS01 provider API calls to complete.
+	DNS01Timeout time.Duration
 }
 
 // IngressShimOptions contain default Issuer GVK config for the certificate-shim controllers.

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -46,6 +46,7 @@ type DNSProvider struct {
 	authToken        string
 
 	userAgent string
+	timeout   time.Duration
 }
 
 // DNSZone is the Zone-Record returned from Cloudflare (we'll ignore everything we don't need)
@@ -58,15 +59,15 @@ type DNSZone struct {
 // NewDNSProvider returns a DNSProvider instance configured for cloudflare.
 // Credentials must be passed in the environment variables: CLOUDFLARE_EMAIL
 // and CLOUDFLARE_API_KEY.
-func NewDNSProvider(dns01Nameservers []string, userAgent string) (*DNSProvider, error) {
+func NewDNSProvider(dns01Nameservers []string, userAgent string, timeout time.Duration) (*DNSProvider, error) {
 	email := os.Getenv("CLOUDFLARE_EMAIL")
 	key := os.Getenv("CLOUDFLARE_API_KEY")
-	return NewDNSProviderCredentials(email, key, "", dns01Nameservers, userAgent)
+	return NewDNSProviderCredentials(email, key, "", dns01Nameservers, userAgent, timeout)
 }
 
 // NewDNSProviderCredentials uses the supplied credentials to return a
 // DNSProvider instance configured for cloudflare.
-func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []string, userAgent string) (*DNSProvider, error) {
+func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []string, userAgent string, timeout time.Duration) (*DNSProvider, error) {
 	if (email == "" && key != "") || (key == "" && token == "") {
 		return nil, fmt.Errorf("no Cloudflare credential has been given (can be either an API key or an API token)")
 	}
@@ -93,6 +94,7 @@ func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []stri
 		authToken:        token,
 		dns01Nameservers: dns01Nameservers,
 		userAgent:        userAgent,
+		timeout:          timeout,
 	}, nil
 }
 
@@ -275,7 +277,7 @@ func (c *DNSProvider) makeRequest(ctx context.Context, method, uri string, body 
 	req.Header.Set("User-Agent", c.userAgent)
 
 	client := http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: c.timeout,
 	}
 	// #nosec G704 -- the URI is prepared in our own code, and is controlled
 	resp, err := client.Do(req)

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -34,6 +34,9 @@ const CloudFlareAPIURL = "https://api.cloudflare.com/client/v4"
 // and is chosen to be large enough that any reasonable response would fit.
 const cloudFlareMaxBodySize = 1024 * 1024 // 1mb
 
+// defaultTimeout is the API request timeout used when no Timeout option is given.
+const defaultTimeout = 30 * time.Second
+
 // DNSProviderType is the Mockable Interface
 type DNSProviderType interface {
 	makeRequest(ctx context.Context, method, uri string, body io.Reader) (json.RawMessage, error)
@@ -46,6 +49,7 @@ type DNSProvider struct {
 	authToken string
 
 	userAgent string
+	timeout   time.Duration
 }
 
 // DNSZone is the Zone-Record returned from Cloudflare (we'll ignore everything we don't need)
@@ -86,11 +90,17 @@ func NewDNSProviderFromOptions(_ context.Context, options ...DNSProviderOption) 
 		return nil, err
 	}
 
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
 	return &DNSProvider{
 		authEmail: opts.Email,
 		authKey:   opts.APIKey,
 		authToken: opts.APIToken,
 		userAgent: opts.UserAgent,
+		timeout:   timeout,
 	}, nil
 }
 
@@ -299,7 +309,7 @@ func (c *DNSProvider) makeRequest(ctx context.Context, method, uri string, body 
 	req.Header.Set("User-Agent", c.userAgent)
 
 	client := http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: c.timeout,
 	}
 	// #nosec G704 -- the URI is prepared in our own code, and is controlled
 	resp, err := client.Do(req)

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -54,35 +54,35 @@ func init() {
 func TestNewDNSProviderValidAPIKey(t *testing.T) {
 	t.Setenv("CLOUDFLARE_EMAIL", "")
 	t.Setenv("CLOUDFLARE_API_KEY", "")
-	_, err := NewDNSProviderCredentials("123", "123", "", util.RecursiveNameservers, "cert-manager-test")
+	_, err := NewDNSProviderCredentials("123", "123", "", util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.NoError(t, err)
 }
 
 func TestNewDNSProviderValidAPIToken(t *testing.T) {
 	t.Setenv("CLOUDFLARE_EMAIL", "")
 	t.Setenv("CLOUDFLARE_API_KEY", "")
-	_, err := NewDNSProviderCredentials("123", "", "123", util.RecursiveNameservers, "cert-manager-test")
+	_, err := NewDNSProviderCredentials("123", "", "123", util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.NoError(t, err)
 }
 
 func TestNewDNSProviderKeyAndTokenProvided(t *testing.T) {
 	t.Setenv("CLOUDFLARE_EMAIL", "")
 	t.Setenv("CLOUDFLARE_API_KEY", "")
-	_, err := NewDNSProviderCredentials("123", "123", "123", util.RecursiveNameservers, "cert-manager-test")
+	_, err := NewDNSProviderCredentials("123", "123", "123", util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.EqualError(t, err, "the Cloudflare API key and API token cannot be both present simultaneously")
 }
 
 func TestNewDNSProviderValidApiKeyEnv(t *testing.T) {
 	t.Setenv("CLOUDFLARE_EMAIL", "test@example.com")
 	t.Setenv("CLOUDFLARE_API_KEY", "123")
-	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
+	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.NoError(t, err)
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	t.Setenv("CLOUDFLARE_EMAIL", "")
 	t.Setenv("CLOUDFLARE_API_KEY", "")
-	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test")
+	_, err := NewDNSProvider(util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.EqualError(t, err, "no Cloudflare credential has been given (can be either an API key or an API token)")
 }
 
@@ -127,7 +127,7 @@ func TestCloudFlarePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, cflareAPIToken, util.RecursiveNameservers, "cert-manager-test")
+	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, cflareAPIToken, util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.NoError(t, err)
 
 	err = provider.Present(t.Context(), cflareDomain, "_acme-challenge."+cflareDomain+".", "123d==")
@@ -141,7 +141,7 @@ func TestCloudFlareCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, cflareAPIToken, util.RecursiveNameservers, "cert-manager-test")
+	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, cflareAPIToken, util.RecursiveNameservers, "cert-manager-test", 30*time.Second)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(t.Context(), cflareDomain, "_acme-challenge."+cflareDomain+".", "123d==")

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -221,3 +221,27 @@ func TestNewDNSProviderFromOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestNewDNSProviderFromOptionsTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "unset falls back to the default", want: defaultTimeout},
+		{name: "zero falls back to the default", timeout: 0, want: defaultTimeout},
+		{name: "negative falls back to the default", timeout: -1 * time.Second, want: defaultTimeout},
+		{name: "explicit value is honoured", timeout: 90 * time.Second, want: 90 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewDNSProviderFromOptions(t.Context(),
+				APIToken("123"),
+				UserAgent("cert-manager-test"),
+				Timeout(tt.timeout))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, provider.timeout)
+		})
+	}
+}

--- a/pkg/issuer/acme/dns/cloudflare/options.go
+++ b/pkg/issuer/acme/dns/cloudflare/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package cloudflare
 
+import "time"
+
 // DNSProviderOptions holds the full configuration for the Cloudflare DNS provider.
 type DNSProviderOptions struct {
 	// Email is the Cloudflare account email address. Required when using API key authentication.
@@ -26,6 +28,8 @@ type DNSProviderOptions struct {
 	APIToken string
 	// UserAgent is the HTTP User-Agent string sent to the Cloudflare API.
 	UserAgent string
+	// Timeout is the maximum duration of a single Cloudflare API request. Defaults to 30s when unset.
+	Timeout time.Duration
 }
 
 // DNSProviderOption is a functional option for configuring a DNSProvider.
@@ -63,4 +67,12 @@ type UserAgent string
 // ApplyToDNSProviderOptions sets the UserAgent field.
 func (u UserAgent) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
 	o.UserAgent = string(u)
+}
+
+// Timeout sets the maximum duration of a single Cloudflare API request on DNSProviderOptions.
+type Timeout time.Duration
+
+// ApplyToDNSProviderOptions sets the Timeout field.
+func (t Timeout) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
+	o.Timeout = time.Duration(t)
 }

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -61,7 +61,7 @@ type solver interface {
 // constructors may be set.
 type dnsProviderConstructors struct {
 	cloudDNS     func(ctx context.Context, project string, serviceAccount []byte, dns01Nameservers []string, ambient bool, hostedZoneName string) (*clouddns.DNSProvider, error)
-	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string) (*cloudflare.DNSProvider, error)
+	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string, timeout time.Duration) (*cloudflare.DNSProvider, error)
 	route53      func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
 	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity, opts ...azuredns.ProviderOption) (*azuredns.DNSProvider, error)
 	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
@@ -276,7 +276,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 		}
 
 		email := providerConfig.Cloudflare.Email
-		impl, err = s.dnsProviderConstructors.cloudFlare(email, apiKey, apiToken, s.DNS01Nameservers, s.RESTConfig.UserAgent)
+		impl, err = s.dnsProviderConstructors.cloudFlare(email, apiKey, apiToken, s.DNS01Nameservers, s.RESTConfig.UserAgent, s.DNS01Timeout)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err)
 		}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -302,7 +302,8 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			cloudflare.Email(email),
 			cloudflare.APIKey(apiKey),
 			cloudflare.APIToken(apiToken),
-			cloudflare.UserAgent(s.RESTConfig.UserAgent))
+			cloudflare.UserAgent(s.RESTConfig.UserAgent),
+			cloudflare.Timeout(s.DNS01Timeout))
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err)
 		}

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -122,7 +123,7 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("clouddns", project, serviceAccount, util.RecursiveNameservers, ambient, hostedZoneName)
 			return nil, nil
 		},
-		cloudFlare: func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string) (*cloudflare.DNSProvider, error) {
+		cloudFlare: func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string, timeout time.Duration) (*cloudflare.DNSProvider, error) {
 			f.call("cloudflare", email, apikey, apiToken, util.RecursiveNameservers)
 			if email == "" || (apikey == "" && apiToken == "") {
 				return nil, errors.New("invalid email or apikey or apitoken")


### PR DESCRIPTION
## Summary

The Cloudflare DNS01 provider has a hardcoded 30-second HTTP client timeout for API calls. In environments with slow or restricted internet connectivity, this timeout is insufficient and causes DNS01 challenges to fail.

This PR adds a new `--dns01-timeout` controller flag that allows configuring the HTTP client timeout for DNS01 provider API calls. The default remains 30s for backwards compatibility.

### Changes

- Added `Timeout` field to `ACMEDNS01Config` (internal and v1alpha1 types)
- Added `--dns01-timeout` CLI flag to the controller
- Wired the timeout through the controller context to the Cloudflare DNS provider
- Replaced the hardcoded `30 * time.Second` in Cloudflare's `makeRequest()` with the configurable value
- Updated generated code (conversion, deepcopy), fuzzer, defaults, and tests

Fixes #8493

```release-note
Added a new `--dns01-timeout` controller flag to configure the HTTP client timeout for DNS01 provider API calls (default: 30s). This replaces the previously hardcoded 30-second timeout in the Cloudflare provider.
```