### PR TITLE
feat: add per-issuer CertificateApprovalPolicy field

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -3378,6 +3378,15 @@ spec:
                   required:
                     - secretName
                   type: object
+                certificateApprovalPolicy:
+                  description: |-
+                    CertificateApprovalPolicy configures the approval policy used for this
+                    issuer. By default all certificates are automatically approved unless
+                    the approval controller is disabled.
+                  enum:
+                    - Always
+                    - External
+                  type: string
                 selfSigned:
                   description: |-
                     SelfSigned configures this issuer to 'self sign' certificates using the

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -3377,6 +3377,15 @@ spec:
                   required:
                     - secretName
                   type: object
+                certificateApprovalPolicy:
+                  description: |-
+                    CertificateApprovalPolicy configures the approval policy used for this
+                    issuer. By default all certificates are automatically approved unless
+                    the approval controller is disabled.
+                  enum:
+                    - Always
+                    - External
+                  type: string
                 selfSigned:
                   description: |-
                     SelfSigned configures this issuer to 'self sign' certificates using the

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -3625,6 +3625,15 @@ spec:
                 required:
                 - secretName
                 type: object
+              certificateApprovalPolicy:
+                description: |-
+                  CertificateApprovalPolicy configures the approval policy used for this
+                  issuer. By default all certificates are automatically approved unless
+                  the approval controller is disabled.
+                enum:
+                - Always
+                - External
+                type: string
               selfSigned:
                 description: |-
                   SelfSigned configures this issuer to 'self sign' certificates using the

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -3624,6 +3624,15 @@ spec:
                 required:
                 - secretName
                 type: object
+              certificateApprovalPolicy:
+                description: |-
+                  CertificateApprovalPolicy configures the approval policy used for this
+                  issuer. By default all certificates are automatically approved unless
+                  the approval controller is disabled.
+                enum:
+                - Always
+                - External
+                type: string
               selfSigned:
                 description: |-
                   SelfSigned configures this issuer to 'self sign' certificates using the

--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -82,6 +82,11 @@ type IssuerList struct {
 // configuration required for the issuer.
 type IssuerSpec struct {
 	IssuerConfig
+
+	// CertificateApprovalPolicy configures the approval policy used for this
+	// issuer. By default all certificates are automatically approved unless
+	// the approval controller is disabled.
+	CertificateApprovalPolicy *IssuerCertificateApprovalPolicy
 }
 
 // IssuerConfig is a generic wrapper around custom issuer types
@@ -378,6 +383,22 @@ type CAIssuer struct {
 	// +optional
 	IssuingCertificateURLs []string `json:"issuingCertificateURLs,omitempty"`
 }
+
+// IssuerCertificateApprovalPolicy controls whether cert-manager automatically
+// approves CertificateRequests targeting this issuer, or delegates approval to
+// an external controller.
+type IssuerCertificateApprovalPolicy string
+
+const (
+	// IssuerCertificateApprovalPolicyAlways causes cert-manager to automatically
+	// approve every CertificateRequest that references this issuer.
+	IssuerCertificateApprovalPolicyAlways IssuerCertificateApprovalPolicy = "Always"
+
+	// IssuerCertificateApprovalPolicyExternal causes cert-manager to leave
+	// CertificateRequests in a pending state, requiring an external controller
+	// to approve or deny them.
+	IssuerCertificateApprovalPolicyExternal IssuerCertificateApprovalPolicy = "External"
+)
 
 // IssuerStatus contains status information about an Issuer
 type IssuerStatus struct {

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1311,6 +1311,7 @@ func autoConvert_v1_IssuerSpec_To_certmanager_IssuerSpec(in *certmanagerv1.Issue
 	if err := Convert_v1_IssuerConfig_To_certmanager_IssuerConfig(&in.IssuerConfig, &out.IssuerConfig, s); err != nil {
 		return err
 	}
+	out.CertificateApprovalPolicy = (*certmanager.IssuerCertificateApprovalPolicy)(unsafe.Pointer(in.CertificateApprovalPolicy))
 	return nil
 }
 
@@ -1323,6 +1324,7 @@ func autoConvert_certmanager_IssuerSpec_To_v1_IssuerSpec(in *certmanager.IssuerS
 	if err := Convert_certmanager_IssuerConfig_To_v1_IssuerConfig(&in.IssuerConfig, &out.IssuerConfig, s); err != nil {
 		return err
 	}
+	out.CertificateApprovalPolicy = (*certmanagerv1.IssuerCertificateApprovalPolicy)(unsafe.Pointer(in.CertificateApprovalPolicy))
 	return nil
 }
 

--- a/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -790,6 +790,11 @@ func (in *IssuerList) DeepCopyObject() runtime.Object {
 func (in *IssuerSpec) DeepCopyInto(out *IssuerSpec) {
 	*out = *in
 	in.IssuerConfig.DeepCopyInto(&out.IssuerConfig)
+	if in.CertificateApprovalPolicy != nil {
+		in, out := &in.CertificateApprovalPolicy, &out.CertificateApprovalPolicy
+		*out = new(IssuerCertificateApprovalPolicy)
+		**out = **in
+	}
 	return
 }
 

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -3955,6 +3955,13 @@ func schema_pkg_apis_certmanager_v1_IssuerSpec(ref common.ReferenceCallback) com
 							Ref:         ref("github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1.VenafiIssuer"),
 						},
 					},
+					"certificateApprovalPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CertificateApprovalPolicy configures the approval policy used for this issuer. By default all certificates are automatically approved unless the approval controller is disabled.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -99,6 +99,12 @@ type IssuerList struct {
 // configuration required for the issuer.
 type IssuerSpec struct {
 	IssuerConfig `json:",inline"`
+
+	// CertificateApprovalPolicy configures the approval policy used for this
+	// issuer. By default all certificates are automatically approved unless
+	// the approval controller is disabled.
+	// +optional
+	CertificateApprovalPolicy *IssuerCertificateApprovalPolicy `json:"certificateApprovalPolicy,omitempty"`
 }
 
 // The configuration for the issuer.
@@ -433,6 +439,23 @@ type CAIssuer struct {
 	// +listType=atomic
 	IssuingCertificateURLs []string `json:"issuingCertificateURLs,omitempty"`
 }
+
+// IssuerCertificateApprovalPolicy controls whether cert-manager automatically
+// approves CertificateRequests targeting this issuer, or delegates approval to
+// an external controller.
+// +kubebuilder:validation:Enum=Always;External
+type IssuerCertificateApprovalPolicy string
+
+const (
+	// IssuerCertificateApprovalPolicyAlways causes cert-manager to automatically
+	// approve every CertificateRequest that references this issuer.
+	IssuerCertificateApprovalPolicyAlways IssuerCertificateApprovalPolicy = "Always"
+
+	// IssuerCertificateApprovalPolicyExternal causes cert-manager to leave
+	// CertificateRequests in a pending state, requiring an external controller
+	// to approve or deny them.
+	IssuerCertificateApprovalPolicyExternal IssuerCertificateApprovalPolicy = "External"
+)
 
 // IssuerStatus contains status information about an Issuer
 type IssuerStatus struct {

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -790,6 +790,11 @@ func (in *IssuerList) DeepCopyObject() runtime.Object {
 func (in *IssuerSpec) DeepCopyInto(out *IssuerSpec) {
 	*out = *in
 	in.IssuerConfig.DeepCopyInto(&out.IssuerConfig)
+	if in.CertificateApprovalPolicy != nil {
+		in, out := &in.CertificateApprovalPolicy, &out.CertificateApprovalPolicy
+		*out = new(IssuerCertificateApprovalPolicy)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/applyconfigurations/certmanager/v1/issuerspec.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/issuerspec.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	acmev1 "github.com/cert-manager/cert-manager/pkg/client/applyconfigurations/acme/v1"
 )
 
@@ -29,6 +30,10 @@ import (
 // configuration required for the issuer.
 type IssuerSpecApplyConfiguration struct {
 	IssuerConfigApplyConfiguration `json:",inline"`
+	// CertificateApprovalPolicy configures the approval policy used for this
+	// issuer. By default all certificates are automatically approved unless
+	// the approval controller is disabled.
+	CertificateApprovalPolicy *certmanagerv1.IssuerCertificateApprovalPolicy `json:"certificateApprovalPolicy,omitempty"`
 }
 
 // IssuerSpecApplyConfiguration constructs a declarative configuration of the IssuerSpec type for use with
@@ -74,5 +79,13 @@ func (b *IssuerSpecApplyConfiguration) WithSelfSigned(value *SelfSignedIssuerApp
 // If called multiple times, the Venafi field is set to the value of the last call.
 func (b *IssuerSpecApplyConfiguration) WithVenafi(value *VenafiIssuerApplyConfiguration) *IssuerSpecApplyConfiguration {
 	b.IssuerConfigApplyConfiguration.Venafi = value
+	return b
+}
+
+// WithCertificateApprovalPolicy sets the CertificateApprovalPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CertificateApprovalPolicy field is set to the value of the last call.
+func (b *IssuerSpecApplyConfiguration) WithCertificateApprovalPolicy(value certmanagerv1.IssuerCertificateApprovalPolicy) *IssuerSpecApplyConfiguration {
+	b.CertificateApprovalPolicy = &value
 	return b
 }

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -1568,6 +1568,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: ca
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.certmanager.v1.CAIssuer
+    - name: certificateApprovalPolicy
+      type:
+        scalar: string
     - name: selfSigned
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.certmanager.v1.SelfSignedIssuer

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -30,6 +30,7 @@ import (
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
@@ -49,6 +50,10 @@ type Controller struct {
 	certificateRequestLister cmlisters.CertificateRequestLister
 	cmClient                 cmclient.Interface
 	fieldManager             string
+
+	issuerLister        cmlisters.IssuerLister
+	clusterIssuerLister cmlisters.ClusterIssuerLister
+	helper              issuer.Helper
 
 	recorder record.EventRecorder
 
@@ -76,7 +81,15 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	)
 
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
-	mustSync := []cache.InformerSynced{certificateRequestInformer.Informer().HasSynced}
+	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1().Issuers()
+	clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
+
+	mustSync := []cache.InformerSynced{
+		certificateRequestInformer.Informer().HasSynced,
+		issuerInformer.Informer().HasSynced,
+		clusterIssuerInformer.Informer().HasSynced,
+	}
+
 	if _, err := certificateRequestInformer.Informer().AddEventHandler(controllerpkg.QueuingEventHandler(c.queue)); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
@@ -85,6 +98,10 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	c.cmClient = ctx.CMClient
 	c.fieldManager = ctx.FieldManager
 	c.recorder = ctx.Recorder
+
+	c.issuerLister = issuerInformer.Lister()
+	c.clusterIssuerLister = clusterIssuerInformer.Lister()
+	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 
 	c.log.V(logf.DebugLevel).Info("certificate request approver controller registered")
 

--- a/pkg/controller/certificaterequests/approver/approver_test.go
+++ b/pkg/controller/certificaterequests/approver/approver_test.go
@@ -21,9 +21,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	fakeclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -39,6 +41,10 @@ func TestProcessItem(t *testing.T) {
 		// if not set, the 'namespace/name' of the 'CertificateRequest' field will be used.
 		// if neither is set, the key will be ""
 		key types.NamespacedName
+
+		// issuer is the Issuer or ClusterIssuer the CertificateRequest's issuerRef
+		// points to. If set, it is added to the builder's CertManagerObjects.
+		issuer cmapi.GenericIssuer
 
 		// CertificateRequest to be synced for the test.
 		// if not set, the 'key' will be passed to ProcessItem instead.
@@ -124,8 +130,12 @@ func TestProcessItem(t *testing.T) {
 			},
 		},
 		"approve CertificateRequest if no condition": {
+			issuer: &cmapi.Issuer{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test-issuer"}},
 			request: &cmapi.CertificateRequest{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Spec: cmapi.CertificateRequestSpec{
+					IssuerRef: cmmeta.IssuerReference{Name: "test-issuer", Kind: "Issuer", Group: "cert-manager.io"},
+				},
 				Status: cmapi.CertificateRequestStatus{
 					Conditions: []cmapi.CertificateRequestCondition{},
 				},
@@ -142,8 +152,12 @@ func TestProcessItem(t *testing.T) {
 			expectedEvent: "Normal cert-manager.io Certificate request has been approved by cert-manager.io",
 		},
 		"approve CertificateRequest has 'Ready' Pending condition": {
+			issuer: &cmapi.Issuer{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test-issuer"}},
 			request: &cmapi.CertificateRequest{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Spec: cmapi.CertificateRequestSpec{
+					IssuerRef: cmmeta.IssuerReference{Name: "test-issuer", Kind: "Issuer", Group: "cert-manager.io"},
+				},
 				Status: cmapi.CertificateRequestStatus{
 					Conditions: []cmapi.CertificateRequestCondition{
 						{
@@ -170,6 +184,50 @@ func TestProcessItem(t *testing.T) {
 			},
 			expectedEvent: "Normal cert-manager.io Certificate request has been approved by cert-manager.io",
 		},
+		"approve CertificateRequest when policy is explicitly Always": {
+			issuer: &cmapi.Issuer{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test-issuer"},
+				Spec: cmapi.IssuerSpec{
+					CertificateApprovalPolicy: ptr.To(cmapi.IssuerCertificateApprovalPolicyAlways),
+				},
+			},
+			request: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Spec: cmapi.CertificateRequestSpec{
+					IssuerRef: cmmeta.IssuerReference{Name: "test-issuer", Kind: "Issuer", Group: "cert-manager.io"},
+				},
+				Status: cmapi.CertificateRequestStatus{
+					Conditions: []cmapi.CertificateRequestCondition{},
+				},
+			},
+			expectedConditions: []cmapi.CertificateRequestCondition{
+				{
+					Type:               cmapi.CertificateRequestConditionApproved,
+					Status:             cmmeta.ConditionTrue,
+					Reason:             "cert-manager.io",
+					Message:            ApprovedMessage,
+					LastTransitionTime: &metaNow,
+				},
+			},
+			expectedEvent: "Normal cert-manager.io Certificate request has been approved by cert-manager.io",
+		},
+		"do nothing when approval policy is External": {
+			issuer: &cmapi.Issuer{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test-issuer"},
+				Spec: cmapi.IssuerSpec{
+					CertificateApprovalPolicy: ptr.To(cmapi.IssuerCertificateApprovalPolicyExternal),
+				},
+			},
+			request: &cmapi.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Spec: cmapi.CertificateRequestSpec{
+					IssuerRef: cmmeta.IssuerReference{Name: "test-issuer", Kind: "Issuer", Group: "cert-manager.io"},
+				},
+				Status: cmapi.CertificateRequestStatus{
+					Conditions: []cmapi.CertificateRequestCondition{},
+				},
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -180,6 +238,9 @@ func TestProcessItem(t *testing.T) {
 			}
 			if test.request != nil {
 				builder.CertManagerObjects = append(builder.CertManagerObjects, test.request)
+			}
+			if test.issuer != nil {
+				builder.CertManagerObjects = append(builder.CertManagerObjects, test.issuer.(runtime.Object))
 			}
 			builder.Init()
 

--- a/pkg/controller/certificaterequests/approver/sync.go
+++ b/pkg/controller/certificaterequests/approver/sync.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	internalcertificaterequests "github.com/cert-manager/cert-manager/internal/controller/certificaterequests"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
@@ -52,6 +53,18 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 		// If the CertificateRequest is "Issued" or "Failed", exit early.
 		apiutil.CertificateRequestReadyReason(cr) == cmapi.CertificateRequestReasonFailed,
 		apiutil.CertificateRequestReadyReason(cr) == cmapi.CertificateRequestReasonIssued:
+		return nil
+	}
+
+	// Get the Issuer/ClusterIssuer
+	issuer, err := c.helper.GetGenericIssuer(cr.Spec.IssuerRef, cr.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// Get the approval policy, defaulting to always approved
+	approvalPolicy := ptr.Deref(issuer.GetSpec().CertificateApprovalPolicy, cmapi.IssuerCertificateApprovalPolicyAlways)
+	if approvalPolicy != cmapi.IssuerCertificateApprovalPolicyAlways {
 		return nil
 	}
 


### PR DESCRIPTION
### Pull Request Motivation

Adds a `CertificateApprovalPolicy` field to `IssuerSpec` (and `ClusterIssuerSpec`) with two values: `Always` (default) and `External`.

When set to `External`, the cert-manager approval controller skips the `CertificateRequest`, leaving it pending for another controller to approve or deny. When unset or `Always`, behaviour is unchanged.

This allows cert-manager to be deployed alongside components such as [csi-driver-spiffe](https://github.com/cert-manager/csi-driver-spiffe) that ship their own approver, scoped per-issuer, without needing to disable the cert-manager approval controller globally or introduce approver-policy for the whole cluster.

### Kind

/kind feature

### Release Note

```release-note
Add CertificateApprovalPolicy field to IssuerSpec and ClusterIssuerSpec. When set to External, the built-in approval controller will leave CertificateRequests pending for an external approver to handle, enabling per-issuer approval delegation without disabling the approval controller globally.
```