### PR TITLE
feat: add autoAnnotations support for Gateway-API

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -105,9 +105,11 @@ func SyncFnFor(
 
 		// The flag --auto-certificate-annotations as well as the default
 		// "kubernetes.io/tls-acme" annotation are only enabled for the Ingress
-		// resource.
+		// and gateway resource.
 		var autoAnnotations []string
 		if _, ok := ingLike.(*networkingv1.Ingress); ok {
+			autoAnnotations = defaults.DefaultAutoCertificateAnnotations
+		} else if _, ok := ingLike.(*gwapi.Gateway); ok {
 			autoAnnotations = defaults.DefaultAutoCertificateAnnotations
 		}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I want to use the same, easy annotation `kubernetes.io/tls-acme` used for ingress for gateway api as well.

I haven't yet tested this, though as far as I looked through the code this shuold just work,
I first wanted to get your input, as the current code explicitly states that only ingress is supported.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->

/kind feature

<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
add support for autoAnnotations for gateway api
```
