### PR TITLE
Build-on-tag now requires a logging option

### DIFF
--- a/gcb/build_cert_manager.yaml
+++ b/gcb/build_cert_manager.yaml
@@ -37,3 +37,5 @@ options:
   # https://cloud.google.com/build/docs/optimize-builds/increase-vcpu-for-builds
   # https://cloud.google.com/build/pricing
   machineType: E2_HIGHCPU_32
+  logging: CLOUD_LOGGING_ONLY
+


### PR DESCRIPTION
**Companion PR of https://github.com/cert-manager/infrastructure/pull/83.**

In https://github.com/cert-manager/infrastructure/pull/74, we changed from using the default GCB service account:

    1021342095237@cloudbuild.gserviceaccount.com

to using a custom service account:

    cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com

When triggering builds (either automatically by pushing a tag, or manually with "Run" in the UI), the following error message is now thrown:

```
Failed to trigger build: if 'build.service_account' is specified, the build
must either (a) specify 'build.logs_bucket', (b) use the
REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior
option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options: invalid
argument
```

Let's use the newer Cloud Logs backend. No point in keeping things in Cloud Bucket.

/kind cleanup


```release-note
NONE
```
