### PR TITLE
Feature/ignore namespaces

### DIFF
--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -230,6 +230,7 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 
 	setupOptions := cainjector.SetupOptions{
 		Namespace:                    opts.Namespace,
+		IgnoreNamespaces:             opts.IgnoreNamespaces,
 		EnableCertificatesDataSource: opts.EnableDataSourceConfig.Certificates,
 		EnabledReconcilersFor: map[string]bool{
 			cainjector.MutatingWebhookConfigurationName:   opts.EnableInjectableConfig.MutatingWebhookConfigurations,

--- a/cmd/cainjector/app/options/options.go
+++ b/cmd/cainjector/app/options/options.go
@@ -65,6 +65,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.CAInjectorConfiguration) {
 		"If set, this limits the scope of cainjector to a single namespace. "+
 		"If set, cainjector will not update resources with certificates outside of the "+
 		"configured namespace.")
+	fs.StringSliceVar(&c.IgnoreNamespaces, "ignore-namespaces", c.IgnoreNamespaces, ""+
+		"Comma-separated list of namespaces to ignore secrets from. "+
+		"Should not be used with --namespace.")
 	fs.BoolVar(&c.LeaderElectionConfig.Enabled, "leader-elect", c.LeaderElectionConfig.Enabled, ""+
 		"If true, cainjector will perform leader election between instances to ensure no more "+
 		"than one instance of cainjector operates at a time")

--- a/internal/apis/config/cainjector/types.go
+++ b/internal/apis/config/cainjector/types.go
@@ -36,6 +36,10 @@ type CAInjectorConfiguration struct {
 	// watched
 	Namespace string
 
+	// Comma-separated list of namespaces to ignore secrets from.
+	// Should not be used with --namespace.
+	IgnoreNamespaces []string
+
 	// LeaderElectionConfig configures the behaviour of the leader election
 	LeaderElectionConfig shared.LeaderElectionConfig
 

--- a/internal/apis/config/cainjector/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/cainjector/v1alpha1/zz_generated.conversion.go
@@ -75,6 +75,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_CAInjectorConfiguration_To_cainjector_CAInjectorConfiguration(in *cainjectorv1alpha1.CAInjectorConfiguration, out *cainjector.CAInjectorConfiguration, s conversion.Scope) error {
 	out.KubeConfig = in.KubeConfig
 	out.Namespace = in.Namespace
+	out.IgnoreNamespaces = *(*[]string)(unsafe.Pointer(&in.IgnoreNamespaces))
 	if err := sharedv1alpha1.Convert_v1alpha1_LeaderElectionConfig_To_shared_LeaderElectionConfig(&in.LeaderElectionConfig, &out.LeaderElectionConfig, s); err != nil {
 		return err
 	}
@@ -103,6 +104,7 @@ func Convert_v1alpha1_CAInjectorConfiguration_To_cainjector_CAInjectorConfigurat
 func autoConvert_cainjector_CAInjectorConfiguration_To_v1alpha1_CAInjectorConfiguration(in *cainjector.CAInjectorConfiguration, out *cainjectorv1alpha1.CAInjectorConfiguration, s conversion.Scope) error {
 	out.KubeConfig = in.KubeConfig
 	out.Namespace = in.Namespace
+	out.IgnoreNamespaces = *(*[]string)(unsafe.Pointer(&in.IgnoreNamespaces))
 	if err := sharedv1alpha1.Convert_shared_LeaderElectionConfig_To_v1alpha1_LeaderElectionConfig(&in.LeaderElectionConfig, &out.LeaderElectionConfig, s); err != nil {
 		return err
 	}

--- a/internal/apis/config/cainjector/validation/validation.go
+++ b/internal/apis/config/cainjector/validation/validation.go
@@ -30,5 +30,12 @@ func ValidateCAInjectorConfiguration(cfg *config.CAInjectorConfiguration, fldPat
 	allErrors = append(allErrors, logsapi.Validate(&cfg.Logging, nil, fldPath.Child("logging"))...)
 	allErrors = append(allErrors, sharedvalidation.ValidateLeaderElectionConfig(&cfg.LeaderElectionConfig, fldPath.Child("leaderElectionConfig"))...)
 
+	if cfg.Namespace != "" && len(cfg.IgnoreNamespaces) > 0 {
+		allErrors = append(allErrors, field.Forbidden(
+			fldPath.Child("ignoreNamespaces"),
+			"should not be used with --namespace.",
+		))
+	}
+
 	return allErrors
 }

--- a/internal/apis/config/cainjector/zz_generated.deepcopy.go
+++ b/internal/apis/config/cainjector/zz_generated.deepcopy.go
@@ -29,6 +29,11 @@ import (
 func (in *CAInjectorConfiguration) DeepCopyInto(out *CAInjectorConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.IgnoreNamespaces != nil {
+		in, out := &in.IgnoreNamespaces, &out.IgnoreNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.LeaderElectionConfig = in.LeaderElectionConfig
 	out.EnableDataSourceConfig = in.EnableDataSourceConfig
 	out.EnableInjectableConfig = in.EnableInjectableConfig

--- a/pkg/apis/config/cainjector/v1alpha1/types.go
+++ b/pkg/apis/config/cainjector/v1alpha1/types.go
@@ -37,6 +37,10 @@ type CAInjectorConfiguration struct {
 	// configured namespace.
 	Namespace string `json:"namespace,omitempty"`
 
+	// Comma-separated list of namespaces to ignore secrets from.
+	// Should not be used with --namespace.
+	IgnoreNamespaces []string `json:"ignoreNamespaces,omitempty"`
+
 	// LeaderElectionConfig configures the behaviour of the leader election
 	LeaderElectionConfig sharedv1alpha1.LeaderElectionConfig `json:"leaderElectionConfig"`
 

--- a/pkg/apis/config/cainjector/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/cainjector/v1alpha1/zz_generated.deepcopy.go
@@ -29,6 +29,11 @@ import (
 func (in *CAInjectorConfiguration) DeepCopyInto(out *CAInjectorConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.IgnoreNamespaces != nil {
+		in, out := &in.IgnoreNamespaces, &out.IgnoreNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.LeaderElectionConfig.DeepCopyInto(&out.LeaderElectionConfig)
 	in.EnableDataSourceConfig.DeepCopyInto(&out.EnableDataSourceConfig)
 	in.EnableInjectableConfig.DeepCopyInto(&out.EnableInjectableConfig)

--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -45,10 +46,10 @@ const (
 // Certificate that is configured as a CA source for an injectable via
 // inject-ca-from annotation, a reconcile loop will be triggered for this
 // injectable
-func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config setup, ignoreNamespaces map[string]struct{}) handler.MapFunc {
+func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config setup, ignoreNamespaces sets.Set[string]) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []ctrl.Request {
 
-		if _, ok := ignoreNamespaces[obj.GetNamespace()]; ok {
+		if ignoreNamespaces.Has(obj.GetNamespace()) {
 			return nil
 		}
 

--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -45,8 +45,13 @@ const (
 // Certificate that is configured as a CA source for an injectable via
 // inject-ca-from annotation, a reconcile loop will be triggered for this
 // injectable
-func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config setup) handler.MapFunc {
+func certFromSecretToInjectableMapFuncBuilder(cl client.Reader, log logr.Logger, config setup, ignoreNamespaces map[string]struct{}) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+
+		if _, ok := ignoreNamespaces[obj.GetNamespace()]; ok {
+			return nil
+		}
+
 		secretName := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 		certName := owningCertForSecret(obj.(*metav1.PartialObjectMetadata))
 		if certName == nil {

--- a/pkg/controller/cainjector/indexers_test.go
+++ b/pkg/controller/cainjector/indexers_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controller/cainjector/indexers_test.go
+++ b/pkg/controller/cainjector/indexers_test.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCertFromSecretToInjectableMapFuncBuilder_IgnoresNamespaces(t *testing.T) {
-	ignoreNamespaces := map[string]struct{}{"ignored-ns": {}}
+	ignoreNamespaces := sets.New("ignored-ns")
 	cl := fake.NewClientBuilder().Build()
 	log := logr.Discard()
 	setup := setup{resourceName: "test"}

--- a/pkg/controller/cainjector/indexers_test.go
+++ b/pkg/controller/cainjector/indexers_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cainjector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCertFromSecretToInjectableMapFuncBuilder_IgnoresNamespaces(t *testing.T) {
+	ignoreNamespaces := map[string]struct{}{"ignored-ns": {}}
+	cl := fake.NewClientBuilder().Build()
+	log := logr.Discard()
+	setup := setup{resourceName: "test"}
+
+	mapFunc := certFromSecretToInjectableMapFuncBuilder(cl, log, setup, ignoreNamespaces)
+
+	secret := &metav1.PartialObjectMetadata{}
+	secret.SetNamespace("ignored-ns")
+	secret.SetName("my-secret")
+
+	reqs := mapFunc(context.Background(), secret)
+	if reqs != nil {
+		t.Errorf("Expected nil for ignored namespace, got: %v", reqs)
+	}
+}

--- a/pkg/controller/cainjector/indexers_test.go
+++ b/pkg/controller/cainjector/indexers_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cainjector
 
 import (

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,6 +57,9 @@ type reconciler struct {
 
 	// if set, the reconciler is namespace scoped
 	namespace string
+
+	// a set of namespaces the reconciler should ignore when reconciling.
+	ignoreNamespaces sets.Set[string]
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -100,7 +100,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil //nolint:nilerr
 	}
 
-	caData, err := dataSource.ReadCA(ctx, log, obj, r.namespace)
+	caData, err := dataSource.ReadCA(ctx, log, obj, r.namespace, r.ignoreNamespaces)
 	if apierrors.IsForbidden(err) {
 		log.V(logf.InfoLevel).Info("cainjector was forbidden to retrieve the ca data source")
 		return ctrl.Result{}, nil

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -190,9 +190,16 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, opts SetupOptio
 				err := fmt.Errorf("error making injectable indexable by inject-ca-from path: %w", err)
 				return err
 			}
+
+			// Convert ignoreNamespaces slice to a map for more efficient lookups in the mapFunc
+			ignoreNamespacesMap := make(map[string]struct{})
+			for _, ns := range opts.IgnoreNamespaces {
+				ignoreNamespacesMap[ns] = struct{}{}
+			}
+
 			b.Watches(
 				new(corev1.Secret),
-				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup)),
+				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup, ignoreNamespacesMap)),
 				// See "Why do we use builder.OnlyMetadata?" above.
 				builder.OnlyMetadata,
 			).Watches(

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -111,6 +111,7 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, opts SetupOptio
 		apiserverCABundle: caBundle,
 	}
 	injectorSetups := []setup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, CRDSetup}
+	ignoreNamespacesSet := sets.New(opts.IgnoreNamespaces...)
 	// Registers a c/r controller for each of APIService, CustomResourceDefinition, Mutating/ValidatingWebhookConfiguration
 	for _, setup := range injectorSetups {
 		log := ctrl.Log.WithValues("kind", setup.resourceName)
@@ -194,7 +195,7 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, opts SetupOptio
 
 			b.Watches(
 				new(corev1.Secret),
-				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup, sets.New(opts.IgnoreNamespaces...))),
+				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup, ignoreNamespacesSet)),
 				// See "Why do we use builder.OnlyMetadata?" above.
 				builder.OnlyMetadata,
 			).Watches(

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -58,6 +58,7 @@ type setup struct {
 
 type SetupOptions struct {
 	Namespace                    string
+	IgnoreNamespaces             []string
 	EnableCertificatesDataSource bool
 	EnabledReconcilersFor        map[string]bool
 }

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -122,6 +122,7 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, opts SetupOptio
 		log.Info("Registering a reconciler for injectable")
 		r := &reconciler{
 			namespace:           opts.Namespace,
+			ignoreNamespaces:    ignoreNamespacesSet,
 			resourceName:        setup.resourceName,
 			newInjectableTarget: setup.newInjectableTarget,
 			log:                 log,

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -191,15 +192,9 @@ func RegisterAllInjectors(ctx context.Context, mgr ctrl.Manager, opts SetupOptio
 				return err
 			}
 
-			// Convert ignoreNamespaces slice to a map for more efficient lookups in the mapFunc
-			ignoreNamespacesMap := make(map[string]struct{})
-			for _, ns := range opts.IgnoreNamespaces {
-				ignoreNamespacesMap[ns] = struct{}{}
-			}
-
 			b.Watches(
 				new(corev1.Secret),
-				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup, ignoreNamespacesMap)),
+				handler.EnqueueRequestsFromMapFunc(certFromSecretToInjectableMapFuncBuilder(mgr.GetClient(), log, setup, sets.New(opts.IgnoreNamespaces...))),
 				// See "Why do we use builder.OnlyMetadata?" above.
 				builder.OnlyMetadata,
 			).Watches(

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -46,7 +46,7 @@ type caDataSource interface {
 
 	// ReadCA reads the CA that should be injected into the InjectTarget based
 	// on the configuration provided in the InjectTarget.
-	// ReadCA may return nil, nil if the CA data cannot or should not be read.
+	// ReadCA may return nil, nil if the CA data cannot be read.
 	// In this case, the caller should not retry the operation.
 	// It is up to the ReadCA implementation to inform the user why the CA
 	// failed to read.

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -97,7 +97,7 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	}
 
 	if ignoreNamespaces.Has(certName.Namespace) {
-		log.V(logf.InfoLevel).Info("ignoring CA data from Certificate in namespace %s, namespace is ignored", certName.Namespace)
+		log.V(logf.InfoLevel).Info("ignoring CA data from Certificate, namespace is ignored", "namespace", certName.Namespace)
 		return nil, nil
 	}
 
@@ -180,7 +180,7 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 	}
 
 	if ignoreNamespaces.Has(secretName.Namespace) {
-		log.V(logf.InfoLevel).Info("ignoring CA data from Secret in namespace %s, namespace is ignored", secretName.Namespace)
+		log.V(logf.InfoLevel).Info("ignoring CA data from Secret, namespace is ignored", "namespace", secretName.Namespace)
 		return nil, nil
 	}
 

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -97,8 +97,10 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	}
 
 	if ignoreNamespaces.Has(certName.Namespace) {
-		log.V(logf.InfoLevel).Info("ignoring CA data from Certificate, namespace is ignored", "namespace", certName.Namespace)
-		return nil, nil
+		err := fmt.Errorf("cannot read CA data from Certificate in namespace %s, namespace is ignored", certName.Namespace)
+		forbiddenErr := apierrors.NewForbidden(cmapi.Resource("certificates"), certName.Name, err)
+		log.Error(forbiddenErr, "cannot read data source")
+		return nil, forbiddenErr
 	}
 
 	if namespace != "" && certName.Namespace != namespace {
@@ -180,8 +182,10 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 	}
 
 	if ignoreNamespaces.Has(secretName.Namespace) {
-		log.V(logf.InfoLevel).Info("ignoring CA data from Secret, namespace is ignored", "namespace", secretName.Namespace)
-		return nil, nil
+		err := fmt.Errorf("cannot read CA data from Secret in namespace %s, namespace is ignored", secretName.Namespace)
+		forbiddenErr := apierrors.NewForbidden(cmapi.Resource("certificates"), secretName.Name, err)
+		log.Error(forbiddenErr, "cannot read data source")
+		return nil, forbiddenErr
 	}
 
 	if namespace != "" && secretName.Namespace != namespace {

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -45,11 +46,11 @@ type caDataSource interface {
 
 	// ReadCA reads the CA that should be injected into the InjectTarget based
 	// on the configuration provided in the InjectTarget.
-	// ReadCA may return nil, nil if the CA data cannot be read.
+	// ReadCA may return nil, nil if the CA data cannot or should not be read.
 	// In this case, the caller should not retry the operation.
 	// It is up to the ReadCA implementation to inform the user why the CA
 	// failed to read.
-	ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string) (ca []byte, err error)
+	ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string, ignoreNamespaces sets.Set[string]) (ca []byte, err error)
 }
 
 // kubeconfigDataSource reads the ca bundle provided as part of the struct
@@ -63,7 +64,7 @@ func (c *kubeconfigDataSource) Configured(log logr.Logger, metaObj metav1.Object
 	return metaObj.GetAnnotations()[cmapi.WantInjectAPIServerCAAnnotation] == "true"
 }
 
-func (c *kubeconfigDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string) (ca []byte, err error) {
+func (c *kubeconfigDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string, ignoreNamespaces sets.Set[string]) (ca []byte, err error) {
 	return c.apiserverCABundle, nil
 }
 
@@ -83,7 +84,7 @@ func (c *certificateDataSource) Configured(log logr.Logger, metaObj metav1.Objec
 	return true
 }
 
-func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string) (ca []byte, err error) {
+func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string, ignoreNamespaces sets.Set[string]) (ca []byte, err error) {
 	certNameRaw := metaObj.GetAnnotations()[cmapi.WantInjectAnnotation]
 	certName := splitNamespacedName(certNameRaw)
 	log = log.WithValues("certificate", certName)
@@ -94,6 +95,12 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil
 	}
+
+	if ignoreNamespaces.Has(certName.Namespace) {
+		log.V(logf.InfoLevel).Info("ignoring CA data from Certificate in namespace %s, namespace is ignored", certName.Namespace)
+		return nil, nil
+	}
+
 	if namespace != "" && certName.Namespace != namespace {
 		err := fmt.Errorf("cannot read CA data from Certificate in namespace %s, cainjector is scoped to namespace %s", certName.Namespace, namespace)
 		forbiddenErr := apierrors.NewForbidden(cmapi.Resource("certificates"), certName.Name, err)
@@ -160,7 +167,7 @@ func (c *secretDataSource) Configured(log logr.Logger, metaObj metav1.Object) bo
 	return true
 }
 
-func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string) ([]byte, error) {
+func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object, namespace string, ignoreNamespaces sets.Set[string]) ([]byte, error) {
 	secretNameRaw := metaObj.GetAnnotations()[cmapi.WantInjectFromSecretAnnotation]
 	secretName := splitNamespacedName(secretNameRaw)
 	log = log.WithValues("secret", secretName)
@@ -169,6 +176,11 @@ func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj 
 		log.Error(err, "invalid secret source: missing namespace/ prefix")
 		// TODO: should we return error here to prevent the caller from proceeding?
 		// don't return an error, requeuing won't help till this is changed
+		return nil, nil
+	}
+
+	if ignoreNamespaces.Has(secretName.Namespace) {
+		log.V(logf.InfoLevel).Info("ignoring CA data from Secret in namespace %s, namespace is ignored", secretName.Namespace)
 		return nil, nil
 	}
 


### PR DESCRIPTION
### Pull Request Motivation

Allow ignoring namespaces from the CA Injector so "configuration namespaces" by other controllers that might copy resources, i.e. secrets, verbatim, doesn't trigger the "unable to fetch certificate that owns the secret"-error, when the certificate is not also copied to that namespace.

Fixes: #8513 

### Kind

/kind feature

### Release Note

```release-note
cainjector:
- A new flag `--ignore-namespaces` was added to the cainjector binary. It can be used to filter out namespaces from being watched for secrets to use for injectables.
```

### Question for the maintainers

The issue referenced was about specifically ignoring secrets in the `certFromSecretToInjectableMapFuncBuilder`-logic, but I understand that `ignore-namespaces` feels very general. Should the flag be renamed, or should the ignore-logic be applied in other places as well for consistency, e.g. `secretForInjectableMapFuncBuilder`?

For the purpose of the specific issue, it would be okay to completely disable cainjector in e.g. the `cilium` config namespace.

### Anything else

The documentation on <https://cert-manager.io/docs/cli/cainjector/> should also be updated to reflect the new flag.