### PR TITLE
Cleanup Helm metrics path and port

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -880,21 +880,6 @@ The namespace that the service monitor should live in, defaults to the cert-mana
 > ```
 
 Specifies the `prometheus` label on the created ServiceMonitor. This is used when different Prometheus instances have label selectors matching different ServiceMonitors.
-#### **prometheus.servicemonitor.targetPort** ~ `string,integer`
-> Default value:
-> ```yaml
-> http-metrics
-> ```
-
-The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics.
-
-#### **prometheus.servicemonitor.path** ~ `string`
-> Default value:
-> ```yaml
-> /metrics
-> ```
-
-The path to scrape for metrics.
 #### **prometheus.servicemonitor.interval** ~ `string`
 > Default value:
 > ```yaml
@@ -969,13 +954,6 @@ The namespace that the pod monitor should live in, defaults to the cert-manager 
 > ```
 
 Specifies the `prometheus` label on the created PodMonitor. This is used when different Prometheus instances have label selectors matching different PodMonitors.
-#### **prometheus.podmonitor.path** ~ `string`
-> Default value:
-> ```yaml
-> /metrics
-> ```
-
-The path to scrape for metrics.
 #### **prometheus.podmonitor.interval** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -53,7 +53,7 @@ spec:
 {{- end }}
   podMetricsEndpoints:
     - port: http-metrics
-      path: {{ .Values.prometheus.podmonitor.path }}
+      path: /metrics
       interval: {{ .Values.prometheus.podmonitor.interval }}
       scrapeTimeout: {{ .Values.prometheus.podmonitor.scrapeTimeout }}
       honorLabels: {{ .Values.prometheus.podmonitor.honorLabels }}

--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -28,8 +28,7 @@ spec:
   ports:
   - protocol: TCP
     port: 9402
-    name: tcp-prometheus-servicemonitor
-    targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
+    name: http-metrics
   selector:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -54,8 +54,8 @@ spec:
       - {{ include "cert-manager.namespace" . }}
 {{- end }}
   endpoints:
-  - targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
-    path: {{ .Values.prometheus.servicemonitor.path }}
+  - targetPort: http-metrics
+    path: /metrics
     {{- if .Values.prometheus.servicemonitor.interval }}
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     {{- end }}

--- a/deploy/charts/cert-manager/tests/controller/__snapshot__/defaults_test.yaml.snap
+++ b/deploy/charts/cert-manager/tests/controller/__snapshot__/defaults_test.yaml.snap
@@ -98,10 +98,9 @@ should render a Service matching the default snapshot:
       namespace: cert-manager
     spec:
       ports:
-        - name: tcp-prometheus-servicemonitor
+        - name: http-metrics
           port: 9402
           protocol: TCP
-          targetPort: http-metrics
       selector:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager

--- a/deploy/charts/cert-manager/tests/controller/service_test.yaml
+++ b/deploy/charts/cert-manager/tests/controller/service_test.yaml
@@ -69,13 +69,3 @@ tests:
             ipFamilies:
               - IPv4
               - IPv6
-
-  - it: should use custom targetPort from servicemonitor config
-    set:
-      prometheus:
-        servicemonitor:
-          targetPort: 8080
-    asserts:
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 8080

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1266,9 +1266,6 @@
         "namespace": {
           "$ref": "#/$defs/helm-values.prometheus.podmonitor.namespace"
         },
-        "path": {
-          "$ref": "#/$defs/helm-values.prometheus.podmonitor.path"
-        },
         "prometheusInstance": {
           "$ref": "#/$defs/helm-values.prometheus.podmonitor.prometheusInstance"
         },
@@ -1312,11 +1309,6 @@
       "description": "The namespace that the pod monitor should live in, defaults to the cert-manager namespace.",
       "type": "string"
     },
-    "helm-values.prometheus.podmonitor.path": {
-      "default": "/metrics",
-      "description": "The path to scrape for metrics.",
-      "type": "string"
-    },
     "helm-values.prometheus.podmonitor.prometheusInstance": {
       "default": "default",
       "description": "Specifies the `prometheus` label on the created PodMonitor. This is used when different Prometheus instances have label selectors matching different PodMonitors.",
@@ -1351,17 +1343,11 @@
         "namespace": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.namespace"
         },
-        "path": {
-          "$ref": "#/$defs/helm-values.prometheus.servicemonitor.path"
-        },
         "prometheusInstance": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.prometheusInstance"
         },
         "scrapeTimeout": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.scrapeTimeout"
-        },
-        "targetPort": {
-          "$ref": "#/$defs/helm-values.prometheus.servicemonitor.targetPort"
         }
       },
       "type": "object"
@@ -1400,11 +1386,6 @@
       "description": "The namespace that the service monitor should live in, defaults to the cert-manager namespace.",
       "type": "string"
     },
-    "helm-values.prometheus.servicemonitor.path": {
-      "default": "/metrics",
-      "description": "The path to scrape for metrics.",
-      "type": "string"
-    },
     "helm-values.prometheus.servicemonitor.prometheusInstance": {
       "default": "default",
       "description": "Specifies the `prometheus` label on the created ServiceMonitor. This is used when different Prometheus instances have label selectors matching different ServiceMonitors.",
@@ -1414,10 +1395,6 @@
       "default": "30s",
       "description": "The timeout before a metrics scrape fails.",
       "type": "string"
-    },
-    "helm-values.prometheus.servicemonitor.targetPort": {
-      "default": "http-metrics",
-      "description": "The target port to set on the ServiceMonitor. This must match the port that the cert-manager controller is listening on for metrics."
     },
     "helm-values.replicaCount": {
       "default": 1,

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -668,14 +668,6 @@ prometheus:
     # different ServiceMonitors.
     prometheusInstance: default
 
-    # The target port to set on the ServiceMonitor. This must match the port that the
-    # cert-manager controller is listening on for metrics.
-    # +docs:type=string,integer
-    targetPort: http-metrics
-
-    # The path to scrape for metrics.
-    path: /metrics
-
     # The interval to scrape metrics.
     interval: 60s
 
@@ -719,9 +711,6 @@ prometheus:
     # used when different Prometheus instances have label selectors matching
     # different PodMonitors.
     prometheusInstance: default
-
-    # The path to scrape for metrics.
-    path: /metrics
 
     # The interval to scrape metrics.
     interval: 60s


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR was motivated by https://github.com/cert-manager/cert-manager/pull/8141#issuecomment-3386180623. I took a closer look, and the chart is indeed very messy in this area. In this PR, I removed the Helm values to configure the metrics path and targetPort, as these make no sense to configure.

⚠️ This is technically a breaking change, as the (metrics) service port is renamed from `tcp-prometheus-servicemonitor` to `http-metrics`.

Closes https://github.com/cert-manager/cert-manager/pull/8141

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Remove Helm values `prometheus.servicemonitor.targetPort`, `prometheus.servicemonitor.path`, and `prometheus.podmonitor.path`. The metrics path is always `/metrics` and the target port is always `http-metrics`. Rename the controller service metrics port from `tcp-prometheus-servicemonitor` to `http-metrics` for consistency with other workloads. Users must remove these keys from their value overrides before upgrading.
```
