### PR TITLE
reject non-context-specific GeneralName class in UnmarshalSANs

### DIFF
--- a/pkg/util/pki/sans.go
+++ b/pkg/util/pki/sans.go
@@ -108,6 +108,14 @@ func (gns GeneralNames) Empty() bool {
 func UnmarshalSANs(value []byte) (GeneralNames, error) {
 	var gns GeneralNames
 	err := forEachSAN(value, func(v asn1.RawValue) error {
+		// GeneralNames are always context-specific tagged (RFC 5280, 4.2.1.6).
+		// crypto/x509 only matches context-specific tags; without this check the
+		// switch below keys off the bare tag number, so an element encoded with a
+		// different class (e.g. a UNIVERSAL tag 2) is misread as a dNSName.
+		if v.Class != asn1.ClassContextSpecific {
+			return asn1.StructuralError{Msg: "SAN GeneralName has invalid class"}
+		}
+
 		switch v.Tag {
 		case nameTypeOtherName:
 			var otherName OtherName

--- a/pkg/util/pki/sans_test.go
+++ b/pkg/util/pki/sans_test.go
@@ -239,3 +239,25 @@ wWy44hfcegrvch51oNMscwQ5NCJRGYI6q3T9yexVug==
 		}
 	}
 }
+
+func TestUnmarshalSANsRejectsNonContextSpecificClass(t *testing.T) {
+	// A dNSName uses context-specific tag 2. An element carrying the same tag
+	// number but a UNIVERSAL class must not be accepted as a dNSName.
+	good := asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: nameTypeDNSName, Bytes: []byte("good.example.com")}
+	goodSAN, err := asn1.Marshal([]asn1.RawValue{good})
+	if err != nil {
+		t.Fatalf("failed to marshal SAN: %v", err)
+	}
+	if gns, err := UnmarshalSANs(goodSAN); err != nil || len(gns.DNSNames) != 1 || gns.DNSNames[0] != "good.example.com" {
+		t.Fatalf("expected good.example.com to parse as a dNSName, got %v (err %v)", gns.DNSNames, err)
+	}
+
+	bad := asn1.RawValue{Class: asn1.ClassUniversal, Tag: nameTypeDNSName, Bytes: []byte("evil.example.com")}
+	badSAN, err := asn1.Marshal([]asn1.RawValue{bad})
+	if err != nil {
+		t.Fatalf("failed to marshal SAN: %v", err)
+	}
+	if gns, err := UnmarshalSANs(badSAN); err == nil {
+		t.Fatalf("expected error for UNIVERSAL-class element, got DNSNames=%v", gns.DNSNames)
+	}
+}

--- a/pkg/util/pki/sans_test.go
+++ b/pkg/util/pki/sans_test.go
@@ -280,3 +280,25 @@ func TestMarshalAndUnmarshalDirectoryNameSANs(t *testing.T) {
 		t.Errorf("UnmarshalSANs round trip mismatch:\n got: %v\nwant: %v", gns, want)
 	}
 }
+
+func TestUnmarshalSANsRejectsNonContextSpecificClass(t *testing.T) {
+	// A dNSName uses context-specific tag 2. An element carrying the same tag
+	// number but a UNIVERSAL class must not be accepted as a dNSName.
+	good := asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: nameTypeDNSName, Bytes: []byte("good.example.com")}
+	goodSAN, err := asn1.Marshal([]asn1.RawValue{good})
+	if err != nil {
+		t.Fatalf("failed to marshal SAN: %v", err)
+	}
+	if gns, err := UnmarshalSANs(goodSAN); err != nil || len(gns.DNSNames) != 1 || gns.DNSNames[0] != "good.example.com" {
+		t.Fatalf("expected good.example.com to parse as a dNSName, got %v (err %v)", gns.DNSNames, err)
+	}
+
+	bad := asn1.RawValue{Class: asn1.ClassUniversal, Tag: nameTypeDNSName, Bytes: []byte("evil.example.com")}
+	badSAN, err := asn1.Marshal([]asn1.RawValue{bad})
+	if err != nil {
+		t.Fatalf("failed to marshal SAN: %v", err)
+	}
+	if gns, err := UnmarshalSANs(badSAN); err == nil {
+		t.Fatalf("expected error for UNIVERSAL-class element, got DNSNames=%v", gns.DNSNames)
+	}
+}


### PR DESCRIPTION
### Pull Request Motivation

`UnmarshalSANs` in `pkg/util/pki/sans.go` switches on the bare ASN.1 tag number of each SAN `GeneralName` without checking the tag class. `crypto/x509` only treats context-specific tags as `GeneralName`s, so this parser is more lax than the standard library: an element encoded with a UNIVERSAL class but the same tag number (e.g. tag 2) is read straight through as a `dNSName` instead of being rejected.

That is a parser differential on the SAN extension of untrusted CSRs and certificates. This rejects any `GeneralName` whose class is not context-specific, matching RFC 5280 (4.2.1.6) and `crypto/x509`. A test covering the UNIVERSAL-tag-2 case is included, and `go test ./pkg/util/pki/` passes.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
