### PR TITLE
fix: remove OS-dependent path literals from TestFSLoader_Load

### DIFF
--- a/pkg/cainjector/configfile/configfile_test.go
+++ b/pkg/cainjector/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	cainjectorConfig := New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if cainjectorConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, cainjectorConfig.Config.KubeConfig)
 	}

--- a/pkg/controller/configfile/configfile_test.go
+++ b/pkg/controller/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	controllerConfig := New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if controllerConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, controllerConfig.Config.KubeConfig)
 	}

--- a/pkg/util/configfile/configfile_test.go
+++ b/pkg/util/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/webhook/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	webhookConfig := configfile.New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if webhookConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, webhookConfig.Config.KubeConfig)
 	}


### PR DESCRIPTION
Fixes `TestFSLoader_Load` in three packages so it passes on Windows.

The hardcoded `"/path/to/config/path/to/kubeconfig/file"` only matches on Unix; `filepath.Join` produces backslash paths on Windows. Replace the literal with `filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)` so the assertion produces the correct platform-specific path.

Three files updated with the same one-line fix: `pkg/util/configfile`, `pkg/cainjector/configfile`, `pkg/controller/configfile`.

Fixes #8612


### Kind

/kind cleanup

### Release Note
```release-note
NONE
```