### PR TITLE
Harden ACME Challenge and Order RBAC (GHSA-8rvj-mm4h-c258)

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -470,9 +470,29 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates/status"]
     verbs: ["update"]
+  {{- /*
+    Challenge and Order resources are not intended to be created by users
+    (GHSA-8rvj-mm4h-c258).
+
+    Challenges: "create" is excluded because a user-created Challenge with
+    attacker-controlled spec.solver can exfiltrate ClusterIssuer credentials
+    cross-namespace. "patch" and "update" are retained because spec is
+    immutable after creation (ValidateChallengeUpdate) so they cannot change
+    solver config, and because users need them to remove stuck finalizers
+    (see cert-manager/cert-manager#3851, cert-manager/cert-manager#3870).
+
+    Orders: "create", "patch", and "update" are excluded because a user
+    who can update an Order can change spec.issuerRef to reference a
+    different ClusterIssuer, then delete the Challenge; the Orders
+    controller recreates the Challenge with the attacker-chosen Issuer's
+    solver config, exfiltrating its credentials.
+  */}}
   - apiGroups: ["acme.cert-manager.io"]
-    resources: ["challenges", "orders"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+    resources: ["challenges"]
+    verbs: ["delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["delete", "deletecollection"]
 
 ---
 


### PR DESCRIPTION
## Motivation

Port the RBAC fix for [GHSA-8rvj-mm4h-c258](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258) to master.

This change was already shipped in v1.19.6 and v1.20.3 via cert-manager/cert-manager#8940 and cert-manager/cert-manager#8941. Splitting from cert-manager/cert-manager#8948 so that the uncontroversial RBAC fix can be merged independently of the validation and controller hardening changes.

## Changes

Remove Challenge `create` and Order `create`, `patch`, `update` from the `cert-manager-edit` aggregate ClusterRole.

- A user-created Challenge with attacker-controlled `spec.solver` can exfiltrate ClusterIssuer credentials cross-namespace.
- A user who can update an Order can change `spec.issuerRef` to reference a different ClusterIssuer, triggering credential exfiltration when the controller recreates the Challenge.
- Challenge `patch`/`update` are retained because spec is immutable after creation (`ValidateChallengeUpdate`) and users need them to remove stuck finalizers (cert-manager/cert-manager#3851, cert-manager/cert-manager#3870).

## Test plan

- Helm unit tests pass
- Identical RBAC change already deployed and verified in v1.19.6 and v1.20.3 patch releases

/kind bug

```release-note
Remove ACME Challenge `create` and Order `create`/`patch`/`update` from
the cert-manager-edit aggregate ClusterRole to prevent direct
manipulation of these internal resources (GHSA-8rvj-mm4h-c258).
```