### PR TITLE
fix(vault): support cross-signed intermediate CAs

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -869,7 +869,15 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 			vbundle.Certificate,
 		), "\n")))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse certificate chain from vault: %w", err)
+		// Vault may return a cross-signed intermediate CA signed by multiple root CAs.
+		// The parser requires a single linear chain and fails in that case.
+		// Fall back to using the raw Vault data directly.
+		chainPEM := strings.Join(append([]string{vbundle.Certificate}, vbundle.CAChain...), "\n")
+		caPEM := vbundle.IssuingCA
+		if caPEM == "" && len(vbundle.CAChain) > 0 {
+			caPEM = vbundle.CAChain[0]
+		}
+		return []byte(chainPEM), []byte(caPEM), nil
 	}
 
 	return bundle.ChainPEM, bundle.CAPEM, nil

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 	"io"
@@ -414,6 +415,64 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 		if test.expectedCA != string(ca) {
 			t.Errorf("%s: unexpected root certificate, exp=%q, got=%q", name, test.expectedCA, cert)
 		}
+	}
+}
+
+func TestExtractCertificatesFromVaultCertificateSecret_CrossSigned(t *testing.T) {
+	// generate two root CAs and a cross-signed intermediate
+	rootAKey, _ := pki.GenerateECPrivateKey(256)
+	rootBKey, _ := pki.GenerateECPrivateKey(256)
+	intKey, _ := pki.GenerateECPrivateKey(256)
+
+	rootATemplate := &x509.Certificate{
+		BasicConstraintsValid: true, IsCA: true,
+		Subject:   pkix.Name{CommonName: "rootA"},
+		NotBefore: time.Now(), NotAfter: time.Now().Add(time.Minute),
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+	rootBTemplate := &x509.Certificate{
+		BasicConstraintsValid: true, IsCA: true,
+		Subject:   pkix.Name{CommonName: "rootB"},
+		NotBefore: time.Now(), NotAfter: time.Now().Add(time.Minute),
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+	intTemplate := &x509.Certificate{
+		BasicConstraintsValid: true, IsCA: true,
+		Subject:   pkix.Name{CommonName: "intermediate"},
+		NotBefore: time.Now(), NotAfter: time.Now().Add(time.Minute),
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+
+	rootAPEM, rootACert, _ := pki.SignCertificate(rootATemplate, rootATemplate, rootAKey.Public(), rootAKey)
+	rootBPEM, rootBCert, _ := pki.SignCertificate(rootBTemplate, rootBTemplate, rootBKey.Public(), rootBKey)
+	intByAPEM, intACert, _ := pki.SignCertificate(intTemplate, rootACert, intKey.Public(), rootAKey)
+	intByBPEM, _, _ := pki.SignCertificate(intTemplate, rootBCert, intKey.Public(), rootBKey)
+	leafPEM, _, _ := pki.SignCertificate(&x509.Certificate{
+		Subject:   pkix.Name{CommonName: "leaf"},
+		NotBefore: time.Now(), NotAfter: time.Now().Add(time.Minute),
+	}, intACert, intKey.Public(), intKey)
+
+	// build the secret as Vault would return it for a cross-signed intermediate
+	secret := &certutil.Secret{
+		Data: map[string]any{
+			"certificate": string(leafPEM),
+			"issuing_ca":  string(intByAPEM),
+			"ca_chain":    []string{string(intByAPEM), string(intByBPEM), string(rootAPEM), string(rootBPEM)},
+		},
+	}
+
+	cert, ca, err := extractCertificatesFromVaultCertificateSecret(secret)
+	t.Logf("cert=%q", string(cert))
+	t.Logf("ca=%q", string(ca))
+
+	if err != nil {
+		t.Fatalf("expected no error for cross-signed intermediate, got: %s", err)
+	}
+	if len(cert) == 0 {
+		t.Error("expected non-empty cert chain")
+	}
+	if strings.TrimSpace(string(ca)) != strings.TrimSpace(string(intByAPEM)) {
+		t.Errorf("unexpected CA: expected issuing_ca, got %q", ca)
 	}
 }
 

--- a/pkg/util/pki/parse_certificate_chain_test.go
+++ b/pkg/util/pki/parse_certificate_chain_test.go
@@ -82,6 +82,24 @@ func joinPEM(first []byte, rest ...[]byte) []byte {
 	return first
 }
 
+func mustCrossSign(t *testing.T, original *testBundle, newIssuer *testBundle) *testBundle {
+	template := &x509.Certificate{
+		BasicConstraintsValid: true,
+		PublicKeyAlgorithm:    x509.ECDSA,
+		PublicKey:             original.pk.(crypto.Signer).Public(),
+		IsCA:                  true,
+		Subject:               original.cert.Subject,
+		NotBefore:             original.cert.NotBefore,
+		NotAfter:              original.cert.NotAfter,
+		KeyUsage:              original.cert.KeyUsage,
+	}
+	pem, cert, err := SignCertificate(template, newIssuer.cert, original.pk.(crypto.Signer).Public(), newIssuer.pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testBundle{pem: pem, cert: cert, pk: original.pk}
+}
+
 func TestParseSingleCertificateChainPEM(t *testing.T) {
 	root := mustCreateBundle(t, nil, "root")
 	intA1 := mustCreateBundle(t, root, "intA-1")
@@ -91,6 +109,10 @@ func TestParseSingleCertificateChainPEM(t *testing.T) {
 	leaf := mustCreateBundle(t, intA2, "leaf")
 	leafInterCN := mustCreateBundle(t, intA2, intA2.cert.Subject.CommonName)
 	random := mustCreateBundle(t, nil, "random")
+	rootA := mustCreateBundle(t, nil, "rootA")
+	rootB := mustCreateBundle(t, nil, "rootB")
+	intSignedByA := mustCreateBundle(t, rootA, "cross-intermediate")
+	intSignedByB := mustCrossSign(t, intSignedByA, rootB)
 
 	var bigCertBundle PEMBundle
 	{
@@ -225,6 +247,12 @@ func TestParseSingleCertificateChainPEM(t *testing.T) {
 			expPEMBundle: PEMBundle{},
 			expErr:       true,
 			expErrString: "provided PEM data was larger than the maximum 95000B",
+		},
+		"cross-signed intermediate currently fails": {
+			inputBundle:  joinPEM(intSignedByA.pem, intSignedByB.pem, rootA.pem, rootB.pem),
+			expPEMBundle: PEMBundle{},
+			expErr:       true,
+			expErrString: "certificate chain is malformed or broken",
 		},
 	}
 


### PR DESCRIPTION
### Pull Request Motivation

When Vault issues a cross-signed intermediate CA (an intermediate certificate
signed by multiple root CAs simultaneously), cert-manager failed with
`certificate chain is malformed or broken`. This is because the chain parser
requires a single linear chain, but cross-signing creates a branching graph.

Cross-signing is the recommended approach for root CA rotation in Vault PKI:
https://developer.hashicorp.com/vault/docs/secrets/pki/rotation-primitives

Fix: fall back to using raw Vault certificate data when the chain cannot be
linearized, so cross-signed intermediates pass through correctly.

Fixes #7645

### Kind

/kind bug

### Release Note

```release-note
Fix cert-manager failing with cross-signed intermediate CAs issued by Vault PKI
