### PR TITLE
feat: Add `--acme-http01-solver-extra-labels` for propagating custom labels to ACME HTTP01 solver resources 

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -336,6 +336,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			HTTP01SolverImage:                 opts.ACMEHTTP01Config.SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 			HTTP01SolverNameservers: opts.ACMEHTTP01Config.SolverNameservers,
+			HTTP01SolverExtraLabels: opts.ACMEHTTP01Config.SolverExtraLabels,
 
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -136,7 +136,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 		"acme-http01-solver-extra-labels",
 		"A set of key=value pairs for additional labels to apply to dynamically-created "+
 			"ACME HTTP01 solver resources (pods, services, ingresses, or Gateway API HTTPRoutes). "+
-			"These labels can be overridden by per-Issuer "+
+			"The following ACME identity label keys are reserved and will be silently "+
+			"ignored: acme.cert-manager.io/http-domain, acme.cert-manager.io/http-token, "+
+			"acme.cert-manager.io/http01-solver. These labels can be overridden by per-Issuer "+
 			"podTemplate/ingressTemplate/GatewayHTTPRoute.Labels.")
 
 	fs.BoolVar(&c.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", c.ClusterIssuerAmbientCredentials, ""+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -132,6 +132,13 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 			"ACME HTTP01 check requests. This should be a list containing host and "+
 			"port, for example 8.8.8.8:53,8.8.4.4:53")
 
+	fs.Var(cliflag.NewMapStringString(&c.ACMEHTTP01Config.SolverExtraLabels),
+		"acme-http01-solver-extra-labels",
+		"A set of key=value pairs for additional labels to apply to dynamically-created "+
+			"ACME HTTP01 solver resources (pods, services, ingresses, or Gateway API HTTPRoutes). "+
+			"These labels can be overridden by per-Issuer "+
+			"podTemplate/ingressTemplate/GatewayHTTPRoute.Labels.")
+
 	fs.BoolVar(&c.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", c.ClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -112,7 +112,7 @@ If a component-specific nodeSelector is also set, it will be merged and take pre
 Labels to apply to all resources.  
 These labels are also applied to dynamically-created ACME HTTP01 solver resources  
 (pods, services, ingresses, or Gateway API HTTPRoutes).  
-For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.
+The following ACME identity label keys are reserved and will be silently ignored on dynamically-created resources: acme.cert-manager.io/http-domain, acme.cert-manager.io/http-token, acme.cert-manager.io/http01-solver. For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.
 #### **global.revisionHistoryLimit** ~ `number`
 
 The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -110,9 +110,9 @@ If a component-specific nodeSelector is also set, it will be merged and take pre
 > ```
 
 Labels to apply to all resources.  
-Please note that this does not add labels to the resources created dynamically by the controllers. For these resources, you have to add the labels in the template in the cert-manager custom resource: For example, podTemplate/ ingressTemplate in ACMEChallengeSolverHTTP01Ingress. For more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01Ingress).  
-For example, secretTemplate in CertificateSpec  
-For more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec).
+These labels are also applied to dynamically-created ACME HTTP01 solver resources  
+(pods, services, ingresses, or Gateway API HTTPRoutes).  
+For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.
 #### **global.revisionHistoryLimit** ~ `number`
 
 The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -132,6 +132,11 @@ spec:
           {{- if .Values.featureGates }}
           - --feature-gates={{ .Values.featureGates }}
           {{- end }}
+          {{- if .Values.global.commonLabels }}
+          {{- range $key, $value := .Values.global.commonLabels }}
+          - --acme-http01-solver-extra-labels={{ $key }}={{ $value }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ .Values.maxConcurrentChallenges }}
           {{- end }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -831,7 +831,7 @@
     },
     "helm-values.global.commonLabels": {
       "default": {},
-      "description": "Labels to apply to all resources.\nPlease note that this does not add labels to the resources created dynamically by the controllers. For these resources, you have to add the labels in the template in the cert-manager custom resource: For example, podTemplate/ ingressTemplate in ACMEChallengeSolverHTTP01Ingress. For more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01Ingress).\nFor example, secretTemplate in CertificateSpec\nFor more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec).",
+      "description": "Labels to apply to all resources.\nThese labels are also applied to dynamically-created ACME HTTP01 solver resources\n(pods, services, ingresses, or Gateway API HTTPRoutes).\nFor per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.",
       "type": "object"
     },
     "helm-values.global.hostUsers": {

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -831,7 +831,7 @@
     },
     "helm-values.global.commonLabels": {
       "default": {},
-      "description": "Labels to apply to all resources.\nThese labels are also applied to dynamically-created ACME HTTP01 solver resources\n(pods, services, ingresses, or Gateway API HTTPRoutes).\nFor per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.",
+      "description": "Labels to apply to all resources.\nThese labels are also applied to dynamically-created ACME HTTP01 solver resources\n(pods, services, ingresses, or Gateway API HTTPRoutes).\nThe following ACME identity label keys are reserved and will be silently ignored on dynamically-created resources: acme.cert-manager.io/http-domain, acme.cert-manager.io/http-token, acme.cert-manager.io/http01-solver. For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute solver labels field for Gateway API HTTPRoute resources.",
       "type": "object"
     },
     "helm-values.global.hostUsers": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -23,12 +23,11 @@ global:
   nodeSelector: {}
 
   # Labels to apply to all resources.
-  # Please note that this does not add labels to the resources created dynamically by the controllers.
-  # For these resources, you have to add the labels in the template in the cert-manager custom resource:
-  # For example, podTemplate/ ingressTemplate in ACMEChallengeSolverHTTP01Ingress
-  # For more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01Ingress).
-  # For example, secretTemplate in CertificateSpec
-  # For more information, see the [cert-manager documentation](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec).
+  # These labels are also applied to dynamically-created ACME HTTP01 solver resources
+  # (pods, services, ingresses, or Gateway API HTTPRoutes).
+  # For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and
+  # ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute
+  # solver labels field for Gateway API HTTPRoute resources.
   commonLabels: {}
 
   # The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -25,6 +25,9 @@ global:
   # Labels to apply to all resources.
   # These labels are also applied to dynamically-created ACME HTTP01 solver resources
   # (pods, services, ingresses, or Gateway API HTTPRoutes).
+  # The following ACME identity label keys are reserved and will be
+  # silently ignored on dynamically-created resources: acme.cert-manager.io/http-domain,
+  # acme.cert-manager.io/http-token, acme.cert-manager.io/http01-solver.
   # For per-Issuer-specific labels, use the HTTP01 ingress solver podTemplate and
   # ingressTemplate fields for pod/ingress resources, or the gatewayHTTPRoute
   # solver labels field for Gateway API HTTPRoute resources.

--- a/internal/apis/config/controller/fuzzer/fuzzer.go
+++ b/internal/apis/config/controller/fuzzer/fuzzer.go
@@ -111,6 +111,10 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []any {
 				s.ACMEHTTP01Config.SolverResourceLimitsMemory = "test-roundtrip"
 			}
 
+			if len(s.ACMEHTTP01Config.SolverExtraLabels) == 0 {
+				s.ACMEHTTP01Config.SolverExtraLabels = map[string]string{"test-roundtrip": "value"}
+			}
+
 			if s.ACMEDNS01Config.CheckRetryPeriod == time.Duration(0) {
 				s.ACMEDNS01Config.CheckRetryPeriod = time.Second * 8875
 			}

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -218,6 +218,11 @@ type ACMEHTTP01Config struct {
 	// port, for example ["8.8.8.8:53","8.8.4.4:53"]
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 	SolverNameservers []string
+
+	// Extra labels applied to all dynamically-created ACME HTTP01 solver
+	// resources (pods, services, ingresses, or Gateway API HTTPRoutes). Applied
+	// in addition to the standard ACME challenge identification labels.
+	SolverExtraLabels map[string]string
 }
 
 type ACMEDNS01Config struct {

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -222,6 +222,9 @@ type ACMEHTTP01Config struct {
 	// Extra labels applied to all dynamically-created ACME HTTP01 solver
 	// resources (pods, services, ingresses, or Gateway API HTTPRoutes). Applied
 	// in addition to the standard ACME challenge identification labels.
+	// The following ACME identity label keys are reserved and will be silently
+	// ignored: acme.cert-manager.io/http-domain, acme.cert-manager.io/http-token,
+	// acme.cert-manager.io/http01-solver.
 	SolverExtraLabels map[string]string
 }
 

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -154,6 +154,7 @@ func autoConvert_v1alpha1_ACMEHTTP01Config_To_controller_ACMEHTTP01Config(in *co
 		return err
 	}
 	out.SolverNameservers = *(*[]string)(unsafe.Pointer(&in.SolverNameservers))
+	out.SolverExtraLabels = *(*map[string]string)(unsafe.Pointer(&in.SolverExtraLabels))
 	return nil
 }
 
@@ -172,6 +173,7 @@ func autoConvert_controller_ACMEHTTP01Config_To_v1alpha1_ACMEHTTP01Config(in *co
 		return err
 	}
 	out.SolverNameservers = *(*[]string)(unsafe.Pointer(&in.SolverNameservers))
+	out.SolverExtraLabels = *(*map[string]string)(unsafe.Pointer(&in.SolverExtraLabels))
 	return nil
 }
 

--- a/internal/apis/config/controller/zz_generated.deepcopy.go
+++ b/internal/apis/config/controller/zz_generated.deepcopy.go
@@ -54,6 +54,13 @@ func (in *ACMEHTTP01Config) DeepCopyInto(out *ACMEHTTP01Config) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SolverExtraLabels != nil {
+		in, out := &in.SolverExtraLabels, &out.SolverExtraLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -221,9 +221,12 @@ type ACMEHTTP01Config struct {
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 	SolverNameservers []string `json:"solverNameservers,omitempty"`
 
-	// Additional labels applied to all dynamically-created ACME HTTP01 solver
-	// resources (pods, services, ingresses, or gateway HTTPRoutes). Applied in
-	// addition to the standard ACME challenge identification labels.
+	// Extra labels applied to all dynamically-created ACME HTTP01 solver
+	// resources (pods, services, ingresses, or Gateway API HTTPRoutes). Applied
+	// in addition to the standard ACME challenge identification labels.
+	// The following ACME identity label keys are reserved and will be silently
+	// ignored: acme.cert-manager.io/http-domain, acme.cert-manager.io/http-token,
+	// acme.cert-manager.io/http01-solver.
 	SolverExtraLabels map[string]string `json:"solverExtraLabels,omitempty"`
 }
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -220,6 +220,11 @@ type ACMEHTTP01Config struct {
 	// port, for example ["8.8.8.8:53","8.8.4.4:53"]
 	// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
 	SolverNameservers []string `json:"solverNameservers,omitempty"`
+
+	// Additional labels applied to all dynamically-created ACME HTTP01 solver
+	// resources (pods, services, ingresses, or gateway HTTPRoutes). Applied in
+	// addition to the standard ACME challenge identification labels.
+	SolverExtraLabels map[string]string `json:"solverExtraLabels,omitempty"`
 }
 
 type ACMEDNS01Config struct {

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -70,6 +70,13 @@ func (in *ACMEHTTP01Config) DeepCopyInto(out *ACMEHTTP01Config) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SolverExtraLabels != nil {
+		in, out := &in.SolverExtraLabels, &out.SolverExtraLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -201,6 +201,10 @@ type ACMEOptions struct {
 	// for ACME HTTP01 validations.
 	HTTP01SolverNameservers []string
 
+	// HTTP01SolverExtraLabels are additional labels to apply to ACME HTTP01
+	// solver resources.
+	HTTP01SolverExtraLabels map[string]string
+
 	// DNS01CheckAuthoritative is a flag for controlling if auth nss are used
 	// for checking propagation of an RR. This is the ideal scenario
 	DNS01CheckAuthoritative bool

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -92,6 +92,7 @@ func (s *Solver) getGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge) 
 
 func (s *Solver) createGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge, svcName string) (*gwapi.HTTPRoute, error) {
 	labels := podLabels(ch)
+	maps.Copy(labels, s.ACMEOptions.HTTP01SolverExtraLabels)
 	maps.Copy(labels, ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels)
 	httpRoute := &gwapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -114,6 +115,7 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 	expectedSpec := generateHTTPRouteSpec(ch, svcName)
 	actualSpec := httpRoute.Spec
 	expectedLabels := podLabels(ch)
+	maps.Copy(expectedLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
 	maps.Copy(expectedLabels, ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels)
 	actualLabels := httpRoute.Labels
 	if reflect.DeepEqual(expectedSpec, actualSpec) && reflect.DeepEqual(expectedLabels, actualLabels) {

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -92,7 +92,7 @@ func (s *Solver) getGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge) 
 
 func (s *Solver) createGatewayHTTPRoute(ctx context.Context, ch *cmacme.Challenge, svcName string) (*gwapi.HTTPRoute, error) {
 	labels := podLabels(ch)
-	maps.Copy(labels, s.ACMEOptions.HTTP01SolverExtraLabels)
+	maps.Copy(labels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 	maps.Copy(labels, ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels)
 	httpRoute := &gwapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -115,7 +115,7 @@ func (s *Solver) checkAndUpdateGatewayHTTPRoute(ctx context.Context, ch *cmacme.
 	expectedSpec := generateHTTPRouteSpec(ch, svcName)
 	actualSpec := httpRoute.Spec
 	expectedLabels := podLabels(ch)
-	maps.Copy(expectedLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
+	maps.Copy(expectedLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 	maps.Copy(expectedLabels, ch.Spec.Solver.HTTP01.GatewayHTTPRoute.Labels)
 	actualLabels := httpRoute.Labels
 	if reflect.DeepEqual(expectedSpec, actualSpec) && reflect.DeepEqual(expectedLabels, actualLabels) {

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -151,6 +151,40 @@ func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
 				}
 			},
 		},
+		"should include extra labels from HTTP01SolverExtraLabels": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+				}
+				httpRoute, err := s.Solver.createGatewayHTTPRoute(t.Context(), s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				// Verify extra labels are present on the created HTTPRoute
+				if httpRoute.Labels["custom-extra-label"] != "custom-extra-value" {
+					t.Errorf("expected HTTPRoute to have extra label 'custom-extra-label=custom-extra-value', but got %v", httpRoute.Labels)
+				}
+				s.testResources[createdHTTPRouteKey] = httpRoute
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				createdHTTPRoute := s.testResources[createdHTTPRouteKey].(*gwapi.HTTPRoute)
+				gotHttpRoute := args[0].(*gwapi.HTTPRoute)
+				if !reflect.DeepEqual(gotHttpRoute, createdHTTPRoute) {
+					t.Errorf("Expected %v to equal %v", gotHttpRoute, createdHTTPRoute)
+				}
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -151,7 +151,7 @@ func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
 				}
 			},
 		},
-		"should include extra labels from HTTP01SolverExtraLabels": {
+		"should apply extra labels from HTTP01SolverExtraLabels and filter ACME identity labels": {
 			Challenge: &cmacme.Challenge{
 				Spec: cmacme.ChallengeSpec{
 					DNSName: "example.com",
@@ -164,15 +164,12 @@ func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
 				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
-					"custom-extra-label": "custom-extra-value",
+					cmacme.DomainLabelKey: "badvalue",
+					"custom-extra-label":  "custom-extra-value",
 				}
 				httpRoute, err := s.Solver.createGatewayHTTPRoute(t.Context(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
-				}
-				// Verify extra labels are present on the created HTTPRoute
-				if httpRoute.Labels["custom-extra-label"] != "custom-extra-value" {
-					t.Errorf("expected HTTPRoute to have extra label 'custom-extra-label=custom-extra-value', but got %v", httpRoute.Labels)
 				}
 				s.testResources[createdHTTPRouteKey] = httpRoute
 				s.Builder.Sync()
@@ -180,6 +177,15 @@ func TestGetGatewayHTTPRouteForChallenge(t *testing.T) {
 			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
 				createdHTTPRoute := s.testResources[createdHTTPRouteKey].(*gwapi.HTTPRoute)
 				gotHttpRoute := args[0].(*gwapi.HTTPRoute)
+				// ACME identity label should not be overridden by extra labels
+				if gotHttpRoute.Labels[cmacme.DomainLabelKey] == "badvalue" {
+					t.Errorf("ACME identity label %s should not be overridden by extra labels, got %q",
+						cmacme.DomainLabelKey, gotHttpRoute.Labels[cmacme.DomainLabelKey])
+				}
+				// Non-ACME label should be present
+				if gotHttpRoute.Labels["custom-extra-label"] != "custom-extra-value" {
+					t.Errorf("expected HTTPRoute to have extra label 'custom-extra-label=custom-extra-value', but got %v", gotHttpRoute.Labels)
+				}
 				if !reflect.DeepEqual(gotHttpRoute, createdHTTPRoute) {
 					t.Errorf("Expected %v to equal %v", gotHttpRoute, createdHTTPRoute)
 				}

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -203,7 +203,7 @@ func (s *Solver) buildIngressResource(ch *cmacme.Challenge, svcName string) (*ne
 		},
 	}
 
-	maps.Copy(ing.Labels, s.ACMEOptions.HTTP01SolverExtraLabels)
+	maps.Copy(ing.Labels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 
 	return ing, nil
 }

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -130,7 +130,7 @@ func ingressServiceName(ing *networkingv1.Ingress) string {
 // createIngress will create a challenge solving ingress for the given certificate,
 // domain, token and key.
 func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
-	ing, err := buildIngressResource(ch, svcName)
+	ing, err := s.buildIngressResource(ch, svcName)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (s *Solver) createIngress(ctx context.Context, ch *cmacme.Challenge, svcNam
 	return s.Client.NetworkingV1().Ingresses(ch.Namespace).Create(ctx, ing, metav1.CreateOptions{})
 }
 
-func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
+func (s *Solver) buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.Ingress, error) {
 	http01IngressCfg, err := http01IngressCfgForChallenge(ch)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.I
 	if net.ParseIP(httpHost) != nil {
 		httpHost = ""
 	}
-	return &networkingv1.Ingress{
+	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName:    "cm-acme-http-solver-",
 			Namespace:       ch.Namespace,
@@ -201,7 +201,11 @@ func buildIngressResource(ch *cmacme.Challenge, svcName string) (*networkingv1.I
 				},
 			},
 		},
-	}, nil
+	}
+
+	maps.Copy(ing.Labels, s.ACMEOptions.HTTP01SolverExtraLabels)
+
+	return ing, nil
 }
 
 // Merge object meta from the ingress template. Fall back to default values.

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -630,7 +630,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
+				expectedIngress, err := s.Solver.buildIngressResource(s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -667,6 +667,101 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 
 				if diff := cmp.Diff(expectedIngress, resp); diff != "" {
 					t.Errorf("unexpected ingress generated from merge (-want +got):\n%s", diff)
+				}
+			},
+		},
+		"should include extra labels from HTTP01SolverExtraLabels": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+				}
+				expectedIngress, err := s.Solver.buildIngressResource(s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error building ingress: %v", err)
+				}
+				s.testResources[createdIngressKey] = expectedIngress
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				expectedIngress := s.testResources[createdIngressKey].(*networkingv1.Ingress)
+				resp, ok := args[0].(*networkingv1.Ingress)
+				if !ok {
+					t.Errorf("expected ingress to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				expectedIngress.APIVersion = resp.APIVersion
+				expectedIngress.Kind = resp.Kind
+				expectedIngress.OwnerReferences = resp.OwnerReferences
+				expectedIngress.ManagedFields = resp.ManagedFields
+				expectedIngress.Name = resp.Name
+				if diff := cmp.Diff(expectedIngress, resp); diff != "" {
+					t.Errorf("unexpected ingress generated (-want +got):\n%s", diff)
+				}
+			},
+		},
+		"should allow ingress template to override extra labels from HTTP01SolverExtraLabels": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+								IngressTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressTemplate{
+									ACMEChallengeSolverHTTP01IngressObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressObjectMeta{
+										Labels: map[string]string{
+											"custom-extra-label": "overridden-by-template",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+					"extra-only-label":   "extra-only-value",
+				}
+				expectedIngress, err := s.Solver.buildIngressResource(s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error building ingress: %v", err)
+				}
+				// Apply ingress template (same as createIngress does)
+				expectedIngress = s.Solver.mergeIngressObjectMetaWithIngressResourceTemplate(expectedIngress, s.Challenge.Spec.Solver.HTTP01.Ingress.IngressTemplate)
+				s.testResources[createdIngressKey] = expectedIngress
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				expectedIngress := s.testResources[createdIngressKey].(*networkingv1.Ingress)
+				resp, ok := args[0].(*networkingv1.Ingress)
+				if !ok {
+					t.Errorf("expected ingress to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				expectedIngress.APIVersion = resp.APIVersion
+				expectedIngress.Kind = resp.Kind
+				expectedIngress.OwnerReferences = resp.OwnerReferences
+				expectedIngress.ManagedFields = resp.ManagedFields
+				expectedIngress.Name = resp.Name
+				if diff := cmp.Diff(expectedIngress, resp); diff != "" {
+					t.Errorf("unexpected ingress generated (-want +got):\n%s", diff)
 				}
 			},
 		},
@@ -711,7 +806,7 @@ func TestOverrideNginxIngressWhitelistAnnotation(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedIngress, err := buildIngressResource(s.Challenge, "fakeservice")
+				expectedIngress, err := s.Solver.buildIngressResource(s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -670,7 +670,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 				}
 			},
 		},
-		"should include extra labels from HTTP01SolverExtraLabels": {
+		"should apply extra labels from HTTP01SolverExtraLabels and filter ACME identity labels": {
 			Challenge: &cmacme.Challenge{
 				Spec: cmacme.ChallengeSpec{
 					DNSName: "example.com",
@@ -685,7 +685,8 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
 				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
-					"custom-extra-label": "custom-extra-value",
+					cmacme.DomainLabelKey: "badvalue",
+					"custom-extra-label":  "custom-extra-value",
 				}
 				expectedIngress, err := s.Solver.buildIngressResource(s.Challenge, "fakeservice")
 				if err != nil {
@@ -701,6 +702,16 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 					t.Errorf("expected ingress to be returned, but got %v", args[0])
 					t.Fail()
 					return
+				}
+				// ACME identity label should not be overridden by extra labels
+				if resp.Labels[cmacme.DomainLabelKey] == "badvalue" {
+					t.Errorf("ACME identity label %s should not be overridden by extra labels, got %q",
+						cmacme.DomainLabelKey, resp.Labels[cmacme.DomainLabelKey])
+				}
+				// Non-ACME label should be present
+				if resp.Labels["custom-extra-label"] != "custom-extra-value" {
+					t.Errorf("expected non-ACME extra label %s=%s, got %q",
+						"custom-extra-label", "custom-extra-value", resp.Labels["custom-extra-label"])
 				}
 				expectedIngress.APIVersion = resp.APIVersion
 				expectedIngress.Kind = resp.Kind

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -48,6 +48,30 @@ func podLabels(ch *cmacme.Challenge) map[string]string {
 	}
 }
 
+// acmeIdentityLabelKeys defines the set of label keys reserved for ACME
+// challenge resource discovery. These cannot be overridden by global solver
+// extra labels.
+var acmeIdentityLabelKeys = map[string]bool{
+	cmacme.DomainLabelKey:               true,
+	cmacme.TokenLabelKey:                true,
+	cmacme.SolverIdentificationLabelKey: true,
+}
+
+// filterACMEIdentityLabels returns a copy of labels with ACME identity
+// labels removed. Does not mutate the input map.
+func filterACMEIdentityLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+	result := make(map[string]string, len(labels))
+	for key, val := range labels {
+		if !acmeIdentityLabelKeys[key] {
+			result[key] = val
+		}
+	}
+	return result
+}
+
 func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) error {
 	log := logf.FromContext(ctx).WithName("ensurePod")
 
@@ -173,7 +197,7 @@ func (s *Solver) buildPod(ch *cmacme.Challenge) *corev1.Pod {
 // https://github.com/cert-manager/cert-manager/blob/f1d7c432763100c3fb6eb6a1654d29060b479b3c/pkg/apis/acme/v1/types_issuer.go#L270
 func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	podLabels := podLabels(ch)
-	maps.Copy(podLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
+	maps.Copy(podLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -173,6 +173,7 @@ func (s *Solver) buildPod(ch *cmacme.Challenge) *corev1.Pod {
 // https://github.com/cert-manager/cert-manager/blob/f1d7c432763100c3fb6eb6a1654d29060b479b3c/pkg/apis/acme/v1/types_issuer.go#L270
 func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	podLabels := podLabels(ch)
+	maps.Copy(podLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -283,6 +283,7 @@ func TestGetPodsForChallenge(t *testing.T) {
 		chal           *cmacme.Challenge
 		wantedPodMetas []*metav1.PartialObjectMetadata
 		wantsErr       bool
+		extraLabels    map[string]string
 	}
 	var (
 		testNamespace = "foo"
@@ -323,8 +324,16 @@ func TestGetPodsForChallenge(t *testing.T) {
 			},
 			ObjectMeta: *pod.ObjectMeta.DeepCopy(),
 		}
+		podMetaWithExtraLabels = &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: *pod.ObjectMeta.DeepCopy(),
+		}
 	)
 	podMeta2.Labels[cmacme.DomainLabelKey] = "foo"
+	podMetaWithExtraLabels.Labels["custom-extra"] = "value"
 	tests := map[string]testT{
 		"should return one pod that matches": {
 			chal: chal,
@@ -339,6 +348,14 @@ func TestGetPodsForChallenge(t *testing.T) {
 				PartialMetadataObjects: []runtime.Object{&metav1.PartialObjectMetadata{}},
 			},
 		},
+		"should not be affected by extra labels on solver": {
+			chal: chal,
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{podMetaWithExtraLabels},
+			},
+			wantedPodMetas: []*metav1.PartialObjectMetadata{podMetaWithExtraLabels},
+			extraLabels:    map[string]string{"custom-extra": "value"},
+		},
 	}
 	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -347,6 +364,9 @@ func TestGetPodsForChallenge(t *testing.T) {
 			s := &Solver{
 				Context:   scenario.builder.Context,
 				podLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
+			}
+			if scenario.extraLabels != nil {
+				s.Context.ACMEOptions.HTTP01SolverExtraLabels = scenario.extraLabels
 			}
 			defer scenario.builder.Stop()
 			scenario.builder.Start()
@@ -702,6 +722,93 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("192Mi"),
 				}
 				validateContainerResources(t, container, expectedRequests, expectedLimits)
+			},
+		},
+		"should include extra labels from HTTP01SolverExtraLabels without pod template": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+				}
+				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
+				s.testResources[createdPodKey] = resultingPod
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				resultingPod := s.testResources[createdPodKey].(*corev1.Pod)
+				resp, ok := args[0].(*corev1.Pod)
+				if !ok {
+					t.Errorf("expected pod to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				resultingPod.OwnerReferences = resp.OwnerReferences
+				if resp.String() != resultingPod.String() {
+					t.Errorf("unexpected pod generated\nexp=%s\ngot=%s",
+						resultingPod, resp)
+					t.Fail()
+				}
+			},
+		},
+		"should allow pod template to override extra labels from HTTP01SolverExtraLabels": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+								PodTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressPodTemplate{
+									ACMEChallengeSolverHTTP01IngressPodObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressPodObjectMeta{
+										Labels: map[string]string{
+											"custom-extra-label": "overridden-by-template",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+					"extra-only-label":   "extra-only-value",
+				}
+				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
+				expectedLabels := podLabels(s.Challenge)
+				expectedLabels["custom-extra-label"] = "overridden-by-template"
+				expectedLabels["extra-only-label"] = "extra-only-value"
+				resultingPod.Labels = expectedLabels
+				s.testResources[createdPodKey] = resultingPod
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				resultingPod := s.testResources[createdPodKey].(*corev1.Pod)
+				resp, ok := args[0].(*corev1.Pod)
+				if !ok {
+					t.Errorf("expected pod to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				resultingPod.OwnerReferences = resp.OwnerReferences
+				if resp.String() != resultingPod.String() {
+					t.Errorf("unexpected pod generated\nexp=%s\ngot=%s",
+						resultingPod, resp)
+					t.Fail()
+				}
 			},
 		},
 		"should handle partial resources in podTemplate by merging with ACMEOptions values": {

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -33,6 +33,57 @@ import (
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 )
 
+func TestFilterACMEIdentityLabels(t *testing.T) {
+	tests := map[string]struct {
+		input    map[string]string
+		expected map[string]string
+	}{
+		"should filter out all ACME identity labels": {
+			input: map[string]string{
+				cmacme.DomainLabelKey:               "hash",
+				cmacme.TokenLabelKey:                "hash",
+				cmacme.SolverIdentificationLabelKey: "true",
+			},
+			expected: map[string]string{},
+		},
+		"should preserve non-ACME labels": {
+			input: map[string]string{
+				"custom-label": "custom-value",
+				"app":          "my-app",
+			},
+			expected: map[string]string{
+				"custom-label": "custom-value",
+				"app":          "my-app",
+			},
+		},
+		"should filter ACME identity labels while preserving non-ACME labels": {
+			input: map[string]string{
+				cmacme.DomainLabelKey:               "hash",
+				cmacme.TokenLabelKey:                "hash",
+				cmacme.SolverIdentificationLabelKey: "true",
+				"custom-label":                      "custom-value",
+			},
+			expected: map[string]string{
+				"custom-label": "custom-value",
+			},
+		},
+		"should handle nil input without panicking": {
+			input:    nil,
+			expected: nil,
+		},
+		"should handle empty map": {
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := filterACMEIdentityLabels(tt.input)
+			assert.Equal(t, tt.expected, got, "filterACMEIdentityLabels returned unexpected result")
+		})
+	}
+}
+
 func TestEnsurePod(t *testing.T) {
 	type testT struct {
 		builder     *testpkg.Builder
@@ -283,7 +334,6 @@ func TestGetPodsForChallenge(t *testing.T) {
 		chal           *cmacme.Challenge
 		wantedPodMetas []*metav1.PartialObjectMetadata
 		wantsErr       bool
-		extraLabels    map[string]string
 	}
 	var (
 		testNamespace = "foo"
@@ -354,7 +404,6 @@ func TestGetPodsForChallenge(t *testing.T) {
 				PartialMetadataObjects: []runtime.Object{podMetaWithExtraLabels},
 			},
 			wantedPodMetas: []*metav1.PartialObjectMetadata{podMetaWithExtraLabels},
-			extraLabels:    map[string]string{"custom-extra": "value"},
 		},
 	}
 	for name, scenario := range tests {
@@ -364,9 +413,6 @@ func TestGetPodsForChallenge(t *testing.T) {
 			s := &Solver{
 				Context:   scenario.builder.Context,
 				podLister: scenario.builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
-			}
-			if scenario.extraLabels != nil {
-				s.Context.ACMEOptions.HTTP01SolverExtraLabels = scenario.extraLabels
 			}
 			defer scenario.builder.Stop()
 			scenario.builder.Start()
@@ -724,7 +770,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 				validateContainerResources(t, container, expectedRequests, expectedLimits)
 			},
 		},
-		"should include extra labels from HTTP01SolverExtraLabels without pod template": {
+		"should apply extra labels from HTTP01SolverExtraLabels and filter ACME identity labels": {
 			Challenge: &cmacme.Challenge{
 				Spec: cmacme.ChallengeSpec{
 					DNSName: "example.com",
@@ -739,7 +785,8 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
 				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
-					"custom-extra-label": "custom-extra-value",
+					cmacme.DomainLabelKey: "badvalue",
+					"custom-extra-label":  "custom-extra-value",
 				}
 				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
 				s.testResources[createdPodKey] = resultingPod
@@ -752,6 +799,16 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 					t.Errorf("expected pod to be returned, but got %v", args[0])
 					t.Fail()
 					return
+				}
+				// ACME identity label should not be overridden by extra labels
+				if resp.Labels[cmacme.DomainLabelKey] == "badvalue" {
+					t.Errorf("ACME identity label %s should not be overridden by extra labels, got %q",
+						cmacme.DomainLabelKey, resp.Labels[cmacme.DomainLabelKey])
+				}
+				// Non-ACME label should be present
+				if resp.Labels["custom-extra-label"] != "custom-extra-value" {
+					t.Errorf("expected non-ACME extra label %s=%s, got %q",
+						"custom-extra-label", "custom-extra-value", resp.Labels["custom-extra-label"])
 				}
 				resultingPod.OwnerReferences = resp.OwnerReferences
 				if resp.String() != resultingPod.String() {

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -19,6 +19,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,20 +100,26 @@ func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challen
 // createService will create the service required to solve this challenge
 // in the target API server.
 func (s *Solver) createService(ctx context.Context, ch *cmacme.Challenge) (*corev1.Service, error) {
-	svc, err := buildService(ch)
+	svc, err := s.buildService(ch)
 	if err != nil {
 		return nil, err
 	}
 	return s.Client.CoreV1().Services(ch.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 }
 
-func buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
+func (s *Solver) buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
 	podLabels := podLabels(ch)
+
+	// Service labels get extra labels from ACME options; selector stays as pure podLabels
+	serviceLabels := make(map[string]string)
+	maps.Copy(serviceLabels, podLabels)
+	maps.Copy(serviceLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
+
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "cm-acme-http-solver-",
 			Namespace:    ch.Namespace,
-			Labels:       podLabels,
+			Labels:       serviceLabels,
 			Annotations: map[string]string{
 				"auth.istio.io/8089": "NONE",
 			},

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -113,7 +113,7 @@ func (s *Solver) buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
 	// Service labels get extra labels from ACME options; selector stays as pure podLabels
 	serviceLabels := make(map[string]string)
 	maps.Copy(serviceLabels, podLabels)
-	maps.Copy(serviceLabels, s.ACMEOptions.HTTP01SolverExtraLabels)
+	maps.Copy(serviceLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -243,3 +243,102 @@ func TestGetServicesForChallenge(t *testing.T) {
 
 	}
 }
+
+func TestBuildServiceExtraLabels(t *testing.T) {
+	const createdServiceKey = "createdService"
+	tests := map[string]solverFixture{
+		"should include extra labels from HTTP01SolverExtraLabels": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+				}
+				svc, err := s.Solver.buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("error building service: %v", err)
+				}
+				s.testResources[createdServiceKey] = svc
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				expectedSvc := s.testResources[createdServiceKey].(*corev1.Service)
+				resp, ok := args[0].(*corev1.Service)
+				if !ok {
+					t.Errorf("expected service to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				expectedSvc.OwnerReferences = resp.OwnerReferences
+				expectedSvc.Name = resp.Name
+				expectedSvc.ManagedFields = resp.ManagedFields
+				if resp.String() != expectedSvc.String() {
+					t.Errorf("unexpected service built\nexp=%s\ngot=%s",
+						expectedSvc, resp)
+					t.Fail()
+				}
+			},
+		},
+		"should not include extra labels in service selector": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "token",
+					Key:     "key",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
+					"custom-extra-label": "custom-extra-value",
+				}
+				svc, err := s.Solver.buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("error building service: %v", err)
+				}
+				// Selector should only contain ACME identity labels, NOT extra labels
+				expectedSelector := podLabels(s.Challenge)
+				if !assert.ObjectsAreEqual(expectedSelector, svc.Spec.Selector) {
+					t.Errorf("service selector should not include extra labels\nexp=%s\ngot=%s",
+						expectedSelector, svc.Spec.Selector)
+				}
+				s.testResources[createdServiceKey] = svc
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...any) {
+				resp, ok := args[0].(*corev1.Service)
+				if !ok {
+					t.Errorf("expected service to be returned, but got %v", args[0])
+					t.Fail()
+					return
+				}
+				expectedSelector := podLabels(s.Challenge)
+				if !assert.ObjectsAreEqual(expectedSelector, resp.Spec.Selector) {
+					t.Errorf("service selector should not include extra labels\nexp=%s\ngot=%s",
+						expectedSelector, resp.Spec.Selector)
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.createService(t.Context(), test.Challenge)
+			test.Finish(t, resp, err)
+		})
+	}
+}

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -247,7 +247,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 func TestBuildServiceExtraLabels(t *testing.T) {
 	const createdServiceKey = "createdService"
 	tests := map[string]solverFixture{
-		"should include extra labels from HTTP01SolverExtraLabels": {
+		"should apply extra labels from HTTP01SolverExtraLabels and filter ACME identity labels": {
 			Challenge: &cmacme.Challenge{
 				Spec: cmacme.ChallengeSpec{
 					DNSName: "example.com",
@@ -262,7 +262,8 @@ func TestBuildServiceExtraLabels(t *testing.T) {
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
 				s.Solver.Context.ACMEOptions.HTTP01SolverExtraLabels = map[string]string{
-					"custom-extra-label": "custom-extra-value",
+					cmacme.DomainLabelKey: "badvalue",
+					"custom-extra-label":  "custom-extra-value",
 				}
 				svc, err := s.Solver.buildService(s.Challenge)
 				if err != nil {
@@ -278,6 +279,16 @@ func TestBuildServiceExtraLabels(t *testing.T) {
 					t.Errorf("expected service to be returned, but got %v", args[0])
 					t.Fail()
 					return
+				}
+				// ACME identity label should not be overridden by extra labels
+				if resp.Labels[cmacme.DomainLabelKey] == "badvalue" {
+					t.Errorf("ACME identity label %s should not be overridden by extra labels, got %q",
+						cmacme.DomainLabelKey, resp.Labels[cmacme.DomainLabelKey])
+				}
+				// Non-ACME label should be present
+				if resp.Labels["custom-extra-label"] != "custom-extra-value" {
+					t.Errorf("expected non-ACME extra label %s=%s, got %q",
+						"custom-extra-label", "custom-extra-value", resp.Labels["custom-extra-label"])
 				}
 				expectedSvc.OwnerReferences = resp.OwnerReferences
 				expectedSvc.Name = resp.Name


### PR DESCRIPTION
### Pull Request Motivation

Closes https://github.com/cert-manager/cert-manager/issues/8200

The primary goal is to make common labels set through the Helm value [`global.commonLabels`](https://github.com/cert-manager/cert-manager/blob/d2b2b58944613cc17379eb9e6f186312b96fec4b/deploy/charts/cert-manager/README.template.md?plain=1#L106) also propagate to dynamically-created ACME HTTP01 solver resources (pods, services, ingresses, or Gateway API HTTPRoutes).

Previously, `global.commonLabels` only applied to Helm-managed resources (Deployments, RBAC, etc). Solver resources created at runtime by the controller had no way to receive these labels, which could cause admission webhooks (e.g., Kyverno, OPA) to reject them and block certificate issuance.

The existing per-Issuer `podTemplate`/`ingressTemplate` workaround is insufficient, it requires modifying every Issuer/ClusterIssuer, cannot be applied globally by platform teams, and does not cover services.

### Decisions being made

- A controller flag `--acme-http01-solver-extra-labels` accepts `key=value` pairs and applies them to all dynamically-created solver resources (pods, services, ingresses, HTTPRoutes). Helm automatically passes `global.commonLabels` through to this flag.
- Label precedence: global `--acme-http01-solver-extra-labels` < per-Issuer `PodTemplate`/`IngressTemplate`/`GatewayHTTPRoute.Labels`. Per-Issuer templates retain highest priority to maintain backward compatibility.
- Extra labels are added solely to `ObjectMeta.Labels`, never to service `spec.selector`. All pod/service/ingress lookup selectors continue to use only the [3 ACME identity labels](https://github.com/cert-manager/cert-manager/blob/d2b2b58944613cc17379eb9e6f186312b96fec4b/pkg/issuer/acme/http/pod.go#L45-L47) (`acme.cert-manager.io/http-domain`, `acme.cert-manager.io/http-token`, `acme.cert-manager.io/http01-solver`). This is additive and backward-compatible, avoiding selector pollution.
- The 3 ACME identity labels are defensively filtered out from extra labels to prevent accidental override, which would break HTTP-01 challenge discovery and traffic routing. _(I split it into a separate commit as it's negotiable)_

### E2E Verification

- [x] Verified global extra labels set via Helm value appear on resources created by the solver.
  ```
  helm install cert-manager cert-manager/cert-manager \
    --namespace cert-manager \
    --create-namespace \
    --set global.commonLabels.owner_team=platform

  # or values.yaml
  global:
    commonLabels:
      app.kubernetes.io/name: cert-manager
      owner_team: platform
      environment: production
  ```
  All solver pods, services, ingresses, and HTTPRoutes will have `owner_team=platform`.
- [x] Verified solver-level PodTemplate label or `gatewayHTTPRoute.labels` merge with global extra labels</summary>
  ```
  apiVersion: cert-manager.io/v1
  kind: Issuer
  metadata:
    name: letsencrypt-staging
  spec:
    acme:
      solvers:
      - http01:
          ingress:
            podTemplate:
              metadata:
                labels:
                  owner_team: billing  # overrides global owner_team
  ```
- [x] Verified ACME identity labels cannot be overridden on ingress/HTTPRoutes via extra labels
- [x] Verified Service `spec.selector` retains only ACME identity labels (extra labels on metadata only)

### Kind

/kind feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add new controller flag `--acme-http01-solver-extra-labels`, allowing Helm's `global.commonLabels` to propagate to all dynamically-created ACME HTTP01 solver resources (Pods, Services, Ingresses, or Gateway API HTTPRoutes).
```
