### PR TITLE
Support `runtimeClassName`

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -335,8 +335,9 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			ACMEHTTP01SolverRunAsNonRoot:      ACMEHTTP01SolverRunAsNonRoot,
 			HTTP01SolverImage:                 opts.ACMEHTTP01Config.SolverImage,
 			// Allows specifying a list of custom nameservers to perform HTTP01 checks on.
-			HTTP01SolverNameservers: opts.ACMEHTTP01Config.SolverNameservers,
-			HTTP01SolverExtraLabels: opts.ACMEHTTP01Config.SolverExtraLabels,
+			HTTP01SolverNameservers:      opts.ACMEHTTP01Config.SolverNameservers,
+			HTTP01SolverExtraLabels:      opts.ACMEHTTP01Config.SolverExtraLabels,
+			HTTP01SolverRuntimeClassName: opts.ACMEHTTP01Config.SolverRuntimeClassName,
 
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -141,6 +141,7 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 			"acme.cert-manager.io/http01-solver. These labels can be overridden by per-Issuer "+
 			"podTemplate/ingressTemplate/GatewayHTTPRoute.Labels.")
 
+	fs.StringVar(&c.ACMEHTTP01Config.SolverRuntimeClassName, "acme-http01-solver-runtimeclassname", c.ACMEHTTP01Config.SolverRuntimeClassName, "RuntimeClassName to apply to pod")
 	fs.BoolVar(&c.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", c.ClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -141,7 +141,7 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 			"acme.cert-manager.io/http01-solver. These labels can be overridden by per-Issuer "+
 			"podTemplate/ingressTemplate/GatewayHTTPRoute.Labels.")
 
-	fs.StringVar(&c.ACMEHTTP01Config.SolverRuntimeClassName, "acme-http01-solver-runtimeclassname", c.ACMEHTTP01Config.SolverRuntimeClassName, "RuntimeClassName to apply to pod")
+	fs.StringVar(&c.ACMEHTTP01Config.SolverRuntimeClassName, "acme-http01-solver-runtime-class-name", c.ACMEHTTP01Config.SolverRuntimeClassName, "RuntimeClassName to apply to ACME HTTP01 solver pods")
 	fs.BoolVar(&c.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", c.ClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -192,6 +192,20 @@ The interval between attempts by the acting master to renew a leadership slot be
 
 The duration the clients should wait between attempting acquisition and renewal of a leadership.
 
+#### **global.runtimeClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
+  
+For example:
+
+```yaml
+runtimeClassName: gvisor
+```
+
 #### **installCRDs** ~ `bool`
 > Default value:
 > ```yaml
@@ -764,6 +778,10 @@ affinity:
          - master
 ```
 #### **runtimeClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
 
 A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
   
@@ -1287,6 +1305,10 @@ affinity:
          - master
 ```
 #### **webhook.runtimeClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
 
 A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
   
@@ -1796,6 +1818,10 @@ affinity:
          - master
 ```
 #### **cainjector.runtimeClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
 
 A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
   
@@ -2128,6 +2154,10 @@ affinity:
          - master
 ```
 #### **startupapicheck.runtimeClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
 
 A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
   

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -763,6 +763,16 @@ affinity:
          values:
          - master
 ```
+#### **runtimeClassName** ~ `string`
+
+A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
+  
+For example:
+
+```yaml
+runtimeClassName: gvisor
+```
+
 #### **tolerations** ~ `array`
 > Default value:
 > ```yaml
@@ -1276,6 +1286,16 @@ affinity:
          values:
          - master
 ```
+#### **webhook.runtimeClassName** ~ `string`
+
+A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
+  
+For example:
+
+```yaml
+runtimeClassName: gvisor
+```
+
 #### **webhook.tolerations** ~ `array`
 > Default value:
 > ```yaml
@@ -1775,6 +1795,16 @@ affinity:
          values:
          - master
 ```
+#### **cainjector.runtimeClassName** ~ `string`
+
+A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
+  
+For example:
+
+```yaml
+runtimeClassName: gvisor
+```
+
 #### **cainjector.tolerations** ~ `array`
 > Default value:
 > ```yaml
@@ -2097,6 +2127,16 @@ affinity:
          values:
          - master
 ```
+#### **startupapicheck.runtimeClassName** ~ `string`
+
+A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)  
+  
+For example:
+
+```yaml
+runtimeClassName: gvisor
+```
+
 #### **startupapicheck.tolerations** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -152,7 +152,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.cainjector.runtimeClassName }}
-      runtimeClassName: {{ .Values.cainjector.runtimeClassName }}
+      runtimeClassName: {{ .Values.cainjector.runtimeClassName | quote }}
+      {{- else if .Values.global.runtimeClassName }}
+      runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
       {{- with .Values.cainjector.tolerations }}
       tolerations:

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -151,6 +151,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.cainjector.runtimeClassName }}
+      runtimeClassName: {{ .Values.cainjector.runtimeClassName }}
+      {{- end }}
       {{- with .Values.cainjector.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -220,6 +220,8 @@ spec:
       {{- end }}
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- else if .Values.global.runtimeClassName }}
+      runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.nodeSelector | default dict) }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -219,7 +219,7 @@ spec:
         {{- toYaml .Values.extraContainers | nindent 8 }}
       {{- end }}
       {{- if .Values.runtimeClassName }}
-      runtimeClassName: {{ .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.nodeSelector | default dict) }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -218,6 +218,9 @@ spec:
       {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.nodeSelector | default dict) }}
       {{- with $nodeSelector }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -87,7 +87,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.startupapicheck.runtimeClassName }}
-      runtimeClassName: {{ .Values.startupapicheck.runtimeClassName }}
+      runtimeClassName: {{ .Values.startupapicheck.runtimeClassName | quote }}
+      {{- else if .Values.global.runtimeClassName }}
+      runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.startupapicheck.nodeSelector | default dict) }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -86,6 +86,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.startupapicheck.runtimeClassName }}
+      runtimeClassName: {{ .Values.startupapicheck.runtimeClassName }}
+      {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.startupapicheck.nodeSelector | default dict) }}
       {{- with $nodeSelector }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -205,7 +205,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.webhook.runtimeClassName }}
-      runtimeClassName: {{ .Values.webhook.runtimeClassName }}
+      runtimeClassName: {{ .Values.webhook.runtimeClassName | quote }}
+      {{- else if .Values.global.runtimeClassName }}
+      runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
       {{- with .Values.webhook.tolerations }}
       tolerations:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -204,6 +204,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.webhook.runtimeClassName }}
+      runtimeClassName: {{ .Values.webhook.runtimeClassName }}
+      {{- end }}
       {{- with .Values.webhook.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/cert-manager/tests/cainjector/cainjector-deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/cainjector/cainjector-deployment_test.yaml
@@ -1,0 +1,14 @@
+suite: cainjector Deployment - Configuration
+templates:
+  - templates/cainjector-deployment.yaml
+release:
+  name: cert-manager
+  namespace: cert-manager
+tests:
+  - it: should set runtimeClassName when specified
+    set:
+      cainjector.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/cainjector/cainjector-deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/cainjector/cainjector-deployment_test.yaml
@@ -12,3 +12,18 @@ tests:
     - equal:
         path: spec.template.spec.runtimeClassName
         value: something
+  - it: should favor cainjector over global for runtimeClassName
+    set:
+      cainjector.runtimeClassName: something
+      global.runtimeClassName: ignored
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something
+  - it: should fall back to global for runtimeClassName
+    set:
+      global.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
@@ -424,3 +424,11 @@ tests:
       - equal:
           path: spec.template.spec.hostUsers
           value: false
+
+  - it: should set runtimeClassName when specified
+    set:
+      runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
@@ -432,3 +432,18 @@ tests:
     - equal:
         path: spec.template.spec.runtimeClassName
         value: something
+  - it: should favor controller over global for runtimeClassName
+    set:
+      runtimeClassName: something
+      global.runtimeClassName: ignored
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something
+  - it: should fall back to global for runtimeClassName
+    set:
+      global.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/startupapicheck/startupapicheck-job_test.yaml
+++ b/deploy/charts/cert-manager/tests/startupapicheck/startupapicheck-job_test.yaml
@@ -1,0 +1,14 @@
+suite: startupapicheck Job - Configuration
+templates:
+  - templates/startupapicheck-job.yaml
+release:
+  name: cert-manager
+  namespace: cert-manager
+tests:
+  - it: should set runtimeClassName when specified
+    set:
+      startupapicheck.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/startupapicheck/startupapicheck-job_test.yaml
+++ b/deploy/charts/cert-manager/tests/startupapicheck/startupapicheck-job_test.yaml
@@ -12,3 +12,18 @@ tests:
     - equal:
         path: spec.template.spec.runtimeClassName
         value: something
+  - it: should favor startupapicheck over global for runtimeClassName
+    set:
+      startupapicheck.runtimeClassName: something
+      global.runtimeClassName: ignored
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something
+  - it: should fall back to global for runtimeClassName
+    set:
+      global.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/tests/webhook/webhook-deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/webhook/webhook-deployment_test.yaml
@@ -1,0 +1,14 @@
+suite: webhook Deployment - Configuration
+templates:
+  - templates/webhook-deployment.yaml
+release:
+  name: cert-manager
+  namespace: cert-manager
+tests:
+  - it: should set runtimeClassName when specified
+    set:
+      webhook.runtimeClassName: something
+    asserts:
+    - equal:
+        path: spec.template.spec.runtimeClassName
+        value: something

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -144,6 +144,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "runtimeClassName": {
+          "$ref": "#/$defs/helm-values.runtimeClassName"
+        },
         "securityContext": {
           "$ref": "#/$defs/helm-values.securityContext"
         },
@@ -320,6 +323,9 @@
         },
         "resources": {
           "$ref": "#/$defs/helm-values.cainjector.resources"
+        },
+        "runtimeClassName": {
+          "$ref": "#/$defs/helm-values.cainjector.runtimeClassName"
         },
         "securityContext": {
           "$ref": "#/$defs/helm-values.cainjector.securityContext"
@@ -584,6 +590,10 @@
       "default": {},
       "description": "Resources to provide to the cert-manager cainjector pod.\n\nFor example:\nrequests:\n  cpu: 10m\n  memory: 32Mi\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).",
       "type": "object"
+    },
+    "helm-values.cainjector.runtimeClassName": {
+      "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
+      "type": "string"
     },
     "helm-values.cainjector.securityContext": {
       "default": {
@@ -1410,6 +1420,10 @@
       "description": "Resources to provide to the cert-manager controller pod.\n\nFor example:\nrequests:\n  cpu: 10m\n  memory: 32Mi\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).",
       "type": "object"
     },
+    "helm-values.runtimeClassName": {
+      "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
+      "type": "string"
+    },
     "helm-values.securityContext": {
       "default": {
         "runAsNonRoot": true,
@@ -1527,6 +1541,9 @@
         },
         "resources": {
           "$ref": "#/$defs/helm-values.startupapicheck.resources"
+        },
+        "runtimeClassName": {
+          "$ref": "#/$defs/helm-values.startupapicheck.runtimeClassName"
         },
         "securityContext": {
           "$ref": "#/$defs/helm-values.startupapicheck.securityContext"
@@ -1701,6 +1718,10 @@
       "default": {},
       "description": "Resources to provide to the cert-manager controller pod.\n\nFor example:\nrequests:\n  cpu: 10m\n  memory: 32Mi\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).",
       "type": "object"
+    },
+    "helm-values.startupapicheck.runtimeClassName": {
+      "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
+      "type": "string"
     },
     "helm-values.startupapicheck.securityContext": {
       "default": {
@@ -1895,6 +1916,9 @@
         },
         "resources": {
           "$ref": "#/$defs/helm-values.webhook.resources"
+        },
+        "runtimeClassName": {
+          "$ref": "#/$defs/helm-values.webhook.runtimeClassName"
         },
         "securePort": {
           "$ref": "#/$defs/helm-values.webhook.securePort"
@@ -2250,6 +2274,10 @@
       "default": {},
       "description": "Resources to provide to the cert-manager webhook pod.\n\nFor example:\nrequests:\n  cpu: 10m\n  memory: 32Mi\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).",
       "type": "object"
+    },
+    "helm-values.webhook.runtimeClassName": {
+      "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
+      "type": "string"
     },
     "helm-values.webhook.securePort": {
       "default": 10250,

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -592,6 +592,7 @@
       "type": "object"
     },
     "helm-values.cainjector.runtimeClassName": {
+      "default": "",
       "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
       "type": "string"
     },
@@ -835,6 +836,9 @@
         },
         "revisionHistoryLimit": {
           "$ref": "#/$defs/helm-values.global.revisionHistoryLimit"
+        },
+        "runtimeClassName": {
+          "$ref": "#/$defs/helm-values.global.runtimeClassName"
         }
       },
       "type": "object"
@@ -948,6 +952,11 @@
     "helm-values.global.revisionHistoryLimit": {
       "description": "The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).",
       "type": "number"
+    },
+    "helm-values.global.runtimeClassName": {
+      "default": "",
+      "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
+      "type": "string"
     },
     "helm-values.hostAliases": {
       "default": [],
@@ -1421,6 +1430,7 @@
       "type": "object"
     },
     "helm-values.runtimeClassName": {
+      "default": "",
       "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
       "type": "string"
     },
@@ -1720,6 +1730,7 @@
       "type": "object"
     },
     "helm-values.startupapicheck.runtimeClassName": {
+      "default": "",
       "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
       "type": "string"
     },
@@ -2276,6 +2287,7 @@
       "type": "object"
     },
     "helm-values.webhook.runtimeClassName": {
+      "default": "",
       "description": "A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)\n\nFor example:\nruntimeClassName: gvisor",
       "type": "string"
     },

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -92,6 +92,13 @@ global:
     # +docs:property
     # retryPeriod: 15s
 
+  # A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)
+  #
+  # For example:
+  #   runtimeClassName: gvisor
+  # +docs:property
+  runtimeClassName: ""
+
 # This option is equivalent to setting crds.enabled=true and crds.keep=true.
 # Deprecated: use crds.enabled and crds.keep instead.
 installCRDs: false
@@ -588,7 +595,7 @@ affinity: {}
 # For example:
 #   runtimeClassName: gvisor
 # +docs:property
-# runtimeClassName: ""
+runtimeClassName: ""
 
 # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
 #
@@ -989,7 +996,7 @@ webhook:
   # For example:
   #   runtimeClassName: gvisor
   # +docs:property
-  # runtimeClassName: ""
+  runtimeClassName: ""
 
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #
@@ -1381,7 +1388,7 @@ cainjector:
   # For example:
   #   runtimeClassName: gvisor
   # +docs:property
-  # runtimeClassName: ""
+  runtimeClassName: ""
 
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #
@@ -1631,7 +1638,7 @@ startupapicheck:
   # For example:
   #   runtimeClassName: gvisor
   # +docs:property
-  # runtimeClassName: ""
+  runtimeClassName: ""
 
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -583,6 +583,13 @@ ingressShim: {}
 #            - master
 affinity: {}
 
+# A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)
+#
+# For example:
+#   runtimeClassName: gvisor
+# +docs:property
+# runtimeClassName: ""
+
 # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
 #
 # For example:
@@ -977,6 +984,13 @@ webhook:
   #            - master
   affinity: {}
 
+  # A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)
+  #
+  # For example:
+  #   runtimeClassName: gvisor
+  # +docs:property
+  # runtimeClassName: ""
+
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #
   # For example:
@@ -1362,6 +1376,13 @@ cainjector:
   #            - master
   affinity: {}
 
+  # A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)
+  #
+  # For example:
+  #   runtimeClassName: gvisor
+  # +docs:property
+  # runtimeClassName: ""
+
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #
   # For example:
@@ -1604,6 +1625,13 @@ startupapicheck:
   #            values:
   #            - master
   affinity: {}
+
+  # A Kubernetes Runtime Class, if required. For more information, see [RuntimeClass v1 node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#runtimeclass-v1-node-k8s-io)
+  #
+  # For example:
+  #   runtimeClassName: gvisor
+  # +docs:property
+  # runtimeClassName: ""
 
   # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
   #

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -213,6 +213,9 @@ type ACMEHTTP01Config struct {
 	// issues
 	SolverRunAsNonRoot bool
 
+	// Defines the runtime class for the http01 solver
+	SolverRuntimeClassName string
+
 	// A list of comma separated dns server endpoints used for
 	// ACME HTTP01 check requests. This should be a list containing host and
 	// port, for example ["8.8.8.8:53","8.8.4.4:53"]

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -97,6 +97,7 @@ var (
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
 	defaultACMEHTTP01SolverRunAsNonRoot          = true
+	defaultACMEHTTP01SolverRuntimeclassName      = ""
 	defaultACMEHTTP01SolverNameservers           = []string{}
 
 	defaultCertificateRequestMinimumBackoffDuration = 1 * time.Hour
@@ -344,6 +345,10 @@ func SetDefaults_ACMEHTTP01Config(obj *v1alpha1.ACMEHTTP01Config) {
 
 	if obj.SolverRunAsNonRoot == nil {
 		obj.SolverRunAsNonRoot = &defaultACMEHTTP01SolverRunAsNonRoot
+	}
+
+	if obj.SolverRuntimeClassName == "" {
+		obj.SolverRuntimeClassName = defaultACMEHTTP01SolverRuntimeclassName
 	}
 
 	if len(obj.SolverNameservers) == 0 {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -97,7 +97,7 @@ var (
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
 	defaultACMEHTTP01SolverRunAsNonRoot          = true
-	defaultACMEHTTP01SolverRuntimeclassName      = ""
+	defaultACMEHTTP01SolverRuntimeClassName      = ""
 	defaultACMEHTTP01SolverNameservers           = []string{}
 
 	defaultCertificateRequestMinimumBackoffDuration = 1 * time.Hour
@@ -348,7 +348,7 @@ func SetDefaults_ACMEHTTP01Config(obj *v1alpha1.ACMEHTTP01Config) {
 	}
 
 	if obj.SolverRuntimeClassName == "" {
-		obj.SolverRuntimeClassName = defaultACMEHTTP01SolverRuntimeclassName
+		obj.SolverRuntimeClassName = defaultACMEHTTP01SolverRuntimeClassName
 	}
 
 	if len(obj.SolverNameservers) == 0 {

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -153,6 +153,7 @@ func autoConvert_v1alpha1_ACMEHTTP01Config_To_controller_ACMEHTTP01Config(in *co
 	if err := v1.Convert_Pointer_bool_To_bool(&in.SolverRunAsNonRoot, &out.SolverRunAsNonRoot, s); err != nil {
 		return err
 	}
+	out.SolverRuntimeClassName = in.SolverRuntimeClassName
 	out.SolverNameservers = *(*[]string)(unsafe.Pointer(&in.SolverNameservers))
 	out.SolverExtraLabels = *(*map[string]string)(unsafe.Pointer(&in.SolverExtraLabels))
 	return nil
@@ -172,6 +173,7 @@ func autoConvert_controller_ACMEHTTP01Config_To_v1alpha1_ACMEHTTP01Config(in *co
 	if err := v1.Convert_bool_To_Pointer_bool(&in.SolverRunAsNonRoot, &out.SolverRunAsNonRoot, s); err != nil {
 		return err
 	}
+	out.SolverRuntimeClassName = in.SolverRuntimeClassName
 	out.SolverNameservers = *(*[]string)(unsafe.Pointer(&in.SolverNameservers))
 	out.SolverExtraLabels = *(*map[string]string)(unsafe.Pointer(&in.SolverExtraLabels))
 	return nil

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/make/config/samplewebhook/chart/templates/deployment.yaml
+++ b/make/config/samplewebhook/chart/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.runtimeClassName }}
-      runtimeClassName: {{ .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/make/config/samplewebhook/chart/values.yaml
+++ b/make/config/samplewebhook/chart/values.yaml
@@ -41,3 +41,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+runtimeClassName: ""

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -215,6 +215,10 @@ type ACMEHTTP01Config struct {
 	// issues
 	SolverRunAsNonRoot *bool `json:"solverRunAsNonRoot,omitempty"`
 
+	// Defines the runtime class used when spawning new ACME HTTP01 challenge
+	// solver pods.
+	SolverRuntimeClassName string `json:"solverRuntimeClassName,omitempty"`
+
 	// A list of comma separated dns server endpoints used for
 	// ACME HTTP01 check requests. This should be a list containing host and
 	// port, for example ["8.8.8.8:53","8.8.4.4:53"]

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -197,6 +197,9 @@ type ACMEOptions struct {
 	// ACMEHTTP01SolverRunAsNonRoot sets the ACME pod's ability to run as root
 	ACMEHTTP01SolverRunAsNonRoot bool
 
+	// HTTP01SolverRuntimeClassName defines the ACME pod's runtimeClassName
+	HTTP01SolverRuntimeClassName string
+
 	// HTTP01SolverNameservers is a list of nameservers to use when performing self-checks
 	// for ACME HTTP01 validations.
 	HTTP01SolverNameservers []string

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -199,8 +199,7 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	maps.Copy(podLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
 	var runtimeClassName *string
 	if s.ACMEOptions.HTTP01SolverRuntimeClassName != "" {
- 		runtimeClassNameValue := s.ACMEOptions.HTTP01SolverRuntimeClassName
- 		runtimeClassName = &runtimeClassNameValue
+		runtimeClassName = new(s.ACMEOptions.HTTP01SolverRuntimeClassName)
 	}
 
 	return &corev1.Pod{

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -197,9 +197,10 @@ func (s *Solver) buildPod(ch *cmacme.Challenge) *corev1.Pod {
 func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	podLabels := podLabels(ch)
 	maps.Copy(podLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
-	var runtimeClassName *string = nil
+	var runtimeClassName *string
 	if s.ACMEOptions.HTTP01SolverRuntimeClassName != "" {
-		runtimeClassName = &s.ACMEOptions.HTTP01SolverRuntimeClassName
+ 		runtimeClassNameValue := s.ACMEOptions.HTTP01SolverRuntimeClassName
+ 		runtimeClassName = &runtimeClassNameValue
 	}
 
 	return &corev1.Pod{

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -197,6 +197,10 @@ func (s *Solver) buildPod(ch *cmacme.Challenge) *corev1.Pod {
 func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 	podLabels := podLabels(ch)
 	maps.Copy(podLabels, filterACMEIdentityLabels(s.ACMEOptions.HTTP01SolverExtraLabels))
+	var runtimeClassName *string = nil
+	if s.ACMEOptions.HTTP01SolverRuntimeClassName != "" {
+		runtimeClassName = &s.ACMEOptions.HTTP01SolverRuntimeClassName
+	}
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -220,6 +224,7 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			},
 			RestartPolicy:      corev1.RestartPolicyOnFailure,
 			EnableServiceLinks: new(false),
+			RuntimeClassName:   runtimeClassName,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: new(s.ACMEOptions.ACMEHTTP01SolverRunAsNonRoot),
 				SeccompProfile: &corev1.SeccompProfile{


### PR DESCRIPTION
### Pull Request Motivation

I want to run cert-manager on `gVisor` enabled nodes

(For lack of better documentation: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods#sandboxed-application)

### Kind

/kind feature
### Release Note

```release-note
Add configurable `runtimeClassName` support for cert-manager components and ACME HTTP01 solver pods.
```
