### PR TITLE
Allow ECC keys for ACME account and external account binding

### DIFF
--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -42,7 +42,7 @@ type NewClientOptions struct {
 	SkipTLSVerify bool
 	CABundle      []byte
 	Server        string
-	PrivateKey    *rsa.PrivateKey
+	PrivateKey    crypto.Signer
 }
 
 // NewClientFunc is a function type for building a new ACME client.

--- a/pkg/acme/accounts/registry.go
+++ b/pkg/acme/accounts/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -44,7 +44,7 @@ type Registry interface {
 
 	// IsKeyCheckSumCached checks if the private key checksum is cached with registered client.
 	// If not cached, the account is re-verified for the private key.
-	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 
 	Getter
 }
@@ -88,8 +88,6 @@ type stableOptions struct {
 	serverURL     string
 	skipVerifyTLS bool
 	issuerUID     string
-	publicKey     string
-	exponent      int
 	caBundle      string
 	keyChecksum   [sha256.Size]byte
 }
@@ -99,16 +97,13 @@ func (c stableOptions) equalTo(c2 stableOptions) bool {
 }
 
 func newStableOptions(uid string, options NewClientOptions) stableOptions {
-	// Encoding a big.Int cannot fail
-	publicNBytes, _ := options.PrivateKey.PublicKey.N.GobEncode()
-	checksum := sha256.Sum256(x509.MarshalPKCS1PrivateKey(options.PrivateKey))
+	keyBytes, _ := x509.MarshalPKCS8PrivateKey(options.PrivateKey)
+	checksum := sha256.Sum256(keyBytes)
 
 	return stableOptions{
 		serverURL:     options.Server,
 		skipVerifyTLS: options.SkipTLSVerify,
 		issuerUID:     uid,
-		publicKey:     string(publicNBytes),
-		exponent:      options.PrivateKey.PublicKey.E,
 		caBundle:      string(options.CABundle),
 		keyChecksum:   checksum,
 	}
@@ -197,12 +192,15 @@ func (r *registry) ListClients() map[string]acmecl.Interface {
 // IsKeyCheckSumCached returns true when there is no difference in private key checksum.
 // This can be used to identify if the private key has changed for the existing
 // registered client.
-func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
 	if privateKey != nil && lastPrivateKeyHash != "" {
-		privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return false
+		}
 		checksum := sha256.Sum256(privateKeyBytes)
 		checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 

--- a/pkg/acme/accounts/registry_test.go
+++ b/pkg/acme/accounts/registry_test.go
@@ -187,7 +187,10 @@ func TestRegistry_AddClient_UpdatesClientPKChecksum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkBytes := x509.MarshalPKCS1PrivateKey(pk)
+	pkBytes, err2 := x509.MarshalPKCS8PrivateKey(pk)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
 	pkChecksum := sha256.Sum256(pkBytes)
 	pkChecksumString := base64.StdEncoding.EncodeToString(pkChecksum[:])
 

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"crypto/rsa"
+	"crypto"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -31,7 +31,7 @@ type FakeRegistry struct {
 	RemoveClientFunc        func(uid string)
 	GetClientFunc           func(uid string) (acmecl.Interface, error)
 	ListClientsFunc         func() map[string]acmecl.Interface
-	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 }
 
 func (f *FakeRegistry) AddClient(uid string, options accounts.NewClientOptions) {
@@ -50,6 +50,6 @@ func (f *FakeRegistry) ListClients() map[string]acmecl.Interface {
 	return f.ListClientsFunc()
 }
 
-func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	return f.IsKeyCheckSumCachedFunc(lastPrivateKeyHash, privateKey)
 }

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -18,7 +18,7 @@ package acme
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -67,7 +67,6 @@ const (
 	messageInvalidPrivateKey             = "Account private key is invalid: "
 
 	messageTemplateUpdateToV2              = "Your ACME server URL is set to a v1 endpoint (%s). You should update the spec.acme.server field to %q"
-	messageTemplateNotRSA                  = "ACME private key in %q is not of type RSA"
 	messageTemplateFailedToParseURL        = "Failed to parse existing ACME server URI %q: %v"
 	messageTemplateFailedToParseAccountURL = "Failed to parse existing ACME account URI %q: %v"
 	messageTemplateFailedToGetEABKey       = "failed to get External Account Binding key from secret: %v"
@@ -176,19 +175,6 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			message: msg,
 		}
 	}
-	rsaPk, ok := pk.(*rsa.PrivateKey)
-	if !ok {
-		msg := fmt.Sprintf(messageTemplateNotRSA,
-			issuer.GetSpec().ACME.PrivateKey.Name)
-		return setupResult{
-			err: nil,
-
-			status:  cmmeta.ConditionFalse,
-			reason:  errorAccountVerificationFailed,
-			message: msg,
-		}
-	}
-
 	if warning := a.validateDNSSolvers(ctx, issuer); len(warning) > 0 {
 		return setupResult{
 			err:     nil,
@@ -198,7 +184,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		}
 	}
 
-	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, rsaPk)
+	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, pk)
 
 	// TODO: don't always clear the client cache.
 	//  In future we should intelligently manage items in the account cache
@@ -213,7 +199,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	// TODO: perform a complex check to determine whether we need to verify
@@ -275,7 +261,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 			CABundle:      issuer.GetSpec().ACME.CABundle,
 			Server:        issuer.GetSpec().ACME.Server,
-			PrivateKey:    rsaPk,
+			PrivateKey:    pk,
 		})
 
 		return setupResult{
@@ -423,7 +409,17 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 	}
 
 	log.V(logf.InfoLevel).Info("verified existing registration with ACME server")
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(rsaPk)
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		msg := fmt.Sprintf("failed to marshal account private key: %v", err)
+		return setupResult{
+			err: fmt.Errorf("%s", msg),
+
+			status:  cmmeta.ConditionFalse,
+			reason:  errorAccountVerificationFailed,
+			message: msg,
+		}
+	}
 	checksum := sha256.Sum256(privateKeyBytes)
 	checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 	issuer.GetStatus().ACMEStatus().URI = account.URI
@@ -434,7 +430,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	return setupResult{
@@ -539,7 +535,7 @@ func (a *Acme) getEABKey(ctx context.Context, ns string, eab cmmeta.SecretKeySel
 
 // createAccountPrivateKey will generate a new RSA private key, and create it
 // as a secret resource in the apiserver.
-func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (*rsa.PrivateKey, error) {
+func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (crypto.Signer, error) {
 	sel = acme.PrivateKeySelector(sel)
 	accountPrivKey, err := pki.GenerateRSAPrivateKey(pki.MinRSAKeySize)
 	if err != nil {

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -19,7 +19,6 @@ package acme
 import (
 	"context"
 	"crypto"
-	"crypto/rsa"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -133,7 +132,7 @@ func TestAcme_Setup(t *testing.T) {
 		// Error returned when creating ACME account key.
 		acmePrivKeySecretCreateErr error
 		// ACME account key created by createAccountPrivateKey.
-		acmePrivKey *rsa.PrivateKey
+		acmePrivKey crypto.Signer
 
 		eabSecret       *corev1.Secret
 		eabSecretGetErr error
@@ -190,7 +189,7 @@ func TestAcme_Setup(t *testing.T) {
 		"ACME private key secret does not exist, account key generation is enabled, key creation succeeds": {
 			issuer:      gen.IssuerFrom(baseIssuer),
 			kfsErr:      notFoundErr,
-			acmePrivKey: rsaPrivKey.(*rsa.PrivateKey),
+			acmePrivKey: rsaPrivKey,
 			expectedConditions: []cmapi.IssuerCondition{
 				*gen.IssuerConditionFrom(readyTrueCondition)},
 			removeClientShouldBeCalled: true,
@@ -216,14 +215,15 @@ func TestAcme_Setup(t *testing.T) {
 			},
 			wantsErr: true,
 		},
-		"ACME account's key is not an RSA key": {
+		"ACME account's key is an ECDSA key, registered successfully": {
 			issuer: gen.IssuerFrom(baseIssuer,
 				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
-			kfsKey: ecdsaPrivKey,
+			kfsKey:                     ecdsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
 			expectedConditions: []cmapi.IssuerCondition{
-				*gen.IssuerConditionFrom(readyFalseCondition,
-					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateNotRSA, issuerSecretKeyName))),
+				*gen.IssuerConditionFrom(readyTrueCondition),
 			},
 		},
 		"ACME server URL is an invalid URL": {
@@ -544,7 +544,7 @@ func TestAcme_Setup(t *testing.T) {
 				AddClientFunc: func(string, accounts.NewClientOptions) {
 					addClientWasCalled = true
 				},
-				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 					return true
 				},
 			}


### PR DESCRIPTION
## Summary

Fixes #8434

The ACME issuer setup code previously hardcoded `*rsa.PrivateKey` for account keys, rejecting ECDSA (and any non-RSA) keys with a "not of type RSA" error. This prevented users from reusing existing ACME accounts created with ECC keys using other tools.

This PR changes the account key handling throughout the ACME issuer stack to use `crypto.Signer` instead of `*rsa.PrivateKey`:

- `NewClientOptions.PrivateKey` changed from `*rsa.PrivateKey` to `crypto.Signer`
- `Registry.IsKeyCheckSumCached` changed from `*rsa.PrivateKey` to `crypto.Signer`
- Private key checksum computation switched from `x509.MarshalPKCS1PrivateKey` (RSA-only) to `x509.MarshalPKCS8PrivateKey` (works for all key types)
- Removed the RSA type assertion in `setup.go` that rejected non-RSA keys
- `createAccountPrivateKey` return type changed from `*rsa.PrivateKey` to `crypto.Signer` (still generates RSA by default for new accounts)

The upstream ACME client (`acmeapi.Client.Key`) already accepts `crypto.Signer` and supports RS256, ES256, ES384, and ES512. The `keyFromSecret` function also already returned `crypto.Signer`. The RSA restriction was only in the intermediate layers.

**Note on key checksum compatibility**: existing issuers with RSA keys will recompute their checksum on the next reconciliation using PKCS8 encoding instead of PKCS1. This causes a one-time re-verification with the ACME server but no functional change.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet` passes on all changed packages
- [x] `go test ./pkg/acme/accounts/...` passes (6 tests)
- [x] `go test ./pkg/issuer/acme/ -run TestAcme_Setup` passes (24 tests)
- [x] Updated test: ECDSA key now registers successfully instead of being rejected
- [ ] CI should run full e2e tests

```release-note
ACME issuer now accepts ECDSA (and other non-RSA) private keys for account registration, allowing reuse of existing ACME accounts created with ECC keys.
```