### PR TITLE
Disabling client-go rate-limiting if AP&F is enabled

### DIFF
--- a/internal/apis/config/controller/validation/validation.go
+++ b/internal/apis/config/controller/validation/validation.go
@@ -45,12 +45,12 @@ func ValidateControllerConfiguration(cfg *config.ControllerConfiguration, fldPat
 		allErrors = append(allErrors, field.Required(fldPath.Child("ingressShimConfig").Child("defaultIssuerKind"), "must not be empty"))
 	}
 
-	if cfg.KubernetesAPIBurst <= 0 {
-		allErrors = append(allErrors, field.Invalid(fldPath.Child("kubernetesAPIBurst"), cfg.KubernetesAPIBurst, "must be greater than 0"))
+	if cfg.KubernetesAPIBurst < -1 {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("kubernetesAPIBurst"), cfg.KubernetesAPIBurst, "must be greater than or equal to -1"))
 	}
 
-	if cfg.KubernetesAPIQPS <= 0 {
-		allErrors = append(allErrors, field.Invalid(fldPath.Child("kubernetesAPIQPS"), cfg.KubernetesAPIQPS, "must be greater than 0"))
+	if cfg.KubernetesAPIQPS < -1 {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("kubernetesAPIQPS"), cfg.KubernetesAPIQPS, "must be greater than or equal to -1"))
 	}
 
 	if float32(cfg.KubernetesAPIBurst) < cfg.KubernetesAPIQPS {

--- a/internal/apis/config/controller/validation/validation_test.go
+++ b/internal/apis/config/controller/validation/validation_test.go
@@ -188,13 +188,13 @@ func TestValidateControllerConfiguration(t *testing.T) {
 				IngressShimConfig: config.IngressShimConfig{
 					DefaultIssuerKind: "Issuer",
 				},
-				KubernetesAPIBurst:  -1, // Must be positive
+				KubernetesAPIBurst:  -2,
 				KubernetesAPIQPS:    1,
 				PEMSizeLimitsConfig: validPEMSizeLimitsConfig(),
 			},
 			func(cc *config.ControllerConfiguration) field.ErrorList {
 				return field.ErrorList{
-					field.Invalid(field.NewPath("kubernetesAPIBurst"), cc.KubernetesAPIBurst, "must be greater than 0"),
+					field.Invalid(field.NewPath("kubernetesAPIBurst"), cc.KubernetesAPIBurst, "must be greater than or equal to -1"),
 					field.Invalid(field.NewPath("kubernetesAPIBurst"), cc.KubernetesAPIBurst, "must be higher or equal to kubernetesAPIQPS"),
 				}
 			},
@@ -228,12 +228,12 @@ func TestValidateControllerConfiguration(t *testing.T) {
 					DefaultIssuerKind: "Issuer",
 				},
 				KubernetesAPIBurst:  1,
-				KubernetesAPIQPS:    -1, // Must be positive
+				KubernetesAPIQPS:    -2,
 				PEMSizeLimitsConfig: validPEMSizeLimitsConfig(),
 			},
 			func(cc *config.ControllerConfiguration) field.ErrorList {
 				return field.ErrorList{
-					field.Invalid(field.NewPath("kubernetesAPIQPS"), cc.KubernetesAPIQPS, "must be greater than 0"),
+					field.Invalid(field.NewPath("kubernetesAPIQPS"), cc.KubernetesAPIQPS, "must be greater than or equal to -1"),
 				}
 			},
 		},

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -20,15 +20,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	flowcontrolapi "k8s.io/api/flowcontrol/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -39,6 +44,7 @@ import (
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
@@ -269,19 +275,39 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 		return nil, fmt.Errorf("error creating rest config: %w", err)
 	}
 	restConfig = util.RestConfigWithUserAgent(restConfig)
-	restConfig.QPS = opts.KubernetesAPIQPS
-	restConfig.Burst = opts.KubernetesAPIBurst
+	log := logf.FromContext(ctx)
 
-	// Construct a single RateLimiter used across all built Context's clients. A
-	// single rate limiter (with corresponding QPS and Burst buckets) are
-	// preserved for all Contexts.
-	// Adapted from
-	// https://github.com/kubernetes/client-go/blob/v0.23.3/kubernetes/clientset.go#L431-L435
-	if restConfig.RateLimiter == nil && restConfig.QPS > 0 {
-		if restConfig.Burst <= 0 {
-			return nil, errors.New("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+	const apfProbeTimeout = 5 * time.Second
+	apfProbeCtx, cancel := context.WithTimeout(ctx, apfProbeTimeout)
+	defer cancel()
+
+	apfEnabled, err := isAPFEnabled(apfProbeCtx, restConfig)
+	if err != nil {
+		log.Error(err, "Failed to determine whether API Priority and Fairness is enabled, falling back to client-side rate limiting")
+		apfEnabled = false
+	}
+
+	if apfEnabled {
+		restConfig.QPS = -1
+		restConfig.Burst = -1
+	} else {
+		restConfig.QPS = opts.KubernetesAPIQPS
+		restConfig.Burst = opts.KubernetesAPIBurst
+		// Construct a single RateLimiter used across all built Context's clients.
+		// Adapted from
+		// https://github.com/kubernetes/client-go/blob/v0.23.3/kubernetes/clientset.go#L431-L435
+		if restConfig.RateLimiter == nil && restConfig.QPS >= 0 {
+			if restConfig.QPS == 0 {
+				restConfig.QPS = rest.DefaultQPS // 5
+			}
+			if restConfig.Burst == 0 {
+				restConfig.Burst = rest.DefaultBurst // 10
+			}
+			if restConfig.Burst <= 0 {
+				return nil, errors.New("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+			}
+			restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(restConfig.QPS, restConfig.Burst)
 		}
-		restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(restConfig.QPS, restConfig.Burst)
 	}
 
 	clients, err := buildClients(restConfig, opts)
@@ -314,7 +340,6 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 	gwSharedInformerFactory := gwinformers.NewSharedInformerFactoryWithOptions(clients.gwClient, resyncPeriod, gwinformers.WithNamespace(opts.Namespace))
 
 	clock := clock.RealClock{}
-	log := logf.FromContext(ctx)
 	metrics := metrics.New(log, clock)
 
 	return &ContextFactory{
@@ -452,4 +477,66 @@ func buildClients(restConfig *rest.Config, opts ContextOptions) (contextClients,
 	}
 
 	return contextClients{kubeClient, cmClient, gwClient, metadataOnlyClient, gatewayAvailable}, nil
+}
+
+// serverUrl returns the base URL for the cluster based on the supplied config.
+// Host and Version are required. GroupVersion is ignored.
+// Based on `serverURL` from kubernetes-sigs/cli-utils
+func serverURL(config *rest.Config) (*url.URL, error) {
+	// TODO: move the default to secure when the apiserver supports TLS by default
+	// config.Insecure is taken to mean "I want HTTPS but don't bother checking the certs against a CA."
+	hasCA := len(config.CAFile) != 0 || len(config.CAData) != 0
+	hasCert := len(config.CertFile) != 0 || len(config.CertData) != 0
+	defaultTLS := hasCA || hasCert || config.Insecure
+	host := config.Host
+	if host == "" {
+		host = "localhost"
+	}
+
+	hostURL, _, err := rest.DefaultServerURL(host, config.APIPath, schema.GroupVersion{}, defaultTLS)
+	return hostURL, err
+}
+
+// Based on `IsEnabled` from kubernetes-sigs/cli-utils
+func isAPFEnabled(ctx context.Context, config *rest.Config) (bool, error) {
+	tcfg, err := config.TransportConfig()
+	if err != nil {
+		return false, fmt.Errorf("building transport config: %w", err)
+	}
+	rt, err := transport.New(tcfg)
+	if err != nil {
+		return false, fmt.Errorf("building round tripper: %w", err)
+	}
+
+	u, err := serverURL(config)
+	if err != nil {
+		return false, fmt.Errorf("parsing API server host URL: %w", err)
+	}
+
+	u.Path = path.Join(u.Path, "/livez/ping")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
+	if err != nil {
+		return false, fmt.Errorf("building request: %w", err)
+	}
+
+	if config.UserAgent != "" {
+		req.Header.Set("User-Agent", config.UserAgent)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		return false, fmt.Errorf("making %s request: %w", u.Path, err)
+	}
+
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	// If the flowcontrol header is present, AP&F is enabled.
+	if value := resp.Header.Get(flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID); value != "" {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -513,7 +513,7 @@ func isAPFEnabled(ctx context.Context, config *rest.Config) (bool, error) {
 		return false, fmt.Errorf("parsing API server host URL: %w", err)
 	}
 
-	u.Path = path.Join(u.Path, "/livez/ping")
+	u.Path = path.Join(u.Path, "livez/ping")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
 	if err != nil {

--- a/pkg/controller/context_test.go
+++ b/pkg/controller/context_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	flowcontrolapi "k8s.io/api/flowcontrol/v1"
+	"k8s.io/client-go/rest"
 )
 
 func Test_NewContextFactory(t *testing.T) {
@@ -38,4 +44,70 @@ func Test_NewContextFactory(t *testing.T) {
 
 	assert.NotNil(t, ctx1.RESTConfig.RateLimiter)
 	assert.Same(t, ctx1.RESTConfig.RateLimiter, ctx2.RESTConfig.RateLimiter)
+}
+
+func Test_isAPFEnabled(t *testing.T) {
+	testCases := []struct {
+		name            string
+		responseHeaders map[string]string
+		statusCode      int
+		expectedEnabled bool
+	}{
+		{
+			name: "APF header present indicates enabled",
+			responseHeaders: map[string]string{
+				flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID: "unused-uuid",
+			},
+			statusCode:      http.StatusOK,
+			expectedEnabled: true,
+		},
+		{
+			name:            "no APF header indicates disabled",
+			statusCode:      http.StatusOK,
+			expectedEnabled: false,
+		},
+		{
+			name: "APF header present with non-200 status still indicates enabled",
+			responseHeaders: map[string]string{
+				flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID: "unused-uuid",
+			},
+			statusCode:      http.StatusInternalServerError,
+			expectedEnabled: true,
+		},
+		{
+			name:            "no APF header with non-200 status indicates disabled",
+			statusCode:      http.StatusNotFound,
+			expectedEnabled: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "/livez/ping", req.URL.Path)
+				assert.Equal(t, http.MethodHead, req.Method)
+				for k, v := range tc.responseHeaders {
+					w.Header().Set(k, v)
+				}
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			enabled, err := isAPFEnabled(ctx, &rest.Config{Host: server.URL})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedEnabled, enabled)
+		})
+	}
+}
+
+func Test_isAPFEnabled_invalidHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	enabled, err := isAPFEnabled(ctx, &rest.Config{Host: "://invalid"})
+	assert.Error(t, err)
+	assert.False(t, enabled)
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR aims to disable client side QPS and bursting if server side AP&F is enabled. AP&F or API Priority and Fairness handles server side overloading logic and is enabled by default since v1.20 and is v1 since v1.29. Here's more on [this](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/). The way we do this is we hit the server's ping endpoint and check if the flow control header is returned. If it's returned then we know its enabled (we don't care about the value of it).

This PR also takes care of setting QPS to -1 through controller config which was previously disabled because of validation logic.

Fixes #6890 

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
disabled client side rate-limiting if AP&F is enabled.
```
