### PR TITLE
Fix kind image switch

### DIFF
--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -105,11 +105,10 @@ if printenv K8S_VERSION >/dev/null && [ -n "$K8S_VERSION" ]; then
 fi
 
 case "$k8s_version" in
-1.31*) image=$KIND_IMAGE_K8S_131 ;;
-1.32*) image=$KIND_IMAGE_K8S_132 ;;
 1.33*) image=$KIND_IMAGE_K8S_133 ;;
 1.34*) image=$KIND_IMAGE_K8S_134 ;;
 1.35*) image=$KIND_IMAGE_K8S_135 ;;
+1.36*) image=$KIND_IMAGE_K8S_136 ;;
 v*) printf "${red}${redcross}Error${end}: Kubernetes version must be given without the leading 'v'\n" >&2 && exit 1 ;;
 *) printf "${red}${redcross}Error${end}: unsupported Kubernetes version ${yel}${k8s_version}${end}\n" >&2 && exit 1 ;;
 esac


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

After updating our testgrid configuration to build with K8s 1.36 it's been failing: https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-36. Example: https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-master-e2e-v1-36/2065693826684555264.

This fix updates the switch used to map K8s version to kind image variables:
- Add 1.36
- Remove unsupported version; 1.31 and 1.32

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
