### PR TITLE
scheduler: allow ACME challenges in parallel by ingress class/provider

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/scheduler.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler.go
@@ -186,13 +186,83 @@ func compareChallenges(l, r *cmacme.Challenge) int {
 		return 1
 	}
 
-	// TODO: check the http01.ingressClass attribute and allow two challenges
-	// with different ingress classes specified to be scheduled at once
+	// For HTTP-01, allow parallel challenges with different ingress classes.
+	if l.Spec.Type == cmacme.ACMEChallengeTypeHTTP01 {
+		lIngressClass := getChallengeIngressClass(&l.Spec.Solver)
+		rIngressClass := getChallengeIngressClass(&r.Spec.Solver)
+		if lIngressClass < rIngressClass {
+			return -1
+		}
+		if lIngressClass > rIngressClass {
+			return 1
+		}
+	}
 
-	// TODO: check the dns01.provider attribute and allow two challenges with
-	// different providers to be scheduled at once
+	// For DNS-01, allow parallel challenges with different DNS providers.
+	if l.Spec.Type == cmacme.ACMEChallengeTypeDNS01 {
+		lDNSProvider := getChallengeDNSProvider(&l.Spec.Solver)
+		rDNSProvider := getChallengeDNSProvider(&r.Spec.Solver)
+		if lDNSProvider < rDNSProvider {
+			return -1
+		}
+		if lDNSProvider > rDNSProvider {
+			return 1
+		}
+	}
 
 	return 0
+}
+
+func getChallengeIngressClass(challengeSolver *cmacme.ACMEChallengeSolver) string {
+	if challengeSolver.HTTP01 == nil || challengeSolver.HTTP01.Ingress == nil {
+		return ""
+	}
+
+	if challengeSolver.HTTP01.Ingress.IngressClassName != nil {
+		return *challengeSolver.HTTP01.Ingress.IngressClassName
+	}
+
+	if challengeSolver.HTTP01.Ingress.Class != nil {
+		return *challengeSolver.HTTP01.Ingress.Class
+	}
+
+	return ""
+}
+
+func getChallengeDNSProvider(challengeSolver *cmacme.ACMEChallengeSolver) string {
+	if challengeSolver.DNS01 == nil {
+		return ""
+	}
+
+	if challengeSolver.DNS01.Akamai != nil {
+		return "akamai"
+	}
+	if challengeSolver.DNS01.CloudDNS != nil {
+		return "clouddns"
+	}
+	if challengeSolver.DNS01.Cloudflare != nil {
+		return "cloudflare"
+	}
+	if challengeSolver.DNS01.Route53 != nil {
+		return "route53"
+	}
+	if challengeSolver.DNS01.AzureDNS != nil {
+		return "azuredns"
+	}
+	if challengeSolver.DNS01.DigitalOcean != nil {
+		return "digitalocean"
+	}
+	if challengeSolver.DNS01.AcmeDNS != nil {
+		return "acmedns"
+	}
+	if challengeSolver.DNS01.RFC2136 != nil {
+		return "rfc2136"
+	}
+	if challengeSolver.DNS01.Webhook != nil {
+		return "webhook"
+	}
+
+	return ""
 }
 
 // sortChallenges will sort the provided list of challenges according to the

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -72,6 +72,63 @@ func withCreationTimestamp(i int64) func(*cmacme.Challenge) {
 	}
 }
 
+func withHTTP01IngressClass(className string) gen.ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		// Set challenge type if not already specified by test case.
+		ch.Spec.Type = cmacme.ACMEChallengeTypeHTTP01
+		if ch.Spec.Solver.HTTP01 == nil {
+			ch.Spec.Solver.HTTP01 = &cmacme.ACMEChallengeSolverHTTP01{}
+		}
+		if ch.Spec.Solver.HTTP01.Ingress == nil {
+			ch.Spec.Solver.HTTP01.Ingress = &cmacme.ACMEChallengeSolverHTTP01Ingress{}
+		}
+		if className == "" {
+			ch.Spec.Solver.HTTP01.Ingress.IngressClassName = nil
+			ch.Spec.Solver.HTTP01.Ingress.Class = nil
+			return
+		}
+		ch.Spec.Solver.HTTP01.Ingress.IngressClassName = &className
+		ch.Spec.Solver.HTTP01.Ingress.Class = nil
+	}
+}
+
+func withDNS01Provider(provider string) gen.ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Type = cmacme.ACMEChallengeTypeDNS01
+		if ch.Spec.Solver.DNS01 == nil {
+			ch.Spec.Solver.DNS01 = &cmacme.ACMEChallengeSolverDNS01{}
+		}
+		ch.Spec.Solver.DNS01.Akamai = nil
+		ch.Spec.Solver.DNS01.CloudDNS = nil
+		ch.Spec.Solver.DNS01.Cloudflare = nil
+		ch.Spec.Solver.DNS01.Route53 = nil
+		ch.Spec.Solver.DNS01.AzureDNS = nil
+		ch.Spec.Solver.DNS01.DigitalOcean = nil
+		ch.Spec.Solver.DNS01.AcmeDNS = nil
+		ch.Spec.Solver.DNS01.RFC2136 = nil
+		ch.Spec.Solver.DNS01.Webhook = nil
+
+		switch provider {
+		case "acmeDNS":
+			ch.Spec.Solver.DNS01.AcmeDNS = &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{}
+		case "route53":
+			ch.Spec.Solver.DNS01.Route53 = &cmacme.ACMEIssuerDNS01ProviderRoute53{}
+		case "cloudflare":
+			ch.Spec.Solver.DNS01.Cloudflare = &cmacme.ACMEIssuerDNS01ProviderCloudflare{}
+		case "cloudDNS":
+			ch.Spec.Solver.DNS01.CloudDNS = &cmacme.ACMEIssuerDNS01ProviderCloudDNS{}
+		case "azureDNS":
+			ch.Spec.Solver.DNS01.AzureDNS = &cmacme.ACMEIssuerDNS01ProviderAzureDNS{}
+		case "digitalOcean":
+			ch.Spec.Solver.DNS01.DigitalOcean = &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{}
+		case "rfc2136":
+			ch.Spec.Solver.DNS01.RFC2136 = &cmacme.ACMEIssuerDNS01ProviderRFC2136{}
+		case "webhook":
+			ch.Spec.Solver.DNS01.Webhook = &cmacme.ACMEIssuerDNS01ProviderWebhook{}
+		}
+	}
+}
+
 func BenchmarkScheduleAscending(b *testing.B) {
 	counts := []int{10, 100, 1000, 10000, 100000, 1000000}
 	for _, c := range counts {
@@ -233,6 +290,88 @@ func TestScheduleN(t *testing.T) {
 				gen.Challenge("test2",
 					gen.SetChallengeDNSName("example.com"),
 					gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01)),
+			},
+		},
+		{
+			name: "allow scheduling HTTP01 challenges for same domain with different ingress classes",
+			n:    2,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("nginx"),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("traefik"),
+					withCreationTimestamp(2)),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("nginx"),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("traefik"),
+					withCreationTimestamp(2)),
+			},
+		},
+		{
+			name: "block HTTP01 challenges for same domain and same ingress class",
+			n:    2,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("nginx")),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("nginx")),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withHTTP01IngressClass("nginx")),
+			},
+		},
+		{
+			name: "allow scheduling DNS01 challenges for same domain with different providers",
+			n:    2,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("route53"),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("cloudflare"),
+					withCreationTimestamp(2)),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("route53"),
+					withCreationTimestamp(1)),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("cloudflare"),
+					withCreationTimestamp(2)),
+			},
+		},
+		{
+			name: "block DNS01 challenges for same domain and same provider",
+			n:    2,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("route53")),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("route53")),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					withDNS01Provider("route53")),
 			},
 		},
 		// this test case replicates a failure seen in CI


### PR DESCRIPTION
## What changed

This PR improves ACME challenge scheduling so challenges for the same domain are no longer treated as conflicting when they can safely run in parallel:

- For HTTP-01 challenges, we now compare the configured HTTP01 ingress class (`ingressClassName` and legacy `class`) and allow distinct classes to coexist.
- For DNS-01 challenges, we now compare the configured DNS provider and allow different providers to coexist.
- Added helper functions to extract solver-specific conflict keys.
- Added regression test coverage in `pkg/controller/acmechallenges/scheduler/scheduler_test.go` for:
  - allowing same-domain HTTP-01 with different ingress classes,
  - blocking same-domain HTTP-01 with the same ingress class,
  - allowing same-domain DNS-01 with different providers,
  - blocking same-domain DNS-01 with the same provider.

## Why

This addresses issue #8643 and restores valid concurrency for multi-controller / multi-provider ACME setups without unnecessary serialization.

## Test

`go test ./pkg/controller/acmechallenges/scheduler -run TestScheduleN -count=1`

```release-note
ACME challenges for the same domain can now be scheduled concurrently when they use different HTTP-01 ingress classes or DNS-01 providers.
```
