### PR TITLE
Fix: include annotations derived from ingress in certificate reconciliation loop

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -504,7 +504,7 @@ func buildCertificates(
 				continue
 			}
 
-			if !certNeedsUpdate(existingCrt, crt) {
+			if !certNeedsUpdate(existingCrt, crt) && !issuerSpecificConfigNeedsUpdate(existingCrt, ingLike) {
 				log.V(logf.DebugLevel).Info("certificate resource is already up to date for object")
 				continue
 			}
@@ -523,7 +523,17 @@ func buildCertificates(
 				updateCrt.SetAnnotations(mergeAnnotations(updateCrt.GetAnnotations(), annotations))
 			}
 
-			setIssuerSpecificConfig(crt, ingLike)
+			// Only re-apply issuer-specific config for Ingress resources on the
+			// update path. setIssuerSpecificConfig also sets Gateway/ListenerSet
+			// parent-ref annotations, and calling it unconditionally here would
+			// inject those annotations onto existing Certificates that do not
+			// already have them, changing Gateway/ListenerSet update semantics in
+			// ways that are outside the scope of this fix.
+			// Note: on the creation path (above) it is correctly called for all
+			// ingress-like types.
+			if _, ok := ingLike.(*networkingv1.Ingress); ok {
+				setIssuerSpecificConfig(updateCrt, ingLike)
+			}
 
 			updateCrts = append(updateCrts, updateCrt)
 		} else {
@@ -556,6 +566,55 @@ func mergeAnnotations(a, b map[string]string) map[string]string {
 	maps.Copy(merged, b)
 
 	return merged
+}
+
+func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
+	// This drift check is intentionally scoped to Ingress resources.
+	// Ingress annotations are mapped to Certificate annotations and can change
+	// independently from the Certificate spec. Gateway/ListenerSet semantics are
+	// currently kept unchanged to avoid update behavior regressions.
+	if _, ok := ingLike.(*networkingv1.Ingress); !ok {
+		return false
+	}
+
+	ingAnnotations := ingLike.GetAnnotations()
+	if ingAnnotations == nil {
+		ingAnnotations = map[string]string{}
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
+		return true
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
+		return true
+	}
+
+	return false
+}
+
+// annotationNeedsUpdate checks if a Certificate's annotation differs from a desired value
+// derived from an Ingress annotation. This enables drift detection when Ingress annotations
+// change independently (e.g., during ingress controller migrations).
+//
+// Parameters:
+//   - desiredAnnotations: source annotations (typically from an Ingress)
+//   - desiredKey: key to look up in desiredAnnotations
+//   - existingAnnotations: target annotations (on a Certificate)
+//   - existingKey: key to look up in existingAnnotations (may differ from desiredKey)
+//
+// Returns true if the annotations differ in presence or value.
+func annotationNeedsUpdate(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
+	desiredValue, desiredPresent := desiredAnnotations[desiredKey]
+	desiredHasValue := desiredPresent && desiredValue != ""
+
+	existingValue, existingPresent := existingAnnotations[existingKey]
+
+	if desiredHasValue != existingPresent {
+		return true
+	}
+
+	return desiredHasValue && desiredValue != existingValue
 }
 
 func secretNameUsedIn(secretName string, ingLike metav1.Object) bool {
@@ -762,17 +821,26 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 	ingressClassVal, hasIngressClassVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey]
 	ingressClassNameVal, hasIngressClassNameVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey]
 
+	// Apply or remove ingressClass override based on Ingress annotation presence/value.
+	// This enables drift detection when Ingress annotations change (e.g., during controller migration).
 	if hasIngressClassVal && ingressClassVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassOverride] = ingressClassVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride)
 	}
+	// Apply or remove ingressClassName override based on Ingress annotation presence/value.
 	if hasIngressClassNameVal && ingressClassNameVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassNameOverride] = ingressClassNameVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride)
 	}
 
 	switch ingLike.(type) {
@@ -788,6 +856,12 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01ParentRefKind] = "ListenerSet"
 		crt.Annotations[cmacme.ACMECertificateHTTP01ParentRefName] = ingLike.GetName()
+	}
+
+	// Avoid creating an empty annotations map; use nil instead to keep
+	// the Certificate clean and match idiomatic Kubernetes conventions.
+	if len(crt.Annotations) == 0 {
+		crt.Annotations = nil
 	}
 
 	ingLike.SetAnnotations(ingAnnotations)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -465,7 +465,7 @@ func buildCertificates(
 				continue
 			}
 
-			if !certNeedsUpdate(existingCrt, crt) {
+			if !certNeedsUpdate(existingCrt, crt) && !issuerSpecificConfigNeedsUpdate(existingCrt, ingLike) {
 				log.V(logf.DebugLevel).Info("certificate resource is already up to date for object")
 				continue
 			}
@@ -484,7 +484,17 @@ func buildCertificates(
 				updateCrt.SetAnnotations(mergeAnnotations(updateCrt.GetAnnotations(), annotations))
 			}
 
-			setIssuerSpecificConfig(crt, ingLike)
+			// Only re-apply issuer-specific config for Ingress resources on the
+			// update path. setIssuerSpecificConfig also sets Gateway/ListenerSet
+			// parent-ref annotations, and calling it unconditionally here would
+			// inject those annotations onto existing Certificates that do not
+			// already have them, changing Gateway/ListenerSet update semantics in
+			// ways that are outside the scope of this fix.
+			// Note: on the creation path (above) it is correctly called for all
+			// ingress-like types.
+			if _, ok := ingLike.(*networkingv1.Ingress); ok {
+				setIssuerSpecificConfig(updateCrt, ingLike)
+			}
 
 			updateCrts = append(updateCrts, updateCrt)
 		} else {
@@ -558,6 +568,55 @@ func mergeAnnotations(a, b map[string]string) map[string]string {
 	maps.Copy(merged, b)
 
 	return merged
+}
+
+func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
+	// This drift check is intentionally scoped to Ingress resources.
+	// Ingress annotations are mapped to Certificate annotations and can change
+	// independently from the Certificate spec. Gateway/ListenerSet semantics are
+	// currently kept unchanged to avoid update behavior regressions.
+	if _, ok := ingLike.(*networkingv1.Ingress); !ok {
+		return false
+	}
+
+	ingAnnotations := ingLike.GetAnnotations()
+	if ingAnnotations == nil {
+		ingAnnotations = map[string]string{}
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
+		return true
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
+		return true
+	}
+
+	return false
+}
+
+// annotationNeedsUpdate checks if a Certificate's annotation differs from a desired value
+// derived from an Ingress annotation. This enables drift detection when Ingress annotations
+// change independently (e.g., during ingress controller migrations).
+//
+// Parameters:
+//   - desiredAnnotations: source annotations (typically from an Ingress)
+//   - desiredKey: key to look up in desiredAnnotations
+//   - existingAnnotations: target annotations (on a Certificate)
+//   - existingKey: key to look up in existingAnnotations (may differ from desiredKey)
+//
+// Returns true if the annotations differ in presence or value.
+func annotationNeedsUpdate(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
+	desiredValue, desiredPresent := desiredAnnotations[desiredKey]
+	desiredHasValue := desiredPresent && desiredValue != ""
+
+	existingValue, existingPresent := existingAnnotations[existingKey]
+
+	if desiredHasValue != existingPresent {
+		return true
+	}
+
+	return desiredHasValue && desiredValue != existingValue
 }
 
 func secretNameUsedIn(secretName string, ingLike metav1.Object) bool {
@@ -764,17 +823,26 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 	ingressClassVal, hasIngressClassVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey]
 	ingressClassNameVal, hasIngressClassNameVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey]
 
+	// Apply or remove ingressClass override based on Ingress annotation presence/value.
+	// This enables drift detection when Ingress annotations change (e.g., during controller migration).
 	if hasIngressClassVal && ingressClassVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassOverride] = ingressClassVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride)
 	}
+	// Apply or remove ingressClassName override based on Ingress annotation presence/value.
 	if hasIngressClassNameVal && ingressClassNameVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassNameOverride] = ingressClassNameVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride)
 	}
 
 	switch ingLike := ingLike.(type) {
@@ -786,6 +854,12 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 		crt.Annotations[cmacme.ACMECertificateHTTP01ParentRefName] = ingLike.GetName()
 	case *gwapi.ListenerSet:
 		setListenerSetParentRefAnnotations(crt, ingLike, ingAnnotations)
+	}
+
+	// Avoid creating an empty annotations map; use nil instead to keep
+	// the Certificate clean and match idiomatic Kubernetes conventions.
+	if len(crt.Annotations) == 0 {
+		crt.Annotations = nil
 	}
 
 	ingLike.SetAnnotations(ingAnnotations)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -465,7 +465,7 @@ func buildCertificates(
 				continue
 			}
 
-			if !certNeedsUpdate(existingCrt, crt) && !issuerSpecificConfigNeedsUpdate(existingCrt, ingLike) {
+			if !certNeedsUpdate(existingCrt, crt) && !shimAnnotationsNeedsUpdate(existingCrt, ingLike) {
 				log.V(logf.DebugLevel).Info("certificate resource is already up to date for object")
 				continue
 			}
@@ -570,7 +570,7 @@ func mergeAnnotations(a, b map[string]string) map[string]string {
 	return merged
 }
 
-func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
+func shimAnnotationsNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
 	// This drift check is intentionally scoped to Ingress resources.
 	// Ingress annotations are mapped to Certificate annotations and can change
 	// independently from the Certificate spec. Gateway/ListenerSet semantics are
@@ -584,39 +584,28 @@ func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike met
 		ingAnnotations = map[string]string{}
 	}
 
-	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
+	annotationDrifted := func(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
+		desiredValue, desiredPresent := desiredAnnotations[desiredKey]
+		desiredHasValue := desiredPresent && desiredValue != ""
+
+		existingValue, existingPresent := existingAnnotations[existingKey]
+
+		if desiredHasValue != existingPresent {
+			return true
+		}
+
+		return desiredHasValue && desiredValue != existingValue
+	}
+
+	if annotationDrifted(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
 		return true
 	}
 
-	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
+	if annotationDrifted(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
 		return true
 	}
 
 	return false
-}
-
-// annotationNeedsUpdate checks if a Certificate's annotation differs from a desired value
-// derived from an Ingress annotation. This enables drift detection when Ingress annotations
-// change independently (e.g., during ingress controller migrations).
-//
-// Parameters:
-//   - desiredAnnotations: source annotations (typically from an Ingress)
-//   - desiredKey: key to look up in desiredAnnotations
-//   - existingAnnotations: target annotations (on a Certificate)
-//   - existingKey: key to look up in existingAnnotations (may differ from desiredKey)
-//
-// Returns true if the annotations differ in presence or value.
-func annotationNeedsUpdate(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
-	desiredValue, desiredPresent := desiredAnnotations[desiredKey]
-	desiredHasValue := desiredPresent && desiredValue != ""
-
-	existingValue, existingPresent := existingAnnotations[existingKey]
-
-	if desiredHasValue != existingPresent {
-		return true
-	}
-
-	return desiredHasValue && desiredValue != existingValue
 }
 
 func secretNameUsedIn(secretName string, ingLike metav1.Object) bool {

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -453,7 +453,7 @@ func buildCertificates(
 				continue
 			}
 
-			if !certNeedsUpdate(existingCrt, crt) {
+			if !certNeedsUpdate(existingCrt, crt) && !issuerSpecificConfigNeedsUpdate(existingCrt, ingLike) {
 				log.V(logf.DebugLevel).Info("certificate resource is already up to date for object")
 				continue
 			}
@@ -473,6 +473,18 @@ func buildCertificates(
 
 			if len(crt.GetAnnotations()) > 0 {
 				updateCrt.SetAnnotations(mergeAnnotations(updateCrt.GetAnnotations(), crt.GetAnnotations()))
+			}
+
+			// Only re-apply issuer-specific config for Ingress resources on the
+			// update path. setIssuerSpecificConfig also sets Gateway/ListenerSet
+			// parent-ref annotations, and calling it unconditionally here would
+			// inject those annotations onto existing Certificates that do not
+			// already have them, changing Gateway/ListenerSet update semantics in
+			// ways that are outside the scope of this fix.
+			// Note: on the creation path (above) it is correctly called for all
+			// ingress-like types.
+			if _, ok := ingLike.(*networkingv1.Ingress); ok {
+				setIssuerSpecificConfig(updateCrt, ingLike)
 			}
 
 			updateCrts = append(updateCrts, updateCrt)
@@ -567,6 +579,55 @@ func mergeAnnotations(a, b map[string]string) map[string]string {
 	maps.Copy(merged, b)
 
 	return merged
+}
+
+func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
+	// This drift check is intentionally scoped to Ingress resources.
+	// Ingress annotations are mapped to Certificate annotations and can change
+	// independently from the Certificate spec. Gateway/ListenerSet semantics are
+	// currently kept unchanged to avoid update behavior regressions.
+	if _, ok := ingLike.(*networkingv1.Ingress); !ok {
+		return false
+	}
+
+	ingAnnotations := ingLike.GetAnnotations()
+	if ingAnnotations == nil {
+		ingAnnotations = map[string]string{}
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
+		return true
+	}
+
+	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
+		return true
+	}
+
+	return false
+}
+
+// annotationNeedsUpdate checks if a Certificate's annotation differs from a desired value
+// derived from an Ingress annotation. This enables drift detection when Ingress annotations
+// change independently (e.g., during ingress controller migrations).
+//
+// Parameters:
+//   - desiredAnnotations: source annotations (typically from an Ingress)
+//   - desiredKey: key to look up in desiredAnnotations
+//   - existingAnnotations: target annotations (on a Certificate)
+//   - existingKey: key to look up in existingAnnotations (may differ from desiredKey)
+//
+// Returns true if the annotations differ in presence or value.
+func annotationNeedsUpdate(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
+	desiredValue, desiredPresent := desiredAnnotations[desiredKey]
+	desiredHasValue := desiredPresent && desiredValue != ""
+
+	existingValue, existingPresent := existingAnnotations[existingKey]
+
+	if desiredHasValue != existingPresent {
+		return true
+	}
+
+	return desiredHasValue && desiredValue != existingValue
 }
 
 func secretNameUsedIn(secretName string, ingLike metav1.Object) bool {
@@ -773,17 +834,26 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 	ingressClassVal, hasIngressClassVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey]
 	ingressClassNameVal, hasIngressClassNameVal := ingAnnotations[cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey]
 
+	// Apply or remove ingressClass override based on Ingress annotation presence/value.
+	// This enables drift detection when Ingress annotations change (e.g., during controller migration).
 	if hasIngressClassVal && ingressClassVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassOverride] = ingressClassVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride)
 	}
+	// Apply or remove ingressClassName override based on Ingress annotation presence/value.
 	if hasIngressClassNameVal && ingressClassNameVal != "" {
 		if crt.Annotations == nil {
 			crt.Annotations = make(map[string]string)
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassNameOverride] = ingressClassNameVal
+	} else {
+		// Remove override if no longer present or empty in Ingress.
+		delete(crt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride)
 	}
 
 	switch ingLike := ingLike.(type) {
@@ -795,6 +865,12 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ingLike metav1.Object) {
 		crt.Annotations[cmacme.ACMECertificateHTTP01ParentRefName] = ingLike.GetName()
 	case *gwapi.ListenerSet:
 		setListenerSetParentRefAnnotations(crt, ingLike, ingAnnotations)
+	}
+
+	// Avoid creating an empty annotations map; use nil instead to keep
+	// the Certificate clean and match idiomatic Kubernetes conventions.
+	if len(crt.Annotations) == 0 {
+		crt.Annotations = nil
 	}
 
 	ingLike.SetAnnotations(ingAnnotations)

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -453,7 +453,7 @@ func buildCertificates(
 				continue
 			}
 
-			if !certNeedsUpdate(existingCrt, crt) && !issuerSpecificConfigNeedsUpdate(existingCrt, ingLike) {
+			if !certNeedsUpdate(existingCrt, crt) && !shimAnnotationsNeedsUpdate(existingCrt, ingLike) {
 				log.V(logf.DebugLevel).Info("certificate resource is already up to date for object")
 				continue
 			}
@@ -581,7 +581,7 @@ func mergeAnnotations(a, b map[string]string) map[string]string {
 	return merged
 }
 
-func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
+func shimAnnotationsNeedsUpdate(existingCrt *cmapi.Certificate, ingLike metav1.Object) bool {
 	// This drift check is intentionally scoped to Ingress resources.
 	// Ingress annotations are mapped to Certificate annotations and can change
 	// independently from the Certificate spec. Gateway/ListenerSet semantics are
@@ -595,39 +595,28 @@ func issuerSpecificConfigNeedsUpdate(existingCrt *cmapi.Certificate, ingLike met
 		ingAnnotations = map[string]string{}
 	}
 
-	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
+	annotationDrifted := func(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
+		desiredValue, desiredPresent := desiredAnnotations[desiredKey]
+		desiredHasValue := desiredPresent && desiredValue != ""
+
+		existingValue, existingPresent := existingAnnotations[existingKey]
+
+		if desiredHasValue != existingPresent {
+			return true
+		}
+
+		return desiredHasValue && desiredValue != existingValue
+	}
+
+	if annotationDrifted(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassOverride) {
 		return true
 	}
 
-	if annotationNeedsUpdate(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
+	if annotationDrifted(ingAnnotations, cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey, existingCrt.Annotations, cmacme.ACMECertificateHTTP01IngressClassNameOverride) {
 		return true
 	}
 
 	return false
-}
-
-// annotationNeedsUpdate checks if a Certificate's annotation differs from a desired value
-// derived from an Ingress annotation. This enables drift detection when Ingress annotations
-// change independently (e.g., during ingress controller migrations).
-//
-// Parameters:
-//   - desiredAnnotations: source annotations (typically from an Ingress)
-//   - desiredKey: key to look up in desiredAnnotations
-//   - existingAnnotations: target annotations (on a Certificate)
-//   - existingKey: key to look up in existingAnnotations (may differ from desiredKey)
-//
-// Returns true if the annotations differ in presence or value.
-func annotationNeedsUpdate(desiredAnnotations map[string]string, desiredKey string, existingAnnotations map[string]string, existingKey string) bool {
-	desiredValue, desiredPresent := desiredAnnotations[desiredKey]
-	desiredHasValue := desiredPresent && desiredValue != ""
-
-	existingValue, existingPresent := existingAnnotations[existingKey]
-
-	if desiredHasValue != existingPresent {
-		return true
-	}
-
-	return desiredHasValue && desiredValue != existingValue
 }
 
 func secretNameUsedIn(secretName string, ingLike metav1.Object) bool {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -2243,6 +2243,282 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "should update a Certificate when ingressClassName override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:                      "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                             "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                            "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClassName override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "nginx",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should update a Certificate when ingressClass override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:               "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                      "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                     "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClass override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
 	}
 
 	testGatewayShim := []testT{

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -2242,6 +2242,282 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "should update a Certificate when ingressClassName override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:                      "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                             "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                            "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClassName override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "nginx",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should update a Certificate when ingressClass override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:               "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                      "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                     "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClass override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
 	}
 
 	testGatewayShim := []testT{

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -2406,6 +2406,282 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "should update a Certificate when ingressClassName override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:                      "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                             "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                            "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassNameAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClassName override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassNameOverride: "nginx",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should update a Certificate when ingressClass override annotation changes",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey:               "issuer-name",
+						cmapi.IssuerKindAnnotationKey:                      "Issuer",
+						cmapi.IssuerGroupAnnotationKey:                     "cert-manager.io",
+						cmapi.IngressACMEIssuerHTTP01IngressClassAnnotationKey: "bar",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "bar",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			Name:         "should remove Certificate ingressClass override annotation when not present on ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01IngressClassOverride: "foo",
+						},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
 	}
 
 	testGatewayShim := []testT{


### PR DESCRIPTION
### Pull Request Motivation

This PR fixes a bug where ingress-shim does not reconcile existing Certificate HTTP01 ingress class override annotations when the source Ingress annotation changes.

**Related Issue**: Resolves #8733

During ingress controller migrations (e.g., nginx → apisix), if the Ingress `acme.cert-manager.io/http01-ingress-ingressclassname` annotation is updated, existing managed Certificates were not updated to reflect the change. This caused renewals to continue routing to the old ingress controller, resulting in HTTP-01 challenge failures.

**Problem**:
- New Certificates correctly receive the HTTP01 override annotation from the Ingress
- Existing Certificates do not detect or reconcile drift in these annotations
- Stale override annotations propagate through issuance (Certificate → CertificateRequest → Order → solver)

**Solution**:
1. Added `issuerSpecificConfigNeedsUpdate()` to detect mutable HTTP01 solver class override annotation drift (scoped to Ingress resources only)
2. Added `annotationNeedsUpdate()` helper to centralize annotation drift comparison logic
3. Extended `setIssuerSpecificConfig()` to both add and remove override annotations based on current Ingress state
4. Updated the Certificate update decision logic to include issuer-specific config drift detection
5. Added regression tests for Ingress annotation changes on existing Certificates

**Scope**: This fix intentionally targets only mutable HTTP01 solver-routing class override annotations:
- `acme.cert-manager.io/http01-override-ingress-class`
- `acme.cert-manager.io/http01-override-ingress-ingressclassname`

Other annotations (ingress-name, temporary certificate, Gateway/ListenerSet parent-refs) are outside this scope.

---

As mentioned in the issue, the code

https://github.com/cert-manager/cert-manager/blob/e6548797920f2c672f7fbc6f370d531e10f0b7bd/pkg/controller/certificate-shim/sync.go#L526

from what i can tell originally did nothing.
Fixing only that caused tests related to gateway to break.

Hence the reason why that call is now guarded.
Since I am not sure about the original intent, i cannot also be sure if this is now correct or not.

The tests are green, but an expert pair of eyes is probably more effective here.

--- 

> [!NOTE]
> **DISCAIMER**
> This was built with the help of copilot.
> I am not a go developer, this is just intended as a mean to provide a starting point as I really appreciated the work everyone is doing here and wanted to at least try to contribute something instead of simply complaining :)
> I did multiple iterations to steer copilot to keep the scope as focused/tight as possible though and to respect the existing way in which the rest of the code is written.
> I believe that there are better more elegant solutions to this, i tried some but those had a larger footprint and as mentioned, i wanted to keep this small and focused.
>
> I am not sure what other side effects this might have as I honestly did not have the required knowledge of the codebase to make that assertion.
> If this is completely misplaced or there are reason for the current behaviour, feel free to reject/close this.
> I understand that the time available for reviewing external contributions is limited.

### Kind

/kind bug

### Release Note

Fixed ingress-shim not reconciling existing Certificate HTTP01 ingress class override annotations when the source Ingress annotation changes.