### PR TITLE
fix(certificate-shim): removing duplicate parentRefs

### DIFF
--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -226,22 +226,33 @@ func applyGatewayAPIAnnotationParentRefOverride(o *cmacme.Order, s *cmacme.ACMEC
 	}
 
 	if hasParentRefKind && hasParentRefName {
-		if s.HTTP01.GatewayHTTPRoute.ParentRefs == nil {
-			s.HTTP01.GatewayHTTPRoute.ParentRefs = []gwapi.ParentReference{}
+		ns := gwapi.Namespace(o.GetNamespace())
+		name := gwapi.ObjectName(parentRefName)
+		kind := gwapi.Kind(parentRefKind)
+
+		filtered := make([]gwapi.ParentReference, 0, len(s.HTTP01.GatewayHTTPRoute.ParentRefs))
+		for _, pr := range s.HTTP01.GatewayHTTPRoute.ParentRefs {
+			// Drop the issuer-configured parentRef if it matches the annotation override target.
+			// A nil Kind in issuer config is treated as matching any kind for this name/ns pair.
+			sameNamespace := pr.Namespace != nil && *pr.Namespace == ns
+			sameName := pr.Name == name
+			sameKind := pr.Kind == nil || *pr.Kind == kind
+
+			// TODO: we are ignoring section checks until we come up with an approach to support section name overrides.
+			if sameNamespace && sameName && sameKind {
+				continue
+			}
+
+			filtered = append(filtered, pr)
 		}
 
-		parentRefNs := o.GetNamespace()
-		s.HTTP01.GatewayHTTPRoute.ParentRefs = append(s.HTTP01.GatewayHTTPRoute.ParentRefs, gwapi.ParentReference{
-			Kind: func() *gwapi.Kind {
-				g := gwapi.Kind(parentRefKind)
-				return &g
-			}(),
-			Name: gwapi.ObjectName(parentRefName),
-			Namespace: func() *gwapi.Namespace {
-				ns := gwapi.Namespace(parentRefNs)
-				return &ns
-			}(),
+		filtered = append(filtered, gwapi.ParentReference{
+			Name:      name,
+			Namespace: &ns,
+			Kind:      &kind,
 		})
+
+		s.HTTP01.GatewayHTTPRoute.ParentRefs = filtered
 	}
 
 	// If after processing annotations we don't find any parentRefs this means the HTTPRoute

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -58,6 +58,25 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 			GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
 		},
 	}
+	parentRefsSelectorSolverHTTP01HTTPRoute := cmacme.ACMEChallengeSolver{
+		HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+			GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
+				ParentRefs: []gwapi.ParentReference{
+					{
+						Kind: func() *gwapi.Kind {
+							g := gwapi.Kind("Gateway")
+							return &g
+						}(),
+						Name: gwapi.ObjectName("sample-gateway"),
+						Namespace: func() *gwapi.Namespace {
+							ns := gwapi.Namespace("test-ns")
+							return &ns
+						}(),
+					},
+				},
+			},
+		},
+	}
 	emptySelectorSolverDNS01 := cmacme.ACMEChallengeSolver{
 		DNS01: &cmacme.ACMEChallengeSolverDNS01{
 			Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
@@ -384,6 +403,55 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 									}(),
 									Name:      gwapi.ObjectName("test-parent-ref-name"),
 									Namespace: (*gwapi.Namespace)(ptr.To("")),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"should remove duplicate parentRefs if issuer has same parentRef": {
+			acmeClient: basicACMEClient,
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						ACME: &cmacme.ACMEIssuer{
+							Solvers: []cmacme.ACMEChallengeSolver{parentRefsSelectorSolverHTTP01HTTPRoute},
+						},
+					},
+				},
+			},
+			order: &cmacme.Order{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						cmacme.ACMECertificateHTTP01ParentRefName: "sample-gateway",
+						cmacme.ACMECertificateHTTP01ParentRefKind: "Gateway",
+					},
+				},
+				Spec: cmacme.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &cmacme.ACMEAuthorization{
+				Identifier: "example.com",
+				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
+			},
+			expectedChallengeSpec: &cmacme.ChallengeSpec{
+				Type:    cmacme.ACMEChallengeTypeHTTP01,
+				DNSName: "example.com",
+				Token:   acmeChallengeHTTP01.Token,
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
+							ParentRefs: []gwapi.ParentReference{
+								{
+									Kind: func() *gwapi.Kind {
+										ls := gwapi.Kind("Gateway")
+										return &ls
+									}(),
+									Name:      gwapi.ObjectName("sample-gateway"),
+									Namespace: (*gwapi.Namespace)(ptr.To("test-ns")),
 								},
 							},
 						},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Adding extra validation so that we dont duplicate parentRefs from issuer config with the annotations on the cert object.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
fixed duplicate `parentRef` bug when both issuer config and annotations are present.
```