### PR TITLE
feat(metrics): instrument Vault issuer Sign() requests

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -46,6 +46,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -53,7 +54,7 @@ var _ Interface = &Vault{}
 
 // ClientBuilder is a function type that returns a new Interface.
 // Can be used in tests to create a mock signer of Vault certificate requests.
-type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error)
+type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer, canUseAmbientCredentials bool, _ *metrics.Metrics) (Interface, error)
 
 // Interface implements various high level functionality related to connecting
 // with a Vault server, verifying its status and signing certificate request for
@@ -109,19 +110,22 @@ type Vault struct {
 	// header is provided
 	// See https://developer.hashicorp.com/vault/docs/enterprise/namespaces#root-only-api-paths
 	clientSys Client
+
+	metrics *metrics.Metrics
 }
 
 // New returns a new Vault instance with the given namespace, issuer and
 // secrets lister.
 // Returned errors may be network failures and should be considered for
 // retrying.
-func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error) {
+func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool, metrics *metrics.Metrics) (Interface, error) {
 	v := &Vault{
 		createToken:              createTokenFn(namespace),
 		secretsLister:            secretsLister,
 		namespace:                namespace,
 		issuer:                   issuer,
 		canUseAmbientCredentials: canUseAmbientCredentials,
+		metrics:                  metrics,
 	}
 
 	cfg, err := v.newConfig()
@@ -185,7 +189,11 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 		return nil, nil, fmt.Errorf("failed to build vault request: %s", err)
 	}
 
+	start := time.Now()
 	resp, err := v.client.RawRequest(request)
+	if v.metrics != nil {
+		v.metrics.ObserveVaultRequestDuration(time.Since(start), "sign")
+	}
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -46,6 +46,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -53,7 +54,7 @@ var _ Interface = &Vault{}
 
 // ClientBuilder is a function type that returns a new Interface.
 // Can be used in tests to create a mock signer of Vault certificate requests.
-type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error)
+type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer, canUseAmbientCredentials bool, _ *metrics.Metrics) (Interface, error)
 
 // Interface implements various high level functionality related to connecting
 // with a Vault server, verifying its status and signing certificate request for
@@ -109,14 +110,16 @@ type Vault struct {
 	// header is provided
 	// See https://developer.hashicorp.com/vault/docs/enterprise/namespaces#root-only-api-paths
 	clientSys Client
+
+	metrics *metrics.Metrics
 }
 
 // New returns a new Vault instance with the given namespace, issuer and
 // secrets lister.
 // Returned errors may be network failures and should be considered for
 // retrying.
-func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error) {
-	v, err := newVault(ctx, namespace, createTokenFn, secretsLister, issuer, canUseAmbientCredentials)
+func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool, metrics *metrics.Metrics) (Interface, error) {
+	v, err := newVault(ctx, namespace, createTokenFn, secretsLister, issuer, canUseAmbientCredentials, metrics)
 	if err != nil {
 		return nil, sanitizeError(err)
 	}
@@ -124,13 +127,14 @@ func New(ctx context.Context, namespace string, createTokenFn func(ns string) Cr
 	return v, nil
 }
 
-func newVault(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (*Vault, error) {
+func newVault(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool, metrics *metrics.Metrics) (*Vault, error) {
 	v := &Vault{
 		createToken:              createTokenFn(namespace),
 		secretsLister:            secretsLister,
 		namespace:                namespace,
 		issuer:                   issuer,
 		canUseAmbientCredentials: canUseAmbientCredentials,
+		metrics:                  metrics,
 	}
 
 	cfg, err := v.newConfig()
@@ -200,7 +204,11 @@ func (v *Vault) sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 		return nil, nil, fmt.Errorf("failed to build vault request: %s", err)
 	}
 
+	start := time.Now()
 	resp, err := v.client.RawRequest(request)
+	if v.metrics != nil {
+		v.metrics.ObserveVaultRequestDuration(time.Since(start), "sign")
+	}
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1707,7 +1707,7 @@ func TestNewWithVaultNamespaces(t *testing.T) {
 							},
 						},
 					},
-				}, false)
+				}, false, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.vaultNS, c.(*Vault).client.(*vaultClientWrapper).Client.Namespace(),
 				"The vault client should have the namespace provided in the Issuer resource")
@@ -1764,7 +1764,7 @@ func TestIsVaultInitiatedAndUnsealedIntegration(t *testing.T) {
 					},
 				},
 			},
-		}, false)
+		}, false, nil)
 	require.NoError(t, err)
 
 	err = v.IsVaultInitializedAndUnsealed()
@@ -1831,7 +1831,7 @@ func TestSignIntegration(t *testing.T) {
 					},
 				},
 			},
-		}, false)
+		}, false, nil)
 	require.NoError(t, err)
 
 	certPEM, caPEM, err := v.Sign(csrPEM, time.Hour)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1808,7 +1808,7 @@ func TestNewWithVaultNamespaces(t *testing.T) {
 							},
 						},
 					},
-				}, false)
+				}, false, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.vaultNS, c.(*Vault).client.(*vaultClientWrapper).Client.Namespace(),
 				"The vault client should have the namespace provided in the Issuer resource")
@@ -1865,7 +1865,7 @@ func TestIsVaultInitiatedAndUnsealedIntegration(t *testing.T) {
 					},
 				},
 			},
-		}, false)
+		}, false, nil)
 	require.NoError(t, err)
 
 	err = v.IsVaultInitializedAndUnsealed()
@@ -1933,7 +1933,7 @@ func TestSignIntegration(t *testing.T) {
 					},
 				},
 			},
-		}, false)
+		}, false, nil)
 	require.NoError(t, err)
 
 	certPEM, caPEM, err := v.Sign(csrPEM, time.Hour)

--- a/pkg/controller/certificaterequests/vault/fuzz_test.go
+++ b/pkg/controller/certificaterequests/vault/fuzz_test.go
@@ -35,6 +35,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -173,7 +174,7 @@ func FuzzVaultCRController(f *testing.F) {
 
 			fakeVault := fakevault.New().WithSign(rsaPEMCert, rsaPEMCert, nil)
 			vault.vaultClientBuilder = func(_ context.Context, ns string, _ func(ns string) internalvault.CreateToken, sl internalinformers.SecretLister,
-				iss cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+				iss cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return fakeVault.New(ns, sl, iss)
 			}
 		}

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -30,6 +30,7 @@ import (
 	crutil "github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/util"
 	"github.com/cert-manager/cert-manager/pkg/issuer"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
 )
 
@@ -45,6 +46,7 @@ type Vault struct {
 	createTokenFn func(ns string) vaultinternal.CreateToken
 	secretsLister internalinformers.SecretLister
 	reporter      *crutil.Reporter
+	metrics       *metrics.Metrics
 
 	vaultClientBuilder vaultinternal.ClientBuilder
 }
@@ -67,6 +69,7 @@ func NewVault(ctx *controllerpkg.Context) certificaterequests.Issuer {
 		},
 		secretsLister:      ctx.KubeSharedInformerFactory.Secrets().Lister(),
 		reporter:           crutil.NewReporter(ctx.Clock, ctx.Recorder),
+		metrics:           ctx.Metrics,
 		vaultClientBuilder: vaultinternal.New,
 	}
 }
@@ -79,7 +82,7 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
-	client, err := v.vaultClientBuilder(ctx, resourceNamespace, v.createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
+	client, err := v.vaultClientBuilder(ctx, resourceNamespace, v.createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj), v.metrics)
 	if k8sErrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -43,6 +43,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificaterequests"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -563,7 +564,7 @@ func runTest(t *testing.T, test testT) {
 
 	if test.fakeVault != nil {
 		vault.vaultClientBuilder = func(_ context.Context, ns string, _ func(ns string) internalvault.CreateToken, sl internalinformers.SecretLister,
-			iss cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			iss cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 			return test.fakeVault.New(ns, sl, iss)
 		}
 	}

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
 
@@ -53,6 +54,7 @@ type Vault struct {
 
 	certClient    certificatesclient.CertificateSigningRequestInterface
 	clientBuilder internalvault.ClientBuilder
+	metrics       *metrics.Metrics
 
 	// fieldManager is the manager name used for the Apply operations.
 	fieldManager string
@@ -74,6 +76,7 @@ func NewVault(ctx *controllerpkg.Context) certificatesigningrequests.Signer {
 		recorder:      ctx.Recorder,
 		certClient:    ctx.Client.CertificatesV1().CertificateSigningRequests(),
 		clientBuilder: internalvault.New,
+		metrics:       ctx.Metrics,
 		fieldManager:  ctx.FieldManager,
 	}
 }
@@ -89,7 +92,7 @@ func (v *Vault) Sign(ctx context.Context, csr *certificatesv1.CertificateSigning
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
 	createTokenFn := func(ns string) internalvault.CreateToken { return v.kclient.CoreV1().ServiceAccounts(ns).CreateToken }
-	client, err := v.clientBuilder(ctx, resourceNamespace, createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
+	client, err := v.clientBuilder(ctx, resourceNamespace, createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj), v.metrics)
 	if apierrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 		log.Error(err, message)

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -43,6 +43,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
 	"github.com/cert-manager/cert-manager/pkg/controller/certificatesigningrequests/util"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -131,7 +132,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -192,7 +193,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -236,7 +237,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return fakevault.New(), nil
 			},
 			builder: &testpkg.Builder{
@@ -298,7 +299,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return fakevault.New().WithSign(nil, nil, errors.New("sign error")), nil
 			},
 			builder: &testpkg.Builder{
@@ -359,7 +360,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool, _ *metrics.Metrics) (internalvault.Interface, error) {
 				return fakevault.New().WithSign([]byte("signed-cert"), []byte("signing-ca"), nil), nil
 			},
 			builder: &testpkg.Builder{

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -146,7 +146,7 @@ func (v *Vault) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 		return nil
 	}
 
-	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer))
+	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer), v.Metrics)
 	if err != nil {
 		logf.FromContext(ctx).V(logf.WarnLevel).Info(messageVaultClientInitFailed, "err", err, "issuer", klog.KObj(issuer))
 		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultClientInitFailed, err.Error()))

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -146,7 +146,7 @@ func (v *Vault) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 		return nil
 	}
 
-	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer))
+	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer), v.Metrics)
 	if err != nil {
 		msg := vaultinternal.SafeErrorMessage(err)
 		logVaultError(ctx, issuer, messageVaultClientInitFailed, msg, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,6 +63,7 @@ type Metrics struct {
 	venafiClientRequestDurationSeconds  *prometheus.SummaryVec
 	venafiOAuthTokenRequestsTotal       *prometheus.CounterVec
 	venafiOAuthTokenRequestDurationSecs prometheus.Histogram
+	vaultClientRequestDurationSeconds  *prometheus.SummaryVec
 	controllerSyncCallCount             *prometheus.CounterVec
 	controllerSyncErrorCount            *prometheus.CounterVec
 	challengeCollector                  prometheus.Collector
@@ -174,6 +175,17 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			},
 		)
 
+		vaultClientRequestDurationSeconds = prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace:  namespace,
+				Name:       "vault_client_request_duration_seconds",
+				Help:       "The HTTP request latencies in seconds for the Vault client used by the Vault issuer.",
+				Subsystem:  "http",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			},
+			[]string{"api_call"},
+		)
+
 		controllerSyncCallCount = prometheus.NewCounterVec(
 			//nolint:promlinter
 			prometheus.CounterOpts{
@@ -213,6 +225,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 		venafiClientRequestDurationSeconds:  venafiClientRequestDurationSeconds,
 		venafiOAuthTokenRequestsTotal:       venafiOAuthTokenRequestsTotal,
 		venafiOAuthTokenRequestDurationSecs: venafiOAuthTokenRequestDurationSecs,
+		vaultClientRequestDurationSeconds:   vaultClientRequestDurationSeconds,
 		controllerSyncCallCount:             controllerSyncCallCount,
 		controllerSyncErrorCount:            controllerSyncErrorCount,
 	}
@@ -248,6 +261,7 @@ func (m *Metrics) NewServer(ln net.Listener) *http.Server {
 	m.registry.MustRegister(m.venafiClientRequestDurationSeconds)
 	m.registry.MustRegister(m.venafiOAuthTokenRequestsTotal)
 	m.registry.MustRegister(m.venafiOAuthTokenRequestDurationSecs)
+	m.registry.MustRegister(m.vaultClientRequestDurationSeconds)
 	m.registry.MustRegister(m.acmeClientRequestCount)
 	m.registry.MustRegister(m.controllerSyncCallCount)
 	m.registry.MustRegister(m.controllerSyncErrorCount)

--- a/pkg/metrics/vault.go
+++ b/pkg/metrics/vault.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "time"
+
+// ObserveVaultRequestDuration records the duration of a Vault client API call.
+func (m *Metrics) ObserveVaultRequestDuration(duration time.Duration, labels ...string) {
+	m.vaultClientRequestDurationSeconds.WithLabelValues(labels...).Observe(duration.Seconds())
+}


### PR DESCRIPTION
## Summary

Fixes #8441.

Adds Prometheus instrumentation for the Vault issuer `Sign()` path, mirroring the existing Venafi client metrics pattern.

## Changes

- Register `certmanager_http_vault_client_request_duration_seconds` SummaryVec with an `api_call` label
- Record request duration in `internal/vault.Sign()` after the Vault raw request completes
- Thread `*metrics.Metrics` through the Vault client builder and controller setup paths
- Update affected unit tests and mocks

## Testing

- `go test ./pkg/metrics/... ./internal/vault/... ./pkg/controller/certificaterequests/vault/... ./pkg/controller/certificatesigningrequests/vault/...`

```release-note
Added the `certmanager_http_vault_client_request_duration_seconds` metric to expose request durations for Vault issuer signing requests.
```