### PR TITLE
replace non-breaking spaces with spaces

### DIFF
--- a/design/20230302.gomod.md
+++ b/design/20230302.gomod.md
@@ -126,30 +126,30 @@ at this stage).
 ```text
 cmd
 ├── acmesolver
-│   ├── ...
-│   ├── go.mod
-│   ├── go.sum
-│   ├── main.go
+│   ├── ...
+│   ├── go.mod
+│   ├── go.sum
+│   ├── main.go
 ├── cainjector
-│   ├── ...
-│   ├── go.mod
-│   ├── go.sum
-│   └── main.go
+│   ├── ...
+│   ├── go.mod
+│   ├── go.sum
+│   └── main.go
 ├── controller
-│   ├── ...
-│   ├── go.mod
-│   ├── go.sum
-│   └── main.go
+│   ├── ...
+│   ├── go.mod
+│   ├── go.sum
+│   └── main.go
 ├── ctl
-│   ├── go.mod
-│   ├── go.sum
-│   ├── main.go
-│   └── ...
+│   ├── go.mod
+│   ├── go.sum
+│   ├── main.go
+│   └── ...
 └── webhook
-    ├── go.mod
-    ├── go.sum
-    ├── main.go
-    └── ...
+    ├── go.mod
+    ├── go.sum
+    ├── main.go
+    └── ...
 ```
 
 These changes will also require tweaks to how modules are built and tested, which will be done in our `Makefile`.

--- a/design/20250703.gatewayapi-listenerset.md
+++ b/design/20250703.gatewayapi-listenerset.md
@@ -27,7 +27,7 @@
   - [Alternative 0: Devs and Ops coordination](#alternative-0-devs-and-ops-coordination)
   - [Alternative 1: Let Devs edit Gateways](#alternative-1-let-devs-edit-gateways)
   - [Alternative 2: Catch-all hostname + multiple certificates attached to the Gateway resource](#alternative-2-catch-all-hostname--multiple-certificates-attached-to-the-gateway-resource)
-  - [Alternative 3: Dynamic creation of `listener` entries on the Gateway resource](#alternative-3-dynamic-creation-of-listenerentries-on-the-gateway-resource)
+  - [Alternative 3: Dynamic creation of `listener` entries on the Gateway resource](#alternative-3-dynamic-creation-of-listenerentries-on-the-gateway-resource)
 - [Appendix](#appendix)
   - [Example of migration using `ingress2gateway`](#example-of-migration-using-ingress2gateway)
 
@@ -263,8 +263,8 @@ set with the `cert-manager.io/cluster-issuer` annotation?
 ### Alternative 0: Devs and Ops coordination
 
 You can already do that today: the developer creates an HTTPRoute, and then asks
-the Platform team to add a new entry under `listeners` on the Gateway
-resource. This solution isn't practical.
+the Platform team to add a new entry under `listeners` on the Gateway
+resource. This solution isn't practical.
 
 ### Alternative 1: Let Devs edit Gateways
 
@@ -297,8 +297,8 @@ spec:
           - name: route-3-tls
 ```
 
-This approach wasn't pursued because "Core" Gateway API only supports a single
-entry in `certificateRefs`. This limitation stems from the fact that Gateway API's
+This approach wasn't pursued because "Core" Gateway API only supports a single
+entry in `certificateRefs`. This limitation stems from the fact that Gateway API's
 authors aim to have as much configuration as possible structured and explicit (i.e., in API fields
 rather than in undocumented annotations or, even worse, embedded in annotations as JSON blobs).
 Having multiple certificates under `certificateRefs` defeats this goal since implementations
@@ -307,7 +307,7 @@ than just having to look at the Gateway object.
 
 This alternative has also been proposed in [20230601.gateway-route-hostnames.md](https://github.com/cert-manager/cert-manager/blob/master/design/20230601.gateway-route-hostnames.md) with the idea of avoiding the duplication of hostnames that are both present in Gateway and HTTPRoute objects.
 
-### Alternative 3: Dynamic creation of `listener` entries on the Gateway resource
+### Alternative 3: Dynamic creation of `listener` entries on the Gateway resource
 
 Similarly to the alternative 1, we could imagine letting cert-manager create 443 listeners dynamically, e.g.:
 

--- a/design/acme-orders-challenges-crd.md
+++ b/design/acme-orders-challenges-crd.md
@@ -343,7 +343,7 @@ Just before retrying the Order, the old Order resource will be deleted to
 ensure we don't accumulate too many Order & Challenge resources when an issuance
 keeps failing.
 
-#### Order controller
+#### Order controller
 
 When an order is created, all of the spec fields must be defined, including CSR.
 The Order controller will be responsible for handling the entirety of an ACME

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -658,7 +658,7 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address or hostname of an authoritative DNS server supporting
 	// RFC2136 in the form host:port. If the host is an IPv6 address it must be
-	// enclosed in square brackets (e.g [2001:db8::1]) port is optional.
+	// enclosed in square brackets (e.g [2001:db8::1]) port is optional.
 	// This field is required.
 	Nameserver string
 

--- a/pkg/issuer/acme/dns/util/fqdn_test.go
+++ b/pkg/issuer/acme/dns/util/fqdn_test.go
@@ -40,7 +40,7 @@ func Test_FindZoneByFqdn_NoPanic(t *testing.T) {
 		t.Fatalf("first call too FindZoneByFqdn failed: %v", err)
 	}
 
-	// We want to test that the second call does not panic; catch a panic here for prettier log output
+	// We want to test that the second call does not panic; catch a panic here for prettier log output
 
 	defer func() {
 		r := recover()


### PR DESCRIPTION
### Pull Request Motivation

I found this through a warning from Renovate in a repo containing kube manifests; there was an nbsp (U+00A0) in the upstream release version of cert-manager.yaml which got flagged. that one had been generated from a source code comment.

I figure that any instances of nbsp's in cert-manager's docs and source are not intentional; so, replace them with spaces.
<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
