### PR TITLE
Normalize challenge reason in certmanager_certificate_challenge_status metric

### DIFF
--- a/internal/collectors/acme_collector.go
+++ b/internal/collectors/acme_collector.go
@@ -18,6 +18,9 @@ package collectors
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +33,33 @@ var (
 	challengeValidStatuses  = [...]acmemeta.State{acmemeta.Ready, acmemeta.Valid, acmemeta.Errored, acmemeta.Expired, acmemeta.Invalid, acmemeta.Processing, acmemeta.Unknown, acmemeta.Pending}
 	certChallengeMetricDesc = prometheus.NewDesc("certmanager_certificate_challenge_status", "The status of certificate challenges", []string{"status", "domain", "reason", "processing", "name", "namespace", "type"}, nil)
 )
+
+// maxChallengeReasonLabelLen caps the "reason" label: ACME status text can embed HTML
+// responses and unbounded detail, which breaks Prometheus scraping and explodes series size.
+const maxChallengeReasonLabelLen = 256
+
+// normalizeChallengeReason converts arbitrary challenge reason text into a
+// bounded, printable string suitable for use as a Prometheus label value.
+func normalizeChallengeReason(reason string) string {
+	var b strings.Builder
+	if reasonLen := len(reason); reasonLen > maxChallengeReasonLabelLen {
+		b.Grow(maxChallengeReasonLabelLen)
+	} else {
+		b.Grow(reasonLen)
+	}
+
+	for _, r := range reason {
+		if unicode.IsControl(r) {
+			r = ' '
+		}
+		runeLen := utf8.RuneLen(r)
+		if b.Len()+runeLen > maxChallengeReasonLabelLen {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
 
 type ACMECollector struct {
 	challengesLister                 cmacmelisters.ChallengeLister
@@ -65,7 +95,7 @@ func (ac *ACMECollector) Collect(ch chan<- prometheus.Metric) {
 				value,
 				string(status),
 				challenge.Spec.DNSName,
-				challenge.Status.Reason,
+				normalizeChallengeReason(challenge.Status.Reason),
 				fmt.Sprint(challenge.Status.Processing),
 				challenge.Name,
 				challenge.Namespace,

--- a/internal/collectors/acme_collector_test.go
+++ b/internal/collectors/acme_collector_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNormalizeChallengeReason(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", maxChallengeReasonLabelLen+100)
+	got := normalizeChallengeReason(long)
+	if len(got) != maxChallengeReasonLabelLen {
+		t.Fatalf("expected length %d, got %d", maxChallengeReasonLabelLen, len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("truncated string is not valid UTF-8")
+	}
+
+	withNewlines := "before\nafter\r\n\tand\x00ctrl"
+	got = normalizeChallengeReason(withNewlines)
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Fatalf("expected newlines replaced: %q", got)
+	}
+	if strings.ContainsRune(got, '\x00') {
+		t.Fatal("expected control chars removed")
+	}
+}
+
+func TestNormalizeChallengeReason_UTF8ByteBudget(t *testing.T) {
+	t.Parallel()
+	// Four-byte rune must not be written if it would exceed the byte cap mid-rune.
+	prefix := strings.Repeat("a", maxChallengeReasonLabelLen-1)
+	got := normalizeChallengeReason(prefix + "😀")
+	if len(got) != maxChallengeReasonLabelLen-1 {
+		t.Fatalf("expected emoji dropped to stay under byte cap: got len %d %q", len(got), got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("output must be valid UTF-8")
+	}
+}
+
+func TestNormalizeChallengeReason_UTF8ByteBudget_FitsExactRune(t *testing.T) {
+	t.Parallel()
+
+	prefix := strings.Repeat("a", maxChallengeReasonLabelLen-4)
+	got := normalizeChallengeReason(prefix + "😀")
+
+	if len(got) != maxChallengeReasonLabelLen {
+		t.Fatalf("expected exact byte-budget fit, got len %d %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "😀") {
+		t.Fatalf("expected emoji to fit exactly: %q", got)
+	}
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
#### Normalize and bound ACME challenge reason label values

ACME challenge status.reason can contain unbounded and sometimes noisy text (e.g. full HTTP responses or error bodies). 
<details><summary>Example from lived experience</summary>

```
certmanager_certificate_challenge_status{domain="redacted.redacted.com",name="redacted.redacted.com-11-685778633-214040689",namespace="kong",processing="true",reason="Waiting for HTTP-01 challenge propagation: did not get expected response when querying endpoint, expected \"bJckM54gxyU6_hMhivXxJm8aQiblStYDXtUlWxTzDfU.iWvtXtECx8oaEtFOgLER2HCc925eZ2zFMG5O2zDOPyA\" but got: <!DOCT\n<ht... (truncated)",status="",type="HTTP-01"} 0
```
</details>

Exposing this directly as a Prometheus label can:
- break scrapes if label values become excessively large
- significantly increase series cardinality
- introduce control characters (newlines, tabs, etc.) that make metrics harder to work with

This PR introduces normalization for the reason label:
- replaces all Unicode control characters with spaces (ensuring a single-line, printable value)
- enforces a maximum byte length (256 bytes) to bound label size
- preserves valid UTF-8 by constructing the result rune-by-rune and avoiding mid-rune truncation

The implementation uses a single-pass strings.Builder approach, ensuring that:
- output is always valid UTF-8
- the byte limit is respected without post-processing
- no additional allocations or fix-up passes are required

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
