### PR TITLE
add renderMode options for prometheus monitors

### DIFF
--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -265,3 +265,49 @@ set .installCRDs and disabled .crds.keep.
     {{- fail "ERROR: .crds.keep is not compatible with .installCRDs, please use .crds.enabled and .crds.keep instead" }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Decide whether to render the ServiceMonitor resources.
+*/}}
+{{- define "cert-manager.shouldRenderServiceMonitor" -}}
+  {{- $mode := .Values.prometheus.servicemonitor.renderMode -}}
+  {{- if eq $mode "alwaysRender" -}}
+    true
+  {{- else if eq $mode "skipIfMissing" -}}
+    {{- if has "monitoring.coreos.com/v1/ServiceMonitor" .Capabilities.APIVersions -}}
+      true
+    {{- else -}}
+      false
+    {{- end -}}
+  {{- else if eq $mode "failIfMissing" -}}
+    {{- if not (has "monitoring.coreos.com/v1/ServiceMonitor" .Capabilities.APIVersions) -}}
+      {{- fail "ServiceMonitor CRD is required but not present in the cluster. See https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml or the settings for .Values.serviceMonitor.renderMode to suppress this error." -}}
+    {{- end -}}
+    true
+  {{- else -}}
+    {{- fail (printf "Invalid renderMode '%s'. Must be one of: skipIfMissing, failIfMissing, alwaysRender." $mode) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Decide whether to render the PodMonitor resources.
+*/}}
+{{- define "cert-manager.shouldRenderPodMonitor" -}}
+  {{- $mode := .Values.prometheus.podmonitor.renderMode -}}
+  {{- if eq $mode "alwaysRender" -}}
+    true
+  {{- else if eq $mode "skipIfMissing" -}}
+    {{- if has "monitoring.coreos.com/v1/PodMonitor" .Capabilities.APIVersions -}}
+      true
+    {{- else -}}
+      false
+    {{- end -}}
+  {{- else if eq $mode "failIfMissing" -}}
+    {{- if not (has "monitoring.coreos.com/v1/PodMonitor" .Capabilities.APIVersions) -}}
+      {{- fail "PodMonitor CRD is required but not present in the cluster. See https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml or the settings for .Values.serviceMonitor.renderMode to suppress this error." -}}
+    {{- end -}}
+    true
+  {{- else -}}
+    {{- fail (printf "Invalid renderMode '%s'. Must be one of: skipIfMissing, failIfMissing, alwaysRender." $mode) -}}
+  {{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -1,6 +1,7 @@
+{{- $shouldRenderStr := include "cert-manager.shouldRenderPodMonitor" . | trim }}
 {{- if and .Values.prometheus.enabled (and .Values.prometheus.podmonitor.enabled .Values.prometheus.servicemonitor.enabled) }}
 {{- fail "Either .Values.prometheus.podmonitor.enabled or .Values.prometheus.servicemonitor.enabled can be enabled at a time, but not both." }}
-{{- else if and .Values.prometheus.enabled .Values.prometheus.podmonitor.enabled }}
+{{- else if and .Values.prometheus.enabled .Values.prometheus.podmonitor.enabled (eq $shouldRenderStr "true") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -1,6 +1,7 @@
+{{- $shouldRenderStr := include "cert-manager.shouldRenderServiceMonitor" . | trim }}
 {{- if and .Values.prometheus.enabled (and .Values.prometheus.podmonitor.enabled .Values.prometheus.servicemonitor.enabled) }}
 {{- fail "Either .Values.prometheus.podmonitor.enabled or .Values.prometheus.servicemonitor.enabled can be enabled at a time, but not both." }}
-{{- else if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- else if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled (eq $shouldRenderStr "true") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -658,6 +658,13 @@ prometheus:
     # Create a ServiceMonitor to add cert-manager to Prometheus.
     enabled: false
 
+    # Rendering behavior for the ServiceMonitor resource, when the ServiceMonitor CRD
+    # is not found by Helm (.Capabilities.APIVersions check):
+    # * skipIfMissing: don't render, don't fail
+    # * failIfMissing: fail
+    # * alwaysRender: render anyways
+    renderMode: skipIfMissing
+
     # The namespace that the service monitor should live in, defaults
     # to the cert-manager namespace.
     # +docs:property
@@ -709,6 +716,13 @@ prometheus:
   podmonitor:
     # Create a PodMonitor to add cert-manager to Prometheus.
     enabled: false
+
+    # Rendering behavior for the PodMonitor resource, when the PodMonitor CRD
+    # is not found by Helm (.Capabilities.APIVersions check):
+    # * skipIfMissing: don't render, don't fail
+    # * failIfMissing: fail
+    # * alwaysRender: render anyways
+    renderMode: skipIfMissing
 
     # The namespace that the pod monitor should live in, defaults
     # to the cert-manager namespace.


### PR DESCRIPTION
Allows having the prometheus Monitor resources enabled when those CRD's are not (yet) available.


### Pull Request Motivation

Having the prometheus Monitor resources enabled by default (e.g. through a wrapper chart), but only rendering them when the CRD's are available helps greatly when bootstrapping a new cluster, by minimising dependency loops between charts.

### Kind


/kind feature


### Release Note


```release-note
Added `.prometheus.servicemonitor.renderMode` and `.prometheus.podmonitor.renderMode` options to the Helm Chart.
```
