### PR TITLE
Fix typo "commonname" in PreferredChain field comment

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -161,7 +161,7 @@ spec:
                         "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
                         This value picks the first certificate bundle in the combined set of
                         ACME default and alternative chains that has a root-most certificate with
-                        this value as its issuer's commonname.
+                        this value as its issuer's common name.
                       maxLength: 64
                       type: string
                     privateKeySecretRef:

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -160,7 +160,7 @@ spec:
                         "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
                         This value picks the first certificate bundle in the combined set of
                         ACME default and alternative chains that has a root-most certificate with
-                        this value as its issuer's commonname.
+                        this value as its issuer's common name.
                       maxLength: 64
                       type: string
                     privateKeySecretRef:

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -161,7 +161,7 @@ spec:
                       "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
                       This value picks the first certificate bundle in the combined set of
                       ACME default and alternative chains that has a root-most certificate with
-                      this value as its issuer's commonname.
+                      this value as its issuer's common name.
                     maxLength: 64
                     type: string
                   privateKeySecretRef:

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -160,7 +160,7 @@ spec:
                       "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
                       This value picks the first certificate bundle in the combined set of
                       ACME default and alternative chains that has a root-most certificate with
-                      this value as its issuer's commonname.
+                      this value as its issuer's common name.
                     maxLength: 64
                     type: string
                   privateKeySecretRef:

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1344,7 +1344,7 @@ func schema_pkg_apis_acme_v1_ACMEIssuer(ref common.ReferenceCallback) common.Ope
 					},
 					"preferredChain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST cross-sign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer's commonname.",
+							Description: "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST cross-sign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer's common name.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -50,7 +50,7 @@ type ACMEIssuer struct {
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
 	// This value picks the first certificate bundle in the combined set of
 	// ACME default and alternative chains that has a root-most certificate with
-	// this value as its issuer's commonname.
+	// this value as its issuer's common name.
 	// +optional
 	// +kubebuilder:validation:MaxLength=64
 	PreferredChain string `json:"preferredChain,omitempty"`

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
@@ -48,7 +48,7 @@ type ACMEIssuerApplyConfiguration struct {
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
 	// This value picks the first certificate bundle in the combined set of
 	// ACME default and alternative chains that has a root-most certificate with
-	// this value as its issuer's commonname.
+	// this value as its issuer's common name.
 	PreferredChain *string `json:"preferredChain,omitempty"`
 	// Base64-encoded bundle of PEM CAs which can be used to validate the certificate
 	// chain presented by the ACME server.


### PR DESCRIPTION
### Pull Request Motivation

Fix a typo in the `PreferredChain` field comment on `ACMEIssuer`: "commonname" > "common name". The X.509 term is "Common Name".
