### PR TITLE
fix: apply ingressTemplate annotations to edit-in-place ingresses

### DIFF
--- a/pkg/cainjector/configfile/configfile_test.go
+++ b/pkg/cainjector/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	cainjectorConfig := New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if cainjectorConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, cainjectorConfig.Config.KubeConfig)
 	}

--- a/pkg/controller/configfile/configfile_test.go
+++ b/pkg/controller/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/util/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	controllerConfig := New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if controllerConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, controllerConfig.Config.KubeConfig)
 	}

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -243,6 +243,14 @@ func (s *Solver) addChallengePathToIngress(ctx context.Context, ch *cmacme.Chall
 	if err != nil {
 		return nil, err
 	}
+	ing = ing.DeepCopy()
+
+	// Apply ingressTemplate annotations/labels to the existing ingress so that
+	// solver-specific metadata (e.g. ingress.cilium.io/force-https) is honoured
+	// for edit-in-place ingresses, not only for newly created ones.
+	if ch.Spec.Solver.HTTP01 != nil && ch.Spec.Solver.HTTP01.Ingress != nil {
+		ing = s.mergeIngressObjectMetaWithIngressResourceTemplate(ing, ch.Spec.Solver.HTTP01.Ingress.IngressTemplate)
+	}
 
 	ingPathToAdd := ingressPath(ch.Spec.Token, svcName)
 	// check for an existing Rule for the given domain on the ingress resource

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -761,3 +761,73 @@ func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
 		})
 	}
 }
+
+// TestEnsureIngressEditInPlaceAppliesIngressTemplate is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/8572: when
+// acme.cert-manager.io/http01-edit-in-place is set on an existing Ingress,
+// ingressTemplate annotations must be applied to that Ingress, not only to
+// newly created ones.
+func TestEnsureIngressEditInPlaceAppliesIngressTemplate(t *testing.T) {
+	const (
+		existingIngressName = "acme-ingress"
+		wantAnnotation      = "ingress.cilium.io/force-https"
+		wantAnnotationValue = "disabled"
+	)
+
+	ch := &cmacme.Challenge{
+		Spec: cmacme.ChallengeSpec{
+			DNSName: "example.com",
+			Solver: cmacme.ACMEChallengeSolver{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Name: existingIngressName,
+						IngressTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressTemplate{
+							ACMEChallengeSolverHTTP01IngressObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressObjectMeta{
+								Annotations: map[string]string{
+									wantAnnotation: wantAnnotationValue,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture := solverFixture{
+		Challenge: ch,
+		PreFn: func(t *testing.T, s *solverFixture) {
+			// Create the existing Ingress that will be edited in-place.
+			existing := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      existingIngressName,
+					Namespace: s.Challenge.Namespace,
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: ch.Spec.DNSName,
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{},
+							},
+						},
+					},
+				},
+			}
+			_, err := s.Builder.FakeKubeClient().NetworkingV1().Ingresses(s.Challenge.Namespace).Create(t.Context(), existing, metav1.CreateOptions{})
+			require.NoError(t, err)
+			s.Builder.Sync()
+		},
+		CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+			ingresses, err := s.Solver.ingressLister.List(labels.NewSelector())
+			require.NoError(t, err)
+			require.Len(t, ingresses, 1)
+			assert.Equal(t, wantAnnotationValue, ingresses[0].Annotations[wantAnnotation],
+				"ingressTemplate annotation should be applied to the edit-in-place ingress")
+		},
+	}
+
+	fixture.Setup(t)
+	resp, err := fixture.Solver.ensureIngress(t.Context(), fixture.Challenge, "fakeservice")
+	fixture.Finish(t, resp, err)
+}

--- a/pkg/util/configfile/configfile_test.go
+++ b/pkg/util/configfile/configfile_test.go
@@ -18,13 +18,14 @@ package configfile
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cert-manager/cert-manager/pkg/webhook/configfile"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	const expectedFilename = "/path/to/config/file"
+	expectedFilename := filepath.FromSlash("/path/to/config/file")
 	const kubeConfigPath = "path/to/kubeconfig/file"
 
 	webhookConfig := configfile.New()
@@ -47,7 +48,7 @@ kubeConfig: %s`, kubeConfigPath), nil
 	}
 
 	// the config loader will force paths to be 'absolute' if they are provided as relative.
-	absKubeConfigPath := "/path/to/config/path/to/kubeconfig/file"
+	absKubeConfigPath := filepath.Join(filepath.Dir(expectedFilename), kubeConfigPath)
 	if webhookConfig.Config.KubeConfig != absKubeConfigPath {
 		t.Errorf("expected kubeConfig to be set to %q but got %q", absKubeConfigPath, webhookConfig.Config.KubeConfig)
 	}


### PR DESCRIPTION
## Problem

When `acme.cert-manager.io/http01-edit-in-place: 'true'` is set on an Ingress, cert-manager edits the existing Ingress in-place rather than creating a new one. The `ingressTemplate` annotations/labels defined in the solver were silently ignored in this path — only newly created Ingresses received them.

Fixes #8572

## Root cause

`mergeIngressObjectMetaWithIngressResourceTemplate` was called only inside `createIngress`. The edit-in-place code path (`addChallengePathToIngress`) fetched and updated the existing Ingress without applying the template.

## Fix

Add `DeepCopy()` + `mergeIngressObjectMetaWithIngressResourceTemplate` at the start of `addChallengePathToIngress` so template metadata is applied before the Ingress is updated.

## Test

`TestEnsureIngressEditInPlaceAppliesIngressTemplate` creates an existing Ingress with a known name, calls `ensureIngress` with a challenge that specifies `ingressTemplate` annotations, and asserts the annotation is present on the updated Ingress.