### PR TITLE
Harden ACME Challenge and Order validation (GHSA-8rvj-mm4h-c258)

### DIFF
--- a/internal/apis/acme/validation/challenge.go
+++ b/internal/apis/acme/validation/challenge.go
@@ -18,12 +18,15 @@ package validation
 
 import (
 	"reflect"
+	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
+	"github.com/cert-manager/cert-manager/pkg/apis/acme"
 )
 
 func ValidateChallengeUpdate(a *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
@@ -34,13 +37,38 @@ func ValidateChallengeUpdate(a *admissionv1.AdmissionRequest, oldObj, newObj run
 		return nil, nil
 	}
 
-	el := field.ErrorList{}
+	var el field.ErrorList
 	if !reflect.DeepEqual(oldChallenge.Spec, newChallenge.Spec) {
 		el = append(el, field.Forbidden(field.NewPath("spec"), "challenge spec is immutable after creation"))
 	}
 	return el, nil
 }
 
+// ValidateChallenge rejects Challenge resources that lack a controller owner
+// reference to an Order. This is defence in depth against Challenge smuggling
+// (GHSA-8rvj-mm4h-c258); it is not a hard security boundary because owner
+// references are not access-controlled in Kubernetes.
 func ValidateChallenge(a *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
-	return nil, nil
+	ch := obj.(*cmacme.Challenge)
+	var el field.ErrorList
+
+	if !hasOrderControllerOwner(ch) {
+		el = append(el, field.Invalid(
+			field.NewPath("metadata", "ownerReferences"),
+			ch.GetOwnerReferences(),
+			"challenge resources must be owned by an Order resource",
+		))
+	}
+
+	return el, nil
+}
+
+func hasOrderControllerOwner(ch metav1.Object) bool {
+	controllerRef := metav1.GetControllerOfNoCopy(ch)
+	if controllerRef == nil {
+		return false
+	}
+
+	return controllerRef.Kind == "Order" &&
+		strings.HasPrefix(controllerRef.APIVersion, acme.GroupName+"/")
 }

--- a/internal/apis/acme/validation/challenge_test.go
+++ b/internal/apis/acme/validation/challenge_test.go
@@ -100,13 +100,113 @@ func TestValidateChallengeUpdate(t *testing.T) {
 	}
 }
 
+// TestValidateChallenge verifies that the webhook rejects Challenge resources
+// lacking a controller owner reference to an Order. This is defence in depth
+// against Challenge smuggling (GHSA-8rvj-mm4h-c258).
 func TestValidateChallenge(t *testing.T) {
+	someAdmissionRequest := &admissionv1.AdmissionRequest{
+		RequestKind: &metav1.GroupVersionKind{
+			Group:   "test",
+			Kind:    "test",
+			Version: "test",
+		},
+	}
+
+	ownerRefPath := field.NewPath("metadata", "ownerReferences")
+	ownerRefDetail := "challenge resources must be owned by an Order resource"
+
 	scenarios := map[string]struct {
 		chal     *cmacme.Challenge
 		a        *admissionv1.AdmissionRequest
 		errs     []*field.Error
 		warnings []string
-	}{}
+	}{
+		"accepts challenge with Order controller owner reference": {
+			chal: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "acme.cert-manager.io/v1",
+							Kind:       "Order",
+							Name:       "my-order",
+							UID:        "abc-123",
+							Controller: new(true),
+						},
+					},
+				},
+			},
+			a: someAdmissionRequest,
+		},
+		"rejects challenge with no owner references": {
+			chal: &cmacme.Challenge{},
+			a:    someAdmissionRequest,
+			errs: []*field.Error{
+				field.Invalid(ownerRefPath, []metav1.OwnerReference(nil), ownerRefDetail),
+			},
+		},
+		"rejects challenge with wrong Kind in owner reference": {
+			chal: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "acme.cert-manager.io/v1",
+							Kind:       "Certificate",
+							Name:       "my-cert",
+							UID:        "abc-123",
+							Controller: new(true),
+						},
+					},
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Invalid(ownerRefPath, []metav1.OwnerReference{
+					{APIVersion: "acme.cert-manager.io/v1", Kind: "Certificate", Name: "my-cert", UID: "abc-123", Controller: new(true)},
+				}, ownerRefDetail),
+			},
+		},
+		"rejects challenge with owner reference that is not a controller": {
+			chal: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "acme.cert-manager.io/v1",
+							Kind:       "Order",
+							Name:       "my-order",
+							UID:        "abc-123",
+						},
+					},
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Invalid(ownerRefPath, []metav1.OwnerReference{
+					{APIVersion: "acme.cert-manager.io/v1", Kind: "Order", Name: "my-order", UID: "abc-123"},
+				}, ownerRefDetail),
+			},
+		},
+		"rejects challenge with owner reference to wrong API group": {
+			chal: &cmacme.Challenge{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cert-manager.io/v1",
+							Kind:       "Order",
+							Name:       "my-order",
+							UID:        "abc-123",
+							Controller: new(true),
+						},
+					},
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Invalid(ownerRefPath, []metav1.OwnerReference{
+					{APIVersion: "cert-manager.io/v1", Kind: "Order", Name: "my-order", UID: "abc-123", Controller: new(true)},
+				}, ownerRefDetail),
+			},
+		},
+	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
 			errs, warnings := ValidateChallenge(s.a, s.chal)

--- a/internal/apis/acme/validation/order.go
+++ b/internal/apis/acme/validation/order.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -44,10 +45,14 @@ func ValidateOrder(a *admissionv1.AdmissionRequest, obj runtime.Object) (field.E
 	return nil, nil
 }
 
+// ValidateOrderSpecUpdate rejects any modification to the Order spec after
+// creation. This closes an attack vector where a user with update permissions
+// could change spec.issuerRef to redirect Challenge creation to a different
+// ClusterIssuer's solver credentials.
 func ValidateOrderSpecUpdate(oldOrder, newOrder cmacme.OrderSpec, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
-	if len(oldOrder.Request) > 0 && !bytes.Equal(oldOrder.Request, newOrder.Request) {
-		el = append(el, field.Forbidden(fldPath.Child("request"), "field is immutable once set"))
+	if !apiequality.Semantic.DeepEqual(oldOrder, newOrder) {
+		el = append(el, field.Forbidden(fldPath, "order spec is immutable after creation"))
 	}
 	return el
 }

--- a/internal/apis/acme/validation/order_test.go
+++ b/internal/apis/acme/validation/order_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
+	cmmeta "github.com/cert-manager/cert-manager/internal/apis/meta"
 )
 
 type testValue string
@@ -93,11 +94,59 @@ func TestValidateOrderUpdate(t *testing.T) {
 	authorizationsFldPath := field.NewPath("status", "authorizations")
 	challengesFldPath := authorizationsFldPath.Index(0).Child("challenges")
 
-	testImmutableOrderField(t, field.NewPath("spec", "request"), func(o *cmacme.Order, s testValue) {
-		if s == testValueNone {
-			o.Spec.Request = nil
+	// Verifies that Order spec immutability prevents an attacker from changing
+	// spec.issuerRef to redirect Challenge creation to a different ClusterIssuer.
+	t.Run("should reject updates to spec", func(t *testing.T) {
+		expectedErrs := []*field.Error{
+			field.Forbidden(field.NewPath("spec"), "order spec is immutable after creation"),
 		}
-		o.Spec.Request = []byte(s)
+		oldOrder := &cmacme.Order{
+			Spec: cmacme.OrderSpec{
+				Request: []byte("old-csr"),
+				IssuerRef: cmmeta.IssuerReference{
+					Name: "my-issuer",
+					Kind: "ClusterIssuer",
+				},
+			},
+		}
+		newOrder := oldOrder.DeepCopy()
+		newOrder.Spec.IssuerRef.Name = "attacker-issuer"
+		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, oldOrder, newOrder)
+		if len(errs) != len(expectedErrs) {
+			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
+			return
+		}
+		for i, e := range errs {
+			expectedErr := expectedErrs[i] //nolint:gosec // bounds checked by len comparison above
+			if !reflect.DeepEqual(e, expectedErr) {
+				t.Errorf("Expected error %v but got %v", expectedErr, e)
+			}
+		}
+		if !reflect.DeepEqual(warnings, []string(nil)) {
+			t.Errorf("Expected no warnings but got %v", warnings)
+		}
+	})
+	// Ensures the Orders controller (which only mutates status fields) is not
+	// blocked by the spec immutability check.
+	t.Run("should allow updates that do not change spec", func(t *testing.T) {
+		oldOrder := &cmacme.Order{
+			Spec: cmacme.OrderSpec{
+				Request: []byte("csr-bytes"),
+				IssuerRef: cmmeta.IssuerReference{
+					Name: "my-issuer",
+					Kind: "ClusterIssuer",
+				},
+			},
+		}
+		newOrder := oldOrder.DeepCopy()
+		newOrder.Status.URL = "https://acme.example.com/order/1"
+		errs, warnings := ValidateOrderUpdate(someAdmissionRequest, oldOrder, newOrder)
+		if len(errs) != 0 {
+			t.Errorf("Expected no errors but got %v", errs)
+		}
+		if !reflect.DeepEqual(warnings, []string(nil)) {
+			t.Errorf("Expected no warnings but got %v", warnings)
+		}
 	})
 	testImmutableOrderField(t, field.NewPath("status", "url"), func(o *cmacme.Order, s testValue) {
 		o.Status.URL = string(s)

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -131,8 +131,13 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 		return nil
 	}
 
+	requiredChallenges, err = ensureKeysForChallenges(cl, requiredChallenges)
+	if err != nil {
+		return err
+	}
+
 	dbg.Info("Determining if any challenge resources need to be created")
-	needToCreateChallenges, err := c.anyRequiredChallengesDoNotExist(requiredChallenges)
+	needToCreateChallenges, err := c.anyRequiredChallengesDoNotExist(o, requiredChallenges)
 	if err != nil {
 		return err
 	}
@@ -145,10 +150,6 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	switch {
 	case needToCreateChallenges:
 		log.V(logf.DebugLevel).Info("Creating additional Challenge resources to complete Order")
-		requiredChallenges, err = ensureKeysForChallenges(cl, requiredChallenges)
-		if err != nil {
-			return err
-		}
 		return c.createRequiredChallenges(ctx, o, requiredChallenges)
 	case needToDeleteChallenges:
 		log.V(logf.DebugLevel).Info("Deleting leftover Challenge resources no longer required by Order")
@@ -446,23 +447,51 @@ func (c *controller) fetchMetadataForAuthorizations(ctx context.Context, o *cmac
 	return nil
 }
 
-func (c *controller) anyRequiredChallengesDoNotExist(requiredChallenges []*cmacme.Challenge) (bool, error) {
+// anyRequiredChallengesDoNotExist returns true if any required Challenge is
+// missing or does not exactly match the Challenge this Order expects. A same-
+// name Challenge is treated as missing if it is not controlled by this Order
+// or if its spec differs from the expected solver-selected spec, to defend
+// against pre-placed Challenge substitution (GHSA-6gm5-38r5-7pxp).
+func (c *controller) anyRequiredChallengesDoNotExist(o *cmacme.Order, requiredChallenges []*cmacme.Challenge) (bool, error) {
 	for _, ch := range requiredChallenges {
-		_, err := c.challengeLister.Challenges(ch.Namespace).Get(ch.Name)
+		existing, err := c.challengeLister.Challenges(ch.Namespace).Get(ch.Name)
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		if err != nil {
 			return false, err
 		}
+		if !challengeMatchesExpectedForOrder(existing, ch, o) {
+			return true, nil
+		}
 	}
 	return false, nil
 }
 
+// createRequiredChallenges creates the Challenge resources needed to complete
+// this Order. If a same-name Challenge already exists but is not the exact
+// Challenge this Order expects, it is deleted so a later sync can recreate the
+// expected Challenge. This prevents an attacker from pre-placing a Challenge
+// that would otherwise be adopted by the controller (GHSA-6gm5-38r5-7pxp).
 func (c *controller) createRequiredChallenges(ctx context.Context, o *cmacme.Order, requiredChallenges []*cmacme.Challenge) error {
 	for _, ch := range requiredChallenges {
 		_, err := c.cmClient.AcmeV1().Challenges(ch.Namespace).Create(ctx, ch, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
+			existing, getErr := c.challengeLister.Challenges(ch.Namespace).Get(ch.Name)
+			if getErr != nil {
+				return fmt.Errorf("failed to get existing challenge %q: %w", ch.Name, getErr)
+			}
+			if challengeMatchesExpectedForOrder(existing, ch, o) {
+				continue
+			}
+			if existing.DeletionTimestamp != nil {
+				continue
+			}
+			if delErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).Delete(ctx, ch.Name, metav1.DeleteOptions{}); delErr != nil {
+				return fmt.Errorf("failed to delete unexpected challenge %q: %w", ch.Name, delErr)
+			}
+			c.recorder.Eventf(o, corev1.EventTypeWarning, "DeletedUnexpectedChallenge",
+				"Deleted pre-existing Challenge %q that did not match the expected spec for this Order", ch.Name)
 			continue
 		}
 		if err != nil {
@@ -471,6 +500,13 @@ func (c *controller) createRequiredChallenges(ctx context.Context, o *cmacme.Ord
 		c.recorder.Eventf(o, corev1.EventTypeNormal, reasonCreated, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
 	}
 	return nil
+}
+
+func challengeMatchesExpectedForOrder(existing, expected *cmacme.Challenge, o *cmacme.Order) bool {
+	if !metav1.IsControlledBy(existing, o) {
+		return false
+	}
+	return apiequality.Semantic.DeepEqual(existing.Spec, expected.Spec)
 }
 
 func (c *controller) anyLeftoverChallengesExist(o *cmacme.Order, requiredChallenges []*cmacme.Challenge) (bool, error) {

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -966,6 +966,91 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 			},
 			acmeClient: &acmecl.FakeACME{},
 		},
+		// Verifies that the controller deletes a pre-placed Challenge not owned
+		// by this Order, preventing Challenge substitution (GHSA-6gm5-38r5-7pxp).
+		"delete pre-existing unowned challenge with the same name": {
+			order: testOrderPending,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					testIssuerHTTP01TestCom,
+					testOrderPending,
+					func() runtime.Object {
+						unowned := testAuthorizationChallenge.DeepCopy()
+						unowned.OwnerReferences = nil
+						return unowned
+					}(),
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge)),
+					testpkg.NewAction(coretesting.NewDeleteAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge.Name)),
+				},
+				ExpectedEvents: []string{
+					fmt.Sprintf("Warning DeletedUnexpectedChallenge Deleted pre-existing Challenge %q that did not match the expected spec for this Order", testAuthorizationChallenge.Name),
+				},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
+					return "key", nil
+				},
+			},
+		},
+		// Verifies that ownership metadata alone is not enough: a pre-placed
+		// same-name Challenge with a forged owner reference but attacker-chosen
+		// spec must still be deleted.
+		"delete pre-existing owned challenge with a mismatched spec": {
+			order: testOrderPending,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					testIssuerHTTP01TestCom,
+					testOrderPending,
+					func() runtime.Object {
+						forged := testAuthorizationChallenge.DeepCopy()
+						forged.Spec.Token = "attacker-token"
+						forged.Spec.Key = "attacker-key"
+						return forged
+					}(),
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge)),
+					testpkg.NewAction(coretesting.NewDeleteAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge.Name)),
+				},
+				ExpectedEvents: []string{
+					fmt.Sprintf("Warning DeletedUnexpectedChallenge Deleted pre-existing Challenge %q that did not match the expected spec for this Order", testAuthorizationChallenge.Name),
+				},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
+					return "key", nil
+				},
+			},
+		},
+		// Verifies that an unexpected Challenge already pending deletion is left
+		// alone until a later sync, which avoids immediate recreate churn while a
+		// finalizer is still being processed.
+		"wait for unexpected challenge deletion before recreating": {
+			order: testOrderPending,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					testIssuerHTTP01TestCom,
+					testOrderPending,
+					func() runtime.Object {
+						deleting := testAuthorizationChallenge.DeepCopy()
+						deleting.OwnerReferences = nil
+						deleting.DeletionTimestamp = &nowMetaTime
+						deleting.Finalizers = []string{"example.com/test-finalizer"}
+						return deleting
+					}(),
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge)),
+				},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
+					return "key", nil
+				},
+			},
+		},
 		"acme-profiles:profiles-not-implemented": {
 			// Simulate an attempt to create an order with a profile on an ACME
 			// server which does not support profiles.

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -235,7 +235,16 @@ func applyGatewayAPIAnnotationParentRefOverride(o *cmacme.Order, s *cmacme.ACMEC
 			filtered = append(filtered, pr)
 		}
 
+		// Set Group explicitly to match the CRD OpenAPI default
+		// ("gateway.networking.k8s.io"). The API server applies this default
+		// when storing Challenges, but there is no programmatic mechanism to
+		// apply CRD OpenAPI defaults in a controller. Without this,
+		// challengeMatchesExpectedForOrder would see a nil-vs-populated
+		// mismatch on Group when comparing the in-memory expected spec
+		// against the stored spec.
+		group := gwapi.Group(gwapi.GroupVersion.Group)
 		filtered = append(filtered, gwapi.ParentReference{
+			Group:     &group,
 			Name:      name,
 			Namespace: &ns,
 			Kind:      &kind,

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -396,6 +396,10 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 						GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
 							ParentRefs: []gwapi.ParentReference{
 								{
+									Group: func() *gwapi.Group {
+										group := gwapi.Group(gwapi.GroupVersion.Group)
+										return &group
+									}(),
 									Kind: func() *gwapi.Kind {
 										ls := gwapi.Kind("ListenerSet")
 										return &ls
@@ -445,6 +449,10 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 						GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
 							ParentRefs: []gwapi.ParentReference{
 								{
+									Group: func() *gwapi.Group {
+										group := gwapi.Group(gwapi.GroupVersion.Group)
+										return &group
+									}(),
 									Kind: func() *gwapi.Kind {
 										ls := gwapi.Kind("Gateway")
 										return &ls
@@ -770,7 +778,9 @@ func acmeChallengeHTTP01() cmacme.ACMEChallenge {
 }
 
 func ref(kind, name, namespace string) gwapi.ParentReference {
+	group := gwapi.Group(gwapi.GroupVersion.Group)
 	return gwapi.ParentReference{
+		Group:     &group,
 		Kind:      new(gwapi.Kind(kind)),
 		Name:      gwapi.ObjectName(name),
 		Namespace: new(gwapi.Namespace(namespace)),

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -204,17 +204,35 @@ func TestMetricsController(t *testing.T) {
 		gen.SetCertificateUID("uid-1"),
 	)
 
-	challenge := gen.Challenge("test-challenge-status",
-		gen.SetChallengeDNSName("example.com"),
-		gen.SetChallengeProcessing(false),
-		gen.SetChallengeType(acmemeta.ACMEChallengeTypeDNS01),
-		gen.SetChallengeNamespace(namespace),
+	order := gen.Order("test-order",
+		gen.SetOrderNamespace(namespace),
+		gen.SetOrderDNSNames("example.com"),
+		gen.SetOrderCsr([]byte("dummy")),
 	)
 
 	crt, err = cmClient.CertmanagerV1().Certificates(namespace).Create(t.Context(), crt, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	order, err = cmClient.AcmeV1().Orders(namespace).Create(t.Context(), order, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	challenge := gen.Challenge("test-challenge-status",
+		gen.SetChallengeDNSName("example.com"),
+		gen.SetChallengeProcessing(false),
+		gen.SetChallengeType(acmemeta.ACMEChallengeTypeDNS01),
+		gen.SetChallengeNamespace(namespace),
+	)
+	challenge.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "acme.cert-manager.io/v1",
+		Kind:       "Order",
+		Name:       order.Name,
+		UID:        order.UID,
+		Controller: new(true),
+	}}
 
 	challenge, err = cmClient.AcmeV1().Challenges(namespace).Create(t.Context(), challenge, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
## Motivation

Defence in depth for [GHSA-8rvj-mm4h-c258](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258). The RBAC fix (the primary mitigation) has been split into cert-manager/cert-manager#8958. This PR adds the webhook validation and controller hardening changes.

## Changes

**Webhook validation:**
- `ValidateChallenge`: reject Challenges lacking a controller owner reference to an Order.
- `ValidateOrderSpecUpdate`: reject any Order spec mutation after creation.

**Controller hardening:**
- Order controller verifies both ownership AND exact spec equivalence for same-name Challenges. Mismatched Challenges are deleted and recreated.
- Set gateway parentRef `Group` explicitly to match the CRD OpenAPI default, preventing a nil-vs-populated mismatch in spec comparison (see cert-manager/cert-manager#7890, cert-manager/cert-manager#8518, cert-manager/cert-manager#8619).

## Test plan

- Unit tests for all new webhook validations (challenge owner ref, order spec immutability)
- Unit tests for same-name Challenge spec mismatch detection
- Unit test expectations updated for gateway parentRef Group field
- Lint fixes for import grouping (`challenge_test.go`) and false-positive suppressions (`order_test.go`, `sync_test.go`)
- Full E2E suite run locally against Kind cluster

/kind bug

```release-note
Harden ACME Challenge and Order resources: reject user-created Challenges
without Order ownership, enforce Order spec immutability, and detect
pre-placed same-name Challenges with mismatched specs.
```