### PR TITLE
Reject '..' path segments in Vault Issuer path fields

### DIFF
--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -294,6 +295,8 @@ func ValidateVaultIssuerConfig(iss *certmanager.VaultIssuer, fldPath *field.Path
 
 	if len(iss.Path) == 0 {
 		el = append(el, field.Required(fldPath.Child("path"), ""))
+	} else if containsDotDotSegment(iss.Path) {
+		el = append(el, field.Invalid(fldPath.Child("path"), iss.Path, "must not contain '..' path segments"))
 	}
 
 	if len(iss.CABundle) > 0 {
@@ -336,10 +339,17 @@ func ValidateVaultIssuerAuth(auth *certmanager.VaultAuth, fldPath *field.Path) f
 		if auth.AppRole.SecretRef.Name == "" {
 			el = append(el, field.Required(fldPath.Child("appRole", "secretRef", "name"), ""))
 		}
+
+		if containsDotDotSegment(auth.AppRole.Path) {
+			el = append(el, field.Invalid(fldPath.Child("appRole", "path"), auth.AppRole.Path, "must not contain '..' path segments"))
+		}
 		unionCount++
 	}
 
 	if auth.ClientCertificate != nil {
+		if containsDotDotSegment(auth.ClientCertificate.Path) {
+			el = append(el, field.Invalid(fldPath.Child("clientCertificate", "path"), auth.ClientCertificate.Path, "must not contain '..' path segments"))
+		}
 		unionCount++
 	}
 
@@ -348,6 +358,10 @@ func ValidateVaultIssuerAuth(auth *certmanager.VaultAuth, fldPath *field.Path) f
 
 		if auth.Kubernetes.Role == "" {
 			el = append(el, field.Required(fldPath.Child("kubernetes", "role"), ""))
+		}
+
+		if containsDotDotSegment(auth.Kubernetes.Path) {
+			el = append(el, field.Invalid(fldPath.Child("kubernetes", "path"), auth.Kubernetes.Path, "must not contain '..' path segments"))
 		}
 
 		kubeCount := 0
@@ -377,6 +391,10 @@ func ValidateVaultIssuerAuth(auth *certmanager.VaultAuth, fldPath *field.Path) f
 			el = append(el, field.Required(fldPath.Child("aws", "role"), ""))
 		}
 
+		if containsDotDotSegment(auth.AWS.MountPath) {
+			el = append(el, field.Invalid(fldPath.Child("aws", "mountPath"), auth.AWS.MountPath, "must not contain '..' path segments"))
+		}
+
 		if auth.AWS.ServiceAccountRef != nil {
 			if len(auth.AWS.ServiceAccountRef.Name) == 0 {
 				el = append(el, field.Required(fldPath.Child("aws", "serviceAccountRef", "name"), ""))
@@ -399,6 +417,14 @@ func ValidateVaultIssuerAuth(auth *certmanager.VaultAuth, fldPath *field.Path) f
 	// that it is the first field that is set gets used.
 
 	return el
+}
+
+// containsDotDotSegment checks for literal ".." path segments only.
+// We considered using path.Clean(p) != p instead, which also catches
+// double slashes and trailing slashes, but that risks rejecting
+// existing working Issuers on update with cosmetically non-canonical paths.
+func containsDotDotSegment(p string) bool {
+	return slices.Contains(strings.Split(p, "/"), "..")
 }
 
 func ValidateVenafiTPP(tpp *certmanager.VenafiTPP, fldPath *field.Path) (el field.ErrorList) {

--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -171,6 +171,18 @@ func TestValidateVaultIssuerConfig(t *testing.T) {
 				field.Invalid(fldPath.Child("clientCertSecretRef"), "<snip>", "clientCertSecretRef must be provided when defining the clientKeySecretRef"),
 			},
 		},
+		"invalid vault issuer: path contains '..' segments": {
+			spec: &cmapi.VaultIssuer{
+				Server: "https://vault.example.com",
+				Path:   "pki/../sys/seal",
+				Auth: cmapi.VaultAuth{
+					TokenSecretRef: &validSecretKeyRef,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("path"), "pki/../sys/seal", "must not contain '..' path segments"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
@@ -386,6 +398,56 @@ func TestValidateVaultIssuerAuth(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Required(fldPath.Child("aws", "iamRoleArn"), "iamRoleArn is required when using serviceAccountRef for IRSA"),
+			},
+		},
+		"invalid auth.appRole: path contains '..' segments": {
+			auth: &cmapi.VaultAuth{
+				AppRole: &cmapi.VaultAppRole{
+					RoleId: "role-id",
+					SecretRef: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "secret"},
+						Key:                  "key",
+					},
+					Path: "../../sys/seal",
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("appRole", "path"), "../../sys/seal", "must not contain '..' path segments"),
+			},
+		},
+		"invalid auth.clientCertificate: path contains '..' segments": {
+			auth: &cmapi.VaultAuth{
+				ClientCertificate: &cmapi.VaultClientCertificateAuth{
+					Path: "../other",
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("clientCertificate", "path"), "../other", "must not contain '..' path segments"),
+			},
+		},
+		"invalid auth.kubernetes: path contains '..' segments": {
+			auth: &cmapi.VaultAuth{
+				Kubernetes: &cmapi.VaultKubernetesAuth{
+					Path: "../other",
+					Role: "role",
+					ServiceAccountRef: &cmapi.ServiceAccountRef{
+						Name: "service-account",
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("kubernetes", "path"), "../other", "must not contain '..' path segments"),
+			},
+		},
+		"invalid auth.aws: mountPath contains '..' segments": {
+			auth: &cmapi.VaultAuth{
+				AWS: &cmapi.VaultAWSAuth{
+					Role:      "my-role",
+					MountPath: "../other",
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("aws", "mountPath"), "../other", "must not contain '..' path segments"),
 			},
 		},
 		"valid auth: all five auth types can be set simultaneously": {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -523,7 +522,7 @@ func (v *Vault) requestTokenWithClientCertificate(client Client, clientCertifica
 		mountPath = v1.DefaultVaultClientCertificateAuthMountPath
 	}
 
-	url := filepath.Join(mountPath, "login")
+	url := path.Join(mountPath, "login")
 	request := client.NewRequest("POST", url)
 	err := request.SetJSONBody(parameters)
 	if err != nil {
@@ -626,7 +625,7 @@ func (v *Vault) requestTokenWithKubernetesAuth(ctx context.Context, client Clien
 		mountPath = v1.DefaultVaultKubernetesAuthMountPath
 	}
 
-	url := filepath.Join(mountPath, "login")
+	url := path.Join(mountPath, "login")
 	request := client.NewRequest("POST", url)
 	err := request.SetJSONBody(parameters)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Reject `..` sequences in `spec.vault.path` and in the Vault auth
  mount path fields (`appRole.path`, `kubernetes.path`,
  `clientCertificate.path`, `aws.mountPath`) during webhook
  validation.
- Replace `filepath.Join` with `path.Join` in the clientCertificate
  and kubernetes auth code paths.

## Motivation

Go's `path.Join` resolves `..` segments client-side before
constructing the HTTP request to Vault, which can silently produce a
different URL than the user intended. For the auth mount path fields,
`..` can also escape the hard-coded `auth/` prefix in the URL
construction.

`filepath.Join` is OS-dependent and not appropriate for URL path
construction; `path.Join` is already used in the AppRole and Sign code
paths.

Thanks to @jiayuqi7813 and @kodareef5 for reporting this.

### Why only `..`?

We considered whether other dangerous characters (`%`-encoded
traversal, null bytes, backslashes, newlines, query/fragment
delimiters) need sanitising and concluded that `..` is the only
meaningful vector for these fields. The remaining characters are
already handled by layers below the webhook:

| Character class | Why it's safe | Reference |
|---|---|---|
| Percent-encoded traversal (`%2e%2e`, `%2f`) | The Vault Go client sets the path via `url.URL.Path` (the **decoded** field). Go's `URL.String()` re-encodes via `EscapedPath()`, so a literal `%2e` in `Path` becomes `%252e` on the wire — Vault sees the literal string, not `..`. | [pkg.go.dev/net/url#URL](https://pkg.go.dev/net/url#URL): *"the Path field is stored in decoded form: /%47%6f%2f becomes /Go/"* |
| Null bytes and control characters (`\x00`–`\x1f`, `\x7f`) | Go's `net/url.Parse` rejects all ASCII control characters at parse time. Even if a control character reached the Vault client's URL construction, the HTTP request would fail. | [Go 1.12 release notes](https://go.dev/doc/go1.12) (`net/url` section); [golang/go#27302](https://github.com/golang/go/issues/27302); commit [829c5df58694](https://github.com/golang/go/commit/829c5df58694) |
| Backslashes (`\`) | `path.Join` is POSIX-only and treats `\` as an ordinary character, not a separator. (We removed the two `filepath.Join` calls that *were* OS-dependent in this PR.) | [pkg.go.dev/path](https://pkg.go.dev/path): *"This package does not deal with Windows paths with drive letters or backslashes"* |
| Query / fragment injection (`?`, `#`) | The Vault Go client constructs `url.URL` with the path in the `.Path` field and serialises via `RequestURI()`, which percent-encodes these characters. They are never interpreted as delimiters. | [hashicorp/vault api/client.go `NewRequest`](https://github.com/hashicorp/vault/blob/main/api/client.go), [api/request.go `toRetryableHTTP`](https://github.com/hashicorp/vault/blob/main/api/request.go) |
| Newlines (`\r\n`) | Covered by the control-character rejection above (Go 1.12+). | See above |

## Test plan

- [x] New validation test cases in `TestValidateVaultIssuerConfig` and
  `TestValidateVaultIssuerAuth` for `..` rejection in all path fields
- [x] `go test ./internal/apis/certmanager/validation/...` passes
- [x] `go build ./internal/vault/...` confirms clean compilation after
  removing the `path/filepath` import

```release-note
Vault Issuer webhook validation now rejects `..` path segments in `spec.vault.path` and auth mount path fields, preventing `path.Join` from silently resolving relative segments before constructing the Vault API request.
```