### PR TITLE
proposal| add proposal for static metric labels

### DIFF
--- a/design/20260511.metric-labels.md
+++ b/design/20260511.metric-labels.md
@@ -1,0 +1,206 @@
+# Proposal: Metric Labels Configuration
+
+**Author(s):** Nikola
+
+**Status:** Draft **Date:** 2026-05-11
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposed API](#proposed-api)
+  - [Configuration Format](#configuration-format)
+  - [Internal Data Structure](#internal-data-structure)
+- [Controller Logic](#controller-logic)
+- [Metrics Integration](#metrics-integration)
+- [Examples](#examples)
+- [Validation and Error Handling](#validation-and-error-handling)
+
+---
+
+## Summary
+
+Add a configuration option to allow cert-manager operators to attach custom
+labels to certificate metrics exposed by the `CertificateCollector`. This enables
+finer-grained metrics filtering and alerting in monitoring systems like Prometheus.
+
+The configuration format follows the pattern: `metric_name:label=value`
+
+---
+
+## Motivation
+
+Currently, certificate metrics exposed by cert-manager include fixed labels
+(`name`, `namespace`, `issuer_name`, `issuer_kind`, `issuer_group`). Users often
+need to filter or aggregate metrics based on additional criteria such as:
+
+- Environment (dev/staging/prod)
+- Team ownership
+- Application type
+- Cost center
+
+Without the ability to add custom labels, users must rely on complex PromQL
+queries or external metric relabeling tools.
+
+---
+
+### Goals
+
+- Allow operators to configure custom labels for certificate metrics via CLI flag
+- Maintain backward compatibility (default behavior unchanged if no labels configured)
+- Provide a simple, intuitive configuration format
+- Ensure validation of configuration at startup
+- Support multiple labels per metric and multiple metrics
+
+### Non-Goals
+
+- Add per-Certificate resource labels (this would require CRD changes)
+- Support dynamic label updates without controller restart
+- Add admission webhooks or runtime validation beyond startup checks
+
+---
+
+## Proposed API
+
+### Configuration Format
+
+The configuration is provided via the `--metric-labels` CLI flag, supporting multiple
+entries separated by commas:
+
+```
+--metric-labels=certmanager_certificate_ready_status:environment=production,certmanager_certificate_expiration_timestamp_seconds:team=platform
+```
+
+### Internal Data Structure
+
+Internally, labels are stored as a nested map:
+
+```go
+type MetricLabels map[string]map[string]string
+
+// Example:
+// {
+//     "certmanager_certificate_ready_status": {
+//         "environment": "production",
+//         "team": "platform"
+//     },
+//     "certmanager_certificate_expiration_timestamp_seconds": {
+//         "environment": "production"
+//     }
+// }
+```
+
+The outer key is the metric name, and the inner map contains label key-value pairs.
+
+---
+
+## Controller Logic
+
+### Configuration Parsing
+
+1. Parse the CLI flag value as a comma-separated list of `metric_name:label=value` entries
+2. Validate each entry:
+   - Must match `metric_name:label_key=label_value` format
+   - Maximum of 10 labels per metric
+   - No duplicate label keys for the same metric
+   - Label key must contain only alphanumeric characters and underscores
+   - Label value must not be empty
+   - Label key must not conflict with existing metric labels (`name`, `namespace`, `issuer_name`, `issuer_kind`, `issuer_group`)
+   - Metric name must match an existing certificate metric
+3. Build the internal `MetricLabels` data structure
+4. Pass configuration to `CertificateCollector`
+
+### CertificateCollector Changes
+
+The `CertificateCollector` struct will be updated to store custom labels:
+
+```go
+type CertificateCollector struct {
+    certificatesLister                    cmlisters.CertificateLister
+    customLabels                          map[string]map[string]string
+    certificateReadyStatusMetric          *prometheus.Desc
+    // ... existing fields
+}
+```
+
+When emitting metrics, the collector will append custom label values to the
+Prometheus metric descriptor and include them in metric emissions.
+
+---
+
+## Metrics Integration
+
+The following certificate metrics will support custom labels:
+
+| Metric Name | Description |
+|-------------|-------------|
+| `certmanager_certificate_ready_status` | Ready status of the certificate |
+| `certmanager_certificate_not_after_timestamp_seconds` | Timestamp after which cert is invalid |
+| `certmanager_certificate_not_before_timestamp_seconds` | Timestamp before which cert is invalid |
+| `certmanager_certificate_expiration_timestamp_seconds` | Certificate expiration timestamp |
+| `certmanager_certificate_renewal_timestamp_seconds` | Certificate renewal timestamp |
+
+For each metric, custom labels are appended to the existing fixed labels
+(`name`, `namespace`, `issuer_name`, `issuer_kind`, `issuer_group`).
+
+---
+
+## Examples
+
+### Example 1: Single label on single metric
+
+```bash
+--metric-labels=certmanager_certificate_expiration_timestamp_seconds:environment=production
+```
+
+Resulting metric:
+```
+certmanager_certificate_expiration_timestamp_seconds{name="my-cert",namespace="default",issuer_name="ca-issuer",issuer_kind="Issuer",issuer_group="cert-manager.io",environment="production"}
+```
+
+### Example 2: Multiple labels on multiple metrics
+
+```bash
+--metric-labels=certmanager_certificate_ready_status:environment=prod,certmanager_certificate_ready_status:team=platform,certmanager_certificate_expiration_timestamp_seconds:environment=prod
+```
+
+Resulting metrics:
+```
+certmanager_certificate_ready_status{name="my-cert",namespace="default",issuer_name="ca-issuer",issuer_kind="Issuer",issuer_group="cert-manager.io",environment="prod",team="platform"}
+certmanager_certificate_expiration_timestamp_seconds{name="my-cert",namespace="default",issuer_name="ca-issuer",issuer_kind="Issuer",issuer_group="cert-manager.io",environment="prod"}
+```
+
+### Example 3: Empty (no custom labels)
+
+```bash
+# No --metric-labels flag provided
+```
+
+Resulting metrics remain unchanged with their default labels only.
+
+---
+
+## Validation and Error Handling
+
+### Startup Validation
+
+The controller validates the `--metric-labels` configuration at startup and fails with a clear error if any of the following conditions are violated:
+
+- **Invalid format**: Each entry must match `metric_name:label_key=label_value`
+- **Maximum labels per metric**: Each metric can have at most 10 custom labels
+- **Duplicate label keys**: A metric cannot have duplicate label keys
+- **Valid label name**: Label keys must contain only alphanumeric characters and underscores
+- **Non-empty value**: Label values must not be empty
+- **No conflict with fixed labels**: Custom label keys cannot conflict with existing metric labels (`name`, `namespace`, `issuer_name`, `issuer_kind`, `issuer_group`)
+- **Known metric**: Metric name must match an existing certificate metric
+
+### Error Messages
+
+```
+metric-labels: too many labels (maximum 10 per metric): 'certmanager_certificate_ready_status' has 15 labels
+metric-labels: duplicate label key 'environment' for metric 'certmanager_certificate_ready_status'
+metric-labels: invalid label key 'invalid-key': must contain only alphanumeric characters and underscores
+metric-labels: empty label value for label 'environment' in metric 'certmanager_certificate_ready_status'
+metric-labels: label 'name' conflicts with existing metric label for 'certmanager_certificate_ready_status'
+metric-labels: unknown metric 'certmanager_unknown_metric'
+```


### PR DESCRIPTION
### Pull Request Motivation

Currently, certificate metrics exposed by cert-manager include fixed labels (name, namespace, issuer_name, issuer_kind, issuer_group). Users often need to filter or aggregate metrics based on additional criteria such as:

* Environment (dev/staging/prod)
* Team ownership
* Application type
* Cost center

/kind design
Issue: https://github.com/cert-manager/cert-manager/issues/8499


### Release Note

```release-note
NONE
```
