### PR TITLE
Fix make e2e-setup-pebble when _bin/downloaded is missing

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -420,6 +420,9 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 	@$(KUBECTL) create ns cert-manager >/dev/null 2>&1 || true
 	$(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
 
+$(bin_dir)/downloaded:
+	@mkdir -p $@
+
 # We are using @inteon's fork of Pebble, which adds support for signing CSRs with
 # Ed25519 keys:
 # - https://github.com/letsencrypt/pebble/pull/468


### PR DESCRIPTION
## Summary

Add the missing `$(bin_dir)/downloaded` directory target used by the Pebble source tarball prerequisite in `make/e2e-setup.mk`.

Without this, `make e2e-setup-pebble` can fail from a clean worktree because its curl output path assumes `_bin/downloaded/` already exists.

Before this fix, the failure looked like:

```bash
$ rm -rf _bin/downloaded
$ make e2e-setup-pebble
make: *** No rule to make target '_bin/downloaded', needed by '_bin/downloaded/pebble-b2a726c05272b9a89115fbd1b5f048da5b0124a8.tar.gz'.  Stop.
```

## Test plan

```bash
rm -rf _bin/downloaded
make e2e-setup-pebble
```

This now succeeds without needing a manual `mkdir -p _bin/downloaded` first.

```release-note
NONE
```
