### PR TITLE
Fix Renovate config for release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,9 @@
       matchFileNames: [
         'make/base_images.mk',
       ],
+      addLabels: [
+        'skip-review', // Adding label to allow PRs to automerge
+      ],
     },
     {
       groupName: null,
@@ -68,26 +71,21 @@
       },
     },
     {
-      description: 'Ignore misc files on release branches',
-      matchBaseBranches: [
-        '/^release-.*/'
-      ],
-      matchFileNames: [
-        '.github/workflows/*', // No workflow updates
-        'klone.yaml', // No makefile-modules updates
-      ],
-      enabled: false
-    },
-    {
-      description: 'Ignore major and minor updates on release branches',
+      description: 'Ignore updates in general on release branches',
       matchBaseBranches: [
         '/^release-.*/',
       ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-      ],
       enabled: false,
+    },
+    {
+      description: 'Enable base image updates on release branches',
+      matchBaseBranches: [
+        '/^release-.*/',
+      ],
+      matchFileNames: [
+        'make/base_images.mk',
+      ],
+      enabled: true,
     },
   ],
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

As discussed in today's stand-up, we generally want to avoid dependency bumps on release branches. This PR should change the behavior of Renovate on release branches to only suggest upgrades for base images. At least for now, but we could consider other bumps for the future.

Also, enabling auto-merge for base image updates in general.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
