### PR TITLE
docs: fix broken appendix anchor in gatewayapi-listenerset design

### DIFF
--- a/design/20250703.gatewayapi-listenerset.md
+++ b/design/20250703.gatewayapi-listenerset.md
@@ -151,7 +151,7 @@ Add support for ListenerSet resources within cert-manager, allowing TLS certific
 
 #### Story 1
 
-As a platform admin, I worry about ingress-nginx's Ingress support being EOL ([https://github.com/cert-manager/cert-manager/issues/7822](https://github.com/cert-manager/cert-manager/issues/7822)) and I need to be able to use `ingress2gateway` to migrate from ingress-nginx + Ingress to InGate's Gateway API implementation. An example of such migration is given [in appendix](#example-using-ingress2gateway).
+As a platform admin, I worry about ingress-nginx's Ingress support being EOL ([https://github.com/cert-manager/cert-manager/issues/7822](https://github.com/cert-manager/cert-manager/issues/7822)) and I need to be able to use `ingress2gateway` to migrate from ingress-nginx + Ingress to InGate's Gateway API implementation. An example of such migration is given [in appendix](#example-of-migration-using-ingress2gateway).
 
 #### Story 2
 


### PR DESCRIPTION
The GatewayAPI ListenerSet design doc links "[in appendix](#example-using-ingress2gateway)", but the heading slug is `example-of-migration-using-ingress2gateway` (the doc's own TOC already links to the correct anchor). Fixed the in-body link to match.

/kind documentation

```release-note
NONE
```