### PR TITLE
scheduler: allow parallel challenges with different HTTP01 ingress classes or DNS01 providers

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/scheduler.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler.go
@@ -186,13 +186,92 @@ func compareChallenges(l, r *cmacme.Challenge) int {
 		return 1
 	}
 
-	// TODO: check the http01.ingressClass attribute and allow two challenges
-	// with different ingress classes specified to be scheduled at once
+	// Allow two HTTP01 challenges with different ingress classes to run in
+	// parallel, since they use separate Ingress resources and do not conflict.
+	if l.Spec.Type == cmacme.ACMEChallengeTypeHTTP01 {
+		lClass := http01IngressClass(l.Spec.Solver.HTTP01)
+		rClass := http01IngressClass(r.Spec.Solver.HTTP01)
+		if lClass < rClass {
+			return -1
+		}
+		if lClass > rClass {
+			return 1
+		}
+	}
 
-	// TODO: check the dns01.provider attribute and allow two challenges with
-	// different providers to be scheduled at once
+	// Allow two DNS01 challenges with different providers to run in parallel,
+	// since they operate on independent DNS infrastructure.
+	if l.Spec.Type == cmacme.ACMEChallengeTypeDNS01 {
+		lProvider := dns01ProviderType(l.Spec.Solver.DNS01)
+		rProvider := dns01ProviderType(r.Spec.Solver.DNS01)
+		if lProvider < rProvider {
+			return -1
+		}
+		if lProvider > rProvider {
+			return 1
+		}
+	}
 
 	return 0
+}
+
+// http01IngressClass returns a string identifying the ingress class used by an
+// HTTP01 solver. Two challenges are considered equivalent (and therefore cannot
+// be scheduled concurrently) if they return the same value.
+//
+// IngressClassName (the modern field) takes precedence over Class (deprecated).
+// GatewayHTTPRoute challenges are assigned a sentinel value so they can run in
+// parallel with ingress-based challenges for the same domain.
+func http01IngressClass(solver *cmacme.ACMEChallengeSolverHTTP01) string {
+	if solver == nil {
+		return ""
+	}
+	if solver.GatewayHTTPRoute != nil {
+		// Gateway-based HTTP01 uses a completely separate mechanism from
+		// Ingress-based HTTP01; treat it as its own class so the two can
+		// run in parallel.
+		return "__gateway__"
+	}
+	if solver.Ingress != nil {
+		if solver.Ingress.IngressClassName != nil {
+			return *solver.Ingress.IngressClassName
+		}
+		if solver.Ingress.Class != nil {
+			return *solver.Ingress.Class
+		}
+	}
+	return ""
+}
+
+// dns01ProviderType returns a string identifying which DNS01 provider type is
+// configured. Two challenges using the same provider type are considered
+// equivalent; two challenges using different provider types can run in parallel.
+func dns01ProviderType(solver *cmacme.ACMEChallengeSolverDNS01) string {
+	if solver == nil {
+		return ""
+	}
+	switch {
+	case solver.Akamai != nil:
+		return "akamai"
+	case solver.CloudDNS != nil:
+		return "clouddns"
+	case solver.Cloudflare != nil:
+		return "cloudflare"
+	case solver.Route53 != nil:
+		return "route53"
+	case solver.AzureDNS != nil:
+		return "azuredns"
+	case solver.DigitalOcean != nil:
+		return "digitalocean"
+	case solver.AcmeDNS != nil:
+		return "acmedns"
+	case solver.RFC2136 != nil:
+		return "rfc2136"
+	case solver.Webhook != nil:
+		return "webhook"
+	default:
+		return ""
+	}
 }
 
 // sortChallenges will sort the provided list of challenges according to the

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -34,6 +34,8 @@ import (
 
 const maxConcurrentChallenges = 60
 
+func ptrTo[T any](v T) *T { return &v }
+
 func randomChallenge(dnsNamelength int) *cmacme.Challenge {
 	if dnsNamelength == 0 {
 		dnsNamelength = 10
@@ -233,6 +235,286 @@ func TestScheduleN(t *testing.T) {
 				gen.Challenge("test2",
 					gen.SetChallengeDNSName("example.com"),
 					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01)),
+			},
+		},
+		// HTTP01 ingress class scheduling tests
+		{
+			name: "schedule HTTP01 challenges for the same domain in parallel if they have different ingress classes (Class field)",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					})),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("traefik"),
+						},
+					})),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					})),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("traefik"),
+						},
+					})),
+			},
+		},
+		{
+			name: "schedule HTTP01 challenges for the same domain in parallel if they have different IngressClassNames",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							IngressClassName: ptrTo("nginx"),
+						},
+					})),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							IngressClassName: ptrTo("traefik"),
+						},
+					})),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							IngressClassName: ptrTo("nginx"),
+						},
+					})),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							IngressClassName: ptrTo("traefik"),
+						},
+					})),
+			},
+		},
+		{
+			name: "do not schedule two HTTP01 challenges for the same domain and same ingress class in parallel",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					}),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					}),
+					withCreationTimestamp(2)),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					}),
+					withCreationTimestamp(1)),
+			},
+		},
+		{
+			name: "schedule HTTP01 challenge when a different ingress class is already in progress for the same domain",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test-processing",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					}),
+					gen.SetChallengeProcessing(true)),
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("traefik"),
+						},
+					})),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("traefik"),
+						},
+					})),
+			},
+		},
+		{
+			name: "do not schedule HTTP01 challenge when the same ingress class is already in progress for the same domain",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test-processing",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					}),
+					gen.SetChallengeProcessing(true)),
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengeSolverHTTP01(cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							Class: ptrTo("nginx"),
+						},
+					})),
+			},
+		},
+		// DNS01 provider type scheduling tests
+		{
+			name: "schedule DNS01 challenges for the same domain in parallel if they use different providers",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					})),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{},
+					})),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{},
+					})),
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					})),
+			},
+		},
+		{
+			name: "do not schedule two DNS01 challenges for the same domain and same provider type in parallel",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					}),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					}),
+					withCreationTimestamp(2)),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					}),
+					withCreationTimestamp(1)),
+			},
+		},
+		{
+			name: "schedule DNS01 challenge when a different provider is already in progress for the same domain",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test-processing",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					}),
+					gen.SetChallengeProcessing(true)),
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{},
+					})),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{},
+					})),
+			},
+		},
+		{
+			name: "do not schedule DNS01 challenge when the same provider is already in progress for the same domain",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test-processing",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					}),
+					gen.SetChallengeProcessing(true)),
+				gen.Challenge("test-pending",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+					})),
 			},
 		},
 		// this test case replicates a failure seen in CI

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -142,3 +142,9 @@ func SetChallengeSolverDNS01(solver cmacme.ACMEChallengeSolverDNS01) ChallengeMo
 		ch.Spec.Solver.DNS01 = &solver
 	}
 }
+
+func SetChallengeSolverHTTP01(solver cmacme.ACMEChallengeSolverHTTP01) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Solver.HTTP01 = &solver
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Extends `compareChallenges` in the ACME challenge scheduler to consider the HTTP01 ingress class and DNS01 provider type when determining whether two challenges conflict. Previously, any two challenges for the same domain and solver type were treated as conflicting and serialized, even when they targeted completely independent ingress controllers or DNS providers.

### Changes

- **`pkg/controller/acmechallenges/scheduler/scheduler.go`**: Replace the two `// TODO` blocks in `compareChallenges` with calls to two new helpers:
  - `http01IngressClass` — returns the ingress class string for an HTTP01 solver (`IngressClassName` takes precedence over the deprecated `Class` field; `GatewayHTTPRoute` uses a distinct sentinel so it can run in parallel with ingress-based challenges)
  - `dns01ProviderType` — returns the provider type name for a DNS01 solver; all nine provider types are handled exhaustively

- **`test/unit/gen/challenge.go`**: Add `SetChallengeSolverHTTP01` modifier (parallel to the existing `SetChallengeSolverDNS01`)

- **`pkg/controller/acmechallenges/scheduler/scheduler_test.go`**: Add `ptrTo` helper and 9 new table-driven test cases covering:
  - HTTP01: parallel scheduling with different `Class` / `IngressClassName` values
  - HTTP01: serialization when the same ingress class is pending or in-progress
  - DNS01: parallel scheduling with different provider types (Route53 vs CloudDNS)
  - DNS01: serialization when the same provider type is pending or in-progress

Fixes #8643

/kind bug

```release-note
The ACME challenge scheduler now allows challenges for the same domain to run in parallel when they use different HTTP01 ingress classes or DNS01 provider types.
```