### PR TITLE
fix: avoid cron timezone prefix panic

### DIFF
--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -934,6 +934,30 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
+		"invalid renewal cron with timezone prefix and no schedule": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					PrivateKey: &internalcmapi.CertificatePrivateKey{
+						RotationPolicy: internalcmapi.RotationPolicyNever,
+					},
+					Renewal: &internalcmapi.CertificateRenewal{
+						Policy: internalcmapi.RenewBefore,
+						Windows: []internalcmapi.CertificateRenewalWindows{
+							{
+								WindowDuration: &metav1.Duration{Duration: time.Hour * 2},
+								Cron:           "CRON_TZ=UTC",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("renewal", "windows").Index(0).Child("cron"), "CRON_TZ=UTC", "invalid cron syntax: failed to parse cron spec 'CRON_TZ=UTC': expected timezone prefix to be followed by a cron spec: CRON_TZ=UTC. cron needs to follow: cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/internal/cron/parser.go
+++ b/internal/cron/parser.go
@@ -104,6 +104,9 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		var err error
 		i := strings.Index(spec, " ")
 		eq := strings.Index(spec, "=")
+		if i == -1 {
+			return nil, fmt.Errorf("expected timezone prefix to be followed by a cron spec: %s", spec)
+		}
 		if loc, err = time.LoadLocation(spec[eq+1 : i]); err != nil {
 			return nil, fmt.Errorf("provided bad location %s: %v", spec[eq+1:i], err)
 		}

--- a/internal/cron/parser_test.go
+++ b/internal/cron/parser_test.go
@@ -1,0 +1,29 @@
+// +skip_license_check
+
+/*
+This file contains portions of code directly taken from the 'robfig/cron' project.
+A copy of the license for this code can be found in the file named LICENSE in
+this directory.
+*/
+
+package cron
+
+import "testing"
+
+func TestParserParseReturnsErrorForTimezoneWithoutSchedule(t *testing.T) {
+	parser := NewParser(Minute | Hour | Dom | Month | Dow)
+
+	for _, spec := range []string{"TZ=UTC", "CRON_TZ=UTC"} {
+		t.Run(spec, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Parse panicked for %q: %v", spec, r)
+				}
+			}()
+
+			if _, err := parser.Parse(spec); err == nil {
+				t.Fatalf("expected error for %q, got nil", spec)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Pull Request Motivation

A renewal window cron value like `CRON_TZ=UTC` could make cron parsing panic instead of returning a validation error. Tiny footgun, because the CRD only requires `spec.renewal.windows[].cron` to be non-empty, so this can hit webhook validation.

Repro before this fix:
1. create a Certificate with `spec.renewal.policy: RenewBefore`
2. set one window with `cron: CRON_TZ=UTC` and a valid `windowDuration`
3. validation calls cron parsing and boom, panic

Now it returns a normal invalid cron error. Added parser and Certificate validation tests.

Related: #8258

### Kind
/kind bug

### Release Note

```release-note
Fixed validation of timezone-prefixed renewal window cron specs without a schedule.
```