### PR TITLE
[release-1.20] Update Go to v1.26.4

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -32,7 +32,7 @@ export GOVENDOR_DIR ?= $(default_shared_dir)/go_vendor
 
 # https://go.dev/dl/
 # renovate: datasource=golang-version packageName=go
-VENDORED_GO_VERSION := 1.26.3
+VENDORED_GO_VERSION := 1.26.4
 
 $(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
 	@mkdir -p $@
@@ -468,10 +468,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556
-go_linux_arm64_SHA256SUM=9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565
-go_darwin_amd64_SHA256SUM=278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63
-go_darwin_arm64_SHA256SUM=875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c
+go_linux_amd64_SHA256SUM=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
+go_linux_arm64_SHA256SUM=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
+go_darwin_amd64_SHA256SUM=05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d
+go_darwin_arm64_SHA256SUM=b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
> go1.26.4 (released 2026-06-02) includes security fixes to the `crypto/x509`, `mime`, and `net/textproto` packages, as well as bug fixes to the compiler, the runtime, the `go fix` command, and the `crypto/fips140` package. See the [Go 1.26.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.4+label%3ACherryPickApproved) on our issue tracker for details.
> -- https://go.dev/doc/devel/release#go1.26.minor

Should fix testgrid failures in the release-1.20 branch:
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.20

`govulncheck` confirms all three vulnerabilities affect cert-manager code:
 * [CVE-2026-27145](https://pkg.go.dev/vuln/GO-2026-5037): `crypto/x509` — quadratic hostname verification (DoS)
 * [CVE-2026-42504](https://pkg.go.dev/vuln/GO-2026-5038): `mime` — quadratic `WordDecoder.DecodeHeader` (DoS)
 * [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039): `net/textproto` — arbitrary input included in errors

<details>
<summary>govulncheck output</summary>

```
$ make verify-govulncheck
Running 'GOTOOLCHAIN=go1.26.3 _bin/tools/govulncheck ./...' in directory './cmd/controller'
=== Symbol Results ===

Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.26.3
    Fixed in: net/textproto@go1.26.4
    Example traces found:
      #1: app/controller.go:101:7: app.Run calls errgroup.Group.Go, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2026-5038
    Quadratic complexity in WordDecoder.DecodeHeader in mime
  More info: https://pkg.go.dev/vuln/GO-2026-5038
  Standard library
    Found in: mime@go1.26.3
    Fixed in: mime@go1.26.4
    Example traces found:
      #1: app/controller.go:84:30: app.Run calls controller.ContextFactory.Build, which eventually calls mime.WordDecoder.DecodeHeader

Vulnerability #3: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.26.3
    Fixed in: crypto/x509@go1.26.4
    Example traces found:
      #1: app/controller.go:101:7: app.Run calls errgroup.Group.Go, which eventually calls x509.Certificate.Verify

Your code is affected by 3 vulnerabilities from the Go standard library.
```

</details>

Checksums copied from `master` (which is already on Go 1.26.4) and verified locally with `make vendor-go HOST_OS=<os> HOST_ARCH=<arch>` for all four platform combinations.

Prior art: cert-manager/cert-manager#8294

/kind cleanup

```release-note
Update Go to `v1.26.4` to fix CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507
```