### PR TITLE
feat(metrics): add Vault Sign() request duration instrumentation

### DIFF
--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -18,6 +18,7 @@ package vault
 
 import (
 	"context"
+	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -30,6 +31,7 @@ import (
 	crutil "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/util"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
 )
 
@@ -45,6 +47,7 @@ type Vault struct {
 	createTokenFn func(ns string) vaultinternal.CreateToken
 	secretsLister internalinformers.SecretLister
 	reporter      *crutil.Reporter
+	metrics       *metrics.Metrics
 
 	vaultClientBuilder vaultinternal.ClientBuilder
 }
@@ -67,6 +70,7 @@ func NewVault(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		},
 		secretsLister:      ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:           crutil.NewReporter(ctx.Clock, ctx.Recorder),
+		metrics:            ctx.Metrics,
 		vaultClientBuilder: vaultinternal.New,
 	}
 }
@@ -101,7 +105,9 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 	}
 
 	certDuration := apiutil.DefaultCertDuration(cr.Spec.Duration)
+	callStart := time.Now()
 	certPem, caPem, err := client.Sign(cr.Spec.Request, certDuration)
+	v.metrics.ObserveVaultRequestDuration(time.Since(callStart), "sign_certificate")
 	if err != nil {
 		message := "Vault failed to sign certificate"
 

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -19,6 +19,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -53,6 +55,7 @@ type Vault struct {
 
 	certClient    certificatesclient.CertificateSigningRequestInterface
 	clientBuilder internalvault.ClientBuilder
+	metrics       *metrics.Metrics
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
@@ -74,6 +77,7 @@ func NewVault(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 		recorder:      ctx.Recorder,
 		certClient:    ctx.Client.CertificatesV1().CertificateSigningRequests(),
 		clientBuilder: internalvault.New,
+		metrics:       ctx.Metrics,
 		fieldManager:  ctx.FieldManager,
 	}
 }
@@ -115,7 +119,9 @@ func (v *Vault) Sign(ctx context.Context, csr *certificatesv1.CertificateSigning
 		return nil
 	}
 
+	callStart := time.Now()
 	certPEM, _, err := client.Sign(csr.Spec.Request, duration)
+	v.metrics.ObserveVaultRequestDuration(time.Since(callStart), "sign_certificate")
 	if err != nil {
 		message := fmt.Sprintf("Vault failed to sign: %s", err)
 		log.Error(err, message)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -22,6 +22,7 @@ limitations under the License.
 // certificate_challenge_status{status, domain, reason, processing, id, type}
 // acme_client_request_count{"scheme", "host", "action", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "action", "method", "status"}
+// vault_client_request_duration_seconds{"api_call"}
 // venafi_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
 // controller_sync_call_count{"controller"}
 package metrics
@@ -61,6 +62,7 @@ type Metrics struct {
 	acmeClientRequestDurationSeconds   *prometheus.SummaryVec
 	acmeClientRequestCount             *prometheus.CounterVec
 	venafiClientRequestDurationSeconds *prometheus.SummaryVec
+	vaultClientRequestDurationSeconds  *prometheus.SummaryVec
 	controllerSyncCallCount            *prometheus.CounterVec
 	controllerSyncErrorCount           *prometheus.CounterVec
 	challengeCollector                 prometheus.Collector
@@ -152,6 +154,21 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			[]string{"api_call"},
 		)
 
+		// vaultClientRequestDurationSeconds is a Prometheus summary to
+		// collect api call latencies for the Vault client. This metric is in
+		// alpha and can be moved to GA once it has been shown to help measure
+		// Vault call latency.
+		vaultClientRequestDurationSeconds = prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace:  namespace,
+				Name:       "vault_client_request_duration_seconds",
+				Help:       "ALPHA: The Vault API request latencies in seconds for the Certificate Manager client. This metric is currently alpha as we would like to understand whether it helps to measure Vault call latency. Please leave feedback if you have any.",
+				Subsystem:  "http",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			},
+			[]string{"api_call"},
+		)
+
 		controllerSyncCallCount = prometheus.NewCounterVec(
 			//nolint:promlinter
 			prometheus.CounterOpts{
@@ -189,6 +206,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		acmeClientRequestCount:             acmeClientRequestCount,
 		acmeClientRequestDurationSeconds:   acmeClientRequestDurationSeconds,
 		venafiClientRequestDurationSeconds: venafiClientRequestDurationSeconds,
+		vaultClientRequestDurationSeconds:  vaultClientRequestDurationSeconds,
 		controllerSyncCallCount:            controllerSyncCallCount,
 		controllerSyncErrorCount:           controllerSyncErrorCount,
 	}
@@ -222,6 +240,7 @@ func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.clockTimeSecondsGauge)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)
 	m.registry.MustRegister(m.venafiClientRequestDurationSeconds)
+	m.registry.MustRegister(m.vaultClientRequestDurationSeconds)
 	m.registry.MustRegister(m.acmeClientRequestCount)
 	m.registry.MustRegister(m.controllerSyncCallCount)
 	m.registry.MustRegister(m.controllerSyncErrorCount)

--- a/pkg/metrics/vault.go
+++ b/pkg/metrics/vault.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+)
+
+// ObserveVaultRequestDuration records the duration of an outbound Vault API
+// call. The api_call label identifies the logical operation (e.g.
+// "sign_certificate").
+func (m *Metrics) ObserveVaultRequestDuration(duration time.Duration, labels ...string) {
+	m.vaultClientRequestDurationSeconds.WithLabelValues(labels...).Observe(duration.Seconds())
+}

--- a/pkg/metrics/vault_test.go
+++ b/pkg/metrics/vault_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fakeclock "k8s.io/utils/clock/testing"
+)
+
+func TestObserveVaultRequestDuration(t *testing.T) {
+	tests := []struct {
+		name             string
+		apiCall          string
+		duration         time.Duration
+		observationCount int
+		expectedSum      float64
+	}{
+		{
+			name:             "single sign_certificate observation",
+			apiCall:          "sign_certificate",
+			duration:         100 * time.Millisecond,
+			observationCount: 1,
+			expectedSum:      0.1,
+		},
+		{
+			name:             "multiple observations are summed",
+			apiCall:          "sign_certificate",
+			duration:         250 * time.Millisecond,
+			observationCount: 3,
+			expectedSum:      0.75,
+		},
+		{
+			name:             "different api_call label is tracked separately",
+			apiCall:          "list_secrets",
+			duration:         50 * time.Millisecond,
+			observationCount: 2,
+			expectedSum:      0.1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(testr.New(t), fakeclock.NewFakeClock(time.Now()))
+
+			for i := 0; i < tt.observationCount; i++ {
+				m.ObserveVaultRequestDuration(tt.duration, tt.apiCall)
+			}
+
+			obs, err := m.vaultClientRequestDurationSeconds.GetMetricWithLabelValues(tt.apiCall)
+			require.NoError(t, err)
+
+			pb := &dto.Metric{}
+			require.NoError(t, obs.(interface {
+				Write(*dto.Metric) error
+			}).Write(pb))
+
+			require.NotNil(t, pb.Summary)
+			assert.Equal(t, uint64(tt.observationCount), pb.Summary.GetSampleCount(),
+				"expected %d observations for api_call=%q", tt.observationCount, tt.apiCall)
+			assert.InDelta(t, tt.expectedSum, pb.Summary.GetSampleSum(), 0.001,
+				"expected sum=%v for api_call=%q", tt.expectedSum, tt.apiCall)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add a Prometheus summary metric for the duration of Vault API `Sign()` calls, following the same pattern established by `venafi_client_request_duration_seconds`. This gives operators of the Vault issuer observability into how much of certificate issuance time is spent in the Vault round trip versus in cert-manager itself.

Fixes #8441

## New metric

```
certmanager_http_vault_client_request_duration_seconds{api_call}
```

Currently only `api_call="sign_certificate"` is emitted. The label is left open so additional Vault operations can be instrumented later without breaking changes.

## Both Vault Sign() callsites instrumented

cert-manager's Vault issuer has two controllers that call `client.Sign()`:

| Controller | File | Used by |
|-----------|------|---------|
| `certificaterequests` | `pkg/controller/certificaterequests/vault/vault.go` | cert-manager `Certificate` resources |
| `certificatesigningrequests` | `pkg/controller/certificatesigningrequests/vault/vault.go` | Kubernetes `CertificateSigningRequest` resources |

Both are instrumented in this PR. (The previously-open #8485 only covered the CSR path.)

## Notes

- Follows the existing alpha-metric convention used for the Venafi client.
- Metric is registered alongside the other client request duration metrics in `pkg/metrics/metrics.go`.
- New unit test `TestObserveVaultRequestDuration` verifies single observation, multiple observations summed correctly, and label separation.

## Verification

- `go build ./pkg/metrics/... ./pkg/controller/{,_signing}requests/vault/...` passes
- `go test ./pkg/metrics/...` passes (3 new + existing)
- `go test ./pkg/controller/.../vault/...` passes (existing 23s + 15s suites unaffected)

Fixes #8441