### PR TITLE
Simplify renewal watcher loop in DynamicSource.Start

### DIFF
--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -133,32 +133,25 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 		var renewMoment time.Time
 
 		for {
-			if done := func() bool {
-				watcherContext, cancel := context.WithCancel(ctx)
-				defer cancel()
-				needsRenewalChan := f.startRenewalWatcher(watcherContext, renewMoment, renewMoment.Add(renewalStaleAfter), renewalCheckInterval)
+			watcherCtx, cancel := context.WithCancel(ctx)
+			needsRenewalChan := f.startRenewalWatcher(watcherCtx, renewMoment, renewMoment.Add(renewalStaleAfter), renewalCheckInterval)
 
-				// Wait for the renewal watcher to signal, or for a new renewal moment to be received
-				select {
-				case <-ctx.Done():
-					// context was cancelled, return nil
-					return true
-				case reason := <-needsRenewalChan:
-					f.log.V(logf.InfoLevel).Info("Certificate needs renewal", "reason", reason)
-					renewMoment = time.Time{}
-				case renewMoment = <-nextRenewCh:
-					// We received a renew moment, next loop iteration will update the timer
-					return false
-				}
-
-				// the renewal channel has a buffer of 1 - drop event if we are already issuing
-				select {
-				case renewalChan <- struct{}{}:
-				default:
-				}
-				return false
-			}(); done {
+			select {
+			case <-ctx.Done():
+				cancel()
 				return nil
+			case reason := <-needsRenewalChan:
+				cancel()
+				f.log.V(logf.InfoLevel).Info("Certificate needs renewal", "reason", reason)
+				renewMoment = time.Time{}
+			case renewMoment = <-nextRenewCh:
+				cancel()
+				continue
+			}
+
+			select {
+			case renewalChan <- struct{}{}:
+			default:
 			}
 		}
 	})

--- a/pkg/server/tls/dynamic_source.go
+++ b/pkg/server/tls/dynamic_source.go
@@ -73,6 +73,15 @@ type DynamicSource struct {
 
 var _ CertificateSource = &DynamicSource{}
 
+// renewalStaleAfter is the grace period after the scheduled renewal moment
+// beyond which the renewal is considered to have been missed, e.g. because
+// the container was paused during the renewal window.
+const renewalStaleAfter = 5 * time.Second
+
+// renewalCheckInterval is how often the renewal watcher polls time.Now() to
+// detect a missed renewal moment.
+const renewalCheckInterval = 1 * time.Minute
+
 // Implements Runnable (https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L287)
 func (f *DynamicSource) Start(ctx context.Context) error {
 	f.log = logf.FromContext(ctx)
@@ -125,22 +134,18 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 
 		for {
 			if done := func() bool {
-				var timerChannel <-chan time.Time
-				if !renewMoment.IsZero() {
-					timer := time.NewTimer(time.Until(renewMoment))
-					defer timer.Stop()
+				watcherContext, cancel := context.WithCancel(ctx)
+				defer cancel()
+				needsRenewalChan := f.startRenewalWatcher(watcherContext, renewMoment, renewMoment.Add(renewalStaleAfter), renewalCheckInterval)
 
-					renewMoment = time.Time{}
-					timerChannel = timer.C
-				}
-
-				// Wait for the timer to expire, or for a new renewal moment to be received
+				// Wait for the renewal watcher to signal, or for a new renewal moment to be received
 				select {
 				case <-ctx.Done():
 					// context was cancelled, return nil
 					return true
-				case <-timerChannel:
-					// Continue to the next select to try to send a message on renewalChan
+				case reason := <-needsRenewalChan:
+					f.log.V(logf.InfoLevel).Info("Certificate needs renewal", "reason", reason)
+					renewMoment = time.Time{}
 				case renewMoment = <-nextRenewCh:
 					// We received a renew moment, next loop iteration will update the timer
 					return false
@@ -151,7 +156,6 @@ func (f *DynamicSource) Start(ctx context.Context) error {
 				case renewalChan <- struct{}{}:
 				default:
 				}
-
 				return false
 			}(); done {
 				return nil
@@ -295,4 +299,69 @@ func (f *DynamicSource) updateCertificate(ctx context.Context, pk crypto.Signer,
 	f.log.V(logf.InfoLevel).Info("Updated cert-manager TLS certificate", "DNSNames", f.DNSNames)
 
 	return nil
+}
+
+type renewalReason string
+
+const (
+	certificateAboutToExpire       renewalReason = "certificateAboutToExpire"
+	certificateRenewalMomentMissed renewalReason = "certificateRenewalMomentMissed"
+)
+
+// startRenewalWatcher monitors whether the serving certificate needs renewal.
+//
+// System suspend (S3/S4) or VM live migration stops CLOCK_MONOTONIC, so the
+// one-shot renewal timer (which uses Go's monotonic clock) never fires. When
+// the system resumes, the timer deadline has not yet been reached — even though
+// wall-clock time has advanced past the renewal moment. To cover this case,
+// startRenewalWatcher runs a periodic ticker that polls time.Now() against the
+// wall-clock deadline (renewalAfter). Because time.Now() uses CLOCK_REALTIME
+// for comparisons with wall-clock timestamps, the ticker detects the missed
+// renewal regardless of whether CLOCK_MONOTONIC advanced.
+//
+// If renewalAt is the zero time (no renewal scheduled yet), no goroutine is
+// started and the returned channel never sends — the caller's select blocks on
+// other cases until a renewal moment is received.
+//
+// Otherwise the watcher sends exactly one renewalReason on the returned channel
+// and then exits. The caller reads one value per invocation and cancels the
+// context to clean up the goroutine.
+func (f *DynamicSource) startRenewalWatcher(ctx context.Context, renewalAt time.Time, renewalAfter time.Time, retryPeriod time.Duration) <-chan renewalReason {
+	var renewalChan = make(chan renewalReason, 1)
+
+	if renewalAt.IsZero() {
+		return renewalChan
+	}
+
+	go func() {
+		timer := time.NewTimer(time.Until(renewalAt))
+		defer timer.Stop()
+
+		ticker := time.NewTicker(retryPeriod)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				select {
+				case renewalChan <- certificateAboutToExpire:
+				case <-ctx.Done():
+				}
+				return
+			case <-ticker.C:
+				if !time.Now().After(renewalAfter) {
+					continue
+				}
+				select {
+				case renewalChan <- certificateRenewalMomentMissed:
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+	}()
+
+	return renewalChan
 }

--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -302,6 +303,75 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 			})
 
 			tc.testFn(t, source, mockAuth)
+		})
+	}
+}
+
+// TestStartRenewalWatcher uses synctest to control fake time, making the tests
+// deterministic and fast. Each case sets renewalAt and renewalAfter as offsets
+// from time.Now() inside the synctest bubble, advances the fake clock by
+// advanceBy, and then checks whether the watcher signalled the expected reason.
+func TestStartRenewalWatcher(t *testing.T) {
+	source := &DynamicSource{}
+
+	testCases := map[string]struct {
+		renewalAt      time.Duration // offset from time.Now(); 0 means zero time
+		renewalAfter   time.Duration // offset from time.Now(); 0 means derive from renewalAt
+		advanceBy      time.Duration // how far to advance the fake clock before checking
+		expectedResult renewalReason // empty means no signal expected
+	}{
+		"certificate about to expire": {
+			renewalAt:      5 * time.Second,
+			renewalAfter:   10 * time.Second,
+			advanceBy:      6 * time.Second,
+			expectedResult: certificateAboutToExpire,
+		},
+		"certificate renewal moment missed while paused": {
+			renewalAt:      100 * time.Second,
+			renewalAfter:   2 * time.Second,
+			advanceBy:      3 * time.Second,
+			expectedResult: certificateRenewalMomentMissed,
+		},
+		"zero renewal moment does not signal": {
+			advanceBy: 10 * time.Second,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var renewalAt time.Time
+				if tc.renewalAt > 0 {
+					renewalAt = time.Now().Add(tc.renewalAt)
+				}
+
+				var renewalAfter time.Time
+				if tc.renewalAfter > 0 {
+					renewalAfter = time.Now().Add(tc.renewalAfter)
+				} else {
+					renewalAfter = renewalAt.Add(renewalStaleAfter)
+				}
+
+				resultCh := source.startRenewalWatcher(t.Context(), renewalAt, renewalAfter, 1*time.Second)
+
+				time.Sleep(tc.advanceBy)
+				synctest.Wait()
+
+				if tc.expectedResult == "" {
+					select {
+					case reason := <-resultCh:
+						assert.Failf(t, "unexpected signal", "expected no signal when renewMoment is zero, got %q", reason)
+					default:
+					}
+				} else {
+					select {
+					case reason := <-resultCh:
+						assert.Equal(t, tc.expectedResult, reason)
+					default:
+						assert.Fail(t, "expected signal but channel was empty")
+					}
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

Follow-up to cert-manager/cert-manager#8464. The nested closure-returning-bool pattern in the errgroup goroutine existed solely to scope `defer cancel()` to each loop iteration. This made the control flow hard to follow.

### Changes

Replace the closure with explicit `cancel()` calls in each `select` branch. Every path through the select either returns or continues, and each cancels the watcher context before doing so. Net result: -24/+17 lines, one fewer indentation level, no functional change.

### Testing

No behavioural change — the `TestStartRenewalWatcher` tests added in cert-manager/cert-manager#8464 continue to pass. The `cancel()` call sites are 1:1 with the previous `defer cancel()` + return/continue paths.

### Release Note

```release-note
NONE
```

/kind cleanup
