### PR TITLE
fix(readiness): schedule re-queue at certificate expiry time

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -19,6 +19,7 @@ package readiness
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
@@ -42,6 +44,7 @@ import (
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/scheduler"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
@@ -67,6 +70,10 @@ type controller struct {
 	policyEvaluator policyEvaluatorFunc
 	// renewalTimeCalculator calculates renewal time of a certificate
 	renewalTimeCalculator pki.RenewalTimeFunc
+	// scheduledWorkQueue is used to schedule re-checks of certificates at their
+	// expiry time, so that the Ready condition is updated without a restart.
+	scheduledWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
+	clock              clock.Clock
 
 	// fieldManager is the string which will be used as the Field Manager on
 	// fields created or edited by the cert-manager Kubernetes client during
@@ -147,6 +154,8 @@ func NewController(
 		},
 		policyEvaluator:       policyEvaluator,
 		renewalTimeCalculator: renewalTimeCalculator,
+		scheduledWorkQueue:    scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
+		clock:                 ctx.Clock,
 		fieldManager:          ctx.FieldManager,
 	}, queue, mustSync, nil
 }
@@ -207,6 +216,11 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		crt.Status.NotAfter = &notAfter
 		crt.Status.RenewalTime = renewalTime
 
+		// Schedule a re-check at the certificate's expiry time so that the
+		// Ready condition is updated immediately when the certificate expires,
+		// without requiring a controller restart.
+		c.scheduleRecheckAtExpiry(log, key, x509cert.NotAfter)
+
 	default:
 		// clear status fields if the secret does not have any data
 		crt.Status.NotAfter = nil
@@ -220,6 +234,21 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return c.updateOrApplyStatus(ctx, crt)
 	}
 	return nil
+}
+
+// scheduleRecheckAtExpiry schedules the Certificate to be re-queued just after
+// its notAfter time. This ensures that the Ready condition is evaluated at
+// expiry without requiring a controller restart, even if no other events occur.
+// If the certificate is already expired, no additional scheduling is needed
+// because the current reconcile will already produce the correct status.
+func (c *controller) scheduleRecheckAtExpiry(log logr.Logger, key types.NamespacedName, notAfter time.Time) {
+	durationUntilExpiry := notAfter.Sub(c.clock.Now())
+	if durationUntilExpiry <= 0 {
+		// Already expired; the current reconcile loop handles this.
+		return
+	}
+	log.V(logf.DebugLevel).Info("scheduling readiness recheck at expiry", "duration_until_expiry", durationUntilExpiry.String())
+	c.scheduledWorkQueue.Add(key, durationUntilExpiry)
 }
 
 // updateOrApplyStatus will update the controller status. If the

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -31,10 +31,28 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
+
+// fakeScheduledWorkQueue records Add calls for testing purposes.
+type fakeScheduledWorkQueue struct {
+	added []struct {
+		key      types.NamespacedName
+		duration time.Duration
+	}
+}
+
+func (f *fakeScheduledWorkQueue) Add(key types.NamespacedName, d time.Duration) {
+	f.added = append(f.added, struct {
+		key      types.NamespacedName
+		duration time.Duration
+	}{key, d})
+}
+
+func (f *fakeScheduledWorkQueue) Forget(_ types.NamespacedName) {}
 
 // policyEvaluatorBuilder returns a fake readyConditionFunc for ReadinessController.
 func policyEvaluatorBuilder(c cmapi.CertificateCondition) policyEvaluatorFunc {
@@ -557,6 +575,66 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 			}
 			if test.violationFound != violationFound {
 				t.Errorf("unexpected 'violationFound' exp=%v, got=%v", test.violationFound, violationFound)
+			}
+		})
+	}
+}
+
+// TestScheduleRecheckAtExpiry verifies that scheduleRecheckAtExpiry enqueues
+// the certificate key at the correct time and is a no-op when already expired.
+func TestScheduleRecheckAtExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	key := types.NamespacedName{Namespace: "ns", Name: "cert"}
+
+	tests := []struct {
+		name        string
+		notAfter    time.Time
+		wantQueued  bool
+		wantAtLeast time.Duration // approximate lower bound on scheduled duration
+	}{
+		{
+			name:        "schedules recheck when certificate is not yet expired",
+			notAfter:    now.Add(time.Hour),
+			wantQueued:  true,
+			wantAtLeast: 59 * time.Minute,
+		},
+		{
+			name:       "does not schedule recheck when certificate is already expired",
+			notAfter:   now.Add(-time.Second),
+			wantQueued: false,
+		},
+		{
+			name:       "does not schedule recheck when notAfter equals now",
+			notAfter:   now,
+			wantQueued: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeQueue := &fakeScheduledWorkQueue{}
+			clk := fakeclock.NewFakeClock(now)
+			c := &controller{
+				scheduledWorkQueue: fakeQueue,
+				clock:              clk,
+			}
+
+			c.scheduleRecheckAtExpiry(logf.Log, key, tc.notAfter)
+
+			if tc.wantQueued {
+				if len(fakeQueue.added) != 1 {
+					t.Fatalf("expected 1 item queued, got %d", len(fakeQueue.added))
+				}
+				if fakeQueue.added[0].key != key {
+					t.Errorf("queued wrong key: got %v, want %v", fakeQueue.added[0].key, key)
+				}
+				if fakeQueue.added[0].duration < tc.wantAtLeast {
+					t.Errorf("queued duration %v is less than expected minimum %v", fakeQueue.added[0].duration, tc.wantAtLeast)
+				}
+			} else {
+				if len(fakeQueue.added) != 0 {
+					t.Fatalf("expected nothing queued, got %d items", len(fakeQueue.added))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes #7895.

When a certificate expires while renewal is still in progress (e.g. an ACME challenge is failing), the `Ready` condition stays `True` until cert-manager restarts. This happens because the readiness controller only re-evaluates when a watched resource changes — if no Secret, CertificateRequest, or Certificate change arrives, the controller never re-runs.

## Root cause

The readiness controller evaluates the `Ready` condition on demand but never schedules a proactive re-check at the certificate's expiry time.

## Fix

Add a `ScheduledWorkQueue` to the readiness controller (the same mechanism the trigger controller already uses for `renewalTime`). After evaluating the current state, if the certificate has a valid `notAfter` in the future, the controller schedules a re-queue at that time. When the certificate expires, the controller re-runs, evaluates the `CurrentCertificateHasExpired` policy, and sets `Ready=False` with reason `Expired` — without requiring a restart.

## Testing

- Added `TestScheduleRecheckAtExpiry` with three cases: future expiry (queues), past expiry (no-op), exact-now expiry (no-op)
- All existing readiness controller tests pass