### PR TITLE
fix(digitalocean): resolve DNS01 zones from managed domains

### DIFF
--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -20,7 +20,9 @@ package digitalocean
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -32,8 +34,7 @@ import (
 
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 type DNSProvider struct {
-	dns01Nameservers []string
-	client           *godo.Client
+	domainsClient godo.DomainsService
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for digitalocean.
@@ -46,6 +47,8 @@ func NewDNSProvider(dns01Nameservers []string, userAgent string) (*DNSProvider, 
 // NewDNSProviderCredentials uses the supplied credentials to return a
 // DNSProvider instance configured for digitalocean.
 func NewDNSProviderCredentials(token string, dns01Nameservers []string, userAgent string) (*DNSProvider, error) {
+	_ = dns01Nameservers
+
 	if token == "" {
 		return nil, fmt.Errorf("DigitalOcean token missing")
 	}
@@ -60,21 +63,19 @@ func NewDNSProviderCredentials(token string, dns01Nameservers []string, userAgen
 	}
 
 	return &DNSProvider{
-		dns01Nameservers: dns01Nameservers,
-		client:           client,
+		domainsClient: client.Domains,
 	}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge
 func (c *DNSProvider) Present(ctx context.Context, _, fqdn, value string) error {
-	// if DigitalOcean does not have this zone then we will find out later
-	zoneName, err := util.FindZoneByFqdn(ctx, fqdn, c.dns01Nameservers)
+	zoneName, err := c.getHostedZone(ctx, fqdn)
 	if err != nil {
 		return err
 	}
 
 	// check if the record has already been created
-	records, err := c.findTxtRecord(ctx, fqdn)
+	records, err := c.findTxtRecord(ctx, zoneName, fqdn)
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,7 @@ func (c *DNSProvider) Present(ctx context.Context, _, fqdn, value string) error 
 		TTL:  60,
 	}
 
-	_, _, err = c.client.Domains.CreateRecord(
+	_, _, err = c.domainsClient.CreateRecord(
 		ctx,
 		util.UnFqdn(zoneName),
 		createRequest,
@@ -107,18 +108,18 @@ func (c *DNSProvider) Present(ctx context.Context, _, fqdn, value string) error 
 
 // CleanUp removes the TXT record matching the specified parameters
 func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) error {
-	zoneName, err := util.FindZoneByFqdn(ctx, fqdn, c.dns01Nameservers)
+	zoneName, err := c.getHostedZone(ctx, fqdn)
 	if err != nil {
 		return err
 	}
 
-	records, err := c.findTxtRecord(ctx, fqdn)
+	records, err := c.findTxtRecord(ctx, zoneName, fqdn)
 	if err != nil {
 		return err
 	}
 
 	for _, record := range records {
-		_, err = c.client.Domains.DeleteRecord(ctx, util.UnFqdn(zoneName), record.ID)
+		_, err = c.domainsClient.DeleteRecord(ctx, util.UnFqdn(zoneName), record.ID)
 
 		if err != nil {
 			return err
@@ -128,13 +129,8 @@ func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 	return nil
 }
 
-func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn string) ([]godo.DomainRecord, error) {
-	zoneName, err := util.FindZoneByFqdn(ctx, fqdn, c.dns01Nameservers)
-	if err != nil {
-		return nil, err
-	}
-
-	allRecords, _, err := c.client.Domains.RecordsByType(
+func (c *DNSProvider) findTxtRecord(ctx context.Context, zoneName, fqdn string) ([]godo.DomainRecord, error) {
+	allRecords, _, err := c.domainsClient.RecordsByType(
 		ctx,
 		util.UnFqdn(zoneName),
 		"TXT",
@@ -154,4 +150,38 @@ func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn string) ([]godo.Do
 	}
 
 	return records, err
+}
+
+// getHostedZone returns the most specific managed DigitalOcean domain for the
+// fqdn. This avoids split-horizon DNS selecting a private zone that is not
+// actually configured in DigitalOcean.
+func (c *DNSProvider) getHostedZone(ctx context.Context, fqdn string) (string, error) {
+	labels := strings.Split(util.UnFqdn(util.ToFqdn(fqdn)), ".")
+
+	for i := range labels {
+		remainingLabels := labels[i:]
+		if len(remainingLabels) < 2 {
+			break
+		}
+
+		zoneName := strings.Join(remainingLabels, ".")
+		_, _, err := c.domainsClient.Get(ctx, zoneName)
+		switch {
+		case err == nil:
+			return util.ToFqdn(zoneName), nil
+		case isDigitalOceanNotFound(err):
+			continue
+		default:
+			return "", err
+		}
+	}
+
+	return "", fmt.Errorf("zone for fqdn %q not found in DigitalOcean domains", fqdn)
+}
+
+func isDigitalOceanNotFound(err error) bool {
+	var target *godo.ErrorResponse
+	return errors.As(err, &target) &&
+		target.Response != nil &&
+		target.Response.StatusCode == http.StatusNotFound
 }

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package digitalocean
 
 import (
+	"context"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
@@ -82,4 +85,146 @@ func TestDigitalOceanCleanUp(t *testing.T) {
 
 	err = provider.CleanUp(t.Context(), doDomain, "_acme-challenge."+doDomain+".", "123d==")
 	assert.NoError(t, err)
+}
+
+func TestGetHostedZonePrefersMostSpecificManagedDomain(t *testing.T) {
+	service := &fakeDomainsService{
+		zones: map[string]struct{}{
+			"sub.example.com": {},
+			"example.com":     {},
+		},
+	}
+	provider := &DNSProvider{domainsClient: service}
+
+	zoneName, err := provider.getHostedZone(t.Context(), "_acme-challenge.foo.sub.example.com.")
+	assert.NoError(t, err)
+	assert.Equal(t, "sub.example.com.", zoneName)
+	assert.Equal(t, []string{
+		"_acme-challenge.foo.sub.example.com",
+		"foo.sub.example.com",
+		"sub.example.com",
+	}, service.getCalls)
+}
+
+func TestGetHostedZoneFallsBackToParentManagedDomain(t *testing.T) {
+	service := &fakeDomainsService{
+		zones: map[string]struct{}{
+			"example.com": {},
+		},
+	}
+	provider := &DNSProvider{domainsClient: service}
+
+	zoneName, err := provider.getHostedZone(t.Context(), "_acme-challenge.foo.sub.example.com.")
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com.", zoneName)
+	assert.Equal(t, []string{
+		"_acme-challenge.foo.sub.example.com",
+		"foo.sub.example.com",
+		"sub.example.com",
+		"example.com",
+	}, service.getCalls)
+}
+
+func TestDigitalOceanPresentUsesManagedDomain(t *testing.T) {
+	service := &fakeDomainsService{
+		zones: map[string]struct{}{
+			"example.com": {},
+		},
+	}
+	provider := &DNSProvider{domainsClient: service}
+
+	err := provider.Present(t.Context(), "", "_acme-challenge.foo.sub.example.com.", "123d==")
+	assert.NoError(t, err)
+	assert.Equal(t, []createRecordCall{
+		{
+			domain: "example.com",
+			record: godo.DomainRecordEditRequest{
+				Type: "TXT",
+				Name: "_acme-challenge.foo.sub.example.com.",
+				Data: "123d==",
+				TTL:  60,
+			},
+		},
+	}, service.createCalls)
+}
+
+func TestDigitalOceanCleanUpUsesManagedDomain(t *testing.T) {
+	service := &fakeDomainsService{
+		zones: map[string]struct{}{
+			"example.com": {},
+		},
+		records: map[string][]godo.DomainRecord{
+			"example.com": {
+				{
+					ID:   10,
+					Type: "TXT",
+					Name: "_acme-challenge.foo.sub",
+					Data: "123d==",
+				},
+			},
+		},
+	}
+	provider := &DNSProvider{domainsClient: service}
+
+	err := provider.CleanUp(t.Context(), "", "_acme-challenge.foo.sub.example.com.", "123d==")
+	assert.NoError(t, err)
+	assert.Equal(t, []deleteRecordCall{
+		{domain: "example.com", id: 10},
+	}, service.deleteCalls)
+}
+
+type fakeDomainsService struct {
+	godo.DomainsService
+
+	zones       map[string]struct{}
+	records     map[string][]godo.DomainRecord
+	getCalls    []string
+	createCalls []createRecordCall
+	deleteCalls []deleteRecordCall
+}
+
+type createRecordCall struct {
+	domain string
+	record godo.DomainRecordEditRequest
+}
+
+type deleteRecordCall struct {
+	domain string
+	id     int
+}
+
+func (f *fakeDomainsService) Get(_ context.Context, name string) (*godo.Domain, *godo.Response, error) {
+	f.getCalls = append(f.getCalls, name)
+
+	if _, ok := f.zones[name]; ok {
+		return &godo.Domain{Name: name}, nil, nil
+	}
+
+	return nil, nil, &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Resource not found",
+	}
+}
+
+func (f *fakeDomainsService) RecordsByType(_ context.Context, domain, ofType string, _ *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+	if ofType != "TXT" {
+		return nil, nil, assert.AnError
+	}
+
+	return f.records[domain], nil, nil
+}
+
+func (f *fakeDomainsService) CreateRecord(_ context.Context, domain string, createRequest *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	f.createCalls = append(f.createCalls, createRecordCall{
+		domain: domain,
+		record: *createRequest,
+	})
+
+	return &godo.DomainRecord{}, nil, nil
+}
+
+func (f *fakeDomainsService) DeleteRecord(_ context.Context, domain string, id int) (*godo.Response, error) {
+	f.deleteCalls = append(f.deleteCalls, deleteRecordCall{domain: domain, id: id})
+
+	return nil, nil
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/8586

The DigitalOcean DNS01 solver currently derives the hosted zone from recursive DNS. In split-horizon setups that can resolve to a private sub-zone that does not exist in DigitalOcean, which leads to repeated 404 responses from the DigitalOcean API and makes challenge cleanup hard to complete cleanly.

This change resolves the zone by walking the challenge FQDN suffixes through the DigitalOcean Domains API and selecting the nearest managed domain instead. That keeps the solver aligned with the zones DigitalOcean can actually serve, even when recursive DNS points at a private child zone.

### Kind

/kind bug

### Release Note

```release-note
DigitalOcean DNS01: resolve the challenge zone from the nearest managed DigitalOcean domain so split-horizon DNS does not select an unmanaged private sub-zone.
```
