### PR TITLE
feat(cert-shim): adding listener ignore annotation

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -130,6 +130,15 @@ const (
 	// Annotation key used to set the PrivateKeyRotationPolicy for a Certificate.
 	// If unset a policy `Never` will be used.
 	PrivateKeyRotationPolicyAnnotationKey = "cert-manager.io/private-key-rotation-policy"
+
+	// CertificateIgnoreTLSListeners is an annotation that specifies which
+	// Gateway API listeners in a ListenerSet or Gateway cert-manager should
+	// ignore while creating Certificate objects through the certificate-shim
+	// controller.
+	// The value of this annotation should be a comma-separated list of listener names.
+	// This is useful for users who want to use cert-manager to manage
+	// certificates for some, but not all, of the listeners for a given parent.
+	CertificateIgnoreTLSListeners = "cert-manager.io/ignore-tls-listeners"
 )
 
 const (

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -27,7 +27,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -300,12 +299,4 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 	}
 
 	return nil
-}
-
-// translateListenerToGWAPIV1Listener adapts a ListenerEntry to a Listener by casting.
-// In gwapi v1, ListenerEntry and Listener currently share the same underlying structure,
-// so this cast is a no-op and is safe. This helper exists to allow code that expects a
-// gwapi.Listener (for example, shared validation logic) to also work with ListenerEntry.
-func translateListenerToGWAPIV1Listener(l gwapi.ListenerEntry) gwapi.Listener {
-	return gwapi.Listener(l)
 }

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
@@ -53,10 +54,11 @@ import (
 )
 
 const (
-	reasonBadConfig         = "BadConfig"
-	reasonCreateCertificate = "CreateCertificate"
-	reasonUpdateCertificate = "UpdateCertificate"
-	reasonDeleteCertificate = "DeleteCertificate"
+	reasonBadConfig                 = "BadConfig"
+	reasonSkippedListenerAnnotation = "SkippedListenerAnnotation"
+	reasonCreateCertificate         = "CreateCertificate"
+	reasonUpdateCertificate         = "UpdateCertificate"
+	reasonDeleteCertificate         = "DeleteCertificate"
 )
 
 const applysetLabel = "applyset.kubernetes.io/part-of"
@@ -321,6 +323,21 @@ func isGatewayAPITLSProtocol(protocol gwapi.ProtocolType, extra sets.Set[string]
 	return extra.Has(string(protocol))
 }
 
+// isGatewayAPIListenerIgnoredThroughAnnotation reports whether a listener with the given name should be ignored for certificate creation. The value of the annotation should be a comma-separated list of listener names to ignore. The listener name(s) on the annotation should match EXACTLY with the listener name(s) defined in the Gateway/ListenerSet spec.
+func isGatewayAPIListenerIgnoredThroughAnnotation(objAnn map[string]string, listenerName string) bool {
+	ignoredListeners, ok := objAnn[cmapi.CertificateIgnoreTLSListeners]
+	if !ok {
+		return false
+	}
+
+	for ignoredListener := range strings.SplitSeq(ignoredListeners, ",") {
+		if strings.TrimSpace(ignoredListener) == listenerName {
+			return true
+		}
+	}
+	return false
+}
+
 func buildCertificates(
 	rec record.EventRecorder,
 	log logr.Logger,
@@ -331,6 +348,7 @@ func buildCertificates(
 	defaults controller.IngressShimOptions,
 ) (newCrts, updateCrts []*cmapi.Certificate, _ error) {
 	tlsHosts := make(map[corev1.ObjectReference][]string)
+
 	switch ingLike := ingLike.(type) {
 	case *networkingv1.Ingress:
 		for i, tls := range ingLike.Spec.TLS {
@@ -346,66 +364,9 @@ func buildCertificates(
 			}] = tls.Hosts
 		}
 	case *gwapi.ListenerSet:
-		for i, l := range ingLike.Spec.Listeners {
-			if !isGatewayAPITLSProtocol(l.Protocol, defaults.GatewayAPIExtraProtocols) {
-				continue
-			}
-
-			// We never issue certificates for TLS Passthrough mode
-			if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwapi.TLSModePassthrough {
-				continue
-			}
-
-			err := validateGatewayListenerBlock(field.NewPath("spec", "listeners").Index(i), translateListenerToGWAPIV1Listener(l), ingLike).ToAggregate()
-			if err != nil {
-				rec.Eventf(ingLike, corev1.EventTypeWarning, reasonBadConfig, "Skipped a listener block: "+err.Error())
-				continue
-			}
-
-			for _, certRef := range l.TLS.CertificateRefs {
-				secretRef := corev1.ObjectReference{
-					Name: string(certRef.Name),
-				}
-				if certRef.Namespace != nil {
-					secretRef.Namespace = string(*certRef.Namespace)
-				} else {
-					secretRef.Namespace = ingLike.GetNamespace()
-				}
-				tlsHosts[secretRef] = append(tlsHosts[secretRef], string(*l.Hostname))
-			}
-		}
+		handleGatewayAPIListeners(ingLike.Spec.Listeners, ingLike, rec, tlsHosts, defaults)
 	case *gwapi.Gateway:
-		for i, l := range ingLike.Spec.Listeners {
-			// TLS is only supported for a limited set of protocol types: https://gateway-api.sigs.k8s.io/guides/tls/#listeners-and-tls
-			if !isGatewayAPITLSProtocol(l.Protocol, defaults.GatewayAPIExtraProtocols) {
-				continue
-			}
-
-			// We never issue certificates for TLS Passthrough mode
-			if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwapi.TLSModePassthrough {
-				continue
-			}
-
-			err := validateGatewayListenerBlock(field.NewPath("spec", "listeners").Index(i), l, ingLike).ToAggregate()
-			if err != nil {
-				rec.Eventf(ingLike, corev1.EventTypeWarning, reasonBadConfig, "Skipped a listener block: "+err.Error())
-				continue
-			}
-
-			for _, certRef := range l.TLS.CertificateRefs {
-				secretRef := corev1.ObjectReference{
-					Name: string(certRef.Name),
-				}
-				if certRef.Namespace != nil {
-					secretRef.Namespace = string(*certRef.Namespace)
-				} else {
-					secretRef.Namespace = ingLike.GetNamespace()
-				}
-				// Gateway API hostname explicitly disallows IP addresses, so this
-				// should be OK.
-				tlsHosts[secretRef] = append(tlsHosts[secretRef], string(*l.Hostname))
-			}
-		}
+		handleGatewayAPIListeners(ingLike.Spec.Listeners, ingLike, rec, tlsHosts, defaults)
 	default:
 		return nil, nil, fmt.Errorf("buildCertificates: expected ingress or gateway or xlistenerset, got %T", ingLike)
 	}
@@ -531,6 +492,47 @@ func buildCertificates(
 		}
 	}
 	return newCrts, updateCrts, nil
+}
+
+func handleGatewayAPIListeners[L gwapi.Listener | gwapi.ListenerEntry](listeners []L, ingLike client.Object, rec record.EventRecorder, tlsHosts map[corev1.ObjectReference][]string, defaults controller.IngressShimOptions) {
+	for i, raw := range listeners {
+		l := gwapi.Listener(raw)
+		// TLS is only supported for a limited set of protocol types: https://gateway-api.sigs.k8s.io/guides/tls/#listeners-and-tls
+		if !isGatewayAPITLSProtocol(l.Protocol, defaults.GatewayAPIExtraProtocols) {
+			continue
+		}
+
+		// We never issue certificates for TLS Passthrough mode
+		if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwapi.TLSModePassthrough {
+			continue
+		}
+
+		if ann := ingLike.GetAnnotations(); ann != nil {
+			if isGatewayAPIListenerIgnoredThroughAnnotation(ann, string(l.Name)) {
+				continue
+			}
+		}
+
+		err := validateGatewayListenerBlock(field.NewPath("spec", "listeners").Index(i), l, ingLike).ToAggregate()
+		if err != nil {
+			rec.Eventf(ingLike, corev1.EventTypeWarning, reasonBadConfig, "Skipped a listener block: "+err.Error())
+			continue
+		}
+
+		for _, certRef := range l.TLS.CertificateRefs {
+			secretRef := corev1.ObjectReference{
+				Name: string(certRef.Name),
+			}
+			if certRef.Namespace != nil {
+				secretRef.Namespace = string(*certRef.Namespace)
+			} else {
+				secretRef.Namespace = ingLike.GetNamespace()
+			}
+			// Gateway API hostname explicitly disallows IP addresses, so this
+			// should be OK.
+			tlsHosts[secretRef] = append(tlsHosts[secretRef], string(*l.Hostname))
+		}
+	}
 }
 
 func findCertificatesToBeRemoved(certs []*cmapi.Certificate, ingLike metav1.Object) []string {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -3950,6 +3950,7 @@ func TestSync(t *testing.T) {
 			ExpectedEvents:           []string{},
 			ExpectedCreate:           nil,
 		},
+		// TODO: @hjoshi123 add more tests for listenersets like the ignore listener annotations when we re-enable listenerset e2e tests
 		{
 			Name:   "ListenerSet: custom extra protocol with valid TLS block generates a Certificate",
 			Issuer: acmeClusterIssuer,
@@ -4105,6 +4106,134 @@ func TestSync(t *testing.T) {
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
 						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:   "GatewayAPI ListenerIgnoreAnnotation should ignore listeners",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.CertificateIgnoreTLSListeners:         "custom-proto-listener",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Name:     "custom-proto-listener",
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{},
+			ExpectedCreate:      nil,
+		},
+		{
+			Name:   "GatewayAPI ListenerIgnoreAnnotation should ignore only listeners with matching name",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.CertificateIgnoreTLSListeners:         "custom-proto-listener,ignore-listener",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Name:     "custom-proto-listener",
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+						{
+							Hostname: ptrHostname("ignore.example.com"),
+							Port:     443,
+							Name:     "ignore-listener",
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "ignore-example-com-tls",
+									},
+								},
+							},
+						},
+						{
+							Hostname: ptrHostname("new.example.com"),
+							Port:     443,
+							Name:     "custom-proto-listener-new",
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: ptrMode(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "new-example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "new-example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "new-example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						Annotations:     buildParentRefAnnotations(),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"new.example.com"},
+						SecretName: "new-example-com-tls",
 						IssuerRef: cmmeta.IssuerReference{
 							Name: "issuer-name",
 							Kind: "ClusterIssuer",
@@ -4569,14 +4698,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 	}{
 		{
 			name: "should not remove Certificate when not owned by the Ingress",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{Name: "ingress-2", Namespace: gen.DefaultTestNamespace, UID: "ingress-2"},
@@ -4586,14 +4717,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 		},
 		{
 			name: "should not remove Certificate when Ingress references the secretName of the Certificate",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: gen.DefaultTestNamespace, UID: "ingress-1"},
@@ -4603,14 +4736,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 		},
 		{
 			name: "should remove Certificate when Ingress does not reference the secretName of the Certificate",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("ingress-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{Name: "ingress-1", Namespace: gen.DefaultTestNamespace, UID: "ingress-1"},
@@ -4619,14 +4754,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 		},
 		{
 			name: "should not remove Certificate when not owned by the Gateway",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("gw-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw-2", Namespace: gen.DefaultTestNamespace, UID: "gw-2"},
@@ -4642,14 +4779,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 		},
 		{
 			name: "should remove Certificate when Gateway does not reference the secretName of the Certificate in one of its listers",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("gw-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
@@ -4661,14 +4800,16 @@ func Test_findCertificatesToBeRemoved(t *testing.T) {
 		},
 		{
 			name: "should not remove Certificate when the Gateway references the secretName of the Certificate in one of its listers",
-			givenCerts: []*cmapi.Certificate{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "cert-1",
-					Namespace:       gen.DefaultTestNamespace,
-					OwnerReferences: buildGatewayOwnerReferences("gw-1"),
-				}, Spec: cmapi.CertificateSpec{
-					SecretName: "secret-name",
-				}},
+			givenCerts: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-1",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("gw-1"),
+					}, Spec: cmapi.CertificateSpec{
+						SecretName: "secret-name",
+					},
+				},
 			},
 			ingLike: &gwapi.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw-1", Namespace: gen.DefaultTestNamespace, UID: "gw-1"},
@@ -4885,6 +5026,72 @@ func TestIsTLSProtocol(t *testing.T) {
 			got := isGatewayAPITLSProtocol(tt.protocol, tt.extra)
 			if got != tt.want {
 				t.Errorf("isGatewayAPITLSProtocol(%q, %v) = %v, want %v", tt.protocol, tt.extra, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isGatewayAPIListenerIgnoredThroughAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		listenerName string
+		want         bool
+	}{
+		{
+			name:         "no annotations returns false",
+			annotations:  nil,
+			listenerName: "https",
+			want:         false,
+		},
+		{
+			name:         "annotation not present returns false",
+			annotations:  map[string]string{"other-annotation": "value"},
+			listenerName: "https",
+			want:         false,
+		},
+		{
+			name:         "single listener match returns true",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: "https"},
+			listenerName: "https",
+			want:         true,
+		},
+		{
+			name:         "single listener no match returns false",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: "other"},
+			listenerName: "https",
+			want:         false,
+		},
+		{
+			name:         "comma-separated list with match returns true",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: "foo,https,bar"},
+			listenerName: "https",
+			want:         true,
+		},
+		{
+			name:         "comma-separated list without match returns false",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: "foo,bar,baz"},
+			listenerName: "https",
+			want:         false,
+		},
+		{
+			name:         "empty annotation value returns false",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: ""},
+			listenerName: "https",
+			want:         false,
+		},
+		{
+			name:         "exact match is required",
+			annotations:  map[string]string{cmapi.CertificateIgnoreTLSListeners: "https-extra"},
+			listenerName: "https",
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGatewayAPIListenerIgnoredThroughAnnotation(tt.annotations, tt.listenerName)
+			if got != tt.want {
+				t.Errorf("isGatewayAPIListenerIgnoredThroughAnnotation(%v, %q) = %v, want %v", tt.annotations, tt.listenerName, got, tt.want)
 			}
 		})
 	}

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -690,6 +690,35 @@ cKK5t8N1YDX5CV+01X3vvxpM3ciYuCY9y+lSegrIEI+izRyD7P9KaZlwMaYmsBZq
 			Expect(cert.Spec.SecretName).To(Equal(secretName))
 		})
 
+		s.it(f, "Creating a Gateway with ignore annotation should not affect existing listeners", func(ctx context.Context, issuerRef cmmeta.IssuerReference) {
+			framework.RequireFeatureGate(utilfeature.DefaultFeatureGate, feature.ExperimentalGatewayAPISupport)
+
+			name := "testcert-gateway-listener-ignore"
+			secretName := "testcert-gateway-listener-ignore-tls"
+			domain := e2eutil.RandomSubdomain(s.DomainSuffix)
+
+			By("Creating a Gateway with ignore annotations")
+			gw := e2eutil.NewGateway(name, f.Namespace.Name, secretName, map[string]string{
+				"cert-manager.io/issuer":               issuerRef.Name,
+				"cert-manager.io/issuer-kind":          issuerRef.Kind,
+				"cert-manager.io/issuer-group":         issuerRef.Group,
+				"cert-manager.io/ignore-tls-listeners": "custom-tls-listener",
+			}, domain)
+
+			gw, err := f.GWClientSet.GatewayV1().Gateways(f.Namespace.Name).Create(ctx, gw, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			certName := string(gw.Spec.Listeners[0].TLS.CertificateRefs[0].Name)
+
+			By("Waiting for the Certificate to exist...")
+			cert, err := f.Helper().WaitForCertificateToExist(ctx, f.Namespace.Name, certName, time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the created Certificate")
+			Expect(cert.Spec.DNSNames).To(ConsistOf(domain))
+			Expect(cert.Spec.SecretName).To(Equal(secretName))
+		})
+
 		s.it(f, "Creating a ListenerSet with annotations for issuer ref and other related fields", func(ctx context.Context, ir cmmeta.IssuerReference) {
 			// TODO: @hjoshi123 No gwapi provider supports ListenerSet yet. Remove this once we upgrade to something that does support it.
 			if s.HTTP01TestType != "ListenerSet" {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR adds the `acme.cert-manager.io/ignore-tls-listeners` annotation so that the certificate-shim controller can ignore listeners for which cert-manager doesn't need the certificate to be created. These listeners could have externally managed TLS certs. Additionally, there are some quality of life improvements to eliminate duplicate code between listenersets and gateways since they use the same underlying types for Listeners.

Fixes #8609 

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
added `cert-manager.io/ignore-tls-listeners` annotation for ignoring gwapi listeners.
```
