### PR TITLE
acmechallenges: retry on transient ACME errors

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -280,6 +281,18 @@ func handleError(ctx context.Context, ch *cmacme.Challenge, err error) error {
 	var acmeErr *acmeapi.Error
 	var ok bool
 	if acmeErr, ok = err.(*acmeapi.Error); !ok {
+		// Transient network errors (TLS handshake timeouts, DNS failures,
+		// connection resets) and context cancellation/deadline errors are
+		// not protocol-level rejections from the ACME server. Returning them
+		// without setting Status.State leaves the challenge in its current
+		// state and lets the workqueue retry with backoff. Without this, a
+		// single transient network blip marks the challenge terminally
+		// Errored, after which IsFinalState() makes the controller stop
+		// reconciling it (see issues #8696 and #8747).
+		if isTransientACMEError(err) {
+			logf.FromContext(ctx).V(logf.ErrorLevel).Error(err, "transient non-ACME API error, will retry")
+			return err
+		}
 		ch.Status.State = cmacme.Errored
 		ch.Status.Reason = fmt.Sprintf("unexpected non-ACME API error: %v", err)
 		logf.FromContext(ctx).V(logf.ErrorLevel).Error(err, "unexpected non-ACME API error")
@@ -305,6 +318,19 @@ func handleError(ctx context.Context, ch *cmacme.Challenge, err error) error {
 	}
 
 	return err
+}
+
+// isTransientACMEError reports whether err is a transient network-layer
+// failure (timeout, DNS resolution failure, connection reset, TLS handshake
+// failure, etc.) or a context cancellation / deadline error. Such errors are
+// not ACME-protocol rejections and should be retried via the workqueue rather
+// than terminally failing the challenge.
+func isTransientACMEError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 // finalize will attempt to 'finalize' the Challenge resource by calling CleanUp

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -781,3 +783,119 @@ func Test_StabilizeSolverErrorMessage(t *testing.T) {
 		})
 	}
 }
+
+func Test_HandleError(t *testing.T) {
+	// timeoutNetErr is a net.Error whose Timeout() reports true; mirrors what
+	// http.Client returns on a connect/read timeout.
+	timeoutNetErr := &net.OpError{Op: "dial", Net: "tcp", Err: &timeoutWrapper{}}
+
+	wrappedNetErr := fmt.Errorf("wrapped: %w", &url.Error{
+		Op:  "Head",
+		URL: "https://acme-v02.api.letsencrypt.org/acme/new-nonce",
+		Err: timeoutNetErr,
+	})
+
+	tests := []struct {
+		name        string
+		err         error
+		wantState   cmacme.State
+		wantReason  string
+		wantErrBack bool
+	}{
+		{
+			name:        "nil error returns nil and leaves state untouched",
+			err:         nil,
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: false,
+		},
+		{
+			name:        "context.Canceled is transient and does not set Errored",
+			err:         context.Canceled,
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+		{
+			name:        "context.DeadlineExceeded is transient and does not set Errored",
+			err:         context.DeadlineExceeded,
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+		{
+			name:        "wrapped context.DeadlineExceeded is transient (errors.Is)",
+			err:         fmt.Errorf("wrapper: %w", context.DeadlineExceeded),
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+		{
+			name:        "net.OpError dial timeout is transient and does not set Errored",
+			err:         timeoutNetErr,
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+		{
+			name:        "url.Error wrapping a net.Error is transient (errors.As)",
+			err:         wrappedNetErr,
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+		{
+			name:        "plain non-ACME non-network error is treated as terminal Errored",
+			err:         errors.New("some unexpected non-network error"),
+			wantState:   cmacme.Errored,
+			wantReason:  "unexpected non-ACME API error: some unexpected non-network error",
+			wantErrBack: true,
+		},
+		{
+			name:        "ACME malformed protocol error marks the challenge Expired",
+			err:         &acmeapi.Error{ProblemType: "urn:ietf:params:acme:error:malformed"},
+			wantState:   cmacme.Expired,
+			wantReason:  "",
+			wantErrBack: false,
+		},
+		{
+			name:        "ACME 4xx response marks the challenge Errored",
+			err:         &acmeapi.Error{StatusCode: 404},
+			wantState:   cmacme.Errored,
+			wantReason:  "Failed to retrieve Order resource: 404 : ",
+			wantErrBack: false,
+		},
+		{
+			name:        "ACME 5xx response leaves state unchanged and returns the error for retry",
+			err:         &acmeapi.Error{StatusCode: 500},
+			wantState:   "",
+			wantReason:  "",
+			wantErrBack: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := &cmacme.Challenge{}
+			gotErr := handleError(context.Background(), ch, tt.err)
+			if tt.wantErrBack {
+				assert.Error(t, gotErr)
+			} else {
+				assert.NoError(t, gotErr)
+			}
+			assert.Equal(t, tt.wantState, ch.Status.State, "Challenge.Status.State")
+			assert.Equal(t, tt.wantReason, ch.Status.Reason, "Challenge.Status.Reason")
+		})
+	}
+}
+
+// timeoutWrapper is a minimal net.Error that reports Timeout() == true; it
+// stands in for the kind of inner error net/http surfaces on TLS/connect
+// timeouts in a way that does not depend on internal stdlib types.
+type timeoutWrapper struct{}
+
+func (t *timeoutWrapper) Error() string   { return "i/o timeout" }
+func (t *timeoutWrapper) Timeout() bool   { return true }
+func (t *timeoutWrapper) Temporary() bool { return true }
+
+var _ net.Error = (*timeoutWrapper)(nil)

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -687,6 +687,80 @@ func TestSyncHappyPath(t *testing.T) {
 				},
 			},
 		},
+		// Transient ACME error paths: the challenge must remain in a non-final
+		// state so the workqueue retries with backoff rather than permanently
+		// marking it Errored (issues #8696 and #8747).
+		"transient net.Error from GetAuthorization leaves challenge in non-final state": {
+			challenge: gen.ChallengeFrom(baseChallenge,
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengeURL("testurl"),
+			),
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
+					gen.SetChallengeProcessing(true),
+					gen.SetChallengeURL("testurl"),
+				), testIssuerHTTP01Enabled},
+				// State is unchanged (still ""), so no status update is issued.
+			},
+			expectErr: true,
+			acmeClient: &acmecl.FakeACME{
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return nil, &net.OpError{Op: "dial", Net: "tcp", Err: &timeoutWrapperError{}}
+				},
+			},
+		},
+		"transient *net.DNSError from GetAuthorization leaves challenge in non-final state": {
+			challenge: gen.ChallengeFrom(baseChallenge,
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengeURL("testurl"),
+			),
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
+					gen.SetChallengeProcessing(true),
+					gen.SetChallengeURL("testurl"),
+				), testIssuerHTTP01Enabled},
+				// State is unchanged (still ""), so no status update is issued.
+			},
+			expectErr: true,
+			acmeClient: &acmecl.FakeACME{
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					return nil, &net.DNSError{Name: "acme.example.com", IsTimeout: true}
+				},
+			},
+		},
+		"transient context.DeadlineExceeded from WaitAuthorization leaves challenge in non-final state": {
+			challenge: gen.ChallengeFrom(baseChallenge,
+				gen.SetChallengeProcessing(true),
+				gen.SetChallengeURL("testurl"),
+				gen.SetChallengeState(cmacme.Pending),
+				gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+				gen.SetChallengePresented(true),
+			),
+			httpSolver: &fakeSolver{
+				fakeCheck: func(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.Challenge) error {
+					return nil
+				},
+			},
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{gen.ChallengeFrom(baseChallenge,
+					gen.SetChallengeProcessing(true),
+					gen.SetChallengeURL("testurl"),
+					gen.SetChallengeState(cmacme.Pending),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
+					gen.SetChallengePresented(true),
+				), testIssuerHTTP01Enabled},
+				// State remains Pending (not Errored/Invalid), so no status update is issued.
+			},
+			expectErr: true,
+			acmeClient: &acmecl.FakeACME{
+				FakeAccept: func(context.Context, *acmeapi.Challenge) (*acmeapi.Challenge, error) {
+					return &acmeapi.Challenge{Status: acmeapi.StatusPending}, nil
+				},
+				FakeWaitAuthorization: func(context.Context, string) (*acmeapi.Authorization, error) {
+					return nil, context.DeadlineExceeded
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -787,7 +861,7 @@ func Test_StabilizeSolverErrorMessage(t *testing.T) {
 func Test_HandleError(t *testing.T) {
 	// timeoutNetErr is a net.Error whose Timeout() reports true; mirrors what
 	// http.Client returns on a connect/read timeout.
-	timeoutNetErr := &net.OpError{Op: "dial", Net: "tcp", Err: &timeoutWrapper{}}
+	timeoutNetErr := &net.OpError{Op: "dial", Net: "tcp", Err: &timeoutWrapperError{}}
 
 	wrappedNetErr := fmt.Errorf("wrapped: %w", &url.Error{
 		Op:  "Head",
@@ -889,13 +963,13 @@ func Test_HandleError(t *testing.T) {
 	}
 }
 
-// timeoutWrapper is a minimal net.Error that reports Timeout() == true; it
-// stands in for the kind of inner error net/http surfaces on TLS/connect
+// timeoutWrapperError is a minimal net.Error that reports Timeout() == true;
+// it stands in for the kind of inner error net/http surfaces on TLS/connect
 // timeouts in a way that does not depend on internal stdlib types.
-type timeoutWrapper struct{}
+type timeoutWrapperError struct{}
 
-func (t *timeoutWrapper) Error() string   { return "i/o timeout" }
-func (t *timeoutWrapper) Timeout() bool   { return true }
-func (t *timeoutWrapper) Temporary() bool { return true }
+func (t *timeoutWrapperError) Error() string   { return "i/o timeout" }
+func (t *timeoutWrapperError) Timeout() bool   { return true }
+func (t *timeoutWrapperError) Temporary() bool { return true }
 
-var _ net.Error = (*timeoutWrapper)(nil)
+var _ net.Error = (*timeoutWrapperError)(nil)


### PR DESCRIPTION
### Pull Request Motivation

Fixes #8747.

`handleError` in `pkg/controller/acmechallenges/sync.go` treats every non-`*acmeapi.Error` as terminal — it sets `ch.Status.State = Errored` and returns. Because `Errored` is final, the next reconcile sees `challengeFinished = true`, the controller stops processing the challenge, and the order is wedged in `pending` until an operator deletes the challenge by hand.

The non-ACME error bucket is too broad. A TLS handshake timeout on a nonce fetch, a DNS blip, a cancelled context — all get the same terminal treatment as a real protocol failure.

This PR carves out the transient cases:

- `context.Canceled` and `context.DeadlineExceeded` — pod restart, parent context cancellation, request timeouts.
- Anything implementing `net.Error`, matched broadly via `errors.As` so `url.Error`-wrapped network failures are caught too — TLS handshake timeouts, DNS failures, connection resets, dial errors.

For these, `handleError` returns the error without touching `Status.State`, leaving the workqueue to retry with backoff. Genuine ACME protocol errors (`*acmeapi.Error`) and other non-transient unknowns still go to `Errored` as before.

Tests cover all transient cases (`context.Canceled`, `context.DeadlineExceeded`, wrapped and unwrapped `net.Error`) plus the still-terminal generic-error path.

I'd been preparing this offline before noticing @onthebed's comments on the issue — happy to coordinate or hand off if they have something further along.

### Kind

/kind bug

### Release Note

```release-note
ACME challenges no longer terminally fail on transient network errors (TLS handshake timeouts, DNS failures, context cancellation) during nonce fetches and authorization waits. The challenge controller returns the error and lets the workqueue retry with backoff.
```

---

AI-assistance disclosure: code and tests were AI-drafted against my manually-verified root-cause direction. I own the design and the patch.