### PR TITLE
fix(dns): propagate caBundle to acmeDNS solver, add per-solver override

### DIFF
--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -139,6 +139,13 @@ spec:
                             required:
                             - name
                             type: object
+                          caBundle:
+                            description: |-
+                              CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+                              connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+                              for TLS connections to the acme-dns server.
+                            format: byte
+                            type: string
                           host:
                             type: string
                         required:

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -252,6 +252,13 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                caBundle:
+                                  description: |-
+                                    CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+                                    connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+                                    for TLS connections to the acme-dns server.
+                                  format: byte
+                                  type: string
                                 host:
                                   type: string
                               required:

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -251,6 +251,13 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                caBundle:
+                                  description: |-
+                                    CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+                                    connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+                                    for TLS connections to the acme-dns server.
+                                  format: byte
+                                  type: string
                                 host:
                                   type: string
                               required:

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -651,6 +651,11 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string
 
 	AccountSecret cmmeta.SecretKeySelector
+
+	// CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+	// connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+	// for TLS connections to the acme-dns server.
+	CABundle []byte
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -673,6 +673,11 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string
 
 	AccountSecret cmmeta.SecretKeySelector
+
+	// CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+	// connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+	// for TLS connections to the acme-dns server.
+	CABundle []byte
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1066,6 +1066,7 @@ func autoConvert_v1_ACMEIssuerDNS01ProviderAcmeDNS_To_acme_ACMEIssuerDNS01Provid
 	if err := metav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.AccountSecret, &out.AccountSecret, s); err != nil {
 		return err
 	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 
@@ -1079,6 +1080,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAcmeDNS_To_v1_ACMEIssuerDNS01Provid
 	if err := metav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.AccountSecret, &out.AccountSecret, s); err != nil {
 		return err
 	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1070,6 +1070,7 @@ func autoConvert_v1_ACMEIssuerDNS01ProviderAcmeDNS_To_acme_ACMEIssuerDNS01Provid
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.AccountSecret, &out.AccountSecret, s); err != nil {
 		return err
 	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 
@@ -1083,6 +1084,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAcmeDNS_To_v1_ACMEIssuerDNS01Provid
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.AccountSecret, &out.AccountSecret, s); err != nil {
 		return err
 	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 

--- a/internal/apis/acme/zz_generated.deepcopy.go
+++ b/internal/apis/acme/zz_generated.deepcopy.go
@@ -139,7 +139,7 @@ func (in *ACMEChallengeSolverDNS01) DeepCopyInto(out *ACMEChallengeSolverDNS01) 
 	if in.AcmeDNS != nil {
 		in, out := &in.AcmeDNS, &out.AcmeDNS
 		*out = new(ACMEIssuerDNS01ProviderAcmeDNS)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RFC2136 != nil {
 		in, out := &in.RFC2136, &out.RFC2136
@@ -552,6 +552,11 @@ func (in *ACMEIssuer) DeepCopy() *ACMEIssuer {
 func (in *ACMEIssuerDNS01ProviderAcmeDNS) DeepCopyInto(out *ACMEIssuerDNS01ProviderAcmeDNS) {
 	*out = *in
 	out.AccountSecret = in.AccountSecret
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/internal/apis/acme/zz_generated.deepcopy.go
+++ b/internal/apis/acme/zz_generated.deepcopy.go
@@ -149,7 +149,7 @@ func (in *ACMEChallengeSolverDNS01) DeepCopyInto(out *ACMEChallengeSolverDNS01) 
 	if in.AcmeDNS != nil {
 		in, out := &in.AcmeDNS, &out.AcmeDNS
 		*out = new(ACMEIssuerDNS01ProviderAcmeDNS)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RFC2136 != nil {
 		in, out := &in.RFC2136, &out.RFC2136
@@ -562,6 +562,11 @@ func (in *ACMEIssuer) DeepCopy() *ACMEIssuer {
 func (in *ACMEIssuerDNS01ProviderAcmeDNS) DeepCopyInto(out *ACMEIssuerDNS01ProviderAcmeDNS) {
 	*out = *in
 	out.AccountSecret = in.AccountSecret
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -594,6 +594,11 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		if len(p.AcmeDNS.Host) == 0 {
 			el = append(el, field.Required(fldPath.Child("acmeDNS", "host"), ""))
 		}
+		if len(p.AcmeDNS.CABundle) > 0 {
+			if err := validateCABundleNotEmpty(p.AcmeDNS.CABundle); err != nil {
+				el = append(el, field.Invalid(fldPath.Child("acmeDNS", "caBundle"), "", err.Error()))
+			}
+		}
 	}
 
 	if p.DigitalOcean != nil {

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -660,6 +660,13 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		requiredSecrets = append(requiredSecrets, &p.AcmeDNS.AccountSecret)
 		if len(p.AcmeDNS.Host) == 0 {
 			el = append(el, field.Required(fldPath.Child("acmeDNS", "host"), ""))
+		} else if !strings.HasPrefix(p.AcmeDNS.Host, "http://") && !strings.HasPrefix(p.AcmeDNS.Host, "https://") {
+			el = append(el, field.Invalid(fldPath.Child("acmeDNS", "host"), p.AcmeDNS.Host, "host must include a URL scheme (e.g. https://auth.example.com)"))
+		}
+		if len(p.AcmeDNS.CABundle) > 0 {
+			if err := validateCABundleNotEmpty(p.AcmeDNS.CABundle); err != nil {
+				el = append(el, field.Invalid(fldPath.Child("acmeDNS", "caBundle"), "", err.Error()))
+			}
 		}
 	}
 

--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -660,8 +660,6 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		requiredSecrets = append(requiredSecrets, &p.AcmeDNS.AccountSecret)
 		if len(p.AcmeDNS.Host) == 0 {
 			el = append(el, field.Required(fldPath.Child("acmeDNS", "host"), ""))
-		} else if !strings.HasPrefix(p.AcmeDNS.Host, "http://") && !strings.HasPrefix(p.AcmeDNS.Host, "https://") {
-			el = append(el, field.Invalid(fldPath.Child("acmeDNS", "host"), p.AcmeDNS.Host, "host must include a URL scheme (e.g. https://auth.example.com)"))
 		}
 		if len(p.AcmeDNS.CABundle) > 0 {
 			if err := validateCABundleNotEmpty(p.AcmeDNS.CABundle); err != nil {

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1138,6 +1138,12 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 
 func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 	fldPath := field.NewPath("test")
+
+	validCAPEM := unitcrypto.MustCreateCryptoBundle(t,
+		&pubcmapi.Certificate{Spec: pubcmapi.CertificateSpec{CommonName: "test"}},
+		clock.RealClock{},
+	).CertBytes
+
 	scenarios := map[string]struct {
 		cfg  *cmacme.ACMEChallengeSolverDNS01
 		errs []*field.Error
@@ -1726,6 +1732,37 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Forbidden(fldPath.Child("cloudflare"), "may not specify more than one provider type"),
+			},
+		},
+		"acmedns with empty caBundle passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"acmedns with valid PEM caBundle passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+					CABundle:      validCAPEM,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"acmedns with invalid PEM caBundle fails validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+					CABundle:      []byte("invalid-pem"),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("acmeDNS", "caBundle"), "", "cert bundle didn't contain any valid certificates"),
 			},
 		},
 	}

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1253,6 +1253,12 @@ func TestValidateACMEIssuerHTTP01Config(t *testing.T) {
 
 func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 	fldPath := field.NewPath("test")
+
+	validCAPEM := unitcrypto.MustCreateCryptoBundle(t,
+		&pubcmapi.Certificate{Spec: pubcmapi.CertificateSpec{CommonName: "test"}},
+		clock.RealClock{},
+	).CertBytes
+
 	scenarios := map[string]struct {
 		cfg  *cmacme.ACMEChallengeSolverDNS01
 		errs []*field.Error
@@ -1881,6 +1887,66 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 			errs: []*field.Error{
 				field.Invalid(fldPath.Child("nameservers").Index(0), "https://", "must be in the format https://<DoH RFC 8484 server address>"),
 			},
+		},
+		"acmedns with empty caBundle passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"acmedns with valid PEM caBundle passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+					CABundle:      validCAPEM,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"acmedns with invalid PEM caBundle fails validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://acme-dns.example.com",
+					AccountSecret: validSecretKeyRef,
+					CABundle:      []byte("invalid-pem"),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("acmeDNS", "caBundle"), "", "cert bundle didn't contain any valid certificates"),
+			},
+		},
+		"acmedns host without scheme fails validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "auth.example.com",
+					AccountSecret: validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("acmeDNS", "host"), "auth.example.com", "host must include a URL scheme (e.g. https://auth.example.com)"),
+			},
+		},
+		"acmedns host with https scheme passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "https://auth.example.com",
+					AccountSecret: validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"acmedns host with http scheme passes validation": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+					Host:          "http://auth.example.com",
+					AccountSecret: validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{},
 		},
 	}
 	for n, s := range scenarios {

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -1919,30 +1919,10 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Invalid(fldPath.Child("acmeDNS", "caBundle"), "", "cert bundle didn't contain any valid certificates"),
 			},
 		},
-		"acmedns host without scheme fails validation": {
+		"acmedns host without scheme passes validation": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
 					Host:          "auth.example.com",
-					AccountSecret: validSecretKeyRef,
-				},
-			},
-			errs: []*field.Error{
-				field.Invalid(fldPath.Child("acmeDNS", "host"), "auth.example.com", "host must include a URL scheme (e.g. https://auth.example.com)"),
-			},
-		},
-		"acmedns host with https scheme passes validation": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
-					Host:          "https://auth.example.com",
-					AccountSecret: validSecretKeyRef,
-				},
-			},
-			errs: []*field.Error{},
-		},
-		"acmedns host with http scheme passes validation": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
-					Host:          "http://auth.example.com",
 					AccountSecret: validSecretKeyRef,
 				},
 			},

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1448,6 +1448,13 @@ func schema_pkg_apis_acme_v1_ACMEIssuerDNS01ProviderAcmeDNS(ref common.Reference
 							Ref:     ref("github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector"),
 						},
 					},
+					"caBundle": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CABundle is a base64 encoded TLS certificate authority bundle to use when verifying connections to the acme-dns server. If set, it overrides the spec.acme.caBundle for TLS connections to the acme-dns server.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
 				},
 				Required: []string{"host", "accountSecretRef"},
 			},

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1478,6 +1478,13 @@ func schema_pkg_apis_acme_v1_ACMEIssuerDNS01ProviderAcmeDNS(ref common.Reference
 							Ref:     ref("github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector"),
 						},
 					},
+					"caBundle": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CABundle is a base64 encoded TLS certificate authority bundle to use when verifying connections to the acme-dns server. If set, it overrides the spec.acme.caBundle for TLS connections to the acme-dns server.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
 				},
 				Required: []string{"host", "accountSecretRef"},
 			},

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -795,6 +795,12 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string `json:"host"`
 
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
+
+	// CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+	// connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+	// for TLS connections to the acme-dns server.
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -825,6 +825,12 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string `json:"host"`
 
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
+
+	// CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+	// connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+	// for TLS connections to the acme-dns server.
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -139,7 +139,7 @@ func (in *ACMEChallengeSolverDNS01) DeepCopyInto(out *ACMEChallengeSolverDNS01) 
 	if in.AcmeDNS != nil {
 		in, out := &in.AcmeDNS, &out.AcmeDNS
 		*out = new(ACMEIssuerDNS01ProviderAcmeDNS)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RFC2136 != nil {
 		in, out := &in.RFC2136, &out.RFC2136
@@ -552,6 +552,11 @@ func (in *ACMEIssuer) DeepCopy() *ACMEIssuer {
 func (in *ACMEIssuerDNS01ProviderAcmeDNS) DeepCopyInto(out *ACMEIssuerDNS01ProviderAcmeDNS) {
 	*out = *in
 	out.AccountSecret = in.AccountSecret
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -149,7 +149,7 @@ func (in *ACMEChallengeSolverDNS01) DeepCopyInto(out *ACMEChallengeSolverDNS01) 
 	if in.AcmeDNS != nil {
 		in, out := &in.AcmeDNS, &out.AcmeDNS
 		*out = new(ACMEIssuerDNS01ProviderAcmeDNS)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RFC2136 != nil {
 		in, out := &in.RFC2136, &out.RFC2136
@@ -562,6 +562,11 @@ func (in *ACMEIssuer) DeepCopy() *ACMEIssuer {
 func (in *ACMEIssuerDNS01ProviderAcmeDNS) DeepCopyInto(out *ACMEIssuerDNS01ProviderAcmeDNS) {
 	*out = *in
 	out.AccountSecret = in.AccountSecret
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01provideracmedns.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01provideracmedns.go
@@ -30,6 +30,10 @@ import (
 type ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration struct {
 	Host          *string                                     `json:"host,omitempty"`
 	AccountSecret *metav1.SecretKeySelectorApplyConfiguration `json:"accountSecretRef,omitempty"`
+	// CABundle is a base64 encoded TLS certificate authority bundle to use when verifying
+	// connections to the acme-dns server. If set, it overrides the spec.acme.caBundle
+	// for TLS connections to the acme-dns server.
+	CABundle []byte `json:"caBundle,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration constructs a declarative configuration of the ACMEIssuerDNS01ProviderAcmeDNS type for use with
@@ -51,5 +55,15 @@ func (b *ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration) WithHost(value string
 // If called multiple times, the AccountSecret field is set to the value of the last call.
 func (b *ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration) WithAccountSecret(value *metav1.SecretKeySelectorApplyConfiguration) *ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration {
 	b.AccountSecret = value
+	return b
+}
+
+// WithCABundle adds the given value to the CABundle field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the CABundle field.
+func (b *ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration) WithCABundle(values ...byte) *ACMEIssuerDNS01ProviderAcmeDNSApplyConfiguration {
+	for i := range values {
+		b.CABundle = append(b.CABundle, values[i])
+	}
 	return b
 }

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -753,6 +753,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.meta.v1.SecretKeySelector
       default: {}
+    - name: caBundle
+      type:
+        scalar: string
     - name: host
       type:
         scalar: string

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -762,6 +762,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.meta.v1.SecretKeySelector
       default: {}
+    - name: caBundle
+      type:
+        scalar: string
     - name: host
       type:
         scalar: string

--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/nrdcg/goacmedns"
@@ -45,14 +46,19 @@ type DNSProvider struct {
 func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
 	host := os.Getenv("ACME_DNS_HOST")
 	accountJSON := os.Getenv("ACME_DNS_ACCOUNT_JSON")
-	return NewDNSProviderHostBytes(host, []byte(accountJSON), dns01Nameservers)
+	return NewDNSProviderHostBytes(host, []byte(accountJSON), dns01Nameservers, nil)
 }
 
 // NewDNSProviderHostBytes returns a DNSProvider instance configured for ACME DNS
 // acme-dns server host is given in a string
 // credentials are stored in json in the given string
-func NewDNSProviderHostBytes(host string, accountJSON []byte, dns01Nameservers []string) (*DNSProvider, error) {
-	client, err := goacmedns.NewClient(host)
+func NewDNSProviderHostBytes(host string, accountJSON []byte, dns01Nameservers []string, httpClient *http.Client) (*DNSProvider, error) {
+	var opts []goacmedns.Option
+	if httpClient != nil {
+		opts = append(opts, goacmedns.WithHTTPClient(httpClient))
+	}
+
+	client, err := goacmedns.NewClient(host, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating acme-dns client: %s", err)
 	}

--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -60,7 +60,12 @@ func NewDNSProviderFromOptions(_ context.Context, options ...DNSProviderOption) 
 		return nil, err
 	}
 
-	client, err := goacmedns.NewClient(opt.Host)
+	var clientOpts []goacmedns.Option
+	if opt.HTTPClient != nil {
+		clientOpts = append(clientOpts, goacmedns.WithHTTPClient(opt.HTTPClient))
+	}
+
+	client, err := goacmedns.NewClient(opt.Host, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating acme-dns client: %s", err)
 	}

--- a/pkg/issuer/acme/dns/acmedns/acmedns_test.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns_test.go
@@ -50,20 +50,20 @@ func TestValidJsonAccount(t *testing.T) {
             "username": "usernom"
         }
     }`)
-	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJSON, util.RecursiveNameservers)
+	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJSON, util.RecursiveNameservers, nil)
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
 	assert.Equal(t, provider.accounts["domain"].FullDomain, "fooldom")
 }
 
 func TestNoValidJsonAccount(t *testing.T) {
 	accountJson := []byte(`{"duck": "quack"}`)
-	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers, nil)
 	assert.Error(t, err, "Expected error constructing DNSProvider from invalid accountJson")
 }
 
 func TestNoValidJson(t *testing.T) {
 	accountJson := []byte("b00m")
-	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers, nil)
 	assert.Error(t, err, "Expected error constructing DNSProvider from invalid JSON")
 }
 
@@ -71,7 +71,7 @@ func TestLiveAcmeDnsPresent(t *testing.T) {
 	if !acmednsLiveTest {
 		t.Skip("skipping live test")
 	}
-	provider, err := NewDNSProviderHostBytes(acmednsHost, acmednsAccountJSON, util.RecursiveNameservers)
+	provider, err := NewDNSProviderHostBytes(acmednsHost, acmednsAccountJSON, util.RecursiveNameservers, nil)
 	assert.NoError(t, err)
 
 	// ACME-DNS requires 43 character keys or it throws a bad TXT error

--- a/pkg/issuer/acme/dns/acmedns/options.go
+++ b/pkg/issuer/acme/dns/acmedns/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package acmedns
 
+import "net/http"
+
 // DNSProviderOptions holds the full configuration for the ACME DNS provider.
 type DNSProviderOptions struct {
 	// Host is the base URL of the acme-dns instance.
@@ -23,6 +25,10 @@ type DNSProviderOptions struct {
 	// AccountJSON contains the JSON-encoded account credentials returned by the
 	// acme-dns registration endpoint.
 	AccountJSON []byte
+	// HTTPClient is an optional custom HTTP client used to communicate with the
+	// acme-dns instance. If nil, the goacmedns default client is used. It is
+	// primarily used to trust a custom CA bundle for the acme-dns endpoint.
+	HTTPClient *http.Client
 }
 
 // DNSProviderOption is a functional option for configuring a DNSProvider.
@@ -44,4 +50,15 @@ type AccountJSON []byte
 // ApplyToDNSProviderOptions sets the AccountJSON field.
 func (a AccountJSON) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
 	o.AccountJSON = a
+}
+
+// HTTPClient sets a custom HTTP client on DNSProviderOptions. This is primarily
+// used to trust a custom CA bundle when connecting to the acme-dns instance.
+type HTTPClient struct {
+	Client *http.Client
+}
+
+// ApplyToDNSProviderOptions sets the HTTPClient field.
+func (h HTTPClient) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
+	o.HTTPClient = h.Client
 }

--- a/pkg/issuer/acme/dns/cabundle.go
+++ b/pkg/issuer/acme/dns/cabundle.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+)
+
+func buildHTTPClientFromCABundle(caBundle []byte) (*http.Client, error) {
+	if len(caBundle) == 0 {
+		return nil, nil
+	}
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(caBundle); !ok {
+		return nil, fmt.Errorf("failed to parse caBundle: no valid certificates found in PEM data")
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+			},
+		},
+	}, nil
+}
+
+func (s *Solver) resolveCABundle(ch *cmacme.Challenge) ([]byte, error) {
+	if ch.Spec.Solver.DNS01 != nil &&
+		ch.Spec.Solver.DNS01.AcmeDNS != nil &&
+		len(ch.Spec.Solver.DNS01.AcmeDNS.CABundle) > 0 {
+		return ch.Spec.Solver.DNS01.AcmeDNS.CABundle, nil
+	}
+
+	if ch.Spec.IssuerRef.Kind == "ClusterIssuer" {
+		if s.clusterIssuerLister == nil {
+			return nil, fmt.Errorf("cannot resolve ClusterIssuer %q: solver is running in namespaced mode", ch.Spec.IssuerRef.Name)
+		}
+		issuer, err := s.clusterIssuerLister.Get(ch.Spec.IssuerRef.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get %s %q: %w", ch.Spec.IssuerRef.Kind, ch.Spec.IssuerRef.Name, err)
+		}
+		if issuer.GetSpec().ACME != nil && len(issuer.GetSpec().ACME.CABundle) > 0 {
+			return issuer.GetSpec().ACME.CABundle, nil
+		}
+		return nil, nil
+	}
+
+	if s.issuerLister == nil {
+		return nil, nil
+	}
+
+	issuer, err := s.issuerLister.Issuers(ch.Namespace).Get(ch.Spec.IssuerRef.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s %q: %w", ch.Spec.IssuerRef.Kind, ch.Spec.IssuerRef.Name, err)
+	}
+	if issuer.GetSpec().ACME != nil && len(issuer.GetSpec().ACME.CABundle) > 0 {
+		return issuer.GetSpec().ACME.CABundle, nil
+	}
+	return nil, nil
+}

--- a/pkg/issuer/acme/dns/cabundle_integration_test.go
+++ b/pkg/issuer/acme/dns/cabundle_integration_test.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	goruntime "k8s.io/apimachinery/pkg/runtime"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+type tlsCerts struct {
+	caPEM         []byte
+	serverCertPEM []byte
+	serverKeyPEM  []byte
+}
+
+func mustGenerateTLSCerts(t *testing.T) tlsCerts {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Integration Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate server key: %v", err)
+	}
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create server cert: %v", err)
+	}
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		t.Fatalf("failed to marshal server key: %v", err)
+	}
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	return tlsCerts{
+		caPEM:         caPEM,
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+	}
+}
+
+func mustStartHTTPSServer(t *testing.T, certs tlsCerts) *httptest.Server {
+	t.Helper()
+
+	serverCert, err := tls.X509KeyPair(certs.serverCertPEM, certs.serverKeyPEM)
+	if err != nil {
+		t.Fatalf("failed to create TLS key pair: %v", err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func buildSolverWithCertManagerObjects(t *testing.T, cmObjs ...goruntime.Object) *Solver {
+	t.Helper()
+	b := &test.Builder{
+		CertManagerObjects: cmObjs,
+	}
+	b.T = t
+	b.InitWithRESTConfig()
+	s := &Solver{
+		Context:             b.Context,
+		secretLister:        b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+		issuerLister:        b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+		clusterIssuerLister: b.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
+	}
+	b.Start()
+	b.Sync()
+	t.Cleanup(func() { b.Stop() })
+	return s
+}
+
+func TestCaBundleIntegration(t *testing.T) {
+	certsA := mustGenerateTLSCerts(t)
+	certsB := mustGenerateTLSCerts(t)
+
+	srvA := mustStartHTTPSServer(t, certsA)
+
+	const (
+		issuerName = "test-issuer"
+		ns         = "test-ns"
+	)
+
+	tests := map[string]struct {
+		buildClient  func(t *testing.T) *http.Client
+		expectGetErr bool
+		errSubstr    string
+	}{
+		"per-solver caBundle — TLS to custom-CA HTTPS server succeeds": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				client, err := buildHTTPClientFromCABundle(certsA.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle: %v", err)
+				}
+				if client == nil {
+					t.Fatal("expected non-nil *http.Client")
+				}
+				return client
+			},
+			expectGetErr: false,
+		},
+		"no caBundle — system trust store — TLS to custom-CA HTTPS server fails with x509 error": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				client, err := buildHTTPClientFromCABundle(nil)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(nil): %v", err)
+				}
+				if client != nil {
+					t.Fatal("expected nil *http.Client for nil caBundle")
+				}
+				return http.DefaultClient
+			},
+			expectGetErr: true,
+			errSubstr:    "certificate",
+		},
+		"per-solver caBundle overrides issuer-level caBundle — wrong CA fails, correct CA succeeds": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				clientA, err := buildHTTPClientFromCABundle(certsA.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(certsA): %v", err)
+				}
+
+				clientB, err := buildHTTPClientFromCABundle(certsB.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(certsB): %v", err)
+				}
+
+				_, wrongCAErr := clientB.Get(srvA.URL)
+				if wrongCAErr == nil {
+					t.Fatal("expected TLS error when using wrong CA (CA-B against CA-A signed server cert)")
+				}
+				if !strings.Contains(wrongCAErr.Error(), "certificate") &&
+					!strings.Contains(wrongCAErr.Error(), "x509") &&
+					!strings.Contains(wrongCAErr.Error(), "tls") {
+					t.Fatalf("expected x509/certificate/tls error from wrong CA, got: %v", wrongCAErr)
+				}
+
+				return clientA
+			},
+			expectGetErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := tc.buildClient(t)
+			resp, err := client.Get(srvA.URL)
+			if tc.expectGetErr {
+				if err == nil {
+					t.Fatal("expected TLS error, got nil")
+				}
+				if tc.errSubstr != "" &&
+					!strings.Contains(err.Error(), tc.errSubstr) &&
+					!strings.Contains(err.Error(), "x509") &&
+					!strings.Contains(err.Error(), "tls") {
+					t.Fatalf("expected error containing %q, got: %v", tc.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected TLS error: %v", err)
+				}
+				resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+				}
+			}
+		})
+	}
+
+	t.Run("issuer-level caBundle — resolveCABundle returns issuer CA — TLS succeeds", func(t *testing.T) {
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: issuerName,
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.Issuer(issuerName,
+				gen.SetIssuerNamespace(ns),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsA.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client from issuer-level caBundle")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("per-solver caBundle overrides issuer-level via resolveCABundle — correct CA used — TLS succeeds", func(t *testing.T) {
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+							CABundle: certsA.caPEM,
+						},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: issuerName,
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.Issuer(issuerName,
+				gen.SetIssuerNamespace(ns),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsB.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		if string(caBundle) != string(certsA.caPEM) {
+			t.Fatalf("resolveCABundle returned issuer bundle instead of per-solver bundle")
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error with per-solver CA: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/pkg/issuer/acme/dns/cabundle_integration_test.go
+++ b/pkg/issuer/acme/dns/cabundle_integration_test.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	goruntime "k8s.io/apimachinery/pkg/runtime"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+type tlsCerts struct {
+	caPEM         []byte
+	serverCertPEM []byte
+	serverKeyPEM  []byte
+}
+
+func mustGenerateTLSCerts(t *testing.T) tlsCerts {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Integration Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate server key: %v", err)
+	}
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create server cert: %v", err)
+	}
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		t.Fatalf("failed to marshal server key: %v", err)
+	}
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	return tlsCerts{
+		caPEM:         caPEM,
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+	}
+}
+
+func mustStartHTTPSServer(t *testing.T, certs tlsCerts) *httptest.Server {
+	t.Helper()
+
+	serverCert, err := tls.X509KeyPair(certs.serverCertPEM, certs.serverKeyPEM)
+	if err != nil {
+		t.Fatalf("failed to create TLS key pair: %v", err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func buildSolverWithCertManagerObjects(t *testing.T, cmObjs ...goruntime.Object) *Solver {
+	t.Helper()
+	b := &test.Builder{
+		CertManagerObjects: cmObjs,
+	}
+	b.T = t
+	b.InitWithRESTConfig()
+	s := &Solver{
+		Context:             b.Context,
+		secretLister:        b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+		issuerLister:        b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+		clusterIssuerLister: b.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
+	}
+	b.Start()
+	b.Sync()
+	t.Cleanup(func() { b.Stop() })
+	return s
+}
+
+func TestCaBundleIntegration(t *testing.T) {
+	certsA := mustGenerateTLSCerts(t)
+	certsB := mustGenerateTLSCerts(t)
+
+	srvA := mustStartHTTPSServer(t, certsA)
+
+	const (
+		issuerName = "test-issuer"
+		ns         = "test-ns"
+	)
+
+	tests := map[string]struct {
+		buildClient  func(t *testing.T) *http.Client
+		expectGetErr bool
+		errSubstr    string
+	}{
+		"per-solver caBundle — TLS to custom-CA HTTPS server succeeds": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				client, err := buildHTTPClientFromCABundle(certsA.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle: %v", err)
+				}
+				if client == nil {
+					t.Fatal("expected non-nil *http.Client")
+				}
+				return client
+			},
+			expectGetErr: false,
+		},
+		"no caBundle — system trust store — TLS to custom-CA HTTPS server fails with x509 error": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				client, err := buildHTTPClientFromCABundle(nil)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(nil): %v", err)
+				}
+				if client != nil {
+					t.Fatal("expected nil *http.Client for nil caBundle")
+				}
+				return http.DefaultClient
+			},
+			expectGetErr: true,
+			errSubstr:    "certificate",
+		},
+		"per-solver caBundle overrides issuer-level caBundle — wrong CA fails, correct CA succeeds": {
+			buildClient: func(t *testing.T) *http.Client {
+				t.Helper()
+				clientA, err := buildHTTPClientFromCABundle(certsA.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(certsA): %v", err)
+				}
+
+				clientB, err := buildHTTPClientFromCABundle(certsB.caPEM)
+				if err != nil {
+					t.Fatalf("buildHTTPClientFromCABundle(certsB): %v", err)
+				}
+
+				_, wrongCAErr := clientB.Get(srvA.URL)
+				if wrongCAErr == nil {
+					t.Fatal("expected TLS error when using wrong CA (CA-B against CA-A signed server cert)")
+				}
+				if !strings.Contains(wrongCAErr.Error(), "certificate") &&
+					!strings.Contains(wrongCAErr.Error(), "x509") &&
+					!strings.Contains(wrongCAErr.Error(), "tls") {
+					t.Fatalf("expected x509/certificate/tls error from wrong CA, got: %v", wrongCAErr)
+				}
+
+				return clientA
+			},
+			expectGetErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := tc.buildClient(t)
+			resp, err := client.Get(srvA.URL)
+			if tc.expectGetErr {
+				if err == nil {
+					t.Fatal("expected TLS error, got nil")
+				}
+				if tc.errSubstr != "" &&
+					!strings.Contains(err.Error(), tc.errSubstr) &&
+					!strings.Contains(err.Error(), "x509") &&
+					!strings.Contains(err.Error(), "tls") {
+					t.Fatalf("expected error containing %q, got: %v", tc.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected TLS error: %v", err)
+				}
+				resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+				}
+			}
+		})
+	}
+
+	t.Run("issuer-level caBundle — resolveCABundle returns issuer CA — TLS succeeds", func(t *testing.T) {
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: issuerName,
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.Issuer(issuerName,
+				gen.SetIssuerNamespace(ns),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsA.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client from issuer-level caBundle")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("per-solver caBundle overrides issuer-level via resolveCABundle — correct CA used — TLS succeeds", func(t *testing.T) {
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+							CABundle: certsA.caPEM,
+						},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: issuerName,
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.Issuer(issuerName,
+				gen.SetIssuerNamespace(ns),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsB.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		if string(caBundle) != string(certsA.caPEM) {
+			t.Fatalf("resolveCABundle returned issuer bundle instead of per-solver bundle")
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error with per-solver CA: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("ClusterIssuer caBundle — resolveCABundle returns ClusterIssuer CA — TLS succeeds", func(t *testing.T) {
+		const clusterIssuerName = "test-cluster-issuer"
+
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: clusterIssuerName,
+					Kind: "ClusterIssuer",
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.ClusterIssuer(clusterIssuerName,
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsA.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client from ClusterIssuer caBundle")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("per-solver caBundle overrides ClusterIssuer via resolveCABundle — correct CA used — TLS succeeds", func(t *testing.T) {
+		const clusterIssuerName = "test-cluster-issuer-override"
+
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+							CABundle: certsA.caPEM,
+						},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: clusterIssuerName,
+					Kind: "ClusterIssuer",
+				},
+			},
+		}
+
+		solver := buildSolverWithCertManagerObjects(t,
+			gen.ClusterIssuer(clusterIssuerName,
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   srvA.URL,
+					CABundle: certsB.caPEM,
+				}),
+			),
+		)
+
+		caBundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("resolveCABundle: unexpected error: %v", err)
+		}
+
+		if string(caBundle) != string(certsA.caPEM) {
+			t.Fatalf("resolveCABundle returned ClusterIssuer bundle instead of per-solver bundle")
+		}
+
+		client, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle: unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+
+		resp, err := client.Get(srvA.URL)
+		if err != nil {
+			t.Fatalf("GET %s: unexpected TLS error with per-solver CA: %v", srvA.URL, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestAcmeDNSProviderEndToEndWithCustomCA(t *testing.T) {
+	certs := mustGenerateTLSCerts(t)
+	srv := mustStartHTTPSServer(t, certs)
+
+	httpClient, err := buildHTTPClientFromCABundle(certs.caPEM)
+	if err != nil {
+		t.Fatalf("buildHTTPClientFromCABundle: %v", err)
+	}
+	if httpClient == nil {
+		t.Fatal("expected non-nil http.Client")
+	}
+
+	accountJSON := []byte(`{
+		"example.com": {
+			"fulldomain": "test.auth.example.com",
+			"subdomain": "test",
+			"username": "testuser",
+			"password": "testpass"
+		}
+	}`)
+
+	t.Run("acmeDNS provider with custom CA httpClient — TLS to private-CA server succeeds", func(t *testing.T) {
+		provider, err := acmedns.NewDNSProviderFromOptions(t.Context(),
+			acmedns.Host(srv.URL),
+			acmedns.AccountJSON(accountJSON),
+			acmedns.HTTPClient{Client: httpClient})
+		if err != nil {
+			t.Fatalf("NewDNSProviderFromOptions: %v", err)
+		}
+
+		err = provider.Present(t.Context(), "example.com", "example.com.", "LG3tptA6W7T1vw4ujbmDxH2lLu6r8TUIqLZD3pzPmgE")
+		if err != nil {
+			t.Fatalf("Present with custom CA httpClient failed: %v", err)
+		}
+	})
+
+	t.Run("acmeDNS provider without custom CA httpClient — TLS to private-CA server fails", func(t *testing.T) {
+		provider, err := acmedns.NewDNSProviderFromOptions(t.Context(),
+			acmedns.Host(srv.URL),
+			acmedns.AccountJSON(accountJSON))
+		if err != nil {
+			t.Fatalf("NewDNSProviderFromOptions: %v", err)
+		}
+
+		err = provider.Present(t.Context(), "example.com", "example.com.", "LG3tptA6W7T1vw4ujbmDxH2lLu6r8TUIqLZD3pzPmgE")
+		if err == nil {
+			t.Fatal("expected TLS error when using default system trust against private CA, got nil")
+		}
+	})
+
+	t.Run("acmeDNS provider with wrong CA httpClient — TLS to private-CA server fails", func(t *testing.T) {
+		wrongCerts := mustGenerateTLSCerts(t)
+		wrongClient, err := buildHTTPClientFromCABundle(wrongCerts.caPEM)
+		if err != nil {
+			t.Fatalf("buildHTTPClientFromCABundle(wrongCA): %v", err)
+		}
+
+		provider, err := acmedns.NewDNSProviderFromOptions(t.Context(),
+			acmedns.Host(srv.URL),
+			acmedns.AccountJSON(accountJSON),
+			acmedns.HTTPClient{Client: wrongClient})
+		if err != nil {
+			t.Fatalf("NewDNSProviderFromOptions: %v", err)
+		}
+
+		err = provider.Present(t.Context(), "example.com", "example.com.", "LG3tptA6W7T1vw4ujbmDxH2lLu6r8TUIqLZD3pzPmgE")
+		if err == nil {
+			t.Fatal("expected TLS error when using wrong CA, got nil")
+		}
+	})
+}

--- a/pkg/issuer/acme/dns/cabundle_test.go
+++ b/pkg/issuer/acme/dns/cabundle_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func mustGenerateCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestBuildHTTPClientFromCABundle(t *testing.T) {
+	validCAPEM := mustGenerateCAPEM(t)
+	tests := map[string]struct {
+		input     []byte
+		wantNil   bool
+		wantErr   bool
+		errSubstr string
+	}{
+		"nil input returns nil client and nil error": {
+			input:   nil,
+			wantNil: true,
+		},
+		"empty input returns nil client and nil error": {
+			input:   []byte{},
+			wantNil: true,
+		},
+		"valid PEM returns non-nil client with configured TLS": {
+			input:   validCAPEM,
+			wantNil: false,
+		},
+		"invalid PEM returns error": {
+			input:     []byte("not-a-cert"),
+			wantNil:   true,
+			wantErr:   true,
+			errSubstr: "failed to parse caBundle",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, err := buildHTTPClientFromCABundle(tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if tc.wantNil {
+				if client != nil {
+					t.Fatalf("expected nil client but got: %v", client)
+				}
+			} else {
+				if client == nil {
+					t.Fatalf("expected non-nil client but got nil")
+				}
+				transport, ok := client.Transport.(*http.Transport)
+				if !ok {
+					t.Fatalf("expected *http.Transport, got %T", client.Transport)
+				}
+				if transport.TLSClientConfig == nil {
+					t.Fatal("expected TLSClientConfig to be non-nil")
+				}
+				if transport.TLSClientConfig.RootCAs == nil {
+					t.Fatal("expected RootCAs to be non-nil")
+				}
+			}
+		})
+	}
+}
+
+func TestResolveCABundle(t *testing.T) {
+	const (
+		issuerName    = "test-issuer"
+		ns            = "test-ns"
+		clusterIssuer = "test-cluster-issuer"
+	)
+
+	perSolverBundle := []byte("per-solver-bundle")
+	issuerBundle := []byte("issuer-bundle")
+
+	buildSolverWithIssuers := func(t *testing.T, cmObjs ...runtime.Object) *Solver {
+		t.Helper()
+		b := &test.Builder{
+			CertManagerObjects: cmObjs,
+		}
+		b.T = t
+		b.InitWithRESTConfig()
+		s := &Solver{
+			Context:             b.Context,
+			secretLister:        b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+			issuerLister:        b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+			clusterIssuerLister: b.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
+		}
+		b.Start()
+		b.Sync()
+		t.Cleanup(func() { b.Stop() })
+		return s
+	}
+
+	tests := map[string]struct {
+		challenge  *cmacme.Challenge
+		cmObjects  []runtime.Object
+		wantBundle []byte
+		wantErr    bool
+	}{
+		"per-solver bundle overrides issuer bundle": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: perSolverBundle,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: perSolverBundle,
+		},
+		"issuer bundle returned when per-solver bundle is empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: nil,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: issuerBundle,
+		},
+		"nil returned when both per-solver and issuer bundles are empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server: "https://acme.example.com",
+					}),
+				),
+			},
+			wantBundle: nil,
+		},
+		"per-solver bundle returned even when issuer lookup would fail": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: perSolverBundle,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: "nonexistent-issuer",
+					},
+				},
+			},
+			cmObjects:  []runtime.Object{},
+			wantBundle: perSolverBundle,
+		},
+		"error when per-solver bundle empty and issuer not found": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: "nonexistent-issuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{},
+			wantErr:   true,
+		},
+		"ClusterIssuer bundle returned when per-solver bundle is empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: clusterIssuer,
+						Kind: "ClusterIssuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.ClusterIssuer(clusterIssuer,
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: issuerBundle,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			solver := buildSolverWithIssuers(t, tc.cmObjects...)
+			bundle, err := solver.resolveCABundle(tc.challenge)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil (bundle=%v)", bundle)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(bundle) != string(tc.wantBundle) {
+				t.Errorf("expected bundle %q, got %q", tc.wantBundle, bundle)
+			}
+		})
+	}
+}

--- a/pkg/issuer/acme/dns/cabundle_test.go
+++ b/pkg/issuer/acme/dns/cabundle_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/pkg/controller/test"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func mustGenerateCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestBuildHTTPClientFromCABundle(t *testing.T) {
+	validCAPEM := mustGenerateCAPEM(t)
+	tests := map[string]struct {
+		input     []byte
+		wantNil   bool
+		wantErr   bool
+		errSubstr string
+	}{
+		"nil input returns nil client and nil error": {
+			input:   nil,
+			wantNil: true,
+		},
+		"empty input returns nil client and nil error": {
+			input:   []byte{},
+			wantNil: true,
+		},
+		"valid PEM returns non-nil client with configured TLS": {
+			input:   validCAPEM,
+			wantNil: false,
+		},
+		"invalid PEM returns error": {
+			input:     []byte("not-a-cert"),
+			wantNil:   true,
+			wantErr:   true,
+			errSubstr: "failed to parse caBundle",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, err := buildHTTPClientFromCABundle(tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if tc.wantNil {
+				if client != nil {
+					t.Fatalf("expected nil client but got: %v", client)
+				}
+			} else {
+				if client == nil {
+					t.Fatalf("expected non-nil client but got nil")
+				}
+				transport, ok := client.Transport.(*http.Transport)
+				if !ok {
+					t.Fatalf("expected *http.Transport, got %T", client.Transport)
+				}
+				if transport.TLSClientConfig == nil {
+					t.Fatal("expected TLSClientConfig to be non-nil")
+				}
+				if transport.TLSClientConfig.RootCAs == nil {
+					t.Fatal("expected RootCAs to be non-nil")
+				}
+			}
+		})
+	}
+}
+
+func TestResolveCABundle(t *testing.T) {
+	const (
+		issuerName    = "test-issuer"
+		ns            = "test-ns"
+		clusterIssuer = "test-cluster-issuer"
+	)
+
+	perSolverBundle := []byte("per-solver-bundle")
+	issuerBundle := []byte("issuer-bundle")
+
+	buildSolverWithIssuers := func(t *testing.T, cmObjs ...runtime.Object) *Solver {
+		t.Helper()
+		b := &test.Builder{
+			CertManagerObjects: cmObjs,
+		}
+		b.T = t
+		b.InitWithRESTConfig()
+		s := &Solver{
+			Context:             b.Context,
+			secretLister:        b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+			issuerLister:        b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+			clusterIssuerLister: b.Context.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
+		}
+		b.Start()
+		b.Sync()
+		t.Cleanup(func() { b.Stop() })
+		return s
+	}
+
+	tests := map[string]struct {
+		challenge  *cmacme.Challenge
+		cmObjects  []runtime.Object
+		wantBundle []byte
+		wantErr    bool
+	}{
+		"per-solver bundle overrides issuer bundle": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: perSolverBundle,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: perSolverBundle,
+		},
+		"issuer bundle returned when per-solver bundle is empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: nil,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: issuerBundle,
+		},
+		"nil returned when both per-solver and issuer bundles are empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server: "https://acme.example.com",
+					}),
+				),
+			},
+			wantBundle: nil,
+		},
+		"per-solver bundle returned even when issuer lookup would fail": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: perSolverBundle,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: "nonexistent-issuer",
+					},
+				},
+			},
+			cmObjects:  []runtime.Object{},
+			wantBundle: perSolverBundle,
+		},
+		"error when per-solver bundle empty and issuer not found": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: "nonexistent-issuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{},
+			wantErr:   true,
+		},
+		"ClusterIssuer bundle returned when per-solver bundle is empty": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: clusterIssuer,
+						Kind: "ClusterIssuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.ClusterIssuer(clusterIssuer,
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: issuerBundle,
+		},
+		"per-solver bundle overrides ClusterIssuer bundle": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+								CABundle: perSolverBundle,
+							},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: clusterIssuer,
+						Kind: "ClusterIssuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.ClusterIssuer(clusterIssuer,
+					gen.SetIssuerACME(cmacme.ACMEIssuer{
+						Server:   "https://acme.example.com",
+						CABundle: issuerBundle,
+					}),
+				),
+			},
+			wantBundle: perSolverBundle,
+		},
+		"error when per-solver bundle empty and ClusterIssuer not found": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: "nonexistent-cluster-issuer",
+						Kind: "ClusterIssuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{},
+			wantErr:   true,
+		},
+		"nil returned when issuer has nil ACME spec": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: issuerName,
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(ns),
+				),
+			},
+			wantBundle: nil,
+		},
+		"nil returned when ClusterIssuer has nil ACME spec": {
+			challenge: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+				Spec: cmacme.ChallengeSpec{
+					Solver: cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+						},
+					},
+					IssuerRef: cmmeta.IssuerReference{
+						Name: clusterIssuer,
+						Kind: "ClusterIssuer",
+					},
+				},
+			},
+			cmObjects: []runtime.Object{
+				gen.ClusterIssuer(clusterIssuer),
+			},
+			wantBundle: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			solver := buildSolverWithIssuers(t, tc.cmObjects...)
+			bundle, err := solver.resolveCABundle(tc.challenge)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil (bundle=%v)", bundle)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(bundle) != string(tc.wantBundle) {
+				t.Errorf("expected bundle %q, got %q", tc.wantBundle, bundle)
+			}
+		})
+	}
+
+	// Tests that require custom Solver construction (nil listers)
+
+	t.Run("error when ClusterIssuer referenced but solver runs in namespaced mode", func(t *testing.T) {
+		b := &test.Builder{
+			CertManagerObjects: []runtime.Object{},
+		}
+		b.T = t
+		b.InitWithRESTConfig()
+		solver := &Solver{
+			Context:      b.Context,
+			secretLister: b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+			issuerLister: b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+			// clusterIssuerLister intentionally nil — simulates namespaced mode
+		}
+		b.Start()
+		b.Sync()
+		t.Cleanup(func() { b.Stop() })
+
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: clusterIssuer,
+					Kind: "ClusterIssuer",
+				},
+			},
+		}
+
+		_, err := solver.resolveCABundle(challenge)
+		if err == nil {
+			t.Fatal("expected error for ClusterIssuer in namespaced mode, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespaced mode") {
+			t.Fatalf("expected error about namespaced mode, got: %v", err)
+		}
+	})
+
+	t.Run("nil returned when issuerLister is nil and issuer kind used", func(t *testing.T) {
+		b := &test.Builder{
+			CertManagerObjects: []runtime.Object{},
+		}
+		b.T = t
+		b.InitWithRESTConfig()
+		solver := &Solver{
+			Context:      b.Context,
+			secretLister: b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+			// issuerLister intentionally nil
+			// clusterIssuerLister intentionally nil
+		}
+		b.Start()
+		b.Sync()
+		t.Cleanup(func() { b.Stop() })
+
+		challenge := &cmacme.Challenge{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec: cmacme.ChallengeSpec{
+				Solver: cmacme.ACMEChallengeSolver{
+					DNS01: &cmacme.ACMEChallengeSolverDNS01{
+						AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
+					},
+				},
+				IssuerRef: cmmeta.IssuerReference{
+					Name: issuerName,
+				},
+			},
+		}
+
+		bundle, err := solver.resolveCABundle(challenge)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if bundle != nil {
+			t.Fatalf("expected nil bundle, got: %v", bundle)
+		}
+	})
+}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/akamai"
@@ -64,7 +66,7 @@ type dnsProviderConstructors struct {
 	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string) (*cloudflare.DNSProvider, error)
 	route53      func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
 	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity, opts ...azuredns.ProviderOption) (*azuredns.DNSProvider, error)
-	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
+	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string, httpClient *http.Client) (*acmedns.DNSProvider, error)
 	digitalOcean func(token string, dns01Nameservers []string, userAgent string) (*digitalocean.DNSProvider, error)
 }
 
@@ -74,6 +76,8 @@ type dnsProviderConstructors struct {
 type Solver struct {
 	*controller.Context
 	secretLister            internalinformers.SecretLister
+	issuerLister            cmlisters.IssuerLister
+	clusterIssuerLister     cmlisters.ClusterIssuerLister
 	dnsProviderConstructors dnsProviderConstructors
 	webhookSolvers          map[string]webhook.Solver
 }
@@ -426,10 +430,21 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			return nil, nil, fmt.Errorf("error getting acmedns accounts secret: key '%s' not found in secret", providerConfig.AcmeDNS.AccountSecret.Key)
 		}
 
+		caBundle, err := s.resolveCABundle(ch)
+		if err != nil {
+			return nil, providerConfig, fmt.Errorf("error resolving caBundle for acmedns: %w", err)
+		}
+
+		httpClient, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			return nil, providerConfig, fmt.Errorf("error building HTTP client from caBundle for acmedns: %w", err)
+		}
+
 		impl, err = s.dnsProviderConstructors.acmeDNS(
 			providerConfig.AcmeDNS.Host,
 			accountSecretBytes,
 			s.DNS01Nameservers,
+			httpClient,
 		)
 		if err != nil {
 			return nil, providerConfig, fmt.Errorf("error instantiating acmedns challenge solver: %s", err)
@@ -534,9 +549,10 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 		}
 	}
 
-	return &Solver{
+	slv := &Solver{
 		Context:      ctx,
 		secretLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
+		issuerLister: ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 		dnsProviderConstructors: dnsProviderConstructors{
 			clouddns.NewDNSProvider,
 			cloudflare.NewDNSProviderCredentials,
@@ -546,7 +562,15 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 			digitalocean.NewDNSProviderCredentials,
 		},
 		webhookSolvers: initialized,
-	}, nil
+	}
+
+	// if we are running in non-namespaced mode (i.e. --namespace=""), we also
+	// obtain a lister for clusterissuers.
+	if ctx.Namespace == "" {
+		slv.clusterIssuerLister = ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister()
+	}
+
+	return slv, nil
 }
 
 func (s *Solver) loadSecretData(selector *cmmeta.SecretKeySelector, ns string) ([]byte, error) {

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -34,6 +34,7 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/akamai"
@@ -74,6 +75,8 @@ type dnsProviderConstructors struct {
 type Solver struct {
 	*controller.Context
 	secretLister            internalinformers.SecretLister
+	issuerLister            cmlisters.IssuerLister
+	clusterIssuerLister     cmlisters.ClusterIssuerLister
 	dnsProviderConstructors dnsProviderConstructors
 	webhookSolvers          map[string]webhook.Solver
 }
@@ -459,10 +462,20 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			return nil, nil, fmt.Errorf("error getting acmedns accounts secret: key '%s' not found in secret", providerConfig.AcmeDNS.AccountSecret.Key)
 		}
 
+		caBundle, err := s.resolveCABundle(ch)
+		if err != nil {
+			return nil, providerConfig, fmt.Errorf("error resolving caBundle for acmedns: %w", err)
+		}
+
+		httpClient, err := buildHTTPClientFromCABundle(caBundle)
+		if err != nil {
+			return nil, providerConfig, fmt.Errorf("error building HTTP client from caBundle for acmedns: %w", err)
+		}
+
 		impl, err = s.dnsProviderConstructors.acmeDNS(ctx,
 			acmedns.Host(providerConfig.AcmeDNS.Host),
-			acmedns.AccountJSON(accountSecretBytes))
-
+			acmedns.AccountJSON(accountSecretBytes),
+			acmedns.HTTPClient{Client: httpClient})
 		if err != nil {
 			return nil, providerConfig, fmt.Errorf("error instantiating acmedns challenge solver: %s", err)
 		}
@@ -568,9 +581,10 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 		}
 	}
 
-	return &Solver{
+	slv := &Solver{
 		Context:      ctx,
 		secretLister: ctx.KubeSharedInformerFactory.Secrets().Lister(),
+		issuerLister: ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 		dnsProviderConstructors: dnsProviderConstructors{
 			akamai.NewDNSProviderFromOptions,
 			clouddns.NewDNSProviderFromOptions,
@@ -581,7 +595,15 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 			digitalocean.NewDNSProviderFromOptions,
 		},
 		webhookSolvers: initialized,
-	}, nil
+	}
+
+	// if we are running in non-namespaced mode (i.e. --namespace=""), we also
+	// obtain a lister for clusterissuers.
+	if ctx.Namespace == "" {
+		slv.clusterIssuerLister = ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister()
+	}
+
+	return slv, nil
 }
 
 func (s *Solver) loadSecretData(selector *cmmeta.SecretKeySelector, ns string) ([]byte, error) {

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dns
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -1049,5 +1050,204 @@ func TestRoute53AssumeRole(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSolverForAcmeDNSPassesHTTPClient(t *testing.T) {
+	validCAPEM := mustGenerateCAPEM(t)
+
+	tests := map[string]struct {
+		caBundle      []byte
+		wantNilClient bool
+	}{
+		"per-solver caBundle produces non-nil httpClient passed to acmeDNS constructor": {
+			caBundle:      validCAPEM,
+			wantNilClient: false,
+		},
+		"no caBundle produces nil httpClient passed to acmeDNS constructor": {
+			caBundle:      nil,
+			wantNilClient: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := &solverFixture{
+				Builder: &test.Builder{
+					KubeObjects: []runtime.Object{
+						newSecret("acmedns-key", map[string][]byte{
+							"acmedns.json": []byte("{}"),
+						}, fakeIssuerNamespace),
+					},
+				},
+				Challenge: &cmacme.Challenge{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: fakeIssuerNamespace,
+					},
+					Spec: cmacme.ChallengeSpec{
+						Solver: cmacme.ACMEChallengeSolver{
+							DNS01: &cmacme.ACMEChallengeSolverDNS01{
+								AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+									Host: "https://acme-dns.example.com",
+									AccountSecret: cmmeta.SecretKeySelector{
+										LocalObjectReference: cmmeta.LocalObjectReference{
+											Name: "acmedns-key",
+										},
+										Key: "acmedns.json",
+									},
+									CABundle: tc.caBundle,
+								},
+							},
+						},
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "test-issuer",
+						},
+					},
+				},
+				dnsProviders: newFakeDNSProviders(),
+			}
+
+			f.Setup(t)
+			defer f.Finish(t)
+
+			_, _, err := f.Solver.solverForChallenge(t.Context(), f.Challenge)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+
+			if len(f.dnsProviders.calls) != 1 {
+				t.Fatalf("expected 1 provider call, got %d", len(f.dnsProviders.calls))
+			}
+
+			call := f.dnsProviders.calls[0]
+			if call.name != "acmedns" {
+				t.Fatalf("expected acmedns call, got %q", call.name)
+			}
+
+			if len(call.args) < 1 {
+				t.Fatalf("expected at least 1 arg in acmedns call, got %d", len(call.args))
+			}
+
+			opt, ok := call.args[0].(acmedns.DNSProviderOptions)
+			if !ok {
+				t.Fatalf("expected acmedns.DNSProviderOptions, got %T", call.args[0])
+			}
+			httpClient := opt.HTTPClient
+
+			if tc.wantNilClient {
+				if httpClient != nil {
+					t.Fatal("expected nil httpClient when no caBundle is set")
+				}
+			} else {
+				if httpClient == nil {
+					t.Fatal("expected non-nil httpClient when caBundle is set")
+				}
+				transport, ok := httpClient.Transport.(*http.Transport)
+				if !ok {
+					t.Fatalf("expected *http.Transport, got %T", httpClient.Transport)
+				}
+				if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+					t.Fatal("expected TLSClientConfig.RootCAs to be set from caBundle")
+				}
+			}
+		})
+	}
+}
+
+func TestSolverForAcmeDNSPassesHTTPClientFromIssuerBundle(t *testing.T) {
+	validCAPEM := mustGenerateCAPEM(t)
+
+	const (
+		issuerName = "test-issuer"
+		ns         = "test-ns"
+	)
+
+	dnsProviders := newFakeDNSProviders()
+
+	b := &test.Builder{
+		KubeObjects: []runtime.Object{
+			newSecret("acmedns-key", map[string][]byte{
+				"acmedns.json": []byte("{}"),
+			}, ns),
+		},
+		CertManagerObjects: []runtime.Object{
+			gen.Issuer(issuerName,
+				gen.SetIssuerNamespace(ns),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					Server:   "https://acme.example.com",
+					CABundle: validCAPEM,
+				}),
+			),
+		},
+	}
+	b.T = t
+	b.InitWithRESTConfig()
+
+	// Register the Issuers informer BEFORE Start() so the informer cache
+	// gets populated with the test issuer.
+	solver := &Solver{
+		Context:                 b.Context,
+		secretLister:            b.Context.KubeSharedInformerFactory.Secrets().Lister(),
+		issuerLister:            b.Context.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
+		dnsProviderConstructors: dnsProviders.constructors,
+	}
+
+	b.Start()
+	b.Sync()
+	defer b.Stop()
+
+	challenge := &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+		},
+		Spec: cmacme.ChallengeSpec{
+			Solver: cmacme.ACMEChallengeSolver{
+				DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+						Host: "https://acme-dns.example.com",
+						AccountSecret: cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{
+								Name: "acmedns-key",
+							},
+							Key: "acmedns.json",
+						},
+					},
+				},
+			},
+			IssuerRef: cmmeta.IssuerReference{
+				Name: issuerName,
+			},
+		},
+	}
+
+	_, _, err := solver.solverForChallenge(t.Context(), challenge)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(dnsProviders.calls) != 1 {
+		t.Fatalf("expected 1 provider call, got %d", len(dnsProviders.calls))
+	}
+
+	call := dnsProviders.calls[0]
+	if len(call.args) < 1 {
+		t.Fatalf("expected at least 1 arg, got %d", len(call.args))
+	}
+
+	opt, ok := call.args[0].(acmedns.DNSProviderOptions)
+	if !ok {
+		t.Fatalf("expected acmedns.DNSProviderOptions, got %T", call.args[0])
+	}
+	httpClient := opt.HTTPClient
+	if httpClient == nil {
+		t.Fatal("expected non-nil httpClient from issuer-level caBundle")
+	}
+
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", httpClient.Transport)
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected TLSClientConfig.RootCAs to be set from issuer caBundle")
 	}
 }

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -19,6 +19,7 @@ package dns
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -137,7 +138,7 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("azuredns", clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient, managedIdentity)
 			return nil, nil
 		},
-		acmeDNS: func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error) {
+		acmeDNS: func(host string, accountJson []byte, dns01Nameservers []string, httpClient *http.Client) (*acmedns.DNSProvider, error) {
 			f.call("acmedns", host, accountJson, dns01Nameservers)
 			return nil, nil
 		},


### PR DESCRIPTION
### Pull Request Motivation
Fixes #6465. The acmeDNS DNS01 solver ignored spec.acme.caBundle on ACME Issuers, causing x509: certificate signed by unknown authority errors when the acme-dns endpoint uses a private CA cert. In some environments making the entire cert-manager trust the CA for all interactions is not desirable.

This PR:
- Propagates the issuer-level spec.acme.caBundle to the acmeDNS HTTP client
- Adds a per-solver caBundle field on ACMEIssuerDNS01ProviderAcmeDNS that overrides the issuer-level bundle when set
Scope is limited to the acmeDNS solver. Cloud-based solvers (Cloudflare, Route53, AzureDNS, CloudDNS, DigitalOcean, Akamai) are not affected.
### Kind
/kind bug feature
### Release Note

```release-note
The acmeDNS DNS01 solver now respects the ACME issuer's `spec.acme.caBundle` when connecting to the acme-dns API server. A new per-solver `caBundle` field on `ACMEIssuerDNS01ProviderAcmeDNS` allows specifying a CA bundle specific to the acme-dns endpoint, overriding the issuer-level bundle when set.
```
