### PR TITLE
fix: ServerSideApply field loss in certificate-shim and issuing controller

### DIFF
--- a/internal/controller/certificates/apply.go
+++ b/internal/controller/certificates/apply.go
@@ -78,6 +78,7 @@ func serializeApply(crt *cmapi.Certificate) ([]byte, error) {
 		Spec:       *crt.Spec.DeepCopy(),
 		Status:     cmapi.CertificateStatus{},
 	}
+	crt.ObjectMeta.ManagedFields = nil
 	crtData, err := json.Marshal(crt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal certificate object: %w", err)

--- a/internal/controller/certificates/apply_test.go
+++ b/internal/controller/certificates/apply_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/randfill"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -44,16 +45,24 @@ func Test_serializeApply(t *testing.T) {
 				t.Run("fuzz_"+strconv.Itoa(j), func(t *testing.T) {
 					var crt cmapi.Certificate
 					randfill.New().NilChance(0.5).Fill(&crt)
-					crt.ManagedFields = nil
+
+					// Seed a non-empty ManagedFields to verify serializeApply
+					// strips it — the API server rejects patches containing
+					// metadata.managedFields.
+					crt.ManagedFields = []metav1.ManagedFieldsEntry{
+						{Manager: "test", Operation: metav1.ManagedFieldsOperationUpdate},
+					}
 
 					crtData, err := serializeApply(&crt)
 					assert.NoError(t, err)
 					assert.Regexp(t, expReg, string(crtData))
 
-					// Test round trip serializing Certificate preserved the spec.
+					// Test round trip serializing Certificate preserved the spec
+					// and stripped ManagedFields.
 					var rtCrt cmapi.Certificate
 					assert.NoError(t, json.Unmarshal(crtData, &rtCrt))
 					assert.Equal(t, rtCrt.Spec, crt.Spec)
+					assert.Nil(t, rtCrt.ManagedFields)
 
 					wg.Done()
 				})

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -164,13 +164,7 @@ func SyncFnFor(
 						OwnerReferences: crt.OwnerReferences,
 						Annotations:     extraAnnotations,
 					},
-					Spec: cmapi.CertificateSpec{
-						DNSNames:    crt.Spec.DNSNames,
-						IPAddresses: crt.Spec.IPAddresses,
-						SecretName:  crt.Spec.SecretName,
-						IssuerRef:   crt.Spec.IssuerRef,
-						Usages:      crt.Spec.Usages,
-					},
+					Spec: crt.Spec,
 				})
 			} else {
 				_, err = cmClient.CertmanagerV1().Certificates(crt.Namespace).Update(ctx, crt, metav1.UpdateOptions{})

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -146,7 +146,22 @@ func SyncFnFor(
 		}
 
 		for _, crt := range newCrts {
-			_, err := cmClient.CertmanagerV1().Certificates(crt.Namespace).Create(ctx, crt, metav1.CreateOptions{FieldManager: fieldManager})
+			// Create with FieldManager records ownership as operation:Update.
+			// Use Apply under SSA so create ownership matches updates (operation:Apply).
+			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
+				err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            crt.Name,
+						Namespace:       crt.Namespace,
+						Labels:          crt.Labels,
+						OwnerReferences: crt.OwnerReferences,
+						Annotations:     extraAnnotations,
+					},
+					Spec: crt.Spec,
+				})
+			} else {
+				_, err = cmClient.CertmanagerV1().Certificates(crt.Namespace).Create(ctx, crt, metav1.CreateOptions{FieldManager: fieldManager})
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package shimhelper
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -31,13 +33,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	coretesting "k8s.io/client-go/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
@@ -4402,6 +4407,261 @@ func TestSync(t *testing.T) {
 			t.Run(test.Name, testFn(test))
 		}
 	})
+}
+
+// matchRootCertificateApply validates a root-resource Certificate Apply patch
+// (verb, patch type, options) and then runs check on the unmarshaled object.
+func matchRootCertificateApply(check func(applied cmapi.Certificate) error) testpkg.ActionMatchFn {
+	return func(_, actual coretesting.Action) error {
+		patchAction, ok := actual.(coretesting.PatchAction)
+		if !ok {
+			return fmt.Errorf("expected PatchAction, got %T", actual)
+		}
+		if patchAction.GetVerb() != "patch" {
+			return fmt.Errorf("expected patch, got %q", patchAction.GetVerb())
+		}
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return fmt.Errorf("expected ApplyPatchType, got %q", patchAction.GetPatchType())
+		}
+		if patchAction.GetSubresource() != "" {
+			return fmt.Errorf("expected root resource Apply, got subresource %q", patchAction.GetSubresource())
+		}
+		optsGetter, ok := actual.(interface{ GetPatchOptions() metav1.PatchOptions })
+		if !ok {
+			return fmt.Errorf("expected GetPatchOptions on action, got %T", actual)
+		}
+		opts := optsGetter.GetPatchOptions()
+		if opts.FieldManager != testpkg.FieldManager {
+			return fmt.Errorf("expected FieldManager %q, got %q", testpkg.FieldManager, opts.FieldManager)
+		}
+		if opts.Force == nil || !*opts.Force {
+			return fmt.Errorf("expected Force=true, got %v", opts.Force)
+		}
+
+		var applied cmapi.Certificate
+		if err := json.Unmarshal(patchAction.GetPatch(), &applied); err != nil {
+			return fmt.Errorf("unmarshal Apply patch: %w", err)
+		}
+		return check(applied)
+	}
+}
+
+// TestSync_ServerSideApplyCreate checks Certificate create uses Apply under SSA.
+func TestSync_ServerSideApplyCreate(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
+
+	acmeClusterIssuer := gen.ClusterIssuer("issuer-name",
+		gen.SetIssuerACME(cmacme.ACMEIssuer{}))
+	revisionHistoryLimit := int32(7)
+	expectedAnnotations := map[string]string{"example.com/foo": "bar"}
+	expectedLabels := map[string]string{"my-test-label": "should-be-applied"}
+	expectedOwnerRefs := buildIngressOwnerReferences("ingress-name")
+
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-name",
+			Namespace: gen.DefaultTestNamespace,
+			Labels: map[string]string{
+				"my-test-label": "should-be-applied",
+			},
+			Annotations: map[string]string{
+				cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+				cmapi.RevisionHistoryLimitAnnotationKey:     "7",
+				"example.com/foo":                           "bar",
+			},
+			UID: types.UID("ingress-name"),
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{
+					Hosts:      []string{"example.com"},
+					SecretName: "example-com-tls",
+				},
+			},
+		},
+	}
+
+	b := &testpkg.Builder{
+		T:                  t,
+		CertManagerObjects: []runtime.Object{acmeClusterIssuer},
+		ExpectedEvents:     []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+		ExpectedActions: []testpkg.Action{
+			testpkg.NewCustomMatch(
+				coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					[]byte(`{}`),
+					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
+				),
+				matchRootCertificateApply(func(applied cmapi.Certificate) error {
+					if applied.Name != "example-com-tls" {
+						return fmt.Errorf("unexpected name %q", applied.Name)
+					}
+					if applied.Spec.RevisionHistoryLimit == nil || *applied.Spec.RevisionHistoryLimit != revisionHistoryLimit {
+						return fmt.Errorf("expected revisionHistoryLimit=%d in Apply Spec, got %v", revisionHistoryLimit, applied.Spec.RevisionHistoryLimit)
+					}
+					if applied.Spec.SecretName != "example-com-tls" {
+						return fmt.Errorf("unexpected secretName %q", applied.Spec.SecretName)
+					}
+					if !reflect.DeepEqual(applied.Spec.DNSNames, []string{"example.com"}) {
+						return fmt.Errorf("unexpected dnsNames %v", applied.Spec.DNSNames)
+					}
+					if !reflect.DeepEqual(applied.Spec.IssuerRef, cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"}) {
+						return fmt.Errorf("unexpected issuerRef %#v", applied.Spec.IssuerRef)
+					}
+					if !reflect.DeepEqual(applied.Spec.Usages, cmapi.DefaultKeyUsages()) {
+						return fmt.Errorf("unexpected usages %v", applied.Spec.Usages)
+					}
+					if !reflect.DeepEqual(applied.Labels, expectedLabels) {
+						return fmt.Errorf("expected Ingress labels on create Apply, got %v", applied.Labels)
+					}
+					if !reflect.DeepEqual(applied.OwnerReferences, expectedOwnerRefs) {
+						return fmt.Errorf("unexpected OwnerReferences %#v", applied.OwnerReferences)
+					}
+					if !reflect.DeepEqual(applied.Annotations, expectedAnnotations) {
+						return fmt.Errorf("unexpected create Apply annotations: %v", applied.Annotations)
+					}
+					return nil
+				}),
+			),
+		},
+	}
+	b.Init()
+	defer b.Stop()
+
+	sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controllerpkg.IngressShimOptions{
+		DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
+		ExtraCertificateAnnotations:       []string{"example.com/foo"},
+	}, testpkg.FieldManager)
+	b.Start()
+
+	err := sync(t.Context(), ing)
+	assert.NoError(t, err)
+	assert.NoError(t, b.AllEventsCalled())
+	assert.NoError(t, b.AllActionsExecuted())
+}
+
+// TestSync_ServerSideApplyUpdate checks Certificate update uses Apply under SSA.
+func TestSync_ServerSideApplyUpdate(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
+
+	acmeClusterIssuer := gen.ClusterIssuer("issuer-name",
+		gen.SetIssuerACME(cmacme.ACMEIssuer{}))
+	revisionHistoryLimit := int32(7)
+	expectedAnnotations := map[string]string{"example.com/foo": "bar"}
+	expectedLabels := map[string]string{"my-test-label": "should-be-applied"}
+	expectedOwnerRefs := buildIngressOwnerReferences("ingress-name")
+
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-name",
+			Namespace: gen.DefaultTestNamespace,
+			Labels: map[string]string{
+				"my-test-label": "should-be-applied",
+			},
+			Annotations: map[string]string{
+				cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+				cmapi.RevisionHistoryLimitAnnotationKey:     "7",
+				"example.com/foo":                           "bar",
+			},
+			UID: types.UID("ingress-name"),
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{
+					Hosts:      []string{"example.com"},
+					SecretName: "example-com-tls",
+				},
+			},
+		},
+	}
+
+	existingCrt := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "example-com-tls",
+			Namespace:       gen.DefaultTestNamespace,
+			OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+			Labels: map[string]string{
+				"stale-label": "remove-me",
+			},
+			Annotations: map[string]string{
+				"user.io/keep": "me",
+			},
+		},
+		Spec: cmapi.CertificateSpec{
+			DNSNames:   []string{"example.com"},
+			SecretName: "example-com-tls",
+			IssuerRef: cmmeta.IssuerReference{
+				Name: "issuer-name",
+				Kind: "ClusterIssuer",
+			},
+			Usages:               cmapi.DefaultKeyUsages(),
+			RevisionHistoryLimit: new(int32(1)),
+		},
+	}
+
+	b := &testpkg.Builder{
+		T:                  t,
+		CertManagerObjects: []runtime.Object{acmeClusterIssuer, existingCrt},
+		ExpectedEvents:     []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+		ExpectedActions: []testpkg.Action{
+			testpkg.NewCustomMatch(
+				coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					[]byte(`{}`),
+					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
+				),
+				matchRootCertificateApply(func(applied cmapi.Certificate) error {
+					if applied.Name != "example-com-tls" {
+						return fmt.Errorf("unexpected name %q", applied.Name)
+					}
+					if applied.Spec.RevisionHistoryLimit == nil || *applied.Spec.RevisionHistoryLimit != revisionHistoryLimit {
+						return fmt.Errorf("expected revisionHistoryLimit=%d in update Apply Spec, got %v", revisionHistoryLimit, applied.Spec.RevisionHistoryLimit)
+					}
+					if applied.Spec.SecretName != "example-com-tls" {
+						return fmt.Errorf("unexpected secretName %q", applied.Spec.SecretName)
+					}
+					if !reflect.DeepEqual(applied.Spec.DNSNames, []string{"example.com"}) {
+						return fmt.Errorf("unexpected dnsNames %v", applied.Spec.DNSNames)
+					}
+					if !reflect.DeepEqual(applied.Spec.IssuerRef, cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"}) {
+						return fmt.Errorf("unexpected issuerRef %#v", applied.Spec.IssuerRef)
+					}
+					if !reflect.DeepEqual(applied.Spec.Usages, cmapi.DefaultKeyUsages()) {
+						return fmt.Errorf("unexpected usages %v", applied.Spec.Usages)
+					}
+					if !reflect.DeepEqual(applied.Labels, expectedLabels) {
+						return fmt.Errorf("expected Ingress labels on update Apply, got %v", applied.Labels)
+					}
+					if !reflect.DeepEqual(applied.OwnerReferences, expectedOwnerRefs) {
+						return fmt.Errorf("unexpected OwnerReferences %#v", applied.OwnerReferences)
+					}
+					if !reflect.DeepEqual(applied.Annotations, expectedAnnotations) {
+						return fmt.Errorf("unexpected update Apply annotations: %v", applied.Annotations)
+					}
+					return nil
+				}),
+			),
+		},
+	}
+	b.Init()
+	defer b.Stop()
+
+	sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controllerpkg.IngressShimOptions{
+		DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
+		ExtraCertificateAnnotations:       []string{"example.com/foo"},
+	}, testpkg.FieldManager)
+	b.Start()
+
+	err := sync(t.Context(), ing)
+	assert.NoError(t, err)
+	assert.NoError(t, b.AllEventsCalled())
+	assert.NoError(t, b.AllActionsExecuted())
 }
 
 func TestIssuerForIngress(t *testing.T) {

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -515,9 +515,10 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 		return internalcertificates.ApplyStatus(ctx, c.client, c.fieldManager, &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{Namespace: crt.Namespace, Name: crt.Name},
 			Status: cmapi.CertificateStatus{
-				Revision:        crt.Status.Revision,
-				LastFailureTime: crt.Status.LastFailureTime,
-				Conditions:      conditions,
+				Revision:               crt.Status.Revision,
+				LastFailureTime:        crt.Status.LastFailureTime,
+				FailedIssuanceAttempts: crt.Status.FailedIssuanceAttempts,
+				Conditions:             conditions,
 			},
 		})
 	} else {

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -18,6 +18,7 @@ package issuing
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -29,12 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates/issuing/internal"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
@@ -1503,6 +1507,247 @@ func TestIssuingController(t *testing.T) {
 			if err == nil && test.expectedErr {
 				t.Errorf("expected to get an error but did not get one")
 			}
+			test.builder.CheckAndFinish(err)
+		})
+	}
+}
+
+// applyStatusFieldMap returns the status object from an ApplyStatus JSON patch.
+func applyStatusFieldMap(t *testing.T, patch []byte) map[string]any {
+	t.Helper()
+	var root map[string]any
+	require.NoError(t, json.Unmarshal(patch, &root))
+	status, ok := root["status"].(map[string]any)
+	require.True(t, ok, "ApplyStatus patch missing status object")
+	return status
+}
+
+// TestIssuingController_ServerSideApplyFailedIssuanceAttempts checks ApplyStatus
+// includes failedIssuanceAttempts on failure and omits it on success.
+func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
+
+	nextPrivateKeySecretName := "next-private-key"
+	baseCert := gen.Certificate("test",
+		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
+		gen.SetCertificateGeneration(3),
+		gen.SetCertificateSecretName("output"),
+		gen.SetCertificateRenewBefore(&metav1.Duration{Duration: time.Hour * 36}),
+		gen.SetCertificateDNSNames("example.com"),
+		gen.SetCertificateRevision(1),
+		gen.SetCertificateNextPrivateKeySecretName(nextPrivateKeySecretName),
+	)
+	exampleBundle := testcrypto.MustCreateCryptoBundle(t, baseCert.DeepCopy(), fixedClock)
+	metaFixedClockStart := metav1.NewTime(fixedClockStart)
+
+	issuingCert := gen.CertificateFrom(baseCert.DeepCopy(),
+		gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+			Type:               cmapi.CertificateConditionIssuing,
+			Status:             cmmeta.ConditionTrue,
+			ObservedGeneration: 3,
+			LastTransitionTime: &metaFixedClockStart,
+		}),
+	)
+
+	nextPrivateKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nextPrivateKeySecretName,
+			Namespace: exampleBundle.Certificate.Namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+		},
+	}
+
+	type testT struct {
+		builder                 *testpkg.Builder
+		certificate             *cmapi.Certificate
+		expSecretUpdateDataCall *internal.SecretData
+		assertApplyStatus       func(t *testing.T, patch []byte)
+	}
+
+	tests := map[string]testT{
+		"failure ApplyStatus includes failedIssuanceAttempts": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestFailed,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2",
+						}),
+						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:    cmapi.CertificateRequestConditionReady,
+							Status:  cmmeta.ConditionFalse,
+							Reason:  cmapi.CertificateRequestReasonFailed,
+							Message: "The certificate request failed because of reasons",
+						}),
+					),
+				},
+				KubeObjects: []runtime.Object{nextPrivateKeySecret},
+				ExpectedEvents: []string{
+					"Warning Failed The certificate request has failed to complete and will be retried: The certificate request failed because of reasons",
+				},
+			},
+			assertApplyStatus: func(t *testing.T, patch []byte) {
+				t.Helper()
+				var applied cmapi.Certificate
+				require.NoError(t, json.Unmarshal(patch, &applied))
+				require.NotNil(t, applied.Status.FailedIssuanceAttempts)
+				assert.Equal(t, 1, *applied.Status.FailedIssuanceAttempts)
+				require.NotNil(t, applied.Status.LastFailureTime)
+				require.NotNil(t, applied.Status.Revision)
+				assert.Equal(t, 1, *applied.Status.Revision)
+				require.Len(t, applied.Status.Conditions, 1)
+				assert.Equal(t, cmapi.CertificateConditionIssuing, applied.Status.Conditions[0].Type)
+				assert.Equal(t, cmmeta.ConditionFalse, applied.Status.Conditions[0].Status)
+				assert.Equal(t, "Failed", applied.Status.Conditions[0].Reason)
+
+				status := applyStatusFieldMap(t, patch)
+				for _, key := range []string{"failedIssuanceAttempts", "lastFailureTime", "revision", "conditions"} {
+					_, ok := status[key]
+					assert.Truef(t, ok, "expected status.%s present in ApplyStatus patch", key)
+				}
+				_, ok := status["nextPrivateKeySecretName"]
+				assert.False(t, ok, "expected status.nextPrivateKeySecretName absent from ApplyStatus patch")
+			},
+		},
+		"success ApplyStatus omits failedIssuanceAttempts and lastFailureTime": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert,
+						gen.SetCertificateLastFailureTime(metaFixedClockStart),
+						gen.SetCertificateIssuanceAttempts(new(4)),
+					),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestReady,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2",
+						}),
+					),
+				},
+				KubeObjects: []runtime.Object{
+					nextPrivateKeySecret,
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: exampleBundle.Certificate.Namespace,
+							Name:      "output",
+							Annotations: map[string]string{
+								"my-custom": "annotation",
+							},
+							Labels: map[string]string{},
+						},
+						Type: corev1.SecretTypeTLS,
+					},
+				},
+				ExpectedEvents: []string{
+					"Normal Issuing The certificate has been successfully issued",
+				},
+			},
+			expSecretUpdateDataCall: &internal.SecretData{
+				Certificate:     exampleBundle.CertificateRequestReady.Status.Certificate,
+				PrivateKey:      exampleBundle.PrivateKeyBytes,
+				CA:              nil,
+				CertificateName: "test",
+				IssuerName:      "ca-issuer",
+				IssuerKind:      "Issuer",
+				IssuerGroup:     "foo.io",
+			},
+			assertApplyStatus: func(t *testing.T, patch []byte) {
+				t.Helper()
+				var applied cmapi.Certificate
+				require.NoError(t, json.Unmarshal(patch, &applied))
+				require.NotNil(t, applied.Status.Revision)
+				assert.Equal(t, 2, *applied.Status.Revision)
+				require.Len(t, applied.Status.Conditions, 1)
+				assert.Equal(t, cmapi.CertificateConditionIssuing, applied.Status.Conditions[0].Type)
+				assert.Equal(t, cmmeta.ConditionFalse, applied.Status.Conditions[0].Status)
+				assert.Equal(t, "Issued", applied.Status.Conditions[0].Reason)
+
+				status := applyStatusFieldMap(t, patch)
+				for _, key := range []string{"revision", "conditions"} {
+					_, ok := status[key]
+					assert.Truef(t, ok, "expected status.%s present in ApplyStatus patch", key)
+				}
+				for _, key := range []string{"failedIssuanceAttempts", "lastFailureTime", "nextPrivateKeySecretName"} {
+					_, ok := status[key]
+					assert.Falsef(t, ok, "expected status.%s absent from ApplyStatus patch", key)
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixedClock.SetTime(fixedClockStart)
+			test.builder.Clock = fixedClock
+			test.builder.T = t
+
+			test.builder.ExpectedActions = []testpkg.Action{
+				testpkg.NewCustomMatch(
+					coretesting.NewPatchSubresourceActionWithOptions(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						exampleBundle.Certificate.Namespace,
+						exampleBundle.Certificate.Name,
+						types.ApplyPatchType,
+						[]byte(`{}`),
+						metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
+						"status",
+					),
+					func(_, actual coretesting.Action) error {
+						patchAction, ok := actual.(coretesting.PatchAction)
+						if !ok {
+							return fmt.Errorf("expected PatchAction, got %T", actual)
+						}
+						if patchAction.GetPatchType() != types.ApplyPatchType {
+							return fmt.Errorf("expected ApplyPatchType, got %q", patchAction.GetPatchType())
+						}
+						if patchAction.GetSubresource() != "status" {
+							return fmt.Errorf("expected status subresource, got %q", patchAction.GetSubresource())
+						}
+						optsGetter, ok := actual.(interface{ GetPatchOptions() metav1.PatchOptions })
+						if !ok {
+							return fmt.Errorf("expected GetPatchOptions on action, got %T", actual)
+						}
+						opts := optsGetter.GetPatchOptions()
+						if opts.FieldManager != testpkg.FieldManager {
+							return fmt.Errorf("expected FieldManager %q, got %q", testpkg.FieldManager, opts.FieldManager)
+						}
+						if opts.Force == nil || !*opts.Force {
+							return fmt.Errorf("expected Force=true, got %v", opts.Force)
+						}
+						test.assertApplyStatus(t, patchAction.GetPatch())
+						return nil
+					},
+				),
+			}
+
+			test.builder.InitWithRESTConfig()
+			defer test.builder.Stop()
+
+			w := controllerWrapper{}
+			_, _, err := w.Register(test.builder.Context)
+			require.NoError(t, err)
+			w.controller.localTemporarySigner = testLocalTemporarySignerFn(exampleBundle.LocalTemporaryCertificateBytes)
+
+			var secretsUpdateDataCalled bool
+			w.controller.secretsUpdateData = func(_ context.Context, _ *cmapi.Certificate, secretData internal.SecretData) error {
+				secretsUpdateDataCalled = true
+				assert.Equal(t, *test.expSecretUpdateDataCall, secretData)
+				return nil
+			}
+			t.Cleanup(func() {
+				wantsSecretUpdateDataCall := test.expSecretUpdateDataCall != nil
+				assert.Equal(t, wantsSecretUpdateDataCall, secretsUpdateDataCalled)
+			})
+
+			test.builder.Start()
+
+			err = w.controller.ProcessItem(t.Context(), types.NamespacedName{
+				Namespace: test.certificate.Namespace,
+				Name:      test.certificate.Name,
+			})
+			require.NoError(t, err)
 			test.builder.CheckAndFinish(err)
 		})
 	}

--- a/test/integration/certificates/status_scalar_apply_test.go
+++ b/test/integration/certificates/status_scalar_apply_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"encoding/json"
+	"testing"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	"github.com/cert-manager/cert-manager/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cert-manager/cert-manager/integration-tests/framework"
+)
+
+// Test_StatusScalarApply ensures Certificate scalar status fields can be
+// cleared by omission from ApplyStatus when owned solely by the applying
+// field manager, and that omission does not clear fields owned by another
+// manager.
+//
+// failedIssuanceAttempts and lastFailureTime are used as representative
+// scalars. Conditions list-map multi-manager behavior is covered separately
+// in condition_list_type_test.go.
+func Test_StatusScalarApply(t *testing.T) {
+	restConfig, stopFn := framework.RunControlPlane(t)
+	t.Cleanup(stopFn)
+
+	issuingRestConfig := util.RestConfigWithUserAgent(restConfig, "cert-manager-certificates-issuing")
+	issuingFieldManager := util.PrefixFromUserAgent(issuingRestConfig.UserAgent)
+	kubeClient, _, issuingCMClient, _, _ := framework.NewClients(t, issuingRestConfig)
+
+	otherRestConfig := util.RestConfigWithUserAgent(restConfig, "other-status-writer")
+	otherFieldManager := util.PrefixFromUserAgent(otherRestConfig.UserAgent)
+	_, _, otherCMClient, _, _ := framework.NewClients(t, otherRestConfig)
+
+	t.Run("omit clears scalars owned by applying manager", func(t *testing.T) {
+		const (
+			namespace = "test-status-scalar-apply-omit"
+			name      = "omit-clears-owned-scalars"
+		)
+
+		t.Log("creating test Namespace")
+		_, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		createEmptyCertificate(t, issuingCMClient, namespace, name)
+
+		attempts := 2
+		now := metav1.Now()
+		t.Log("ApplyStatus sets scalar failure fields")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			FailedIssuanceAttempts: &attempts,
+			LastFailureTime:        &now,
+			Revision:               new(1),
+		})
+
+		crt, err := issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, crt.Status.FailedIssuanceAttempts)
+		assert.Equal(t, 2, *crt.Status.FailedIssuanceAttempts)
+		require.NotNil(t, crt.Status.LastFailureTime)
+
+		t.Log("ApplyStatus omits scalar failure fields")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			Revision: new(2),
+		})
+
+		crt, err = issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, crt.Status.FailedIssuanceAttempts)
+		assert.Nil(t, crt.Status.LastFailureTime)
+		require.NotNil(t, crt.Status.Revision)
+		assert.Equal(t, 2, *crt.Status.Revision)
+	})
+
+	t.Run("omit does not clear scalars owned by another manager", func(t *testing.T) {
+		const (
+			namespace = "test-status-scalar-apply-coown"
+			name      = "omit-keeps-foreign-owned-scalars"
+		)
+
+		t.Log("creating test Namespace")
+		_, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		createEmptyCertificate(t, issuingCMClient, namespace, name)
+
+		attempts := 2
+		now := metav1.Now()
+		t.Log("ApplyStatus sets scalar failure fields")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			FailedIssuanceAttempts: &attempts,
+			LastFailureTime:        &now,
+			Revision:               new(1),
+		})
+
+		otherAttempts := 3
+		t.Log("second field manager ApplyStatus claims failedIssuanceAttempts")
+		applyCertificateStatus(t, otherCMClient, otherFieldManager, namespace, name, cmapi.CertificateStatus{
+			FailedIssuanceAttempts: &otherAttempts,
+		})
+
+		crt, err := issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, crt.Status.FailedIssuanceAttempts)
+		assert.Equal(t, 3, *crt.Status.FailedIssuanceAttempts)
+		require.NotNil(t, crt.Status.LastFailureTime)
+
+		t.Log("original manager omits failedIssuanceAttempts")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			Revision: new(2),
+		})
+
+		crt, err = issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, crt.Status.FailedIssuanceAttempts)
+		assert.Equal(t, 3, *crt.Status.FailedIssuanceAttempts)
+		assert.Nil(t, crt.Status.LastFailureTime)
+		require.NotNil(t, crt.Status.Revision)
+		assert.Equal(t, 2, *crt.Status.Revision)
+	})
+}
+
+func createEmptyCertificate(t *testing.T, cmClient cmclient.Interface, namespace, name string) {
+	t.Helper()
+	t.Log("creating empty Certificate")
+	_, err := cmClient.CertmanagerV1().Certificates(namespace).Create(t.Context(), &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: cmapi.CertificateSpec{
+			CommonName: "test",
+			SecretName: "test",
+			IssuerRef:  cmmeta.IssuerReference{Name: "test"},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func applyCertificateStatus(t *testing.T, cmClient cmclient.Interface, fieldManager, namespace, name string, status cmapi.CertificateStatus) {
+	t.Helper()
+	patch, err := json.Marshal(&cmapi.Certificate{
+		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status:     status,
+	})
+	require.NoError(t, err)
+	_, err = cmClient.CertmanagerV1().Certificates(namespace).Patch(
+		t.Context(), name, apitypes.ApplyPatchType, patch,
+		metav1.PatchOptions{Force: new(true), FieldManager: fieldManager}, "status",
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/8785
Fixes https://github.com/cert-manager/cert-manager/issues/7438

When the `ServerSideApply` feature gate is enabled, few controllers silently drop fields because their SSA apply payloads are incomplete:

(1) Certificate shim: only 5 of 22+ CertificateSpec fields were included in SSA Apply, losing specs like `RevisionHistoryLimit`.

(2) Certificate issuing controller: `FailedIssuanceAttempts` was missing from the `ApplyStatus` payload, breaking issuance retry backoff.

(3) Certificate shim: under SSA, Certificate create also uses Apply so field ownership matches updates (operation:Apply instead of operation:Update).

A secondary bug was exposed by fix (1): `serializeApply` deep-copied ObjectMeta including `ManagedFields` into the SSA patch body, causing the API server to reject patches with `metadata.managedFields must be nil`. This was latent because the old code constructed a fresh object with zero-value ObjectMeta.

### E2E Verification

<details>
<summary>certificate-shim 'spec.revisionHistoryLimit' should survives SSA Apply update</summary>

without the fix
```
$ helm install \
  cert-manager oci://quay.io/jetstack/charts/cert-manager \
  --version v1.20.2 \
  --namespace cert-manager \
  --create-namespace \
  --set crds.enabled=true \
  --set featureGates="ServerSideApply=true" \
  --set "cainjector.extraArgs={--feature-gates=ServerSideApply=true}" \
  --set "dns01RecursiveNameservers=10.0.0.16:53" \
  --set "dns01RecursiveNameserversOnly=true"

$ kubectl create ns e2e-test-1

$ kubectl apply -f - <<EOL
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: smoke-issuer
spec:
  selfSigned: {}
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-shim
  namespace: e2e-test-1
  annotations:
    cert-manager.io/issuer: smoke-issuer
    cert-manager.io/revision-history-limit: "7"
spec:
  rules:
  - host: test.example.com
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: dummy
            port:
              number: 80
  tls:
  - hosts:
    - test.example.com
    secretName: test-shim-tls
EOL

# wait for Certificate creation, verify initial value
$ kubectl get cert test-shim-tls -n e2e-test-1 -o jsonpath='spec.revisionHistoryLimit: {.spec.revisionHistoryLimit}'
spec.revisionHistoryLimit: 7

# change revision-history-limit from 7 to 3 (trigger SSA update path)
$ kubectl annotate ingress test-shim -n e2e-test-1 \
    cert-manager.io/revision-history-limit="3" --overwrite

# wait for shim to reconcile, verify update but still at 7
$ kubectl get cert test-shim-tls -n e2e-test-1 -o jsonpath='spec.revisionHistoryLimit: {.spec.revisionHistoryLimit}'
spec.revisionHistoryLimit: 7
```

with the fix

```
# build and deploy with current branch
$ make e2e-setup-kind

...
# wait for shim to reconcile, verify update successfully to 3
$ kubectl get cert test-shim-tls -n e2e-test-1 -o jsonpath='spec.revisionHistoryLimit: {.spec.revisionHistoryLimit}'
spec.revisionHistoryLimit: 3
```

</details>

<details>
<summary>FailedIssuanceAttempts should persist via SSA ApplyStatus after an ACME failure</summary>

without the fix
```
# pre: make the test domain resolve to ingress-nginx ClusterIP via CoreDNS rewrite to pass self-check

$ kubectl apply -f - <<EOL
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: acme-pebble
  namespace: e2e-test-3
spec:
  acme:
    server: https://pebble.pebble.svc:443/dir
    skipTLSVerify: true
    privateKeySecretRef:
      name: acme-account-key
    solvers:
    - http01:
        ingress: {}
EOL

$ kubectl apply -f - <<EOL
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test-acme
  namespace: e2e-test-3
spec:
  secretName: test-acme-secret
  commonName: fail.test
  dnsNames:
  - fail.test
  issuerRef:
    name: acme-pebble
EOL

# wait for first issuance
$ kubectl get cert test-acme -n e2e-test-3 -w

# break Pebble to simulate ACME failure on re-issuance
$ kubectl scale deploy pebble-pebble -n pebble --replicas=0

# trigger re-issuance
$ kubectl patch cert test-acme -n e2e-test-3 --type=json \
    -p='[{"op":"replace","path":"/spec/commonName","value":"fail2.test"}]'

# verify FailedIssuanceAttempts if persists, but got 'null'
$ kubectl get cert test-acme -n e2e-test-3 -o json --context kind-prod0 | jq -r '.status.revision, .status.failedIssuanceAttempts'
1
null
```

with the fix

```
# build and deploy with current branch
$ make e2e-setup-kind

...

# verify FailedIssuanceAttempts if persists, increment 0 -> 1 as expected
$ kubectl get cert test-acme -n e2e-test-3 -o json --context kind-kind | jq -r '.status.revision, .status.failedIssuanceAttempts'
1
1
```

</details>


### Kind

/kind bug

### Release Note

```release-note
Fix Server-Side Apply silently dropping Certificate spec fields (e.g. RevisionHistoryLimit) in the ingress-shim controller, and FailedIssuanceAttempts in the issuing controller.
```
