### PR TITLE
Add support for specifying CRLDistributionPoints on Certificate resources

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -106,6 +106,14 @@ spec:
                     Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
                     Cannot be set if the `literalSubject` field is set.
                   type: string
+                crlDistributionPoints:
+                  description: |-
+                    The CRL distribution points is an X.509 v3 certificate extension which identifies
+                    the location of the CRL from which the revocation of this certificate can be checked.
+                    If not set, certificates will be issued without distribution points set.
+                  items:
+                    type: string
+                  type: array
                 dnsNames:
                   description: Requested DNS subject alternative names.
                   items:

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -105,6 +105,14 @@ spec:
                   Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
                   Cannot be set if the `literalSubject` field is set.
                 type: string
+              crlDistributionPoints:
+                description: |-
+                  The CRL distribution points is an X.509 v3 certificate extension which identifies
+                  the location of the CRL from which the revocation of this certificate can be checked.
+                  If not set, certificates will be issued without distribution points set.
+                items:
+                  type: string
+                type: array
               dnsNames:
                 description: Requested DNS subject alternative names.
                 items:

--- a/hack/openapi_reports/client.txt
+++ b/hack/openapi_reports/client.txt
@@ -1,3 +1,4 @@
+API rule violation: list_type_missing,github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1,CertificateSpec,CRLDistributionPoints
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEChallengeSolver,DNS01
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEChallengeSolver,HTTP01
 API rule violation: names_match,github.com/cert-manager/cert-manager/pkg/apis/acme/v1,ACMEChallengeSolverDNS01,DigitalOcean

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -200,6 +200,12 @@ type CertificateSpec struct {
 	// resource lives in the same namespace as the Certificate resource.
 	SecretName string
 
+	// The CRL distribution points is an X.509 v3 certificate extension which identifies
+	// the location of the CRL from which the revocation of this certificate can be checked.
+	// If not set, certificates will be issued without distribution points set.
+	// +optional
+	CRLDistributionPoints []string `json:"crlDistributionPoints,omitempty"`
+
 	// Defines annotations and labels to be copied to the Certificate's Secret.
 	// Labels and annotations on the Secret will be changed as they appear on the
 	// SecretTemplate when added or removed. SecretTemplate annotations are added

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -947,6 +947,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *certmanag
 	out.OtherNames = *(*[]certmanager.OtherName)(unsafe.Pointer(&in.OtherNames))
 	out.EmailAddresses = *(*[]string)(unsafe.Pointer(&in.EmailAddresses))
 	out.SecretName = in.SecretName
+	out.CRLDistributionPoints = *(*[]string)(unsafe.Pointer(&in.CRLDistributionPoints))
 	out.SecretTemplate = (*certmanager.CertificateSecretTemplate)(unsafe.Pointer(in.SecretTemplate))
 	if in.Keystores != nil {
 		in, out := &in.Keystores, &out.Keystores
@@ -990,6 +991,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 	out.EmailAddresses = *(*[]string)(unsafe.Pointer(&in.EmailAddresses))
 	out.OtherNames = *(*[]certmanagerv1.OtherName)(unsafe.Pointer(&in.OtherNames))
 	out.SecretName = in.SecretName
+	out.CRLDistributionPoints = *(*[]string)(unsafe.Pointer(&in.CRLDistributionPoints))
 	out.SecretTemplate = (*certmanagerv1.CertificateSecretTemplate)(unsafe.Pointer(in.SecretTemplate))
 	if in.Keystores != nil {
 		in, out := &in.Keystores, &out.Keystores

--- a/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -495,6 +495,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = make([]OtherName, len(*in))
 		copy(*out, *in)
 	}
+	if in.CRLDistributionPoints != nil {
+		in, out := &in.CRLDistributionPoints, &out.CRLDistributionPoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SecretTemplate != nil {
 		in, out := &in.SecretTemplate, &out.SecretTemplate
 		*out = new(CertificateSecretTemplate)

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -3471,6 +3471,21 @@ func schema_pkg_apis_certmanager_v1_CertificateSpec(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"crlDistributionPoints": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"secretTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.",

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -245,6 +245,12 @@ type CertificateSpec struct {
 	// resource lives in the same namespace as the Certificate resource.
 	SecretName string `json:"secretName"`
 
+	// The CRL distribution points is an X.509 v3 certificate extension which identifies
+	// the location of the CRL from which the revocation of this certificate can be checked.
+	// If not set, certificates will be issued without distribution points set.
+	// +optional
+	CRLDistributionPoints []string `json:"crlDistributionPoints,omitempty"`
+
 	// Defines annotations and labels to be copied to the Certificate's Secret.
 	// Labels and annotations on the Secret will be changed as they appear on the
 	// SecretTemplate when added or removed. SecretTemplate annotations are added

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -495,6 +495,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CRLDistributionPoints != nil {
+		in, out := &in.CRLDistributionPoints, &out.CRLDistributionPoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SecretTemplate != nil {
 		in, out := &in.SecretTemplate, &out.SecretTemplate
 		*out = new(CertificateSecretTemplate)

--- a/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
@@ -122,6 +122,10 @@ type CertificateSpecApplyConfiguration struct {
 	// private key and certificate, signed by the denoted issuer. The Secret
 	// resource lives in the same namespace as the Certificate resource.
 	SecretName *string `json:"secretName,omitempty"`
+	// The CRL distribution points is an X.509 v3 certificate extension which identifies
+	// the location of the CRL from which the revocation of this certificate can be checked.
+	// If not set, certificates will be issued without distribution points set.
+	CRLDistributionPoints []string `json:"crlDistributionPoints,omitempty"`
 	// Defines annotations and labels to be copied to the Certificate's Secret.
 	// Labels and annotations on the Secret will be changed as they appear on the
 	// SecretTemplate when added or removed. SecretTemplate annotations are added
@@ -306,6 +310,16 @@ func (b *CertificateSpecApplyConfiguration) WithEmailAddresses(values ...string)
 // If called multiple times, the SecretName field is set to the value of the last call.
 func (b *CertificateSpecApplyConfiguration) WithSecretName(value string) *CertificateSpecApplyConfiguration {
 	b.SecretName = &value
+	return b
+}
+
+// WithCRLDistributionPoints adds the given value to the CRLDistributionPoints field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the CRLDistributionPoints field.
+func (b *CertificateSpecApplyConfiguration) WithCRLDistributionPoints(values ...string) *CertificateSpecApplyConfiguration {
+	for i := range values {
+		b.CRLDistributionPoints = append(b.CRLDistributionPoints, values[i])
+	}
 	return b
 }
 

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -1376,6 +1376,12 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: commonName
       type:
         scalar: string
+    - name: crlDistributionPoints
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
     - name: dnsNames
       type:
         list:

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -113,7 +113,12 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 		return nil, nil
 	}
 
-	template.CRLDistributionPoints = issuerObj.GetSpec().CA.CRLDistributionPoints
+	// Prefer CRL distribution points requested on the Certificate/CSR.
+	// Fall back to issuer-level CRL distribution points for backwards compatibility. 
+	if len(template.CRLDistributionPoints) == 0 {
+		template.CRLDistributionPoints = issuerObj.GetSpec().CA.CRLDistributionPoints
+	}
+	
 	template.OCSPServer = issuerObj.GetSpec().CA.OCSPServers
 	template.IssuingCertificateURL = issuerObj.GetSpec().CA.IssuingCertificateURLs
 

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -212,6 +212,15 @@ func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators 
 			template.UnknownExtKeyUsage = unknownUsages
 		}
 
+		if val.Id.Equal(OIDExtensionCRLDistributionPoints) {
+			crldp, err := UnmarshalCRLDistributionPoints(val.Value)
+			if err != nil {
+				return err
+			}
+
+			template.CRLDistributionPoints = crldp
+		}
+
 		// The SANs fields in the Certificate resource are not enough to
 		// represent the full set of SANs that can be encoded in a CSR.
 		// Therefore, we need to copy the SANs from the CSR into the

--- a/pkg/util/pki/certificatetemplate_test.go
+++ b/pkg/util/pki/certificatetemplate_test.go
@@ -46,6 +46,26 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 		}
 	}
 
+	crlDistributionPointsGenerator := func(t *testing.T, uris []string) pkix.Extension {
+		var distributionPoints []distributionPoint
+
+		for _, uri := range uris {
+			dp := distributionPoint{
+				DistributionPoint: distributionPointName{
+					FullName: []asn1.RawValue{{Tag: asn1.TagOID, Class: asn1.ClassContextSpecific, Bytes: []byte(uri)}},
+				},
+			}
+			distributionPoints = append(distributionPoints, dp)
+		}
+		val, _ := asn1.Marshal(distributionPoints)
+
+		return pkix.Extension{
+			Id:       OIDExtensionCRLDistributionPoints,
+			Critical: false,
+			Value:    val,
+		}
+	}
+
 	testCases := []struct {
 		name     string
 		csr      *x509.CertificateRequest
@@ -140,6 +160,23 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 					sansGenerator(t, []asn1.RawValue{
 						{Tag: 2, Class: 2, Bytes: []byte("test.example.com")},
 					}, true),
+				},
+			},
+		},
+		{
+			name: "should copy CRL Distribution Points",
+			csr: &x509.CertificateRequest{
+				ExtraExtensions: []pkix.Extension{
+					crlDistributionPointsGenerator(t, []string{
+						"http://crl1.example.com/ca1.crl",
+						"http://crl2.example.com/ca1.crl",
+					}),
+				},
+			},
+			expected: &x509.Certificate{
+				CRLDistributionPoints: []string{
+					"http://crl1.example.com/ca1.crl",
+					"http://crl2.example.com/ca1.crl",
 				},
 			},
 		},

--- a/pkg/util/pki/crldistributionpoints.go
+++ b/pkg/util/pki/crldistributionpoints.go
@@ -1,0 +1,101 @@
+package pki
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
+)
+
+// Copied from https://github.com/golang/go/blob/go1.24.4/src/crypto/x509/x509.go#L1375-L1396
+var (
+	OIDExtensionCRLDistributionPoints = []int{2, 5, 29, 31}
+)
+
+// Copied from https://github.com/golang/go/blob/go1.24.4/src/crypto/x509/x509.go#L1066-L1075
+type distributionPointName struct {
+	FullName     []asn1.RawValue  `asn1:"optional,tag:0"`
+	RelativeName pkix.RDNSequence `asn1:"optional,tag:1"`
+}
+
+type distributionPoint struct {
+	DistributionPoint distributionPointName `asn1:"optional,tag:0"`
+	Reason            asn1.BitString        `asn1:"optional,tag:1"`
+	CRLIssuer         asn1.RawValue         `asn1:"optional,tag:2"`
+}
+
+// Adapted from https://github.com/golang/go/blob/go1.24.4/src/crypto/x509/x509.go#L1375-L1396
+func MarshalCRLDistributionPoints(crlDistributionPoints []string) (pkix.Extension, error) {
+	ext := pkix.Extension{Id: OIDExtensionCRLDistributionPoints, Critical: false}
+	var crlDp []distributionPoint
+	for _, name := range crlDistributionPoints {
+		dp := distributionPoint{
+			DistributionPoint: distributionPointName{
+				FullName: []asn1.RawValue{
+					{Tag: asn1.TagOID, Class: asn1.ClassContextSpecific, Bytes: []byte(name)},
+				},
+			},
+		}
+		crlDp = append(crlDp, dp)
+	}
+
+	extValue, err := asn1.Marshal(crlDp)
+	ext.Value = extValue
+	if err != nil {
+		return ext, fmt.Errorf("failed to build CRLDistributionPoints: %w", err)
+	}
+	return ext, nil
+}
+
+// Adapted from https://github.com/golang/go/blob/go1.24.4/src/crypto/x509/parser.go#L705-L748
+func UnmarshalCRLDistributionPoints(value []byte) ([]string, error) {
+	// RFC 5280, 4.2.1.13
+
+	// CRLDistributionPoints ::= SEQUENCE SIZE (1..MAX) OF DistributionPoint
+	//
+	// DistributionPoint ::= SEQUENCE {
+	//     distributionPoint       [0]     DistributionPointName OPTIONAL,
+	//     reasons                 [1]     ReasonFlags OPTIONAL,
+	//     cRLIssuer               [2]     GeneralNames OPTIONAL }
+	//
+	// DistributionPointName ::= CHOICE {
+	//     fullName                [0]     GeneralNames,
+	//     nameRelativeToCRLIssuer [1]     RelativeDistinguishedName }
+	val := cryptobyte.String(value)
+	var crlDistributionPoints []string
+
+	if !val.ReadASN1(&val, cryptobyte_asn1.SEQUENCE) {
+		return crlDistributionPoints, errors.New("x509: invalid CRL distribution points")
+	}
+	for !val.Empty() {
+		var dpDER cryptobyte.String
+		if !val.ReadASN1(&dpDER, cryptobyte_asn1.SEQUENCE) {
+			return crlDistributionPoints, errors.New("x509: invalid CRL distribution point")
+		}
+		var dpNameDER cryptobyte.String
+		var dpNamePresent bool
+		if !dpDER.ReadOptionalASN1(&dpNameDER, &dpNamePresent, cryptobyte_asn1.Tag(0).Constructed().ContextSpecific()) {
+			return crlDistributionPoints, errors.New("x509: invalid CRL distribution point")
+		}
+		if !dpNamePresent {
+			continue
+		}
+		if !dpNameDER.ReadASN1(&dpNameDER, cryptobyte_asn1.Tag(0).Constructed().ContextSpecific()) {
+			return crlDistributionPoints, errors.New("x509: invalid CRL distribution point")
+		}
+		for !dpNameDER.Empty() {
+			if !dpNameDER.PeekASN1Tag(cryptobyte_asn1.Tag(6).ContextSpecific()) {
+				break
+			}
+			var uri cryptobyte.String
+			if !dpNameDER.ReadASN1(&uri, cryptobyte_asn1.Tag(6).ContextSpecific()) {
+				return crlDistributionPoints, errors.New("x509: invalid CRL distribution point")
+			}
+			crlDistributionPoints = append(crlDistributionPoints, string(uri))
+		}
+	}
+	return crlDistributionPoints, nil
+}

--- a/pkg/util/pki/crldistributionpoints_test.go
+++ b/pkg/util/pki/crldistributionpoints_test.go
@@ -1,0 +1,55 @@
+package pki
+
+import (
+	"crypto/x509/pkix"
+	"reflect"
+	"testing"
+)
+
+func TestMarshalAndUnmarshalCRLDistributionPoints(t *testing.T) {
+	type testCase struct {
+		Urls        []string
+		UrlsInBytes []byte
+	}
+	type testCases map[string]testCase
+
+	testcases := testCases{
+		"One simple url": {
+			Urls:        []string{"http://example.com"},
+			UrlsInBytes: []byte{48, 26, 48, 24, 160, 22, 160, 20, 134, 18, 104, 116, 116, 112, 58, 47, 47, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109},
+		},
+		"Two simple urls": {
+			Urls: []string{"http://cer1.example.com/crl1.pem", "http://cer1.example.com/crl2.pem"},
+			UrlsInBytes: []byte{48, 80, 48, 38, 160, 36, 160, 34, 134, 32, 104, 116, 116, 112, 58, 47, 47, 99, 101, 114, 49, 46, 101, 120, 97, 109,
+				112, 108, 101, 46, 99, 111, 109, 47, 99, 114, 108, 49, 46, 112, 101, 109, 48, 38, 160, 36, 160, 34, 134, 32, 104, 116, 116, 112,
+				58, 47, 47, 99, 101, 114, 49, 46, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 47, 99, 114, 108, 50, 46, 112, 101, 109,
+			},
+		},
+		"No urls": {
+			Urls:        []string{},
+			UrlsInBytes: []byte{48, 0},
+		},
+	}
+
+	for testName, tc := range testcases {
+		{
+			result, err := MarshalCRLDistributionPoints(tc.Urls)
+			if err != nil {
+				t.Errorf("test: %s MarshalCRLDistributionPoints returned an error: %v", testName, err)
+			}
+			if !reflect.DeepEqual(pkix.Extension{OIDExtensionCRLDistributionPoints, false, tc.UrlsInBytes}, result) {
+				t.Errorf("test: %s Expected bytes: %v, got: %v", testName, tc.UrlsInBytes, result)
+			}
+		}
+		{
+			newresutl, err := UnmarshalCRLDistributionPoints(tc.UrlsInBytes)
+			if err != nil {
+				t.Errorf("test: %s UnmarshalCRLDistributionPoints returned an error: %v", testName, err)
+			}
+
+			if len(tc.Urls)+len(newresutl) > 0 && !reflect.DeepEqual(tc.Urls, newresutl) {
+				t.Errorf("test: %s Expected urls: %v, got: %v", testName, tc.Urls, newresutl)
+			}
+		}
+	}
+}

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -279,6 +279,14 @@ func GenerateCSR(crt *v1.Certificate, optFuncs ...GenerateCSROption) (*x509.Cert
 		}
 	}
 
+	if len(crt.Spec.CRLDistributionPoints) > 0 {
+		crldp, err := MarshalCRLDistributionPoints(crt.Spec.CRLDistributionPoints)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal CRL Distribution Points: %w", err)
+		}
+		extraExtensions = append(extraExtensions, crldp)
+	}
+
 	// NOTE(@inteon): opts.EncodeBasicConstraintsInRequest is a temporary solution and will
 	// be removed/ replaced in a future release.
 	if opts.EncodeBasicConstraintsInRequest {

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -420,6 +420,26 @@ func TestGenerateCSR(t *testing.T) {
 		return asn1Subject
 	}
 
+	crlDistributionPointsGenerator := func(t *testing.T, uris []string) pkix.Extension {
+		var distributionPoints []distributionPoint
+
+		for _, uri := range uris {
+			dp := distributionPoint{
+				DistributionPoint: distributionPointName{
+					FullName: []asn1.RawValue{{Tag: asn1.TagOID, Class: asn1.ClassContextSpecific, Bytes: []byte(uri)}},
+				},
+			}
+			distributionPoints = append(distributionPoints, dp)
+		}
+		val, _ := asn1.Marshal(distributionPoints)
+
+		return pkix.Extension{
+			Id:       OIDExtensionCRLDistributionPoints,
+			Critical: false,
+			Value:    val,
+		}
+	}
+
 	tests := []struct {
 		name                                    string
 		crt                                     *cmapi.Certificate
@@ -852,6 +872,37 @@ func TestGenerateCSR(t *testing.T) {
 				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
 			},
 			nameConstraintsFeatureEnabled: true,
+		},
+		{
+			name: "Generate CSR from certificate with isCA is false and set CRL Destination Point",
+			crt: &cmapi.Certificate{Spec: cmapi.CertificateSpec{
+				CommonName:            "example.org",
+				IsCA:                  false,
+				CRLDistributionPoints: []string{"http://crl1.example.com/ca1.crl", "http://crl2.example.com/ca1.crl"},
+			}},
+			want: &x509.CertificateRequest{
+				Version:            0,
+				SignatureAlgorithm: x509.SHA256WithRSA,
+				PublicKeyAlgorithm: x509.RSA,
+				ExtraExtensions: []pkix.Extension{
+					{
+						Id:       OIDExtensionKeyUsage,
+						Value:    asn1DefaultKeyUsage,
+						Critical: true,
+					},
+					crlDistributionPointsGenerator(t, []string{
+						"http://crl1.example.com/ca1.crl",
+						"http://crl2.example.com/ca1.crl",
+					}),
+					{
+						Id:       OIDExtensionBasicConstraints,
+						Value:    basicConstraintsGenerator(t, false),
+						Critical: true,
+					},
+				},
+				RawSubject: subjectGenerator(t, pkix.Name{CommonName: "example.org"}),
+			},
+			basicConstraintsFeatureEnabled: true,
 		},
 	}
 

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -136,6 +136,48 @@ func (s *Suite) Define() {
 				requiredFeatures: []featureset.Feature{featureset.CommonNameFeature},
 			},
 			{
+				name: "should issue a certificate with CRLDistributionPoints",
+				certModifiers: []gen.CertificateModifier{
+					gen.SetCertificateDNSNames("test.example.com"),
+					gen.SetCertificateCRLDistributionPoints(
+						[]string{
+							"http://example.com/crl/test.crl",
+							"http://example.org/crl/test.crl",
+						}),
+				},
+				extraValidations: []certificates.ValidationFunc{
+					func(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+						crlDistributionPoints := []string {
+							"http://example.com/crl/test.crl",
+							"http://example.org/crl/test.crl",
+						}						
+						if !reflect.DeepEqual(certificate.Spec.CRLDistributionPoints, crlDistributionPoints) {
+							return fmt.Errorf(
+								"expected CRL distribution points in Сertificate: %v, got: %v",
+								crlDistributionPoints,
+								certificate.Spec.CRLDistributionPoints,
+							)
+						}
+						certBytes, ok := secret.Data[corev1.TLSCertKey]
+						if !ok {
+							return fmt.Errorf("no certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
+						}
+						pemBlock, _ := pem.Decode(certBytes)
+						cert, err := x509.ParseCertificate(pemBlock.Bytes)
+						Expect(err).ToNot(HaveOccurred())
+						if !reflect.DeepEqual(cert.CRLDistributionPoints, crlDistributionPoints) {
+							return fmt.Errorf(
+								"expected CRL distribution points in Secret: %v, got: %v",
+								crlDistributionPoints,
+								cert.CRLDistributionPoints,
+							)
+						}
+						return nil
+					},
+				},				
+				requiredFeatures: []featureset.Feature{featureset.OnlySAN},
+			},			
+			{
 				name: "should issue a certificate with a couple valid otherName SAN values set as well as an emailAddress",
 				certModifiers: []gen.CertificateModifier{
 					gen.SetCertificateOtherNames(

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -308,3 +308,9 @@ func SetCertificateKeystore(keystores *v1.CertificateKeystores) CertificateModif
 		crt.Spec.Keystores = keystores
 	}
 }
+
+func SetCertificateCRLDistributionPoints(crlDistributionPoints []string) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.CRLDistributionPoints = crlDistributionPoints
+	}
+}


### PR DESCRIPTION
### Pull Request Motivation

This PR adds support for specifying crlDistributionPoints on cert-manager.io/v1 Certificate resources.

cert-manager already supports configuring CRL Distribution Points at the CA issuer level via Issuer.spec.ca.crlDistributionPoints and ClusterIssuer.spec.ca.crlDistributionPoints. This change extends support to individual Certificate resources, allowing per-certificate CRL Distribution Point configuration.

The requested CRL Distribution Points are propagated into the generated CSR and preserved in the resulting X.509 certificate.

Related issue: #8767

### Kind

/kind feature

### Release Note

```release-note
Add support for specifying CRLDistributionPoints on Certificate resources.
```
