### PR TITLE
Update Go to 1.26.4

### DIFF
--- a/cmd/acmesolver/go.mod
+++ b/cmd/acmesolver/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/acmesolver-binary
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/cainjector/go.mod
+++ b/cmd/cainjector/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/cainjector-binary
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/controller-binary
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/startupapicheck/go.mod
+++ b/cmd/startupapicheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/startupapicheck-binary
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/cmd/webhook/go.mod
+++ b/cmd/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/webhook-binary
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/e2e-tests
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/cert-manager/integration-tests
 
-go 1.26.0
+go 1.26.4
 
 // Do not remove this comment:
 // please place any replace statements here at the top for visibility and add a


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This PR updates the Go version from 1.26.0 to 1.26.4 across all cert-manager modules to address two high severity vulnerabilities:

- **CVE-2026-39820**: Vulnerability in the `net/mail` package
- **CVE-2026-33811**: Vulnerability in the `net` package

Go 1.26.3+ includes fixes for these CVEs and 1.26.4 is the latest stable patch release.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Updated Go to 1.26.4 to fix CVE-2026-39820 and CVE-2026-33811
```
