### PR TITLE
[release-1.19] Update Go to v1.25.11

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -32,7 +32,7 @@ export GOVENDOR_DIR ?= $(default_shared_dir)/go_vendor
 
 # https://go.dev/dl/
 # renovate: datasource=golang-version packageName=go
-VENDORED_GO_VERSION := 1.25.10
+VENDORED_GO_VERSION := 1.25.11
 
 $(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
 	@mkdir -p $@
@@ -440,10 +440,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70
-go_linux_arm64_SHA256SUM=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08
-go_darwin_amd64_SHA256SUM=52321165a3146cd91865ef98371506a846ed4dc4f9f1c9323e5ad90d2a411e06
-go_darwin_arm64_SHA256SUM=795691a425de7e7cdba3544f354dcd2cebcf52e87dc6898193878f34eb6d634f
+go_linux_amd64_SHA256SUM=34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b
+go_linux_arm64_SHA256SUM=c30bf9e156a54ea4e31fbbbf31a712b32734b58cc9a22426fa5ee632d0885124
+go_darwin_amd64_SHA256SUM=26d0ee4071de42b5c332337db9fdd234072877697c547e46e85efb0f59507c66
+go_darwin_arm64_SHA256SUM=cd8d4920e7930d55da1a5a57ba43a64b1305f71cdf2ca3c76cd8c549272b1680
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
> go1.25.11 (released 2026-06-02) includes security fixes to the `crypto/x509`, `mime`, and `net/textproto` packages, as well as bug fixes to the compiler and the runtime. See the [Go 1.25.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.11+label%3ACherryPickApproved) on our issue tracker for details.
> -- https://go.dev/doc/devel/release#go1.25.minor

Should fix testgrid failures in the release-1.19 branch:
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.19

`govulncheck` confirms all three vulnerabilities affect cert-manager code:
 * [CVE-2026-27145](https://pkg.go.dev/vuln/GO-2026-5037): `crypto/x509` — quadratic hostname verification (DoS)
 * [CVE-2026-42504](https://pkg.go.dev/vuln/GO-2026-5038): `mime` — quadratic `WordDecoder.DecodeHeader` (DoS)
 * [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039): `net/textproto` — arbitrary input included in errors

<details>
<summary>govulncheck output</summary>

```
$ make verify-govulncheck
Running 'GOTOOLCHAIN=go1.25.10 _bin/tools/govulncheck ./...' in directory './cmd/controller'
=== Symbol Results ===

Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.25.10
    Fixed in: net/textproto@go1.25.11
    Example traces found:
      #1: app/controller.go:101:7: app.Run calls errgroup.Group.Go, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2026-5038
    Quadratic complexity in WordDecoder.DecodeHeader in mime
  More info: https://pkg.go.dev/vuln/GO-2026-5038
  Standard library
    Found in: mime@go1.25.10
    Fixed in: mime@go1.25.11
    Example traces found:
      #1: app/controller.go:84:30: app.Run calls controller.ContextFactory.Build, which eventually calls mime.WordDecoder.DecodeHeader

Vulnerability #3: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.25.10
    Fixed in: crypto/x509@go1.25.11
    Example traces found:
      #1: app/controller.go:101:7: app.Run calls errgroup.Group.Go, which eventually calls x509.Certificate.Verify

Your code is affected by 3 vulnerabilities from the Go standard library.
```

</details>

Checksums sourced from https://go.dev/dl/?mode=json and verified locally with `make vendor-go HOST_OS=<os> HOST_ARCH=<arch>` for all four platform combinations.

Prior art: cert-manager/cert-manager#8294

/kind cleanup

```release-note
Update Go to `v1.25.11` to fix CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507
```