### PR TITLE
Remove default tokenrequest RBAC from Helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -45,50 +45,6 @@ subjects:
 
 ---
 
-{{- if .Values.serviceAccount.create }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ template "cert-manager.fullname" . }}-tokenrequest
-  namespace: {{ include "cert-manager.namespace" . }}
-  labels:
-    app: {{ include "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: "controller"
-    {{- include "labels" . | nindent 4 }}
-rules:
-  - apiGroups: [""]
-    resources: ["serviceaccounts/token"]
-    resourceNames: ["{{ template "cert-manager.serviceAccountName" . }}"]
-    verbs: ["create"]
-
----
-
-# grant cert-manager permission to create tokens for the serviceaccount
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "cert-manager.fullname" . }}-tokenrequest
-  namespace: {{ include "cert-manager.namespace" . }}
-  labels:
-    app: {{ include "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: "controller"
-    {{- include "labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ template "cert-manager.fullname" . }}-tokenrequest
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "cert-manager.serviceAccountName" . }}
-    namespace: {{ include "cert-manager.namespace" . }}
-{{- end }}
-
----
-
 # Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Summary

Remove the `Role` and `RoleBinding` that granted the cert-manager controller ServiceAccount permission to create tokens for itself via the TokenRequest API.

## Motivation

This RBAC was added in #7213 (cert-manager 1.16) to support a "Using the cert-manager ServiceAccount" section in the Route53 documentation. That docs section was subsequently removed in cert-manager/website#1555 (Oct 2024) when the Route53 page was restructured into Ambient / Non-ambient credentials.

No documented flow requires the controller to mint tokens for its own ServiceAccount:

- **Route53 IRSA ambient**: uses a projected SA token injected by the IRSA webhook; no TokenRequest call.
- **Route53 non-ambient with dedicated SA**: ships its own per-SA Role/RoleBinding in the user-supplied RBAC.
- **Vault Kubernetes auth**: documented examples all use a dedicated `vault-issuer` ServiceAccount with user-supplied RBAC, not the controller SA.

The original "no harm" assessment on #7212 was made before the security implications of combining this default RBAC with user-controlled `serviceAccountRef` fields were fully understood. Removing it narrows the default-install attack surface without breaking any documented workflow.

Credit to **@everping** and **@kodareef5** for independently identifying (via privately reported security advisories) that this default RBAC widens the trust boundary beyond what cert-manager's published [threat model](https://cert-manager.io/docs/devops-tips/threat-modelling/) documents.

## Impact

Users who rely on the undocumented pattern of pointing `serviceAccountRef.name` at the controller ServiceAccount should create their own `Role` and `RoleBinding`, or migrate to one of the documented patterns (IRSA ambient, or a dedicated ServiceAccount).

## Documentation

Draft upgrade notes and release notes accompany this PR: cert-manager/website#2171.

/kind deprecation

### Release Note

```release-note
**BREAKING**: The Helm chart no longer ships a default `Role` and `RoleBinding` granting the cert-manager controller ServiceAccount permission to create tokens for itself (`serviceaccounts/token: create`). This RBAC was added in v1.16 (#7213) but no documented workflow requires it, and the motivating Route53 docs section was removed in Oct 2024. If you rely on `serviceAccountRef.name` pointing at the controller ServiceAccount (an undocumented pattern), you must now create your own `Role` and `RoleBinding` granting `serviceaccounts/token: create` on that ServiceAccount, or migrate to one of the documented patterns (IRSA ambient, or a dedicated ServiceAccount with its own RBAC).
```

## Test plan

- Verified that no Helm chart tests or snapshots reference `tokenrequest`
- Verified that the Go code references to `tokenrequest` are local variables in `internal/vault/vault.go` and `pkg/issuer/acme/dns/dns.go`, unrelated to the chart RBAC
- Confirmed that the resulting `rbac.yaml` template renders correctly (leaderelection RoleBinding → Issuer controller ClusterRole, separated by `---`)

Reverts #7213
Ref #7212