### PR TITLE
fix: use filepath functions in TestFSLoader_Load for Windows compatibility

### DIFF
--- a/pkg/util/configfile/configfile_test.go
+++ b/pkg/util/configfile/configfile_test.go
@@ -18,14 +18,17 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/webhook/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
-	const kubeConfigPath = "path/to/kubeconfig/file"
+	// Use filepath.FromSlash so the test expectations match OS-native separators
+	// (forward slashes on Unix, backslashes on Windows).
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
+	kubeConfigPath := filepath.FromSlash("path/to/kubeconfig/file")
 
 	webhookConfig := configfile.New()
 
@@ -46,8 +49,9 @@ kubeConfig: %s`, kubeConfigPath), nil
 		t.Fatal(err)
 	}
 
-	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	// The config loader resolves relative paths via filepath.Dir and filepath.Join,
+	// so the expected result must be built the same way to be OS-portable.
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if webhookConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, webhookConfig.Config.KubeConfig)
 	}


### PR DESCRIPTION
## Summary

Fixes #8612

`TestFSLoader_Load` in `pkg/util/configfile/configfile_test.go` uses hardcoded Unix path literals (e.g. `"/path/to/config/file"`) as expected values. The production code in `configfile.go` resolves paths with `filepath.Dir` and `filepath.Join`, which produce OS-native separators. On Windows these functions return backslash-separated paths, causing the test to fail because the expectations still use forward slashes.

### Changes

- Replace `const` string declarations with `filepath.FromSlash(...)` so the test input paths use OS-native separators
- Build `absKubeConfigPath` using `filepath.Join(filepath.Dir(...), ...)` instead of a hardcoded string, mirroring how the production code computes the resolved path

This keeps the test functionally identical on Unix while making it pass on Windows.

/kind bug