### PR TITLE
Fix Venafi issuer auth regression and NGTS Secret watch

### DIFF
--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -73,6 +73,12 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 					continue
 				}
 			}
+			if iss.Spec.Venafi.NGTS != nil {
+				if iss.Spec.Venafi.NGTS.CredentialsRef.Name == secret.Name {
+					affected = append(affected, iss)
+					continue
+				}
+			}
 		case iss.Spec.Vault != nil:
 			if iss.Spec.Vault.Auth.TokenSecretRef != nil {
 				if iss.Spec.Vault.Auth.TokenSecretRef.Name == secret.Name {

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -75,6 +75,12 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 					continue
 				}
 			}
+			if iss.Spec.Venafi.NGTS != nil {
+				if iss.Spec.Venafi.NGTS.CredentialsRef.Name == secret.Name {
+					affected = append(affected, iss)
+					continue
+				}
+			}
 		case iss.Spec.Vault != nil:
 			if iss.Spec.Vault.Auth.TokenSecretRef != nil {
 				if iss.Spec.Vault.Auth.TokenSecretRef.Name == secret.Name {

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -173,6 +173,13 @@ func New(namespace string, secretsLister internalinformers.SecretLister, issuer 
 		logger:        logger,
 	}
 
+	// Authenticate the connector so that subsequent operations (Ping,
+	// RequestCertificate, etc.) have valid credentials. The vcert client
+	// was created with authenticate=false above, so credentials must be
+	// verified explicitly.
+	if err := v.VerifyCredentials(); err != nil {
+		return nil, err
+	}
 	return v, nil
 }
 

--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -54,12 +54,12 @@ func (v *Venafi) Setup(ctx context.Context, issuer cmapi.GenericIssuer) (err err
 		return fmt.Errorf("error building client: %w", err)
 	}
 
-	if err = client.Ping(); err != nil {
-		return fmt.Errorf("error pinging Certificate Manager: %v", err)
-	}
-
 	if err = client.VerifyCredentials(); err != nil {
 		return fmt.Errorf("client.VerifyCredentials: %w", err)
+	}
+
+	if err = client.Ping(); err != nil {
+		return fmt.Errorf("error pinging Certificate Manager: %v", err)
 	}
 
 	// If it does not already have a 'ready' condition, we'll also log an event


### PR DESCRIPTION
## Summary

- Restore the `VerifyCredentials()` call inside `New()` so that every caller gets an authenticated vcert connector
- Swap the `Ping()` and `VerifyCredentials()` calls in `Setup()` so that authentication precedes the ping
- Fix NGTS issuer not reconciling when its credential Secret changes

## Motivation

@erikgb [reported](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1780432292454299) that the Venafi issuer E2E tests have been failing for several days:

> The Venafi issuer tests have been failing for a few days now, ref https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-35-issuers-venafi, and I think it might be related to cert-manager/cert-manager#8808 — as I cannot find any changes overlapping with when it started failing. It might be something else, as I am just guessing here. Maybe a maintainer from Palo Alto could take a look?

Erik's suspicion was correct. PR #8808 moved the `VerifyCredentials()` call out of the client constructor (`New`) into `Setup`, leaving the vcert connector unauthenticated for two call sites:

1. **Setup → Ping**: `Ping()` ran before `VerifyCredentials()`, sending an unauthenticated request to `/vedsdk/` on TPP servers.

2. **Sign (CertificateRequest and CertificateSigningRequest controllers)**: these call `New()` directly and never invoke `VerifyCredentials()`, so certificate requests were sent without an access token, producing:
   ```
   401 Unauthorized: {"error":"invalid_token","error_description":"Authorization:Bearer parameter is missing or empty."}
   ```

### Why only TPP is affected

Both the Cloud and NGTS vcert connectors have no-op `Ping()` implementations (return nil immediately), so the Setup ordering issue is immaterial for those backends. Only the TPP connector's `Ping()` makes a real HTTP request (to `/vedsdk/`), and only TPP's `RequestCertificate` requires the access token to be set on the connector by a prior `VerifyAccessToken` call.

### NGTS Secret watch bug

While running the NGTS E2E tests for the first time (see cert-manager/testing#1208), one test failed: `should set Ready=False with invalid client credentials`. This test updates the NGTS credential Secret to invalid values and expects the issuer to transition to `Ready=False`. The test was correct — the bug is that `issuersForSecret()` in both the Issuer and ClusterIssuer controllers was missing the NGTS case, so the controller never re-reconciled when the NGTS Secret changed. This was introduced in #8779 which added NGTS support but did not update the secret watch mapping.

### Release Note

```release-note
Fix Venafi TPP issuer setup and signing regression on master: restore authentication of the vcert connector in the client constructor, which was removed in #8808.
```

## Test plan

- [x] `go test ./pkg/issuer/venafi/...` passes (all 6 test cases in `TestSetup` including the `AuthFailed` path added by #8808)
- [x] `go test ./pkg/controller/issuers/ ./pkg/controller/clusterissuers/` passes
- [x] `/test pull-cert-manager-master-e2e-v1-35-issuers-venafi-tpp` — pass
- [x] `/test pull-cert-manager-master-e2e-v1-35-issuers-venafi-cloud` — pass
- [x] `/test pull-cert-manager-master-e2e-v1-35-issuers-venafi-ngts` — 13/14 passed before Secret watch fix; re-triggered

*Generated with Claude (Opus 4.6)*