### PR TITLE
[release-1.19] Fix CI support K8s 1.35

### DIFF
--- a/hack/latest-kind-images.sh
+++ b/hack/latest-kind-images.sh
@@ -36,7 +36,7 @@ set -eu -o pipefail
 # [provide machine-readable list of images for release](https://github.com/kubernetes-sigs/kind/issues/2376).
 
 # kind version is maintained by Renovate using a custom regex manager
-kind_version=v0.30.0
+kind_version=v0.31.0
 
 cp ./hack/boilerplate-sh.txt ./make/kind_images.sh.tmp
 

--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -109,6 +109,7 @@ case "$k8s_version" in
 1.32*) image=$KIND_IMAGE_K8S_132 ;;
 1.33*) image=$KIND_IMAGE_K8S_133 ;;
 1.34*) image=$KIND_IMAGE_K8S_134 ;;
+1.35*) image=$KIND_IMAGE_K8S_135 ;;
 v*) printf "${red}${redcross}Error${end}: Kubernetes version must be given without the leading 'v'\n" >&2 && exit 1 ;;
 *) printf "${red}${redcross}Error${end}: unsupported Kubernetes version ${yel}${k8s_version}${end}\n" >&2 && exit 1 ;;
 esac


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Our testgrid for release-1.19 appears to have been broken for a long time, ref. https://testgrid.k8s.io/cert-manager-periodics-release-1.19

I think/hope this minor fix will mend the issue, and believe the core issue is that our CI cannot find the kind image sha for K8s 1.35.

````
Error: unsupported Kubernetes version 1.35
````

I also think kind 0.30.0 does not support K8s 1.35. Running `hack/latest-kind-images.sh ` changes the `make/kind_images.sh` file. While after bumping kind, it doesn't.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
