### PR TITLE
fix: validation for certificates was failing for long durations due to an int overflow

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -381,7 +381,17 @@ func ValidateDuration(crt *internalcmapi.CertificateSpec, fldPath *field.Path) f
 	// If spec.renewBeforePercentage is set, check that it's within the allowed
 	// range.
 	if crt.RenewBeforePercentage != nil {
-		renewBefore := duration * time.Duration(100-*crt.RenewBeforePercentage) / 100
+		// We cast to float64 to avoid an int overflow.
+		//
+		// This would happen because duration is an int64 (nanoseconds),
+		// duration * (100 - pct) is evaluated in int64 before the / 100, so
+		// multiplying a large duration by up to 100 can exceed math.MaxInt64
+		// and wrap to a negative/garbage value.
+		//
+		// Technically we lose precision at around 104 days, however the
+		// precision lost is so small it does not matter (a value of 150k years
+		// is required to lose 1ms of precision)
+		renewBefore := time.Duration(float64(duration) * float64(100-*crt.RenewBeforePercentage) / 100)
 		if renewBefore < cmapi.MinimumRenewBefore {
 			el = append(el, field.Invalid(fldPath.Child("renewBeforePercentage"), *crt.RenewBeforePercentage, fmt.Sprintf("certificate renewBeforePercentage must result in a renewBefore greater than %s", cmapi.MinimumRenewBefore)))
 		}

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -1130,6 +1130,31 @@ func TestValidateDuration(t *testing.T) {
 			},
 			errs: []*field.Error{field.Invalid(fldPath.Child("duration"), usefulDurations["half hour"].Duration, fmt.Sprintf("certificate duration must be greater than %s", cmapi.MinimumCertificateDuration))},
 		},
+		// Regression tests for int64 overflow: duration * (100 - pct) overflows int64 for large
+		// durations with a small renewBeforePercentage (large multiplier). The overflow produced a
+		// negative renewBefore, which falsely triggered the MinimumRenewBefore validation error.
+		"renewBeforePercentage=1 with 10-year duration does not overflow int64": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					Duration:              usefulDurations["ten years"],
+					RenewBeforePercentage: new(int32(1)),
+					CommonName:            "testcn",
+					SecretName:            "abc",
+					IssuerRef:             validIssuerRef,
+				},
+			},
+		},
+		"renewBeforePercentage=1 with 3-year duration does not overflow int64": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					Duration:              &metav1.Duration{Duration: time.Hour * 24 * 365 * 3},
+					RenewBeforePercentage: new(int32(1)),
+					CommonName:            "testcn",
+					SecretName:            "abc",
+					IssuerRef:             validIssuerRef,
+				},
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/util/pki/renewaltime.go
+++ b/pkg/util/pki/renewaltime.go
@@ -129,7 +129,13 @@ func desiredRenewalTime(actualDuration time.Duration, renewBefore *metav1.Durati
 	if renewBefore != nil && renewBefore.Duration > 0 && renewBefore.Duration < actualDuration {
 		return renewBefore.Duration
 	} else if renewBeforePercentage != nil && *renewBeforePercentage > 0 && *renewBeforePercentage < 100 {
-		return actualDuration * time.Duration(*renewBeforePercentage) / 100
+		// We cast to float64 to avoid an int overflow.
+		//
+		// This would happen because actualDuration is an int64 (nanoseconds),
+		// actualDuration * pct is evaluated in int64 before the / 100, so
+		// multiplying a large duration by up to 99 can exceed math.MaxInt64
+		// and wrap to a negative/garbage value.
+		return time.Duration(float64(actualDuration) * float64(*renewBeforePercentage) / 100)
 	}
 
 	// Otherwise, default to renewing 2/3 through certificate's lifetime.

--- a/pkg/util/pki/renewaltime_test.go
+++ b/pkg/util/pki/renewaltime_test.go
@@ -120,9 +120,10 @@ func TestRenewalTime(t *testing.T) {
 }
 
 func TestRenewBefore(t *testing.T) {
-	const duration = time.Hour * 3
+	const defaultDuration = time.Hour * 3
 
 	type scenario struct {
+		duration            time.Duration // defaults to defaultDuration if zero
 		renewBefore         *metav1.Duration
 		renewBeforePct      *int32
 		expectedRenewBefore time.Duration
@@ -153,10 +154,27 @@ func TestRenewBefore(t *testing.T) {
 			renewBefore:         &metav1.Duration{Duration: time.Hour * 4},
 			expectedRenewBefore: time.Hour,
 		},
+		// Regression tests: duration * pct overflows int64 for large durations with a high
+		// renewBeforePercentage (large multiplier). The overflow produced a negative result,
+		// causing desiredRenewalTime to silently return a garbage value.
+		"spec.renewBeforePercentage=99 with 10-year duration does not overflow int64": {
+			duration:            time.Hour * 24 * 365 * 10,
+			renewBeforePct:      new(int32(99)),
+			expectedRenewBefore: time.Duration(float64(time.Hour*24*365*10) * 0.99),
+		},
+		"spec.renewBeforePercentage=99 with 3-year duration does not overflow int64": {
+			duration:            time.Hour * 24 * 365 * 3,
+			renewBeforePct:      new(int32(99)),
+			expectedRenewBefore: time.Duration(float64(time.Hour*24*365*3) * 0.99),
+		},
 	}
 	for n, s := range tests {
 		t.Run(n, func(t *testing.T) {
-			renewBefore := desiredRenewalTime(duration, s.renewBefore, s.renewBeforePct)
+			d := s.duration
+			if d == 0 {
+				d = defaultDuration
+			}
+			renewBefore := desiredRenewalTime(d, s.renewBefore, s.renewBeforePct)
 			assert.Equal(t, s.expectedRenewBefore, renewBefore, fmt.Sprintf("Expected renewBefore time: %v got: %v", s.expectedRenewBefore, renewBefore))
 		})
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This pull request addresses a potential integer overflow issue in the calculation of certificate renewal timing in the `ValidateDuration` function. The main change is to cast the calculation to `float64` to prevent overflow when working with large durations.

fixes #8937

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixed an integer overflow in `renewBeforePercentage` calculations that caused Certificates with durations longer than approximately 3 years to be incorrectly rejected by validation or assigned incorrect renewal times.
```
