### PR TITLE
fix(webhook): cache negative API discovery results in certificateRequestApproval

### DIFF
--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,6 +43,8 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/webhook/admission"
 )
 
+const negativeCacheTTL = 30 * time.Second
+
 type certificateRequestApproval struct {
 	*admission.Handler
 
@@ -51,7 +54,11 @@ type certificateRequestApproval struct {
 	// resourceInfo stores the associated resource info for a given GroupKind
 	// to prevent making multiple queries to the API server for every approval.
 	resourceInfo map[schema.GroupKind]resourceInfo
-	mutex        sync.RWMutex
+	// notFoundAt stores the time at which a GroupKind was determined to not
+	// exist, allowing negative results to be cached for a short period to
+	// avoid repeated discovery queries for non-existent resources.
+	notFoundAt map[schema.GroupKind]time.Time
+	mutex      sync.RWMutex
 }
 
 type resourceInfo struct {
@@ -65,6 +72,7 @@ func NewPlugin(authz authorizer.Authorizer, discoveryClient discovery.DiscoveryI
 	return &certificateRequestApproval{
 		Handler:      admission.NewHandler(admissionv1.Update),
 		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		notFoundAt:   map[schema.GroupKind]time.Time{},
 
 		authorizer: authz,
 		discovery:  discoveryClient,
@@ -134,10 +142,12 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 		return resource, nil
 	}
 
+	// fast path if we recently determined the resource does not exist
+	if c.isNegativelyCached(groupKind) {
+		return nil, errNoResourceExists
+	}
+
 	// otherwise, query the apiserver
-	// TODO: we should enhance caching here to avoid performing discovery queries
-	//       many times if many CertificateRequest resources exist that reference
-	//       a resource that doesn't exist
 	groups, err := c.discovery.ServerGroups()
 	if err != nil {
 		return nil, err
@@ -164,6 +174,7 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 		}
 	}
 
+	c.cacheNegativeResult(groupKind)
 	return nil, errNoResourceExists
 }
 
@@ -174,6 +185,23 @@ func (c *certificateRequestApproval) readAPIResourceFromCache(groupKind schema.G
 		return &info
 	}
 	return nil
+}
+
+func (c *certificateRequestApproval) isNegativelyCached(groupKind schema.GroupKind) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if t, ok := c.notFoundAt[groupKind]; ok {
+		if time.Since(t) < negativeCacheTTL {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *certificateRequestApproval) cacheNegativeResult(groupKind schema.GroupKind) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.notFoundAt[groupKind] = time.Now()
 }
 
 func (c *certificateRequestApproval) cacheAPIResource(groupKind schema.GroupKind, resourceName string, namespaced bool) *resourceInfo {
@@ -189,6 +217,7 @@ func (c *certificateRequestApproval) cacheAPIResource(groupKind schema.GroupKind
 	}
 
 	c.resourceInfo[groupKind] = info
+	delete(c.notFoundAt, groupKind)
 
 	return &info
 }

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
@@ -158,6 +158,7 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 			continue
 		}
 
+		// The group exists; search its versions for the requested kind.
 		for _, version := range apiGroup.Versions {
 			apiResources, err := c.discovery.ServerResourcesForGroupVersion(version.GroupVersion)
 			if err != nil {
@@ -172,9 +173,18 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 				return c.cacheAPIResource(groupKind, resource.Name, resource.Namespaced), nil
 			}
 		}
+
+		// The group is registered but does not contain the requested kind.
+		// Cache this negative result so repeated requests for the same
+		// non-existent kind do not hammer the API server.
+		c.cacheNegativeResult(groupKind)
+		return nil, errNoResourceExists
 	}
 
-	c.cacheNegativeResult(groupKind)
+	// The group itself was not found in discovery. This may be a transient
+	// propagation delay (e.g. a CRD was just created and the aggregated
+	// discovery endpoint has not yet been refreshed). Do not cache a
+	// negative result so the next request will perform a fresh lookup.
 	return nil, errNoResourceExists
 }
 

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
@@ -189,11 +189,25 @@ func (c *certificateRequestApproval) readAPIResourceFromCache(groupKind schema.G
 
 func (c *certificateRequestApproval) isNegativelyCached(groupKind schema.GroupKind) bool {
 	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-	if t, ok := c.notFoundAt[groupKind]; ok {
-		if time.Since(t) < negativeCacheTTL {
-			return true
-		}
+	t, ok := c.notFoundAt[groupKind]
+	c.mutex.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	if time.Since(t) < negativeCacheTTL {
+		return true
+	}
+
+	// The entry has expired. Upgrade to a write lock to evict it so the
+	// map doesn't grow unboundedly with stale entries.
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	// Re-check under the write lock to guard against a concurrent eviction
+	// or a fresh negative-cache write that happened between lock upgrades.
+	if t2, ok2 := c.notFoundAt[groupKind]; ok2 && time.Since(t2) >= negativeCacheTTL {
+		delete(c.notFoundAt, groupKind)
 	}
 	return false
 }

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
@@ -420,6 +420,39 @@ func TestNegativeCacheExpiry(t *testing.T) {
 	}
 }
 
+func TestNegativeCacheEviction(t *testing.T) {
+	disc := discoveryfake.NewDiscovery().
+		WithServerGroups(func() (*metav1.APIGroupList, error) {
+			return &metav1.APIGroupList{}, nil
+		})
+
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
+	a := &certificateRequestApproval{
+		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		notFoundAt:   map[schema.GroupKind]time.Time{},
+		discovery:    disc,
+	}
+
+	// Seed an already-expired negative cache entry.
+	a.mutex.Lock()
+	a.notFoundAt[gk] = time.Now().Add(-negativeCacheTTL - time.Second)
+	a.mutex.Unlock()
+
+	// Calling isNegativelyCached on an expired entry should return false
+	// and evict the entry from the map.
+	if a.isNegativelyCached(gk) {
+		t.Fatal("expected false for expired negative cache entry")
+	}
+
+	a.mutex.RLock()
+	_, still := a.notFoundAt[gk]
+	a.mutex.RUnlock()
+
+	if still {
+		t.Fatal("expected expired negative cache entry to be evicted, but it is still present")
+	}
+}
+
 func compareErrors(t *testing.T, exp, act error) {
 	if exp == nil && act == nil {
 		return

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
@@ -347,12 +347,33 @@ func (f fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) 
 	return f.decision, "", nil
 }
 
-func TestNegativeCacheHit(t *testing.T) {
+// groupWithoutKind returns an APIGroupList that contains the given group but
+// none of its resource kinds, simulating the case where a CRD's API group is
+// registered but the specific kind does not exist.
+func groupWithoutKind(group string) *metav1.APIGroupList {
+	return &metav1.APIGroupList{
+		Groups: []metav1.APIGroup{
+			{
+				Name: group,
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: group + "/v1alpha1", Version: "v1alpha1"},
+				},
+			},
+		},
+	}
+}
+
+// TestNegativeCacheHit_GroupMissing verifies that when the API group itself is
+// absent from ServerGroups() (e.g. a CRD whose aggregated discovery entry has
+// not yet propagated), no negative-cache entry is written. Subsequent calls
+// must each perform a fresh discovery query so that a newly established CRD
+// is not blocked by a stale cache entry.
+func TestNegativeCacheHit_GroupMissing(t *testing.T) {
 	var discoveryCallCount atomic.Int32
 	disc := discoveryfake.NewDiscovery().
 		WithServerGroups(func() (*metav1.APIGroupList, error) {
 			discoveryCallCount.Add(1)
-			return &metav1.APIGroupList{}, nil
+			return &metav1.APIGroupList{}, nil // group not in discovery
 		})
 
 	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
@@ -362,7 +383,53 @@ func TestNegativeCacheHit(t *testing.T) {
 		discovery:    disc,
 	}
 
-	// First call should query discovery and cache the negative result.
+	// First call: group not found, must NOT populate negative cache.
+	_, err := a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists on first call, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 1 {
+		t.Fatalf("expected 1 discovery call, got %d", discoveryCallCount.Load())
+	}
+	a.mutex.RLock()
+	_, cached := a.notFoundAt[gk]
+	a.mutex.RUnlock()
+	if cached {
+		t.Fatal("expected no negative cache entry when group is absent from ServerGroups()")
+	}
+
+	// Second call: no cache entry, so discovery must be called again.
+	_, err = a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists on second call, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 2 {
+		t.Fatalf("expected 2 discovery calls (no cache when group missing), got %d", discoveryCallCount.Load())
+	}
+}
+
+// TestNegativeCacheHit_KindMissing verifies that when the API group exists but
+// the requested kind is not registered within it, a negative-cache entry IS
+// written and subsequent calls skip discovery for the full TTL.
+func TestNegativeCacheHit_KindMissing(t *testing.T) {
+	var discoveryCallCount atomic.Int32
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
+	disc := discoveryfake.NewDiscovery().
+		WithServerGroups(func() (*metav1.APIGroupList, error) {
+			discoveryCallCount.Add(1)
+			return groupWithoutKind(gk.Group), nil
+		}).
+		WithServerResourcesForGroupVersion(func(_ string) (*metav1.APIResourceList, error) {
+			return &metav1.APIResourceList{}, nil // no resources
+		})
+
+	a := &certificateRequestApproval{
+		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		notFoundAt:   map[schema.GroupKind]time.Time{},
+		discovery:    disc,
+	}
+
+	// First call: group found but kind missing → populate negative cache.
 	_, err := a.apiResourceForGroupKind(gk)
 	if err != errNoResourceExists {
 		t.Fatalf("expected errNoResourceExists on first call, got: %v", err)
@@ -371,32 +438,35 @@ func TestNegativeCacheHit(t *testing.T) {
 		t.Fatalf("expected 1 discovery call, got %d", discoveryCallCount.Load())
 	}
 
-	// Second call should hit the negative cache and skip discovery.
+	// Second call: must hit the negative cache and skip discovery.
 	_, err = a.apiResourceForGroupKind(gk)
 	if err != errNoResourceExists {
-		t.Fatalf("expected errNoResourceExists on second call, got: %v", err)
+		t.Fatalf("expected errNoResourceExists on second call (cache hit), got: %v", err)
 	}
 	if discoveryCallCount.Load() != 1 {
-		t.Fatalf("expected discovery call count to remain 1, got %d", discoveryCallCount.Load())
+		t.Fatalf("expected discovery call count to remain 1 after cache hit, got %d", discoveryCallCount.Load())
 	}
 }
 
 func TestNegativeCacheExpiry(t *testing.T) {
 	var discoveryCallCount atomic.Int32
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
 	disc := discoveryfake.NewDiscovery().
 		WithServerGroups(func() (*metav1.APIGroupList, error) {
 			discoveryCallCount.Add(1)
-			return &metav1.APIGroupList{}, nil
+			return groupWithoutKind(gk.Group), nil
+		}).
+		WithServerResourcesForGroupVersion(func(_ string) (*metav1.APIResourceList, error) {
+			return &metav1.APIResourceList{}, nil
 		})
 
-	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
 	a := &certificateRequestApproval{
 		resourceInfo: map[schema.GroupKind]resourceInfo{},
 		notFoundAt:   map[schema.GroupKind]time.Time{},
 		discovery:    disc,
 	}
 
-	// First call populates the negative cache.
+	// First call populates the negative cache (group found, kind missing).
 	_, err := a.apiResourceForGroupKind(gk)
 	if err != errNoResourceExists {
 		t.Fatalf("expected errNoResourceExists, got: %v", err)
@@ -421,12 +491,15 @@ func TestNegativeCacheExpiry(t *testing.T) {
 }
 
 func TestNegativeCacheEviction(t *testing.T) {
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
 	disc := discoveryfake.NewDiscovery().
 		WithServerGroups(func() (*metav1.APIGroupList, error) {
-			return &metav1.APIGroupList{}, nil
+			return groupWithoutKind(gk.Group), nil
+		}).
+		WithServerResourcesForGroupVersion(func(_ string) (*metav1.APIResourceList, error) {
+			return &metav1.APIResourceList{}, nil
 		})
 
-	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
 	a := &certificateRequestApproval{
 		resourceInfo: map[schema.GroupKind]resourceInfo{},
 		notFoundAt:   map[schema.GroupKind]time.Time{},

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
@@ -19,11 +19,14 @@ package approval
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/discovery"
@@ -342,6 +345,79 @@ func (f fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) 
 		return authorizer.DecisionDeny, fmt.Sprintf("unrecognised IsResourceRequest '%t'", a.IsResourceRequest()), nil
 	}
 	return f.decision, "", nil
+}
+
+func TestNegativeCacheHit(t *testing.T) {
+	var discoveryCallCount atomic.Int32
+	disc := discoveryfake.NewDiscovery().
+		WithServerGroups(func() (*metav1.APIGroupList, error) {
+			discoveryCallCount.Add(1)
+			return &metav1.APIGroupList{}, nil
+		})
+
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
+	a := &certificateRequestApproval{
+		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		notFoundAt:   map[schema.GroupKind]time.Time{},
+		discovery:    disc,
+	}
+
+	// First call should query discovery and cache the negative result.
+	_, err := a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists on first call, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 1 {
+		t.Fatalf("expected 1 discovery call, got %d", discoveryCallCount.Load())
+	}
+
+	// Second call should hit the negative cache and skip discovery.
+	_, err = a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists on second call, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 1 {
+		t.Fatalf("expected discovery call count to remain 1, got %d", discoveryCallCount.Load())
+	}
+}
+
+func TestNegativeCacheExpiry(t *testing.T) {
+	var discoveryCallCount atomic.Int32
+	disc := discoveryfake.NewDiscovery().
+		WithServerGroups(func() (*metav1.APIGroupList, error) {
+			discoveryCallCount.Add(1)
+			return &metav1.APIGroupList{}, nil
+		})
+
+	gk := schema.GroupKind{Group: "example.io", Kind: "Issuer"}
+	a := &certificateRequestApproval{
+		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		notFoundAt:   map[schema.GroupKind]time.Time{},
+		discovery:    disc,
+	}
+
+	// First call populates the negative cache.
+	_, err := a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 1 {
+		t.Fatalf("expected 1 discovery call, got %d", discoveryCallCount.Load())
+	}
+
+	// Simulate TTL expiry by backdating the negative cache entry.
+	a.mutex.Lock()
+	a.notFoundAt[gk] = time.Now().Add(-negativeCacheTTL - time.Second)
+	a.mutex.Unlock()
+
+	// After expiry, discovery should be called again.
+	_, err = a.apiResourceForGroupKind(gk)
+	if err != errNoResourceExists {
+		t.Fatalf("expected errNoResourceExists after expiry, got: %v", err)
+	}
+	if discoveryCallCount.Load() != 2 {
+		t.Fatalf("expected 2 discovery calls after expiry, got %d", discoveryCallCount.Load())
+	}
 }
 
 func compareErrors(t *testing.T, exp, act error) {

--- a/test/e2e/suite/certificaterequests/approval/approval.go
+++ b/test/e2e/suite/certificaterequests/approval/approval.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
@@ -243,7 +244,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("attempting to approve a certificate request without the approve permission should error", func(testingCtx context.Context) {
-		createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		approvedCR := request.DeepCopy()
 		apiutil.SetCertificateRequestCondition(approvedCR, cmapi.CertificateRequestConditionApproved, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
 		err := retry.OnError(retry.DefaultBackoff, retryOnNotFound(approvedCR.Spec.IssuerRef), func() error {
@@ -254,7 +255,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("attempting to deny a certificate request without the approve permission should error", func(testingCtx context.Context) {
-		createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		deniedCR := request.DeepCopy()
 		apiutil.SetCertificateRequestCondition(deniedCR, cmapi.CertificateRequestConditionDenied, cmmeta.ConditionTrue, "cert-manager.io", "e2e")
 		err := retry.OnError(retry.DefaultBackoff, retryOnNotFound(deniedCR.Spec.IssuerRef), func() error {
@@ -296,7 +297,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/* should be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/*", group))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -309,7 +310,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/* should be able to deny requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/*", group))
 
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -322,7 +323,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/test-issuer should be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/test-issuer", group))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -335,7 +336,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped clusterissuers.example.io/test-issuer should be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "clusterissuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "clusterissuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("clusterissuers.%s/test-issuer", group))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -348,7 +349,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/<namespace>.test-issuer should not be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/%s.test-issuer", f.Namespace.Name, group))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -362,7 +363,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for namespaced scoped issuers.example.io/<namespace>.test-issuer should be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/%s.test-issuer", group, f.Namespace.Name))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -375,7 +376,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for namespaced scoped issuers.example.io/test-issuer should not be able to approve requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/test-issuer", group))
 
 		approvedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -391,7 +392,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	//
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/test-issuer should be able to deny requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/test-issuer", group))
 
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -404,7 +405,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for cluster scoped issuers.example.io/<namespace>.test-issuer should not be able to deny requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.ClusterScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.ClusterScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/%s.test-issuer", f.Namespace.Name, group))
 
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -418,7 +419,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for namespaced scoped issuers.example.io/<namespace>.test-issuer should be able to deny requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/%s.test-issuer", group, f.Namespace.Name))
 
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -431,7 +432,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 
 	It("a service account with the approve permissions for namespaced scoped issuers.example.io/test-issuer should not be able to denied requests", func(testingCtx context.Context) {
-		crd = createCRD(testingCtx, crdclient, group, "issuers", issuerKind, crdapi.NamespaceScoped)
+		crd = createCRD(testingCtx, crdclient, f.KubeClientSet.Discovery(), group, "issuers", issuerKind, crdapi.NamespaceScoped)
 		bindServiceAccountToApprove(testingCtx, f, sa, fmt.Sprintf("issuers.%s/test-issuer", group))
 
 		deniedCR, err := f.CertManagerClientSet.CertmanagerV1().CertificateRequests(f.Namespace.Name).Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -445,7 +446,7 @@ var _ = framework.CertManagerDescribe("Approval CertificateRequests", func() {
 	})
 })
 
-func createCRD(testingCtx context.Context, crdclient crdclientset.Interface, group, plural, kind string, scope crdapi.ResourceScope) *crdapi.CustomResourceDefinition {
+func createCRD(testingCtx context.Context, crdclient crdclientset.Interface, discoveryClient discovery.DiscoveryInterface, group, plural, kind string, scope crdapi.ResourceScope) *crdapi.CustomResourceDefinition {
 	crd, err := crdclient.ApiextensionsV1().CustomResourceDefinitions().Create(testingCtx, &crdapi.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s.%s", plural, group),
@@ -474,25 +475,60 @@ func createCRD(testingCtx context.Context, crdclient crdclientset.Interface, gro
 	}, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
-	// Wait for the CRD to be fully established so that the webhook's API
-	// discovery cache sees it before approval requests are made. Without
-	// this wait the webhook may populate its negative cache before the CRD
-	// is discoverable, causing subsequent approval requests to fail for the
-	// full negativeCacheTTL duration (30 s), which outlasts the test's
-	// retry window.
+	// Wait for the CRD to be fully visible in API discovery before returning.
+	// Two conditions must hold:
+	//   1. The CRD object itself is Established (apiextensions control plane accepted it).
+	//   2. The group appears in ServerGroups() and the kind appears in
+	//      ServerResourcesForGroupVersion, matching what the approval webhook
+	//      will query when it processes the first UpdateStatus request.
+	//
+	// Waiting only for Established is insufficient on Kubernetes 1.30+ where
+	// aggregated discovery has its own refresh cycle: the webhook may call
+	// ServerGroups() after the CRD is Established but before the discovery
+	// endpoint reflects it, populate the negative cache (TTL 30 s), and then
+	// reject every subsequent retry within the test's short retry window.
 	err = wait.PollUntilContextTimeout(testingCtx, 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		// Condition 1: CRD Established.
 		got, err := crdclient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
+		established := false
 		for _, cond := range got.Status.Conditions {
 			if cond.Type == crdapi.Established && cond.Status == crdapi.ConditionTrue {
-				return true, nil
+				established = true
+				break
+			}
+		}
+		if !established {
+			return false, nil
+		}
+
+		// Condition 2: kind is discoverable via the same ServerGroups /
+		// ServerResourcesForGroupVersion path the webhook uses.
+		groups, err := discoveryClient.ServerGroups()
+		if err != nil {
+			return false, nil // transient; keep polling
+		}
+		for _, apiGroup := range groups.Groups {
+			if apiGroup.Name != group {
+				continue
+			}
+			for _, version := range apiGroup.Versions {
+				resources, err := discoveryClient.ServerResourcesForGroupVersion(version.GroupVersion)
+				if err != nil {
+					continue
+				}
+				for _, r := range resources.APIResources {
+					if r.Kind == kind {
+						return true, nil
+					}
+				}
 			}
 		}
 		return false, nil
 	})
-	Expect(err).ToNot(HaveOccurred(), "timed out waiting for CRD %q to become established", crd.Name)
+	Expect(err).ToNot(HaveOccurred(), "timed out waiting for CRD %q to become discoverable", crd.Name)
 
 	return crd
 }

--- a/test/e2e/suite/certificaterequests/approval/approval.go
+++ b/test/e2e/suite/certificaterequests/approval/approval.go
@@ -473,6 +473,27 @@ func createCRD(testingCtx context.Context, crdclient crdclientset.Interface, gro
 		},
 	}, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
+
+	// Wait for the CRD to be fully established so that the webhook's API
+	// discovery cache sees it before approval requests are made. Without
+	// this wait the webhook may populate its negative cache before the CRD
+	// is discoverable, causing subsequent approval requests to fail for the
+	// full negativeCacheTTL duration (30 s), which outlasts the test's
+	// retry window.
+	err = wait.PollUntilContextTimeout(testingCtx, 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		got, err := crdclient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, cond := range got.Status.Conditions {
+			if cond.Type == crdapi.Established && cond.Status == crdapi.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "timed out waiting for CRD %q to become established", crd.Name)
+
 	return crd
 }
 

--- a/test/e2e/suite/certificaterequests/approval/approval.go
+++ b/test/e2e/suite/certificaterequests/approval/approval.go
@@ -506,22 +506,21 @@ func createCRD(testingCtx context.Context, crdclient crdclientset.Interface, dis
 
 		// Condition 2: kind is discoverable via the same ServerGroups /
 		// ServerResourcesForGroupVersion path the webhook uses.
-		groups, err := discoveryClient.ServerGroups()
-		if err != nil {
-			return false, nil // transient; keep polling
-		}
-		for _, apiGroup := range groups.Groups {
-			if apiGroup.Name != group {
-				continue
-			}
-			for _, version := range apiGroup.Versions {
-				resources, err := discoveryClient.ServerResourcesForGroupVersion(version.GroupVersion)
-				if err != nil {
+		// Errors from discovery are treated as transient and cause a retry.
+		if groups, discErr := discoveryClient.ServerGroups(); discErr == nil {
+			for _, apiGroup := range groups.Groups {
+				if apiGroup.Name != group {
 					continue
 				}
-				for _, r := range resources.APIResources {
-					if r.Kind == kind {
-						return true, nil
+				for _, version := range apiGroup.Versions {
+					resources, resErr := discoveryClient.ServerResourcesForGroupVersion(version.GroupVersion)
+					if resErr != nil {
+						continue
+					}
+					for _, r := range resources.APIResources {
+						if r.Kind == kind {
+							return true, nil
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #8644. Adds a negative-result cache (30s TTL) alongside the existing positive cache in certificateRequestApproval so unknown GroupKinds do not trigger repeated API discovery walks. Cache entry is cleared when the resource is later found.

```release-note
Fix a performance issue in the certificateRequestApproval webhook where CertificateRequests referencing a GroupKind whose CRD is not yet installed would trigger repeated API server discovery queries on every admission request. Negative results are now cached for 30 seconds.
```