### PR TITLE
Clarify gosec suppressions in ACME reachability test

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -266,7 +266,7 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 			// > When redirected to an HTTPS URL, it does not validate certificates (since
 			// > this challenge is intended to bootstrap valid certificates, it may encounter
 			// > self-signed or expired certificates along the way).
-			InsecureSkipVerify: true, // #nosec G402 -- false positive
+			InsecureSkipVerify: true, // #nosec G402 -- ACME HTTP-01 self-check follows redirects to HTTPS where certs may be invalid (see comment above)
 		},
 	}
 
@@ -297,7 +297,7 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 		Timeout:   time.Second * 10,
 	}
 
-	response, err := client.Do(req) // #nosec G704 -- TODO(erikgb): This is probably not a false positive. Investigate!
+	response, err := client.Do(req) // #nosec G704 -- intentional ACME HTTP-01 self-check request; URL is provided by caller (typically Challenge DNSName + token via buildChallengeUrl)
 	if err != nil {
 		log.V(logf.DebugLevel).Info("failed to perform self check GET request", "error", err)
 		return fmt.Errorf("failed to perform self check GET request '%s': %v", url, err)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While browsing our code for the ACME reachability test, I noticed a gosec suppression with a TODO that was added by me as part of a golangci-lint upgrade. After looking closer at the code, I have added a more meaningful suppression reason. I've improved the rationale for the gosec suppression around skipping TLS verification, as the original text was a bit vague.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
