### PR TITLE
handle 404 response from ACME servers as a retryable error

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -324,7 +324,7 @@ func handleError(ctx context.Context, ch *cmacme.Challenge, err error) error {
 	// can be retried.
 	// TODO: don't mark *all* malformed errors as expired, we may be able to be
 	// more informative to the user by further inspecting the Error response.
-	if acmeErr.ProblemType == "urn:ietf:params:acme:error:malformed" {
+	if acmeErr.ProblemType == "urn:ietf:params:acme:error:malformed" && acmeErr.StatusCode != 404 {
 		ch.Status.State = cmacme.Expired
 		// absorb the error as updating the challenge's status will trigger a sync
 		return nil
@@ -333,7 +333,9 @@ func handleError(ctx context.Context, ch *cmacme.Challenge, err error) error {
 	if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 		ch.Status.State = cmacme.Errored
 		ch.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
-		return nil
+		if acmeErr.StatusCode != 404 {
+			return nil
+		}
 	}
 
 	return err

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -107,7 +107,9 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 				log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
 				c.setOrderState(&o.Status, string(cmacme.Errored))
 				o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
-				return nil
+				if acmeErr.StatusCode != 404 {
+					return nil
+				}
 			}
 		}
 		return err
@@ -189,7 +191,9 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 			log.Error(err, "failed to retrieve the ACME order (4xx error) marking Order as failed")
 			c.setOrderState(&o.Status, string(cmacme.Errored))
 			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
-			return nil
+			if acmeErr.StatusCode != 404 {
+				return nil
+			}
 		}
 	}
 	if err != nil {
@@ -574,7 +578,9 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 			log.Error(err, "failed to retrieve the ACME order (4xx error) marking Order as failed")
 			c.setOrderState(&o.Status, string(cmacme.Errored))
 			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
-			return nil
+			if acmeGetOrderErr.StatusCode != 404 {
+				return nil
+			}
 		}
 		if getOrderErr != nil {
 			return getOrderErr
@@ -588,11 +594,13 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 	}
 
 	// Any other ACME 4xx error means that the Order can be considered failed.
-	if ok && acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
+	if ok && acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 && acmeErr.StatusCode != 404 {
 		log.Error(err, "failed to finalize Order resource due to bad request, marking Order as failed")
 		c.setOrderState(&o.Status, string(cmacme.Errored))
 		o.Status.Reason = fmt.Sprintf("Failed to finalize Order: %v", err)
-		return nil
+		if acmeErr.StatusCode != 404 {
+			return nil
+		}
 	}
 
 	if ok && acmeErr.StatusCode >= 500 {
@@ -607,7 +615,10 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 			log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
 			c.setOrderState(&o.Status, string(cmacme.Errored))
 			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", errUpdate)
-			return nil
+			if acmeErr.StatusCode != 404 {
+				return nil
+			}
+
 		}
 		if acmeErr.StatusCode >= 500 {
 			log.Error(acmeErr, "acme server fatal error", "errorCode", acmeErr.StatusCode, "dnsNames", o.Spec.DNSNames, "ipAddresses", o.Spec.IPAddresses, "responseHeaders", acmeErr.Header)
@@ -669,7 +680,9 @@ func (c *controller) syncCertificateData(ctx context.Context, cl acmecl.Interfac
 			log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
 			c.setOrderState(&o.Status, string(cmacme.Errored))
 			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
-			return nil
+			if acmeErr.StatusCode != 404 {
+				return nil
+			}
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR is a proposed fix for the issue mentioned in #8939. It handles a 404 response from an ACME server as a retryable error. 

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note
<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
* retry 404 responses received from ACME servers 
```
