### PR TITLE
fix(dns01): don't follow wildcard CNAMEs for challenge domain

### DIFF
--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -23,14 +23,75 @@ func DNS01LookupFQDN(ctx context.Context, domain string, followCNAME bool, names
 
 	// Check if the domain has CNAME then return that
 	if followCNAME {
-		var err error
-		fqdn, err = followCNAMEs(ctx, fqdn, nameservers)
+		// Before following CNAMEs, check that the CNAME record is explicitly
+		// set on the _acme-challenge subdomain and not inherited from a
+		// wildcard record on the parent domain. Wildcard CNAMEs (e.g.,
+		// *.example.com) should not be followed because they would direct
+		// the challenge to a zone we likely don't control.
+		// See: https://github.com/cert-manager/cert-manager/issues/5751
+		isWildcard, err := isWildcardCNAME(ctx, fqdn, domain, nameservers)
 		if err != nil {
 			return "", err
+		}
+		if !isWildcard {
+			fqdn, err = followCNAMEs(ctx, fqdn, nameservers)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 
 	return fqdn, nil
+}
+
+// isWildcardCNAME checks whether the CNAME record returned for fqdn is
+// synthesized from a wildcard record on the parent domain rather than being an
+// explicit record. It does this by querying both the fqdn and the wildcard
+// entry of the parent domain; if both return CNAME records pointing to the same
+// target, the record is considered to be from a wildcard and should not be
+// followed.
+func isWildcardCNAME(ctx context.Context, fqdn, domain string, nameservers []string) (bool, error) {
+	// Query the CNAME for the exact _acme-challenge FQDN.
+	r, err := dnsQuery(ctx, fqdn, dns.TypeCNAME, nameservers, true)
+	if err != nil {
+		return false, err
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		return false, nil
+	}
+
+	// Extract the CNAME target for the challenge subdomain.
+	var challengeTarget string
+	for _, rr := range r.Answer {
+		if cn, ok := rr.(*dns.CNAME); ok {
+			challengeTarget = cn.Target
+			break
+		}
+	}
+	if challengeTarget == "" {
+		// No CNAME record found, nothing to follow.
+		return false, nil
+	}
+
+	// Query the wildcard CNAME for the parent domain.
+	wildcardFQDN := fmt.Sprintf("*.%s.", domain)
+	rWild, err := dnsQuery(ctx, wildcardFQDN, dns.TypeCNAME, nameservers, true)
+	if err != nil {
+		return false, err
+	}
+	if rWild.Rcode != dns.RcodeSuccess {
+		// No wildcard record exists, so the CNAME is explicit.
+		return false, nil
+	}
+
+	// Check if any wildcard CNAME target matches the challenge CNAME target.
+	for _, rr := range rWild.Answer {
+		if cn, ok := rr.(*dns.CNAME); ok && cn.Target == challengeTarget {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // FindBestMatch returns the longest match for a given domain within a list of domains

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -11,8 +11,11 @@ package util
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/miekg/dns"
+
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
 // DNS01LookupFQDN returns a DNS name which will be updated to solve the dns-01
@@ -21,77 +24,107 @@ import (
 func DNS01LookupFQDN(ctx context.Context, domain string, followCNAME bool, nameservers ...string) (string, error) {
 	fqdn := fmt.Sprintf("_acme-challenge.%s.", domain)
 
-	// Check if the domain has CNAME then return that
-	if followCNAME {
-		// Before following CNAMEs, check that the CNAME record is explicitly
-		// set on the _acme-challenge subdomain and not inherited from a
-		// wildcard record on the parent domain. Wildcard CNAMEs (e.g.,
-		// *.example.com) should not be followed because they would direct
-		// the challenge to a zone we likely don't control.
-		// See: https://github.com/cert-manager/cert-manager/issues/5751
-		isWildcard, err := isWildcardCNAME(ctx, fqdn, domain, nameservers)
-		if err != nil {
-			return "", err
-		}
-		if !isWildcard {
-			fqdn, err = followCNAMEs(ctx, fqdn, nameservers)
-			if err != nil {
-				return "", err
-			}
-		}
+	if !followCNAME {
+		return fqdn, nil
 	}
 
-	return fqdn, nil
+	// Resolve the first hop of the CNAME chain here rather than leaving it to
+	// followCNAMEs, so that the answer can be used both for the wildcard check
+	// below and for the rest of the chain. There is no cache on this path, so
+	// querying it twice would mean an extra live query on every lookup.
+	target, err := lookupCNAMETarget(ctx, fqdn, nameservers)
+	if err != nil {
+		return "", err
+	}
+	if target == "" {
+		// No CNAME record on the challenge name, so there is nothing to follow.
+		return fqdn, nil
+	}
+
+	// A CNAME answer for the challenge name is not necessarily a record of its
+	// own: if a wildcard CNAME covers the name, the resolver synthesizes the
+	// answer from it. Such a target is almost always in a zone we cannot write
+	// to, so following it would put the challenge record where the ACME server
+	// will never look for it.
+	// See: https://github.com/cert-manager/cert-manager/issues/5751
+	if isWildcardCNAME(ctx, domain, target, nameservers) {
+		logf.FromContext(ctx).V(logf.InfoLevel).Info("Not following CNAME because it appears to be synthesized by a wildcard record", "fqdn", fqdn, "cname", target)
+		return fqdn, nil
+	}
+
+	logf.FromContext(ctx).V(logf.DebugLevel).Info("Updating FQDN", "fqdn", fqdn, "cname", target)
+
+	// Continue from the hop that has already been resolved. fqdn is seeded into
+	// the chain so that a CNAME pointing back at it is still reported as a loop.
+	return followCNAMEs(ctx, target, nameservers, fqdn)
 }
 
-// isWildcardCNAME checks whether the CNAME record returned for fqdn is
-// synthesized from a wildcard record on the parent domain rather than being an
-// explicit record. It does this by querying both the fqdn and the wildcard
-// entry of the parent domain; if both return CNAME records pointing to the same
-// target, the record is considered to be from a wildcard and should not be
-// followed.
-func isWildcardCNAME(ctx context.Context, fqdn, domain string, nameservers []string) (bool, error) {
-	// Query the CNAME for the exact _acme-challenge FQDN.
+// isWildcardCNAME reports whether challengeTarget, the CNAME target resolved for
+// the _acme-challenge name of domain, looks like it was synthesized from a
+// wildcard CNAME record rather than read from a record of its own.
+//
+// It probes the literal wildcard name and compares the targets. Querying "*." is
+// legitimate: RFC 4592 section 2.2.1 treats an asterisk in a query name as an
+// ordinary label, so the probe returns the wildcard's own records when one
+// exists at that level. A wildcard higher in the tree is found too. If
+// *.example.com covers _acme-challenge.app.example.com because app.example.com
+// has no records of its own, then the probe name *.app.example.com is
+// synthesized by that same wildcard and gives the same target.
+//
+// A recursive answer does not say which of its records were synthesized, so two
+// corner cases are accepted:
+//
+//   - An explicit _acme-challenge CNAME whose target happens to equal the
+//     wildcard's target is treated as synthesized and is not followed.
+//   - A wildcard-synthesized CNAME further down the chain is still followed,
+//     because only the first hop is checked.
+//
+// Errors are not returned. This probe is an extra query that cert-manager did
+// not previously make, so a transient failure of it must not fail a lookup that
+// used to succeed; the error is logged and the CNAME is followed as before.
+func isWildcardCNAME(ctx context.Context, domain, challengeTarget string, nameservers []string) bool {
+	wildcardFQDN := fmt.Sprintf("*.%s.", domain)
+
+	wildcardTarget, err := lookupCNAMETarget(ctx, wildcardFQDN, nameservers)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to check for a wildcard CNAME record, following the CNAME record as before", "fqdn", wildcardFQDN)
+		return false
+	}
+	if wildcardTarget == "" {
+		// No wildcard record exists, so the CNAME is a record of its own.
+		return false
+	}
+
+	// DNS names compare case-insensitively, and the two answers may not
+	// preserve the same case.
+	return strings.EqualFold(wildcardTarget, challengeTarget)
+}
+
+// lookupCNAMETarget returns the target of the CNAME record owned by fqdn, or an
+// empty string if there is none.
+//
+// A recursive resolver may return the whole chased chain in the answer section,
+// so records owned by another name are skipped rather than assuming the first
+// CNAME in the answer is the one that was asked for.
+func lookupCNAMETarget(ctx context.Context, fqdn string, nameservers []string) (string, error) {
 	r, err := dnsQuery(ctx, fqdn, dns.TypeCNAME, nameservers, true)
 	if err != nil {
-		return false, err
+		return "", err
 	}
+	// Any rcode other than NOERROR (NXDOMAIN, SERVFAIL, ...) means there is no
+	// CNAME to use. followCNAMEs treats these the same way, returning the name
+	// unchanged.
 	if r.Rcode != dns.RcodeSuccess {
-		return false, nil
+		return "", nil
 	}
 
-	// Extract the CNAME target for the challenge subdomain.
-	var challengeTarget string
 	for _, rr := range r.Answer {
-		if cn, ok := rr.(*dns.CNAME); ok {
-			challengeTarget = cn.Target
-			break
-		}
-	}
-	if challengeTarget == "" {
-		// No CNAME record found, nothing to follow.
-		return false, nil
-	}
-
-	// Query the wildcard CNAME for the parent domain.
-	wildcardFQDN := fmt.Sprintf("*.%s.", domain)
-	rWild, err := dnsQuery(ctx, wildcardFQDN, dns.TypeCNAME, nameservers, true)
-	if err != nil {
-		return false, err
-	}
-	if rWild.Rcode != dns.RcodeSuccess {
-		// No wildcard record exists, so the CNAME is explicit.
-		return false, nil
-	}
-
-	// Check if any wildcard CNAME target matches the challenge CNAME target.
-	for _, rr := range rWild.Answer {
-		if cn, ok := rr.(*dns.CNAME); ok && cn.Target == challengeTarget {
-			return true, nil
+		if cn, ok := rr.(*dns.CNAME); ok && strings.EqualFold(cn.Hdr.Name, fqdn) {
+			return cn.Target, nil
 		}
 	}
 
-	return false, nil
+	return "", nil
 }
 
 // FindBestMatch returns the longest match for a given domain within a list of domains

--- a/pkg/issuer/acme/dns/util/dns_test.go
+++ b/pkg/issuer/acme/dns/util/dns_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type input struct {
@@ -95,6 +97,181 @@ func TestLongestMatches(t *testing.T) {
 			if tc.got != tc.want {
 				assert.Equal(t, tc.want, tc.got, fmt.Sprintf("Failed: TestCase: %s | Query: %s | Want: %v | Got: %v", tc.name, tc.input.query, tc.want, tc.got))
 			}
+		})
+	}
+}
+
+func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		follow   bool
+		mockDNS  []interaction
+		wantFQDN string
+		wantErr  bool
+	}{
+		{
+			// When a wildcard CNAME exists on the parent domain (e.g.,
+			// *.monitoring.example.com -> monitoring.westeurope.cloudapp.azure.com),
+			// querying _acme-challenge.monitoring.example.com will return the
+			// wildcard's target. We should NOT follow this CNAME.
+			name:     "wildcard CNAME on parent domain should not be followed",
+			domain:   "monitoring.example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.monitoring.example.com.",
+			mockDNS: []interaction{
+				// First query: CNAME lookup for the challenge subdomain.
+				// DNS returns the wildcard's target because *.monitoring.example.com exists.
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "monitoring.westeurope.cloudapp.azure.com.",
+						},
+					},
+				}},
+				// Second query: CNAME lookup for the wildcard on the parent domain.
+				// This confirms the CNAME is from a wildcard record.
+				{"CNAME *.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "*.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "monitoring.westeurope.cloudapp.azure.com.",
+						},
+					},
+				}},
+			},
+		},
+		{
+			// When an explicit CNAME is set on _acme-challenge.example.com
+			// (intentional DNS-01 delegation), it should be followed as before.
+			name:     "explicit CNAME on _acme-challenge should be followed",
+			domain:   "example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.delegated.example.net.",
+			mockDNS: []interaction{
+				// isWildcardCNAME: query CNAME for _acme-challenge.example.com.
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "_acme-challenge.delegated.example.net.",
+						},
+					},
+				}},
+				// isWildcardCNAME: query CNAME for *.example.com.
+				// No wildcard exists, so this returns NXDOMAIN.
+				{"CNAME *.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
+				}},
+				// followCNAMEs: follows the explicit CNAME chain.
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "_acme-challenge.delegated.example.net.",
+						},
+					},
+				}},
+				// followCNAMEs: no further CNAME on the target.
+				{"CNAME _acme-challenge.delegated.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
+			// When no CNAME record exists at all, the FQDN should be
+			// returned unchanged.
+			name:     "no CNAME record should return original FQDN",
+			domain:   "example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.example.com.",
+			mockDNS: []interaction{
+				// isWildcardCNAME: query CNAME for _acme-challenge.example.com.
+				// No CNAME exists.
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+				// followCNAMEs: also finds no CNAME.
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
+			// When followCNAME is false, no CNAME resolution should happen.
+			name:     "followCNAME disabled should skip CNAME resolution",
+			domain:   "example.com",
+			follow:   false,
+			wantFQDN: "_acme-challenge.example.com.",
+			mockDNS:  []interaction{},
+		},
+		{
+			// When a wildcard CNAME exists but the _acme-challenge subdomain has
+			// a different explicit CNAME (overriding the wildcard), it should be
+			// followed.
+			name:     "explicit CNAME different from wildcard should be followed",
+			domain:   "monitoring.example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.dns-validation.example.net.",
+			mockDNS: []interaction{
+				// isWildcardCNAME: query CNAME for _acme-challenge.monitoring.example.com.
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "_acme-challenge.dns-validation.example.net.",
+						},
+					},
+				}},
+				// isWildcardCNAME: query CNAME for *.monitoring.example.com.
+				// Wildcard exists but points to a different target.
+				{"CNAME *.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "*.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "monitoring.westeurope.cloudapp.azure.com.",
+						},
+					},
+				}},
+				// followCNAMEs: follows the explicit CNAME.
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "_acme-challenge.dns-validation.example.net.",
+						},
+					},
+				}},
+				// followCNAMEs: no further CNAME on the target.
+				{"CNAME _acme-challenge.dns-validation.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withMockDNSQuery(t, tc.mockDNS)
+			got, err := DNS01LookupFQDN(t.Context(), tc.domain, tc.follow, "not-used")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFQDN, got)
 		})
 	}
 }

--- a/pkg/issuer/acme/dns/util/dns_test.go
+++ b/pkg/issuer/acme/dns/util/dns_test.go
@@ -5,6 +5,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -103,12 +104,16 @@ func TestLongestMatches(t *testing.T) {
 
 func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 	tests := []struct {
-		name     string
-		domain   string
-		follow   bool
-		mockDNS  []interaction
-		wantFQDN string
-		wantErr  bool
+		name    string
+		domain  string
+		follow  bool
+		mockDNS []interaction
+		// failQuery, when set, makes that one query return failErr instead of
+		// consuming an entry from mockDNS.
+		failQuery string
+		failErr   error
+		wantFQDN  string
+		wantErr   bool
 	}{
 		{
 			// When a wildcard CNAME exists on the parent domain (e.g.,
@@ -145,14 +150,44 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 			},
 		},
 		{
+			// DNS names compare case-insensitively, and the two answers need
+			// not preserve the same case.
+			name:     "wildcard CNAME differing only in case should not be followed",
+			domain:   "monitoring.example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.monitoring.example.com.",
+			mockDNS: []interaction{
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "Monitoring.WestEurope.CloudApp.Azure.Com.",
+						},
+					},
+				}},
+				{"CNAME *.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "*.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "monitoring.westeurope.cloudapp.azure.com.",
+						},
+					},
+				}},
+			},
+		},
+		{
 			// When an explicit CNAME is set on _acme-challenge.example.com
 			// (intentional DNS-01 delegation), it should be followed as before.
+			// The first hop is resolved by DNS01LookupFQDN itself and reused, so
+			// the challenge name is only queried once.
 			name:     "explicit CNAME on _acme-challenge should be followed",
 			domain:   "example.com",
 			follow:   true,
 			wantFQDN: "_acme-challenge.delegated.example.net.",
 			mockDNS: []interaction{
-				// isWildcardCNAME: query CNAME for _acme-challenge.example.com.
+				// Query the CNAME for _acme-challenge.example.com.
 				{"CNAME _acme-challenge.example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{
@@ -167,17 +202,7 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 				{"CNAME *.example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
 				}},
-				// followCNAMEs: follows the explicit CNAME chain.
-				{"CNAME _acme-challenge.example.com.", &dns.Msg{
-					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
-					Answer: []dns.RR{
-						&dns.CNAME{
-							Hdr:    dns.RR_Header{Name: "_acme-challenge.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
-							Target: "_acme-challenge.delegated.example.net.",
-						},
-					},
-				}},
-				// followCNAMEs: no further CNAME on the target.
+				// followCNAMEs: continues from the already resolved first hop.
 				{"CNAME _acme-challenge.delegated.example.net.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{},
@@ -185,23 +210,113 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 			},
 		},
 		{
-			// When no CNAME record exists at all, the FQDN should be
-			// returned unchanged.
+			// A recursive resolver may return the whole chased chain in the
+			// answer section, in any order. Only the record owned by the queried
+			// name gives the next hop; picking any other record would skip a hop
+			// and resolve the wrong chain.
+			name:     "chased chain in the challenge answer should not skip a hop",
+			domain:   "example.com",
+			follow:   true,
+			wantFQDN: "b.example.net.",
+			mockDNS: []interaction{
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						// Owned by another name; must be skipped even though it
+						// comes first in the answer section.
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "a.example.net.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "b.example.net.",
+						},
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "a.example.net.",
+						},
+					},
+				}},
+				{"CNAME *.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
+				}},
+				{"CNAME a.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "a.example.net.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "b.example.net.",
+						},
+					},
+				}},
+				{"CNAME b.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
+			// Same for the wildcard probe: if the resolver chases the wildcard's
+			// own chain, an intermediate record can share the explicit CNAME's
+			// target. Only the record owned by the wildcard name may be compared,
+			// otherwise a real delegation is misclassified as synthesized.
+			name:     "chased chain in the wildcard answer should not cause a false match",
+			domain:   "monitoring.example.com",
+			follow:   true,
+			wantFQDN: "final.example.net.",
+			mockDNS: []interaction{
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "final.example.net.",
+						},
+					},
+				}},
+				{"CNAME *.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						// Chased by the resolver, and it happens to end at the
+						// same target as the explicit challenge CNAME. Comparing
+						// against this record would wrongly report a wildcard.
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "intermediate.example.net.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "final.example.net.",
+						},
+						// The wildcard's own target, the only one that may be
+						// compared.
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "*.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "intermediate.example.net.",
+						},
+					},
+				}},
+				{"CNAME final.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
+			// When no CNAME record exists at all, the FQDN should be returned
+			// unchanged without probing for a wildcard.
 			name:     "no CNAME record should return original FQDN",
 			domain:   "example.com",
 			follow:   true,
 			wantFQDN: "_acme-challenge.example.com.",
 			mockDNS: []interaction{
-				// isWildcardCNAME: query CNAME for _acme-challenge.example.com.
-				// No CNAME exists.
 				{"CNAME _acme-challenge.example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{},
 				}},
-				// followCNAMEs: also finds no CNAME.
+			},
+		},
+		{
+			name:     "NXDOMAIN for the challenge name should return original FQDN",
+			domain:   "example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.example.com.",
+			mockDNS: []interaction{
 				{"CNAME _acme-challenge.example.com.", &dns.Msg{
-					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
-					Answer: []dns.RR{},
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
 				}},
 			},
 		},
@@ -222,7 +337,6 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 			follow:   true,
 			wantFQDN: "_acme-challenge.dns-validation.example.net.",
 			mockDNS: []interaction{
-				// isWildcardCNAME: query CNAME for _acme-challenge.monitoring.example.com.
 				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{
@@ -243,7 +357,24 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 						},
 					},
 				}},
-				// followCNAMEs: follows the explicit CNAME.
+				// followCNAMEs: no further CNAME on the target.
+				{"CNAME _acme-challenge.dns-validation.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
+			// The wildcard probe is an extra query that cert-manager did not
+			// previously make, so a transient failure of it must not break a
+			// delegation that used to work.
+			name:      "wildcard probe failure should fall back to following the CNAME",
+			domain:    "monitoring.example.com",
+			follow:    true,
+			failQuery: "CNAME *.monitoring.example.com.",
+			failErr:   errors.New("simulated network failure"),
+			wantFQDN:  "_acme-challenge.dns-validation.example.net.",
+			mockDNS: []interaction{
 				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{
@@ -253,18 +384,28 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 						},
 					},
 				}},
-				// followCNAMEs: no further CNAME on the target.
 				{"CNAME _acme-challenge.dns-validation.example.net.", &dns.Msg{
 					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 					Answer: []dns.RR{},
 				}},
 			},
 		},
+		{
+			// Failing to look up the challenge name is not a new failure mode:
+			// followCNAMEs would have made the same query and failed too.
+			name:      "challenge name lookup failure should be returned",
+			domain:    "example.com",
+			follow:    true,
+			failQuery: "CNAME _acme-challenge.example.com.",
+			failErr:   errors.New("simulated network failure"),
+			mockDNS:   []interaction{},
+			wantErr:   true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			withMockDNSQuery(t, tc.mockDNS)
+			withMockDNSQueryFailing(t, tc.mockDNS, tc.failQuery, tc.failErr)
 			got, err := DNS01LookupFQDN(t.Context(), tc.domain, tc.follow, "not-used")
 			if tc.wantErr {
 				require.Error(t, err)

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -293,6 +293,12 @@ type interaction struct {
 var mu = &sync.Mutex{} // Protects the global dnsQuery variable.
 
 func withMockDNSQuery(t *testing.T, mockDNS []interaction) {
+	withMockDNSQueryFailing(t, mockDNS, "", nil)
+}
+
+// Same as above, except that any query equal to failQuery returns failErr
+// instead of consuming a mocked interaction.
+func withMockDNSQueryFailing(t *testing.T, mockDNS []interaction, failQuery string, failErr error) {
 	mu.Lock()
 	t.Cleanup(func() {
 		mu.Unlock()
@@ -310,6 +316,10 @@ func withMockDNSQuery(t *testing.T, mockDNS []interaction) {
 
 	dnsQuery = func(ctx context.Context, fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error) {
 		got := dns.TypeToString[rtype] + " " + fqdn
+
+		if failQuery != "" && got == failQuery {
+			return nil, failErr
+		}
 
 		count.Add(1)
 		if int(count.Load()) > len(mockDNS) {


### PR DESCRIPTION
## Summary

When using ACME DNS-01 with `cnameStrategy: Follow`, cert-manager incorrectly followed wildcard CNAME records from the parent domain when resolving the `_acme-challenge` subdomain. For example, if `*.monitoring.example.com` has a CNAME pointing to `monitoring.westeurope.cloudapp.azure.com`, cert-manager would follow that wildcard CNAME for `_acme-challenge.monitoring.example.com`, attempting to create challenge records in a zone it has no access to.

### Changes

- `isWildcardCNAME()` in `pkg/issuer/acme/dns/util/dns.go` queries the literal name `*.<domain>.`. Equal CNAME targets for `*.<domain>.` and `_acme-challenge.<domain>.` mean that a wildcard record synthesized the answer.
- `DNS01LookupFQDN()` does not follow such a CNAME. It returns `_acme-challenge.<domain>.` unchanged and writes a log message at Info level.
- `lookupCNAMETarget()` reads the CNAME target only from the record that the queried name owns. A recursive resolver can return the complete chain in the answer section.
- An error from the `*.<domain>.` query is not fatal. cert-manager writes the error to the log and follows the CNAME, as it did before this change.
- Names compare with `strings.EqualFold`, because DNS names are not case-sensitive.
- `DNS01LookupFQDN()` resolves the first hop and gives it to `followCNAMEs()`. It queries the challenge name one time instead of two times.
- cert-manager follows an explicit CNAME record on `_acme-challenge.`, as it did before this change.
- The comment on `isWildcardCNAME()` records two limits. cert-manager does not follow an explicit CNAME that has the same target as the wildcard. cert-manager follows a synthesized CNAME later in the chain.

### Test plan

`TestDNS01LookupFQDN_WildcardCNAME` in `pkg/issuer/acme/dns/util/dns_test.go` has 11 cases:

- [x] cert-manager does not follow a wildcard CNAME on the parent domain
- [x] cert-manager does not follow a wildcard CNAME that differs only in case
- [x] cert-manager follows an explicit CNAME on `_acme-challenge`
- [x] cert-manager follows an explicit CNAME that differs from the wildcard
- [x] A complete chain in the challenge answer does not skip a hop
- [x] A complete chain in the wildcard answer does not cause a false match
- [x] No CNAME record returns the original FQDN
- [x] NXDOMAIN for the challenge name returns the original FQDN
- [x] `followCNAME: false` makes no CNAME query
- [x] A failure of the wildcard query still follows the CNAME
- [x] A failure of the challenge query returns an error

Other checks:

- [x] All tests in `./pkg/issuer/acme/dns/...` pass
- [x] `golangci-lint` reports no issues

Fixes #5751
Fixes #5716

/kind bug

### Release Note

```release-note
ACME DNS-01: `cnameStrategy: Follow` no longer follows a CNAME record that a wildcard record such as `*.example.com` synthesizes. cert-manager now creates the challenge record at `_acme-challenge.` in the zone of that domain. If you use a wildcard record to delegate DNS-01 challenges, create an explicit CNAME record at `_acme-challenge.` instead.
```
