### PR TITLE
fix(selector/dns): normalize dns name before comparing

### DIFF
--- a/pkg/controller/acmeorders/selectors/dns_zones.go
+++ b/pkg/controller/acmeorders/selectors/dns_zones.go
@@ -37,9 +37,11 @@ func (s *dnsZonesSelector) Matches(meta metav1.ObjectMeta, dnsName string) (bool
 	if len(s.allowedDNSZones) == 0 {
 		return true, 0
 	}
+	dnsName = dns.Fqdn(dnsName)
 
 	maxMatchingLabels := 0
 	for _, zone := range s.allowedDNSZones {
+		zone = dns.Fqdn(zone)
 		numMatchingLabels := dns.CompareDomainName(zone, dnsName)
 		if numMatchingLabels != dns.CountLabel(zone) {
 			continue

--- a/pkg/controller/acmeorders/selectors/dns_zones_test.go
+++ b/pkg/controller/acmeorders/selectors/dns_zones_test.go
@@ -50,11 +50,47 @@ func TestDNSZones(t *testing.T) {
 			score:   2,
 		},
 		{
+			name: "matching a domain in a zone with a trailing dot",
+			selector: cmacme.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com."},
+			},
+			dnsName: "www.example.com",
+			matches: true,
+			score:   2,
+		},
+		{
+			name: "matching an exact domain in a zone with a trailing dot",
+			selector: cmacme.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com."},
+			},
+			dnsName: "example.com",
+			matches: true,
+			score:   2,
+		},
+		{
 			name: "matching a wildcard domain in a zone",
 			selector: cmacme.CertificateDNSNameSelector{
 				DNSZones: []string{"example.com"},
 			},
 			dnsName: "*.example.com",
+			matches: true,
+			score:   2,
+		},
+		{
+			name: "matching a wildcard domain in a zone with a trailing dot",
+			selector: cmacme.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com."},
+			},
+			dnsName: "*.example.com",
+			matches: true,
+			score:   2,
+		},
+		{
+			name: "matching a domain with a trailing dot in a zone without a trailing dot",
+			selector: cmacme.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com"},
+			},
+			dnsName: "www.example.com.",
 			matches: true,
 			score:   2,
 		},

--- a/pkg/controller/acmeorders/selectors/dns_zones_test.go
+++ b/pkg/controller/acmeorders/selectors/dns_zones_test.go
@@ -85,15 +85,6 @@ func TestDNSZones(t *testing.T) {
 			matches: true,
 			score:   2,
 		},
-		{
-			name: "matching a domain with a trailing dot in a zone without a trailing dot",
-			selector: cmacme.CertificateDNSNameSelector{
-				DNSZones: []string{"example.com"},
-			},
-			dnsName: "www.example.com.",
-			matches: true,
-			score:   2,
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

If dnsZone is a FQDN, the wrong solver will be selected.

We have a similar ClusterIssuer. You can see that the first one is a webhook with a FQDN `sub.example.com`, and the second one is AWS Route53 with parent zone `example.com`.

```yaml
❯ k get clusterissuer cluster-issuer -o yaml
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: cluster-issuer
...
spec:
  acme:
    privateKeySecretRef:
      name: letsencrypt-issuer-account-key
    server: https://acme-v02.api.letsencrypt.org/directory
    solvers:
    - dns01:
        webhook:
          config:
...
      selector:
        dnsZones:
        - sub.example.com.
...
    - dns01:
        route53:
...
      selector:
        dnsZones:
        - example.com
...
```

When issuing a certificate with `sub.example.com`, we see in the `Challenge` that the route53 solver will select.
```yaml
❯ k get certificate cert -o yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: cert
spec:
  dnsNames:
  - sub.example.com
  - '*.sub.example.com'
...
```

```yaml
❯ k get challenge cert-x-xxxx-xxxx -o yaml
apiVersion: acme.cert-manager.io/v1
kind: Challenge
metadata:
...
  ownerReferences:
  - apiVersion: acme.cert-manager.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Order
    name: cert-x-xxxx
spec:
...
  solver:
    dns01:
      route53:
...
    selector:
      dnsZones:
      - example.com
...
```

I found a problem in `pkg/controller/acmeorders/selectors/dns_zones.go` in how dns names are compared in `github.com/miekg/dns`. There is no domain normalization before the comparison.

Simple test:
```go
package dns_test

import (
	"fmt"

	"github.com/miekg/dns"
)

func ExampleCompareDomainName_withTrailingDot() {
	fmt.Println(dns.CompareDomainName("sub.example.com", "sub.example.com."))
	// Output: 0
}

func ExampleCompareDomainName_withFQDNNormalization() {
	fmt.Println(dns.CompareDomainName(dns.Fqdn("sub.example.com"), dns.Fqdn("sub.example.com.")))
	// Output: 3
}
```

I added FQDN normalization to cover this case and choose the right, most appropriate solver, as expected.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
