### PR TITLE
build-on-tag: let's store GCB logs in a bucket

### DIFF
--- a/gcb/build_cert_manager.yaml
+++ b/gcb/build_cert_manager.yaml
@@ -37,5 +37,7 @@ options:
   # https://cloud.google.com/build/docs/optimize-builds/increase-vcpu-for-builds
   # https://cloud.google.com/build/pricing
   machineType: E2_HIGHCPU_32
-  logging: CLOUD_LOGGING_ONLY
+  logging: GCS_ONLY
 
+serviceAccount: projects/cert-manager-release/serviceAccounts/cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com
+logsBucket: gs://cert-manager-release-logs


### PR DESCRIPTION
**Companion PRs:**
- https://github.com/cert-manager/infrastructure/pull/83
- https://github.com/cert-manager/release/pull/310

## Why?

In #8851, I had configured the build-on-tags logs to be stored in Google Cloud Logs.

The problem is that Cloud Logs only keep logs for 30 days, but I'd rather keep them around longer.

```release-note
NONE
```


