### PR TITLE
Add support for GN and SN in LiteralSubject

### DIFF
--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -1242,7 +1242,7 @@ func Test_validateLiteralSubject(t *testing.T) {
 			featureEnabled: true,
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
-					LiteralSubject: "CN=James \\\"Jim\\\" Smith\\, III,DC=dc,DC=net,UID=jamessmith,STREET=La Rambla,L=Barcelona,C=Spain,O=Acme,OU=IT,OU=Admins",
+					LiteralSubject: "CN=James \\\"Jim\\\" Smith\\, III,GN=James,SN=Smith,DC=dc,DC=net,UID=jamessmith,STREET=La Rambla,L=Barcelona,C=Spain,O=Acme,OU=IT,OU=Admins",
 					SecretName:     "abc",
 					IssuerRef:      validIssuerRef,
 				},

--- a/pkg/util/pki/subject.go
+++ b/pkg/util/pki/subject.go
@@ -31,6 +31,8 @@ var OIDConstants = struct {
 	OrganizationalUnit []int
 	CommonName         []int
 	SerialNumber       []int
+	Surname            []int
+	GivenName          []int
 	Locality           []int
 	Province           []int
 	StreetAddress      []int
@@ -42,6 +44,8 @@ var OIDConstants = struct {
 	OrganizationalUnit: []int{2, 5, 4, 11},
 	CommonName:         []int{2, 5, 4, 3},
 	SerialNumber:       []int{2, 5, 4, 5},
+	Surname:            []int{2, 5, 4, 4},
+	GivenName:          []int{2, 5, 4, 42},
 	Locality:           []int{2, 5, 4, 7},
 	Province:           []int{2, 5, 4, 8},
 	StreetAddress:      []int{2, 5, 4, 9},
@@ -58,6 +62,8 @@ var attributeTypeNames = map[string][]int{
 	"OU":           OIDConstants.OrganizationalUnit,
 	"CN":           OIDConstants.CommonName,
 	"SERIALNUMBER": OIDConstants.SerialNumber,
+	"SN":           OIDConstants.Surname,
+	"GN":           OIDConstants.GivenName,
 	"L":            OIDConstants.Locality,
 	"ST":           OIDConstants.Province,
 	"STREET":       OIDConstants.StreetAddress,

--- a/pkg/util/pki/subject_test.go
+++ b/pkg/util/pki/subject_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMustParseRDN(t *testing.T) {
-	subject := "SERIALNUMBER=42, L=some-locality, ST=some-state-or-province, STREET=some-street, CN=foo-long.com, OU=FooLong, OU=Barq, OU=Baz, OU=Dept., O=Corp., C=US+123.544.555= A Test Value "
+	subject := "SERIALNUMBER=42, L=some-locality, GN=given-name, SN=surname, ST=some-state-or-province, STREET=some-street, CN=foo-long.com, OU=FooLong, OU=Barq, OU=Baz, OU=Dept., O=Corp., C=US+123.544.555= A Test Value "
 	rdnSeq, err := UnmarshalSubjectStringToRDNSequence(subject)
 	if err != nil {
 		t.Fatal(err)
@@ -60,6 +60,12 @@ func TestMustParseRDN(t *testing.T) {
 			},
 			[]pkix.AttributeTypeAndValue{
 				{Type: OIDConstants.Province, Value: "some-state-or-province"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.Surname, Value: "surname"},
+			},
+			[]pkix.AttributeTypeAndValue{
+				{Type: OIDConstants.GivenName, Value: "given-name"},
 			},
 			[]pkix.AttributeTypeAndValue{
 				{Type: OIDConstants.Locality, Value: "some-locality"},


### PR DESCRIPTION
### Pull Request Motivation

`LiteralSubject` already accepts numeric OIDs, but the parser only recognizes a small set of short attribute names.

This change adds support for:

- `GN` -> GivenName (`2.5.4.42`)
- `SN` -> Surname (`2.5.4.4`)

so they can be used in `spec.literalSubject` the same way as the existing supported aliases such as `DC` and `UID`.

This follows the same narrow parser / validation approach as the earlier `literalSubject` extension for `DC` and `UID` in #5587.

### Kind

/kind feature

### Release Note

```release-note
Add support for `GN` and `SN` aliases in `Certificate.spec.literalSubject`.
```
