### PR TITLE
Fixed infinite re-issuance loop when issuer returns an already expired certificate

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -365,6 +365,19 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 			})
 		}
 
+		// Check that the certificate is not already expired before storing it.
+		// This prevents infinite re-issuance loops when an issuer (e.g. Vault
+		// with leaf_not_after_behavior=truncate and an expired CA) returns
+		// already-expired certificates.
+		if c.clock.Now().After(x509Cert.NotAfter) {
+			return c.failIssueCertificate(ctx, log, crt, &cmapi.CertificateRequestCondition{
+				Type:    cmapi.CertificateRequestConditionReady,
+				Status:  cmmeta.ConditionFalse,
+				Reason:  "InvalidCertificate",
+				Message: fmt.Sprintf("Issuer returned an already expired certificate (notAfter: %s). This usually indicates an expired CA certificate in the issuer.", x509Cert.NotAfter.Format(time.RFC3339)),
+			})
+		}
+
 		return c.issueCertificate(ctx, nextRevision, crt, req, pk)
 	}
 

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -1416,6 +1416,56 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"if certificate is in Issuing state, CertificateRequest is ready but returns already expired certificate, fail issuance with backoff": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestReady,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+						gen.SetCertificateRequestCertificate(
+							testcrypto.MustCreateCertWithNotBeforeAfter(t, exampleBundle.PrivateKeyBytes, exampleBundle.Certificate,
+								fixedClockStart.Add(-2*time.Hour), fixedClockStart.Add(-1*time.Hour)),
+						),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						exampleBundle.Certificate.Namespace,
+						gen.CertificateFrom(exampleBundle.Certificate,
+							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+								Type:               cmapi.CertificateConditionIssuing,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "InvalidCertificate",
+								Message:            "The certificate request has failed to complete and will be retried: Issuer returned an already expired certificate (notAfter: " + fixedClockStart.Add(-1*time.Hour).UTC().Format(time.RFC3339) + "). This usually indicates an expired CA certificate in the issuer.",
+								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
+							}),
+							gen.SetCertificateLastFailureTime(metaFixedClockStart),
+							gen.SetCertificateIssuanceAttempts(ptr.To(1)),
+						),
+					)),
+				},
+				ExpectedEvents: []string{
+					"Warning InvalidCertificate The certificate request has failed to complete and will be retried: Issuer returned an already expired certificate (notAfter: " + fixedClockStart.Add(-1*time.Hour).UTC().Format(time.RFC3339) + "). This usually indicates an expired CA certificate in the issuer.",
+				},
+			},
+			expectedErr: false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## Summary
When an issuer such as Vault with `leaf_not_after_behavior=truncate` and an expired CA returns an already-expired leaf certificate, cert-manager would store it, detect it as expired via policy checks, and immediately re-issue — creating an infinite loop that can generate thousands of CertificateRequests in minutes. This adds a pre-storage expiry validation that fails with backoff instead, following the same pattern established in PR #8403 for public key mismatch detection.

## Key changes
- Added an expiry check in `issuing_controller.go` that rejects already-expired certificates before storing them, using `failIssueCertificate` to trigger backoff and prevent the loop
- Added a test case in `issuing_controller_test.go` that verifies issuance fails with an `InvalidCertificate` reason when the issuer returns a certificate with `NotAfter` in the past

Fixes #7741

## Test plan
- [x] New test case: expired certificate triggers `failIssueCertificate` with backoff
- [x] Existing issuing controller tests pass (`go test ./pkg/controller/certificates/issuing/...`)

```release-note
Fixed infinite re-issuance loop when issuer returns an already expired certificate
```