### PR TITLE
Document the conservative ACME challenge scheduler key

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/doc.go
+++ b/pkg/controller/acmechallenges/scheduler/doc.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scheduler selects which ACME Challenge resources may be marked
+// processing at a given time.
+//
+// The scheduler has two main jobs:
+//   - apply a coarse global concurrency limit; and
+//   - avoid running challenges that are likely to conflict with one another.
+//
+// It does not attempt to model CA-specific rate limits, tenant fairness, or
+// per-Issuer quotas. In particular, it does not prevent a large number of
+// independent challenges from monopolising the shared backlog. This package is
+// therefore best thought of as a simple back-pressure and conflict-avoidance
+// mechanism rather than a complete rate-limit or fairness controller.
+//
+// The conflict key is intentionally conservative: challenges with the same DNS
+// name and ACME challenge type are treated as conflicting even if their solver
+// backends differ. This is because cert-manager's self-check and the ACME
+// server validate externally visible targets, not cert-manager's internal
+// solver configuration.
+//
+// For example:
+//   - HTTP01 validation is still against the same hostname even if different
+//     ingress classes, named ingresses, or gateway routes are configured.
+//   - DNS01 validation is still against the same _acme-challenge name even if
+//     different DNS provider backends are configured.
+//
+// A single cert-manager instance performs self-checks from one network and DNS
+// viewpoint only. If two challenges for the same DNS name rely on different
+// externally visible paths, that instance will still generally observe only one
+// of them. As a result, differing solver backends do not reliably imply
+// independent ACME-visible validation paths, so the scheduler keeps the key
+// coarse by design.
+package scheduler

--- a/pkg/controller/acmechallenges/scheduler/doc.go
+++ b/pkg/controller/acmechallenges/scheduler/doc.go
@@ -27,6 +27,12 @@ limitations under the License.
 // therefore best thought of as a simple back-pressure and conflict-avoidance
 // mechanism rather than a complete rate-limit or fairness controller.
 //
+// For the same reason, this is not the right layer to enforce multi-tenant
+// isolation or ownership policy for DNS names. Deployments that need stronger
+// guarantees about who may request certificates for which names should rely on
+// admission, approval, policy, or deployment-level separation, rather than on
+// scheduler heuristics alone.
+//
 // The conflict key is intentionally conservative: challenges with the same DNS
 // name and ACME challenge type are treated as conflicting even if their solver
 // backends differ. This is because cert-manager's self-check and the ACME

--- a/pkg/controller/acmechallenges/scheduler/scheduler.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler.go
@@ -111,12 +111,14 @@ func (s *Scheduler) determineChallengeCandidates(allChallenges []*cmacme.Challen
 	// This is the list that we will be filtering/scheduling from
 	unfilteredCandidates := notProcessingChallenges(incomplete)
 
-	// Never process multiple challenges for the same domain and solver type
-	// at any one time
+	// Never process multiple challenges for the same DNS name and ACME
+	// challenge type at any one time. This is intentionally conservative:
+	// challenges that differ only by solver backend may still share the same
+	// externally visible validation target.
 	// In-place deduplication: https://github.com/golang/go/wiki/SliceTricks
 	dedupedCandidates := dedupeChallenges(unfilteredCandidates)
 
-	// If there are any already in-progress challenges for a domain and type,
+	// If there are any already in-progress challenges for a DNS name and type,
 	// filter them out.
 	candidates := filterChallenges(dedupedCandidates, func(ch *cmacme.Challenge) bool {
 		for _, inPCh := range inProgress {
@@ -174,9 +176,10 @@ func filterChallenges(chs []*cmacme.Challenge, fn func(ch *cmacme.Challenge) boo
 	return ret
 }
 
-// compareChallenges is used to compare two challenge resources.
-// If two resources are 'equal', they will not be scheduled at the same time
-// as they could cause a conflict.
+// compareChallenges compares two challenge resources for scheduling purposes.
+// If two challenges compare equal, they are treated as sharing the same
+// externally visible ACME validation target and will not be scheduled at the
+// same time.
 func compareChallenges(l, r *cmacme.Challenge) int {
 	if l.Spec.DNSName < r.Spec.DNSName {
 		return -1
@@ -192,12 +195,22 @@ func compareChallenges(l, r *cmacme.Challenge) int {
 		return 1
 	}
 
-	// TODO: check the http01.ingressClass attribute and allow two challenges
-	// with different ingress classes specified to be scheduled at once
-
-	// TODO: check the dns01.provider attribute and allow two challenges with
-	// different providers to be scheduled at once
-
+	// Intentionally treat challenges for the same DNS name and challenge type
+	// as conflicting, regardless of the configured solver backend.
+	//
+	// This scheduler key is based on the externally observable ACME validation
+	// target, not on cert-manager's internal solver configuration:
+	//
+	//   - HTTP01 validation is performed against the same hostname, even if
+	//     different ingress classes, named ingresses, or gateway routes are
+	//     configured.
+	//   - DNS01 validation is performed against the same _acme-challenge DNS
+	//     name, even if different DNS provider backends are configured.
+	//
+	// Different solver backends do not reliably imply independent validation
+	// paths from the perspective of cert-manager's self-check or the ACME
+	// server. Keeping the scheduling key coarse avoids making topology-specific
+	// assumptions that are not generally valid.
 	return 0
 }
 


### PR DESCRIPTION
## What this PR does

Removes outdated TODO comments in the ACME challenge scheduler and replaces them with documentation explaining why the scheduling key is intentionally conservative.

Related to #8643.

The scheduler currently treats challenges with the same DNS name and challenge type as conflicting, regardless of solver backend. This PR documents the reasoning: different ingress classes, gateways, or DNS providers do not reliably imply independent ACME-visible validation paths.

Related website documentation update: cert-manager/website#2097.

## Why

After revisiting the original TODOs, we concluded that the scheduler key should reflect the externally observable validation target, not cert-manager's internal solver configuration:

- HTTP01 validation is against the same hostname
- DNS01 validation is against the same `_acme-challenge` name

Keeping the key coarse avoids making topology-specific assumptions that are not generally valid.

## Release note

```release-note
NONE
```
