### PR TITLE
docs: add network policy examples for HTTP01 solver pods

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -532,7 +532,9 @@ networkPolicy:
   # outbound traffic to ports 80 and 443, as well as DNS ports.
   #
   # If using HTTP01 challenges, you must also allow egress to the dynamically
-  # created solver pods. The solver pods are labelled with
+  # created solver pods. For more detailed examples, see the best practice docs:
+  # https://cert-manager.io/docs/installation/best-practice/#networkpolicy-examples-for-http01-challenges
+  # The solver pods are labelled with
   # `acme.cert-manager.io/http01-solver: "true"` and run in the same namespace
   # as the Issuer or the namespace of the Ingress challenge. For example:
   # +docs:example

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -530,6 +530,55 @@ networkPolicy:
 
   # Egress rule for the cert-manager network policy. By default, it allows all
   # outbound traffic to ports 80 and 443, as well as DNS ports.
+  #
+  # If using HTTP01 challenges, you must also allow egress to the dynamically
+  # created solver pods. The solver pods are labelled with
+  # `acme.cert-manager.io/http01-solver: "true"` and run in the same namespace
+  # as the Issuer or the namespace of the Ingress challenge. For example:
+  # +docs:example
+  # egress:
+  # - to:
+  #   - podSelector:
+  #       matchLabels:
+  #         acme.cert-manager.io/http01-solver: "true"
+  #   ports:
+  #   - port: 8080
+  #     protocol: TCP
+  # - ports:
+  #     - port: 80
+  #       protocol: TCP
+  #     - port: 443
+  #       protocol: TCP
+  #     - port: 53
+  #       protocol: TCP
+  #     - port: 53
+  #       protocol: UDP
+  #     - port: 6443
+  #       protocol: TCP
+  #
+  # Note: port 6443 (Kubernetes API server) is required because cert-manager
+  # must create, watch, and delete the HTTP01 solver pod via the API server.
+  #
+  # You must also create a NetworkPolicy in the solver's namespace to allow
+  # ingress from cert-manager. For example:
+  # +docs:example
+  # apiVersion: networking.k8s.io/v1
+  # kind: NetworkPolicy
+  # metadata:
+  #   name: allow-cert-manager-resolver
+  #   namespace: <solver-namespace>
+  # spec:
+  #   podSelector:
+  #     matchLabels:
+  #       acme.cert-manager.io/http01-solver: "true"
+  #   ingress:
+  #   - from:
+  #     - namespaceSelector:
+  #         matchLabels:
+  #           kubernetes.io/metadata.name: cert-manager
+  #     ports:
+  #     - port: 8080
+  #       protocol: TCP
   # +docs:property
   egress:
   - ports:


### PR DESCRIPTION
**What this PR does / why we need it:**

When cert-manager is deployed in a cluster with NetworkPolicies enforced, HTTP01 challenges fail silently because the dynamically created solver pods cannot be reached. The cert-manager controller needs egress rules to reach solver pods, and the solver namespace needs ingress rules from the controller.

This PR adds inline documentation in the Helm chart's `values.yaml` to guide users on configuring NetworkPolicy rules for HTTP01 challenge flow.

**Changes:**

1. **`deploy/charts/cert-manager/values.yaml`** â€” Enhanced the `networkPolicy.egress` section:
   - Added documentation explaining that HTTP01 solver pods are labelled with `acme.cert-manager.io/http01-solver: true`
   - Added an `egress` example using `podSelector` to allow traffic from the cert-manager controller to solver pods on port 8080
   - Added an example `NetworkPolicy` resource for the solver namespace that allows ingress from cert-manager (matched via `namespaceSelector` with `app.kubernetes.io/instance: cert-manager`)
   - Existing default values are unchanged â€” this is a documentation-only addition

**Which issue this PR fixes:**

Fixes #2334

```release-note
Added network policy documentation for HTTP01 solver pods in Helm chart values.yaml
```