### PR TITLE
Make cainjector use SSA unconditionally

### DIFF
--- a/cmd/cainjector/app/cainjector.go
+++ b/cmd/cainjector/app/cainjector.go
@@ -24,6 +24,7 @@ import (
 
 	config "github.com/cert-manager/cert-manager/internal/apis/config/cainjector"
 	"github.com/cert-manager/cert-manager/internal/apis/config/cainjector/validation"
+	"github.com/cert-manager/cert-manager/internal/cainjector/feature"
 	cainjectorconfigfile "github.com/cert-manager/cert-manager/pkg/cainjector/configfile"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util"
@@ -109,6 +110,11 @@ servers and webhook servers.`,
 		},
 		// nolint:contextcheck // False positive
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
+				log := logf.FromContext(cmd.Context())
+				log.Info("the ServerSideApply feature flag has been deprecated and cainjector will always use server-side apply")
+			}
+
 			return run(cmd.Context(), cainjectorConfig)
 		},
 	}

--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -43,8 +43,11 @@ const (
 
 	// Owner: @inteon
 	// Alpha: v1.12
+	// Flag deprecated: v1.21
 	//
-	// ServerSideApply enables the use of ServerSideApply in all API calls.
+	// ServerSideApply is deprecated and has no effect in cainjector.
+	// It is kept only for backward compatibility so existing configurations
+	// using this feature gate do not fail with an unrecognized feature gate error.
 	ServerSideApply featuregate.Feature = "ServerSideApply"
 
 	// Owner: @ThatsMrTalbot
@@ -69,6 +72,18 @@ func init() {
 //
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	ServerSideApply:   {Default: false, PreRelease: featuregate.Alpha},
 	CAInjectorMerging: {Default: true, PreRelease: featuregate.GA},
+
+	// NB: Deprecated + removed feature gates are kept here.
+	// `featuregate.Deprecated` exists, but will cause the featuregate library
+	// to emit its own warning when the gate is set:
+	// > W...] Setting deprecated feature gate ServerSideApply=false. It will be removed in a future release.
+	// So we have to set to Alpha to avoid that. `PreAlpha` also exists, but
+	// adds versioning logic we don't want to deal with.
+
+	// If we simply remove the gate from here, then anyone still setting it will
+	// see an error and the cainjector will enter CrashLoopBackOff:
+	// > E...] "error executing command" err="failed to set feature gates from initial flags-based config: unrecognized feature gate: ServerSideApply" logger="cert-manager"
+	// So we leave it here, set to alpha.
+	ServerSideApply: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/controller/cainjector/reconciler.go
+++ b/pkg/controller/cainjector/reconciler.go
@@ -26,13 +26,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/csaupgrade"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/cert-manager/cert-manager/internal/cainjector/feature"
 	certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
 
 // This file contains logic to create reconcilers. By default a
@@ -118,15 +117,20 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// actually do the injection
 	target.SetCA(caData)
 
-	// actually update with injected CA data
-	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-		err = r.Client.Apply(ctx, target.AsApplyObject(), client.ForceOwnership, client.FieldOwner(r.fieldManager))
-	} else {
-		err = r.Client.Update(ctx, obj)
+	// upgrade managed fields from CSA to SSA if required
+	upgradePatch, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(r.fieldManager), r.fieldManager)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("when creating managed fields patch: %w", err)
+	}
+	if len(upgradePatch) > 0 {
+		if err := r.Client.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, upgradePatch)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("when patching managed fields: %w", err)
+		}
 	}
 
-	if err != nil {
-		log.Error(err, "unable to update target object with new CA data")
+	// actually update with injected CA data
+	if err := r.Client.Apply(ctx, target.AsApplyObject(), client.ForceOwnership, client.FieldOwner(r.fieldManager)); err != nil {
+		log.Error(err, "unable to apply target object with CA data")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

As discussed, we plan to deprecate/remove the `ServerSideApply` feature gates, rather than graduate them. For the cert-manager controller, this will require more work, but it was rather simple to do for cainjector. In our clusters, we have been using the cainjector `ServerSideApply` feature gate for years with no issues. Since we use Flux and SSA for most of our work, we've had issues removing API versions from CRDs (and webhook configurations), but this appears to be caused by an unresolved upstream SSA issue: https://github.com/kubernetes/kubernetes/issues/128102

In this PR, I propose to use server-side apply in cainjector unconditionally, and at the same time deprecate the cainjector `ServerSideApply` feature gate. I've tried to look at prior art in this area, and got inspired by how it was done when deprecating the controller's `ValidateCAA` feature gate.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Make cainjector use SSA unconditionally and deprecate the ServerSideApply feature gate
```
