### PR TITLE
reject negative arcs in ParseObjectIdentifier

### DIFF
--- a/pkg/util/pki/asn1_util.go
+++ b/pkg/util/pki/asn1_util.go
@@ -42,6 +42,13 @@ func ParseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err err
 			return nil, err
 		}
 
+		// Negative arcs are not valid and are silently mis-encoded by
+		// asn1.Marshal (the arc is dropped or merged into its neighbour),
+		// producing an OBJECT IDENTIFIER different from the input string.
+		if value < 0 {
+			return nil, fmt.Errorf("invalid OBJECT IDENTIFIER arc %q: must not be negative", part)
+		}
+
 		oid = append(oid, value)
 	}
 

--- a/pkg/util/pki/asn1_util.go
+++ b/pkg/util/pki/asn1_util.go
@@ -37,19 +37,12 @@ func ParseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err err
 
 	oid = make(asn1.ObjectIdentifier, 0, len(parts))
 	for _, part := range parts {
-		value, err := strconv.Atoi(part)
+		value, err := strconv.ParseUint(part, 10, 31)
 		if err != nil {
 			return nil, err
 		}
 
-		// Negative arcs are not valid and are silently mis-encoded by
-		// asn1.Marshal (the arc is dropped or merged into its neighbour),
-		// producing an OBJECT IDENTIFIER different from the input string.
-		if value < 0 {
-			return nil, fmt.Errorf("invalid OBJECT IDENTIFIER arc %q: must not be negative", part)
-		}
-
-		oid = append(oid, value)
+		oid = append(oid, int(value))
 	}
 
 	return oid, nil

--- a/pkg/util/pki/asn1_util_test.go
+++ b/pkg/util/pki/asn1_util_test.go
@@ -64,6 +64,16 @@ func TestParseObjectIdentifier(t *testing.T) {
 			expectedOid: nil,
 			expectedErr: errors.New("strconv.Atoi: parsing \"test\": invalid syntax"),
 		},
+		{
+			oidString:   "1.2.-840.113549",
+			expectedOid: nil,
+			expectedErr: errors.New("invalid OBJECT IDENTIFIER arc \"-840\": must not be negative"),
+		},
+		{
+			oidString:   "-1.2.3",
+			expectedOid: nil,
+			expectedErr: errors.New("invalid OBJECT IDENTIFIER arc \"-1\": must not be negative"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/util/pki/asn1_util_test.go
+++ b/pkg/util/pki/asn1_util_test.go
@@ -47,32 +47,47 @@ func TestParseObjectIdentifier(t *testing.T) {
 		{
 			oidString:   ".",
 			expectedOid: nil,
-			expectedErr: errors.New("strconv.Atoi: parsing \"\": invalid syntax"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"\": invalid syntax"),
 		},
 		{
 			oidString:   ".555",
 			expectedOid: nil,
-			expectedErr: errors.New("strconv.Atoi: parsing \"\": invalid syntax"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"\": invalid syntax"),
 		},
 		{
 			oidString:   "555.",
 			expectedOid: nil,
-			expectedErr: errors.New("strconv.Atoi: parsing \"\": invalid syntax"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"\": invalid syntax"),
 		},
 		{
 			oidString:   "test.5",
 			expectedOid: nil,
-			expectedErr: errors.New("strconv.Atoi: parsing \"test\": invalid syntax"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"test\": invalid syntax"),
 		},
 		{
 			oidString:   "1.2.-840.113549",
 			expectedOid: nil,
-			expectedErr: errors.New("invalid OBJECT IDENTIFIER arc \"-840\": must not be negative"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"-840\": invalid syntax"),
 		},
 		{
 			oidString:   "-1.2.3",
 			expectedOid: nil,
-			expectedErr: errors.New("invalid OBJECT IDENTIFIER arc \"-1\": must not be negative"),
+			expectedErr: errors.New("strconv.ParseUint: parsing \"-1\": invalid syntax"),
+		},
+		{
+			oidString:   "1.2.+840.113549",
+			expectedOid: nil,
+			expectedErr: errors.New("strconv.ParseUint: parsing \"+840\": invalid syntax"),
+		},
+		{
+			oidString:   "1.2.-0.5",
+			expectedOid: nil,
+			expectedErr: errors.New("strconv.ParseUint: parsing \"-0\": invalid syntax"),
+		},
+		{
+			oidString:   "2.9223372036854775800.1",
+			expectedOid: nil,
+			expectedErr: errors.New("strconv.ParseUint: parsing \"9223372036854775800\": value out of range"),
 		},
 	}
 


### PR DESCRIPTION
### Pull Request Motivation

`ParseObjectIdentifier` in `pkg/util/pki/asn1_util.go` parsed each dotted arc with `strconv.Atoi`, which accepts signed input. The validation webhook uses the same parser, so an `otherName` OID such as `1.2.-840.113549` passes admission.

`asn1.Marshal` then silently mis-encodes the negative arc (it contributes zero bytes to the DER, so it is dropped), and the generated CSR/certificate ends up with a different OBJECT IDENTIFIER than the user asked for. For example `1.2.-840.113549` marshals to the bytes for `1.2.113549`.

The parser now uses `strconv.ParseUint(part, 10, 31)` in place of `Atoi`. Beyond negative arcs, this also rejects `+840`-style arcs (accepted-but-non-canonical strings that never match `TypeID.String()` and so trigger a perpetual re-issuance loop), `-0`, and arcs that don't fit in 31 bits (which can overflow `oid[0]*40 + oid[1]` during marshalling and silently encode a different OID).

This guards the webhook and CSR generation call sites directly. The `literalSubject` path swallows the parse error in `subject.go`, so the parser's error message does not surface there: admission of new objects still fails (the nil OID falls through to the "unrecognized key" error), but a stored `literalSubject` containing a signed arc now fails at issuance with the generic asn1 structure error instead of issuing with a wrong subject.

### Kind

/kind bug

### Release Note

```release-note
Potentially breaking: the webhook now rejects X.509 OIDs that contain signed arcs (for example `1.2.-840.113549` in `otherName` SANs or a literal subject) or arcs larger than 2^31-1, instead of silently encoding a certificate with a different OBJECT IDENTIFIER than requested. A Certificate that was previously admitted with such an OID will be rejected on its next update; such objects could not issue a matching certificate and were already stuck in a renewal loop.
```
