### PR TITLE
Add package documentation comment for models-schema command

### DIFF
--- a/internal/generated/openapi/cmd/models-schema/doc.go
+++ b/internal/generated/openapi/cmd/models-schema/doc.go
@@ -14,4 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Package models-schema provides the OpenAPI models schema definitions for cert-manager.
+*/
 package main


### PR DESCRIPTION
## Problem Background
In the cert-manager project, the internal package for OpenAPI models-schema command lacked a descriptive documentation comment. As per Go best practices, every package should have a documentation comment to describe its purpose, enhancing code readability and maintainability.

## Modification Details
Added a package documentation comment to `internal/generated/openapi/cmd/models-schema/doc.go` with the text: "Package models-schema provides the OpenAPI models schema definitions for cert-manager." This comment clearly describes the package's role, aligning with Go documentation standards without altering any functionality or code behavior.

## Verification
This change is a pure documentation update with no impact on code execution. Verification can be done by:
- Reviewing the file to confirm the comment is correctly placed.
- Using Go tools like `go doc` to ensure the documentation is accessible and formatted properly.
- Checking that no other code changes were made, maintaining backward compatibility.