### PR TITLE
Bound DNS-over-HTTPS response read with io.LimitReader

### DIFF
--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -24,6 +24,12 @@ import (
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 )
 
+// maxDNSResponseSize is the max size of a received DNS-over-HTTPS response
+// body. DNS over TCP responses are limited to 65535 bytes by RFC 1035; this
+// is set to a generous 128KB to allow for overhead while still preventing a
+// malicious DoH server from sending an arbitrarily large response.
+const maxDNSResponseSize = 128 * 1024
+
 type preCheckDNSFunc func(ctx context.Context, fqdn, value string, nameservers []string,
 	useAuthoritative bool) (bool, error)
 type dnsQueryFunc func(ctx context.Context, fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error)
@@ -257,7 +263,7 @@ func (c *httpDNSClient) Exchange(ctx context.Context, m *dns.Msg, a string) (r *
 		return nil, 0, fmt.Errorf("dns: unexpected Content-Type %q; expected %q", ct, dohMimeType)
 	}
 
-	p, err = io.ReadAll(resp.Body)
+	p, err = io.ReadAll(io.LimitReader(resp.Body, maxDNSResponseSize))
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
### Pull Request Motivation

`io.ReadAll(resp.Body)` in the DNS-over-HTTPS client (`pkg/issuer/acme/dns/util/wait.go`) reads the full response without a size limit. A malicious or compromised DoH server can send an arbitrarily large response, causing the cert-manager controller to run out of memory.

This is the same class of vulnerability as [CVE-2026-40924](https://github.com/tektoncd/pipeline/security/advisories/GHSA-m2cx-gpqf-qf74) in Tekton Pipelines.

The fix wraps with `io.LimitReader` using a 128 KB cap, which is well above the DNS over TCP maximum of 65,535 bytes ([RFC 1035 section 4.2.2](https://datatracker.ietf.org/doc/html/rfc1035#section-4.2.2)). This matches the existing pattern used in:
- `cloudflare.go:289` (`cloudFlareMaxBodySize`)
- `http.go:312` (`maxAcmeChallengeBodySize`)

Introduced in #5003; last touched mechanically in #6598.

/kind bug

```release-note
Fixed potential OOM in DNS-over-HTTPS client by bounding response body read with io.LimitReader (128 KB cap).
```