### PR TITLE
fix: close Vault response body on RawRequest error to prevent resource leak

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -185,11 +185,12 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 	}
 
 	resp, err := v.client.RawRequest(request)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to sign certificate by vault: %s", err)
 	}
-
-	defer resp.Body.Close()
 
 	vaultResult := certutil.Secret{}
 	err = resp.DecodeJSON(&vaultResult)
@@ -451,11 +452,12 @@ func (v *Vault) requestTokenWithAppRoleRef(client Client, appRole *v1.VaultAppRo
 	}
 
 	resp, err := client.RawRequest(request)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", fmt.Errorf("error logging in to Vault server: %s", err.Error())
 	}
-
-	defer resp.Body.Close()
 
 	vaultResult := vault.Secret{}
 	if err := resp.DecodeJSON(&vaultResult); err != nil {
@@ -529,11 +531,13 @@ func (v *Vault) requestTokenWithClientCertificate(client Client, clientCertifica
 	}
 
 	resp, err := client.RawRequest(request)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
 	}
 
-	defer resp.Body.Close()
 	vaultResult := vault.Secret{}
 	err = resp.DecodeJSON(&vaultResult)
 	if err != nil {
@@ -630,11 +634,13 @@ func (v *Vault) requestTokenWithKubernetesAuth(ctx context.Context, client Clien
 	}
 
 	resp, err := client.RawRequest(request)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
 	}
 
-	defer resp.Body.Close()
 	vaultResult := vault.Secret{}
 	err = resp.DecodeJSON(&vaultResult)
 	if err != nil {


### PR DESCRIPTION
### Pull Request Motivation

Vault's `RawRequest` can return a non-nil `*Response` alongside a non-nil
error (e.g. on HTTP 4xx/5xx status codes). In four call sites the
response body was only closed in the success path, leaking the body
when `RawRequest` returned an error with a non-nil response. Over time
this can exhaust HTTP connections and file descriptors.

Move `defer resp.Body.Close()` above the error check with a nil guard,
matching the pattern already used in `IsVaultInitializedAndUnsealed`.

**Affected functions:**
- `Sign()`
- `requestTokenWithAppRoleRef()`
- `requestTokenWithClientCertificate()`
- `requestTokenWithKubernetesAuth()`

/kind bug

```release-note
NONE
```
