### PR TITLE
Use samplewebhook image name from tarball manifest

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -468,11 +468,16 @@ $(call local-image-tar,samplewebhook): $(call local-image-tar,samplewebhook).dir
 
 .PHONY: e2e-setup-samplewebhook
 e2e-setup-samplewebhook: load-$(call local-image-tar,samplewebhook) e2e-setup-certmanager $(bin_dir)/scratch/kind-exists | $(NEEDS_HELM)
+	@repo_tag="$$(tar xfO $(call local-image-tar,samplewebhook) manifest.json | jq '.[0].RepoTags[0]' -r)"; \
+	repo="$${repo_tag%:*}"; \
+	tag="$${repo_tag##*:}"; \
 	$(HELM) upgrade \
 		--install \
 		--wait \
 		--namespace samplewebhook \
 		--create-namespace \
+		--set image.repository="$$repo" \
+		--set image.tag="$$tag" \
 		samplewebhook make/config/samplewebhook/chart >/dev/null
 
 .PHONY: e2e-setup-gwapi-provider


### PR DESCRIPTION
This fixes a local bug in `e2e-setup-samplewebhook`.

The samplewebhook Helm install was assuming the image would always be available as `local/samplewebhook:local`, but the image reference recorded in the saved tarball manifest can differ. In my local reproduction, kind ended up with `localhost/local/samplewebhook:local`, which caused `ErrImageNeverPull` and left the samplewebhook Deployment unavailable.

This change reads the repository and tag from the saved image tarball manifest and passes them through to the Helm chart, so `e2e-setup-samplewebhook` uses the image name that was actually loaded into kind.

## Tested locally

I ran `make -s e2e-setup-samplewebhook` locally in this branch and then checked the resulting image reference in the saved tarball manifest, the expanded samplewebhook Helm command, and the deployed image in the cluster.

Relevant excerpt:

```text
$ tar xfO _bin/containers/local/samplewebhook+local.tar manifest.json | jq -r '.[0].RepoTags[0]'
local/samplewebhook:local

$ make -n e2e-setup-samplewebhook | tail -n 8
repo_tag="$(tar xfO _bin/containers/local/samplewebhook+local.tar manifest.json | jq '.[0].RepoTags[0]' -r)"; \
repo="${repo_tag%:*}"; \
tag="${repo_tag##*:}"; \
.../helm upgrade \
  --set image.repository="$repo" \
  --set image.tag="$tag" \
  samplewebhook make/config/samplewebhook/chart >/dev/null

$ _bin/tools/kubectl -n samplewebhook get deploy samplewebhook-example-webhook \
    -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}{.status.availableReplicas}/{.status.replicas}{" available\n"}'
local/samplewebhook:local
1/1 available
```

```release-note
Fixed local `e2e-setup-samplewebhook` installation to use the samplewebhook image repository and tag from the saved image tarball manifest.
```
