### PR TITLE
fix: Correctly classify Venafi NGTS network errors

### DIFF
--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Venafi/vcert/v5/pkg/venafi/cloud"
 	"github.com/Venafi/vcert/v5/pkg/venafi/ngts"
 	"github.com/Venafi/vcert/v5/pkg/venafi/tpp"
+	"github.com/Venafi/vcert/v5/pkg/verror"
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
@@ -466,10 +467,13 @@ func (v *Venafi) SetClient(client endpoint.Connector) {
 
 // isNetworkError returns true when err originates from a transport-level
 // failure (DNS, TCP, TLS) rather than an HTTP-level auth response.
+// It also treats verror.ServerUnavailableError as a network error because
+// vcert may wrap transport errors using this sentinel without preserving the
+// underlying error for errors.As (see https://github.com/Venafi/vcert/issues/664).
 func isNetworkError(err error) bool {
 	var netErr *net.OpError
 	var urlErr *url.Error
-	return err != nil && (errors.As(err, &netErr) || errors.As(err, &urlErr))
+	return err != nil && (errors.As(err, &netErr) || errors.As(err, &urlErr) || errors.Is(err, verror.ServerUnavailableError))
 }
 
 // VerifyCredentials remotely verifies the credentials for the client, for both TPP and Cloud.

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -25,6 +25,7 @@ import (
 
 	vcert "github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/verror"
 	corev1 "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
@@ -599,6 +600,24 @@ func TestIsNetworkError(t *testing.T) {
 		{
 			name: "wrapped net.OpError is a network error",
 			err:  fmt.Errorf("outer: %w", &net.OpError{Op: "dial", Err: fmt.Errorf("timeout")}),
+			want: true,
+		},
+		{
+			name: "verror.ServerUnavailableError with underlying net.OpError (simulates vcert bug with %v formatting)",
+			// This simulates current vcert behavior where ServerUnavailableError is used but
+			// the underlying transport error isn't preserved for errors.As (see https://github.com/Venafi/vcert/issues/664).
+			err:  fmt.Errorf("%w: %v", verror.ServerUnavailableError, &net.OpError{Op: "dial", Err: fmt.Errorf("connection refused")}),
+			want: true,
+		},
+		{
+			name: "verror.ServerUnavailableError with underlying url.Error (DNS failure case)",
+			// This simulates a DNS lookup failure wrapped by vcert's ServerUnavailableError
+			err:  fmt.Errorf("%w: %v", verror.ServerUnavailableError, &url.Error{Op: "Post", URL: "https://auth.apps.paloaltonetworks.com/oauth2/access_token", Err: fmt.Errorf("lookup auth.apps.paloaltonetworks.com: server misbehaving")}),
+			want: true,
+		},
+		{
+			name: "verror.ServerUnavailableError alone (no underlying network error)",
+			err:  verror.ServerUnavailableError,
 			want: true,
 		},
 	}


### PR DESCRIPTION
Ref: [VC-54664](https://venafi.atlassian.net/browse/VC-54664)

## Background

When a transport-level failure occurs reaching the NGTS OAuth token endpoint (DNS failure, connection refused, TLS error, timeout), the Venafi Issuer was being set to:

```
Ready=False reason=AuthFailed :: OAuth token request failed: ngtsClient.Authenticate: vcert error: server error: server unavailable: Post "https://auth.apps.paloaltonetworks.com/oauth2/access_token": dial tcp: lookup auth.apps.paloaltonetworks.com on 10.96.0.10:53: server misbehaving
```

But `AuthFailed` is meant to signal actual auth errors, not stuff like network or DNS errors.

The reason we are seeing this is because vcert wraps transport errors with `verror.ServerUnavailableError` using `%v` instead of `%w`:

```go
err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)   // %v, not %w
```

I've already opened https://github.com/Venafi/vcert/pull/665 to fix this, but we don't actually need this fix to improve things in cert-manager's Venafi issuer. Let's just match on the vcert error instead.

## Testing

Let's hardcode the possible errors that are thrown by VCert. Hopefully it's what it returns.

```release-note
NONE
```