### PR TITLE
feat: support ECC keys for ACME account private keys

### DIFF
--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -42,7 +42,7 @@ type NewClientOptions struct {
 	SkipTLSVerify bool
 	CABundle      []byte
 	Server        string
-	PrivateKey    *rsa.PrivateKey
+	PrivateKey    crypto.Signer
 }
 
 // NewClientFunc is a function type for building a new ACME client.

--- a/pkg/acme/accounts/registry.go
+++ b/pkg/acme/accounts/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -44,7 +44,7 @@ type Registry interface {
 
 	// IsKeyCheckSumCached checks if the private key checksum is cached with registered client.
 	// If not cached, the account is re-verified for the private key.
-	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 
 	Getter
 }
@@ -88,8 +88,6 @@ type stableOptions struct {
 	serverURL     string
 	skipVerifyTLS bool
 	issuerUID     string
-	publicKey     string
-	exponent      int
 	caBundle      string
 	keyChecksum   [sha256.Size]byte
 }
@@ -99,16 +97,17 @@ func (c stableOptions) equalTo(c2 stableOptions) bool {
 }
 
 func newStableOptions(uid string, options NewClientOptions) stableOptions {
-	// Encoding a big.Int cannot fail
-	publicNBytes, _ := options.PrivateKey.PublicKey.N.GobEncode()
-	checksum := sha256.Sum256(x509.MarshalPKCS1PrivateKey(options.PrivateKey))
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(options.PrivateKey)
+	if err != nil {
+		// This should never happen for supported key types (RSA, ECDSA, Ed25519).
+		pkcs8Bytes = []byte{}
+	}
+	checksum := sha256.Sum256(pkcs8Bytes)
 
 	return stableOptions{
 		serverURL:     options.Server,
 		skipVerifyTLS: options.SkipTLSVerify,
 		issuerUID:     uid,
-		publicKey:     string(publicNBytes),
-		exponent:      options.PrivateKey.PublicKey.E,
 		caBundle:      string(options.CABundle),
 		keyChecksum:   checksum,
 	}
@@ -197,12 +196,15 @@ func (r *registry) ListClients() map[string]acmecl.Interface {
 // IsKeyCheckSumCached returns true when there is no difference in private key checksum.
 // This can be used to identify if the private key has changed for the existing
 // registered client.
-func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
 	if privateKey != nil && lastPrivateKeyHash != "" {
-		privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return false
+		}
 		checksum := sha256.Sum256(privateKeyBytes)
 		checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 

--- a/pkg/acme/accounts/registry_test.go
+++ b/pkg/acme/accounts/registry_test.go
@@ -187,7 +187,10 @@ func TestRegistry_AddClient_UpdatesClientPKChecksum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkBytes := x509.MarshalPKCS1PrivateKey(pk)
+	pkBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pkChecksum := sha256.Sum256(pkBytes)
 	pkChecksumString := base64.StdEncoding.EncodeToString(pkChecksum[:])
 

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"crypto/rsa"
+	"crypto"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -31,7 +31,7 @@ type FakeRegistry struct {
 	RemoveClientFunc        func(uid string)
 	GetClientFunc           func(uid string) (acmecl.Interface, error)
 	ListClientsFunc         func() map[string]acmecl.Interface
-	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 }
 
 func (f *FakeRegistry) AddClient(uid string, options accounts.NewClientOptions) {
@@ -50,6 +50,6 @@ func (f *FakeRegistry) ListClients() map[string]acmecl.Interface {
 	return f.ListClientsFunc()
 }
 
-func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	return f.IsKeyCheckSumCachedFunc(lastPrivateKeyHash, privateKey)
 }

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -18,7 +18,7 @@ package acme
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -61,7 +61,6 @@ const (
 	messageInvalidPrivateKey             = "Account private key is invalid: "
 
 	messageTemplateUpdateToV2              = "Your ACME server URL is set to a v1 endpoint (%s). You should update the spec.acme.server field to %q"
-	messageTemplateNotRSA                  = "ACME private key in %q is not of type RSA"
 	messageTemplateFailedToParseURL        = "Failed to parse existing ACME server URI %q: %v"
 	messageTemplateFailedToParseAccountURL = "Failed to parse existing ACME account URI %q: %v"
 	messageTemplateFailedToGetEABKey       = "failed to get External Account Binding key from secret: %v"
@@ -170,20 +169,8 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			message: msg,
 		}
 	}
-	rsaPk, ok := pk.(*rsa.PrivateKey)
-	if !ok {
-		msg := fmt.Sprintf(messageTemplateNotRSA,
-			issuer.GetSpec().ACME.PrivateKey.Name)
-		return setupResult{
-			err: nil,
 
-			status:  cmmeta.ConditionFalse,
-			reason:  errorAccountVerificationFailed,
-			message: msg,
-		}
-	}
-
-	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, rsaPk)
+	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, pk)
 
 	// TODO: don't always clear the client cache.
 	//  In future we should intelligently manage items in the account cache
@@ -198,7 +185,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	// TODO: perform a complex check to determine whether we need to verify
@@ -260,7 +247,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 			CABundle:      issuer.GetSpec().ACME.CABundle,
 			Server:        issuer.GetSpec().ACME.Server,
-			PrivateKey:    rsaPk,
+			PrivateKey:    pk,
 		})
 
 		return setupResult{
@@ -408,7 +395,17 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 	}
 
 	log.V(logf.InfoLevel).Info("verified existing registration with ACME server")
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(rsaPk)
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		msg := fmt.Sprintf("failed to marshal account private key: %v", err)
+		return setupResult{
+			err: fmt.Errorf("%s", msg),
+
+			status:  cmmeta.ConditionFalse,
+			reason:  errorAccountVerificationFailed,
+			message: msg,
+		}
+	}
 	checksum := sha256.Sum256(privateKeyBytes)
 	checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 	issuer.GetStatus().ACMEStatus().URI = account.URI
@@ -419,7 +416,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	return setupResult{
@@ -524,9 +521,14 @@ func (a *Acme) getEABKey(ctx context.Context, ns string, eab cmmeta.SecretKeySel
 
 // createAccountPrivateKey will generate a new RSA private key, and create it
 // as a secret resource in the apiserver.
-func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (*rsa.PrivateKey, error) {
+func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (crypto.Signer, error) {
 	sel = acme.PrivateKeySelector(sel)
 	accountPrivKey, err := pki.GenerateRSAPrivateKey(pki.MinRSAKeySize)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedKey, err := pki.EncodePKCS8PrivateKey(accountPrivKey)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +542,7 @@ func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKey
 			},
 		},
 		Data: map[string][]byte{
-			sel.Key: pki.EncodePKCS1PrivateKey(accountPrivKey),
+			sel.Key: encodedKey,
 		},
 	}, metav1.CreateOptions{})
 
@@ -548,7 +550,7 @@ func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKey
 		return nil, err
 	}
 
-	return accountPrivKey, err
+	return accountPrivKey, nil
 }
 
 var (

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -19,7 +19,6 @@ package acme
 import (
 	"context"
 	"crypto"
-	"crypto/rsa"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -128,7 +127,7 @@ func TestAcme_Setup(t *testing.T) {
 		// Error returned when creating ACME account key.
 		acmePrivKeySecretCreateErr error
 		// ACME account key created by createAccountPrivateKey.
-		acmePrivKey *rsa.PrivateKey
+		acmePrivKey crypto.Signer
 
 		eabSecret       *corev1.Secret
 		eabSecretGetErr error
@@ -185,7 +184,7 @@ func TestAcme_Setup(t *testing.T) {
 		"ACME private key secret does not exist, account key generation is enabled, key creation succeeds": {
 			issuer:      gen.IssuerFrom(baseIssuer),
 			kfsErr:      notFoundErr,
-			acmePrivKey: rsaPrivKey.(*rsa.PrivateKey),
+			acmePrivKey: rsaPrivKey,
 			expectedConditions: []cmapi.IssuerCondition{
 				*gen.IssuerConditionFrom(readyTrueCondition)},
 			removeClientShouldBeCalled: true,
@@ -211,14 +210,15 @@ func TestAcme_Setup(t *testing.T) {
 			},
 			wantsErr: true,
 		},
-		"ACME account's key is not an RSA key": {
+		"ACME account's key is an ECDSA key": {
 			issuer: gen.IssuerFrom(baseIssuer,
 				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
-			kfsKey: ecdsaPrivKey,
+			kfsKey:                     ecdsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
 			expectedConditions: []cmapi.IssuerCondition{
-				*gen.IssuerConditionFrom(readyFalseCondition,
-					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateNotRSA, issuerSecretKeyName))),
+				*gen.IssuerConditionFrom(readyTrueCondition),
 			},
 		},
 		"ACME server URL is an invalid URL": {
@@ -539,7 +539,7 @@ func TestAcme_Setup(t *testing.T) {
 				AddClientFunc: func(string, accounts.NewClientOptions) {
 					addClientWasCalled = true
 				},
-				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 					return true
 				},
 			}


### PR DESCRIPTION
## Summary

- Remove the RSA-only restriction for ACME account private keys, allowing ECDSA (and other `crypto.Signer`-compatible) keys to be used for external account binding (EAB) and account registration.
- Change the key handling pipeline to use the `crypto.Signer` interface throughout, which the underlying ACME client library (`x/crypto/acme`) already supports.
- Switch from PKCS1 (RSA-only) to PKCS8 (key-type-agnostic) encoding for private key serialization and checksum computation.

## Motivation

Fixes #8434

Currently, ACME issuer private keys are hardcoded to RSA. The ACME spec (RFC 8555) and many ACME providers support ECC keys (ECDSA P-256, P-384, P-521). Users who have existing ACME accounts created with ECC keys using other tools cannot reuse those accounts with cert-manager — they are forced to re-do account binding with RSA keys.

This change allows users to supply ECC private keys in their Kubernetes Secrets and have them accepted by cert-manager for ACME account operations.

## Changes

| File | Change |
|------|--------|
| `pkg/acme/accounts/client.go` | `NewClientOptions.PrivateKey`: `*rsa.PrivateKey` → `crypto.Signer` |
| `pkg/acme/accounts/registry.go` | `IsKeyCheckSumCached`: accepts `crypto.Signer`; `newStableOptions`: uses PKCS8 marshaling instead of PKCS1 + RSA-specific fields |
| `pkg/acme/accounts/test/registry.go` | `FakeRegistry.IsKeyCheckSumCachedFunc`: updated signature |
| `pkg/issuer/acme/setup.go` | Removed RSA type assertion; uses `crypto.Signer` throughout; `createAccountPrivateKey` returns `crypto.Signer`; PKCS8 encoding for key storage and checksum |
| `pkg/issuer/acme/setup_test.go` | Updated ECDSA test case to expect success; updated mock signatures |
| `pkg/acme/accounts/registry_test.go` | Updated checksum test to use PKCS8 |

## Test plan

- [x] All existing unit tests in `pkg/acme/accounts/...` pass
- [x] All existing unit tests in `pkg/issuer/acme/...` pass
- [x] Updated test "ACME account's key is an ECDSA key" verifies that ECDSA keys are now accepted and registration succeeds
- [x] Checksum caching test updated to use PKCS8 encoding