### PR TITLE
fix: Guard ClusterIssuer metrics collector with controller enable check

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	"github.com/cert-manager/cert-manager/internal/pem"
 	"github.com/cert-manager/cert-manager/pkg/controller"
+	clusterissuerscontroller "github.com/cert-manager/cert-manager/pkg/controller/clusterissuers"
 	"github.com/cert-manager/cert-manager/pkg/healthz"
 	dnsutil "github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -121,7 +122,9 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 	ctx.Metrics.SetupACMECollector(ctx.SharedInformerFactory.Acme().V1().Challenges().Lister())
 	ctx.Metrics.SetupCertificateCollector(ctx.SharedInformerFactory.Certmanager().V1().Certificates().Lister())
 	ctx.Metrics.SetupIssuerCollector(ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister())
-	ctx.Metrics.SetupClusterIssuerCollector(ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister())
+	if enabledControllers.Has(clusterissuerscontroller.ControllerName) {
+		ctx.Metrics.SetupClusterIssuerCollector(ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister())
+	}
 	metricsServer := ctx.Metrics.NewServer(metricsLn)
 
 	g.Go(func() error {

--- a/cmd/controller/app/options/options_test.go
+++ b/cmd/controller/app/options/options_test.go
@@ -27,6 +27,7 @@ import (
 func TestEnabledControllers(t *testing.T) {
 	tests := map[string]struct {
 		controllers []string
+		namespace   string
 		expEnabled  sets.Set[string]
 	}{
 		"if no controllers enabled, return empty": {
@@ -45,7 +46,7 @@ func TestEnabledControllers(t *testing.T) {
 			controllers: []string{"*"},
 			expEnabled:  sets.New(defaults.DefaultEnabledControllers...),
 		},
-		"if all controllers enabled, some disabled, return all controllers with disabled": {
+		"if all controllers enabled, some disabled, return all controllers without disabled": {
 			controllers: []string{"*", "-clusterissuers", "-issuers"},
 			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
 		},
@@ -53,9 +54,20 @@ func TestEnabledControllers(t *testing.T) {
 			controllers: []string{"-clusterissuers", "-issuers"},
 			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete("clusterissuers", "issuers"),
 		},
-		"if both enabled and disabled controllers are specified, return specified controllers": {
-			controllers: []string{"foo", "-bar"},
-			expEnabled:  sets.New("foo"),
+		"if namespace set, remove cluster-scoped controllers": {
+			controllers: []string{"*"},
+			namespace:   "test-ns",
+			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete(defaults.ClusterScopedControllers...),
+		},
+		"if namespace set with explicit controllers, preserve non-cluster-scoped and remove cluster-scoped": {
+			controllers: []string{"issuers", "clusterissuers"},
+			namespace:   "test-ns",
+			expEnabled:  sets.New("issuers"),
+		},
+		"if namespace set with wildcard and disabled controllers, remove cluster-scoped and disabled": {
+			controllers: []string{"*", "-issuers"},
+			namespace:   "test-ns",
+			expEnabled:  sets.New(defaults.DefaultEnabledControllers...).Delete(defaults.ClusterScopedControllers...).Delete("issuers"),
 		},
 	}
 
@@ -63,12 +75,13 @@ func TestEnabledControllers(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			o := config.ControllerConfiguration{
 				Controllers: test.controllers,
+				Namespace:   test.namespace,
 			}
 
 			got := EnabledControllers(&o)
 			if !got.Equal(test.expEnabled) {
-				t.Errorf("got unexpected enabled, exp=%s got=%s",
-					test.expEnabled, got)
+				t.Errorf("got unexpected enabled controllers, exp=%v got=%v",
+					sets.List(test.expEnabled), sets.List(got))
 			}
 		})
 	}


### PR DESCRIPTION
Only initialize the ClusterIssuer metrics collector when the clusterissuers controller is actually enabled. The `enabledControllers` set is already correctly computed by `EnabledControllers()`, which handles both `--namespace` scoping and explicit `--controllers=*,-clusterissuers` disabling.

The second commit adds missing test coverage for namespace-scoped controller filtering in `EnabledControllers`, not directly bonded with the fixing commit but worthy adding.

### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/8806

When the clusterissuers controller is disabled (via `--namespace` or `--controllers`), the metrics collector's unconditional `SetupClusterIssuerCollector` call still registers a ClusterIssuer informer, which ultimately causing "Forbidden" errors in deployments without ClusterIssuer RBAC.

### E2E Verification

<details>
<summary>Namespace-scoped deployment, passing `--namespace=cert-manager` as an extraArgs</summary>

- without the fix: Despite the controller being disabled, the metrics informer unconditionally registers a ClusterIssuer lister.

```
I0523 08:52:05.562398       1 controller.go:237]"skipping disabled controller" controller="clusterissuers"
...
E0523 08:52:05.087922       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343" type="*v1.ClusterIssuer"
```

- with the fix: Controller starts successfully. ClusterIssuer controller is disabled. No Failed to watch *v1.ClusterIssuer errors appear. The guard prevents the metrics informer from being registered.

```
I0523 19:03:36 options.go:305] "disabling all cluster-scoped controllers as cert-manager is scoped to a single namespace" controllers="clusterissuers,..."
```

</details>

<details>
<summary>Keep cluster-scoped mode but disable the clusterissuers controller, by passing `--controllers=issuers`</summary>

- without the fix: ClusterIssuer controller disabled, but metrics informer fires.

```
E0523 09:11:36.739950       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343" type="*v1.ClusterIssuer"
E0523 09:11:38.032209       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343" type="*v1.ClusterIssuer"
E0523 09:11:40.994823       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343" type="*v1.ClusterIssuer"
E0523 09:11:46.144291       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ClusterIssuer: clusterissuers.cert-manager.io is forbidden: User \"system:serviceaccount:cert-manager:cert-manager\" cannot list resource \"clusterissuers\" in API group \"cert-manager.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343" type="*v1.ClusterIssuer"
```

- with the fix: Only mention of ClusterIssuer is the correct skip. No Failed to watch *v1.ClusterIssuer errors. The guard prevents the metrics informer registration.

```
I0523 19:12:30 controller.go:240] "skipping disabled controller" controller="clusterissuers"
```

</details>


### Kind

/kind bug

### Release Note

```release-note
ClusterIssuer metrics collector now correctly respects the enabled-controllers configuration, avoiding a redundant startup when only operating within a namespace.
```