### PR TITLE
fix(controller/trigger): adding check for race condition of get v/s list in trigger ctrl

### DIFF
--- a/internal/controller/certificates/certificates.go
+++ b/internal/controller/certificates/certificates.go
@@ -64,6 +64,15 @@ func CertificateOwnsSecret(
 		}
 	}
 
+	// If the passed Certificate is not present in the lister's cache (for
+	// example, because it was deleted while a reconcile was in progress, such
+	// as during namespace teardown), duplicateCrts will be empty. Return false
+	// so the caller treats the Certificate as not owning the Secret rather
+	// than panicking when indexing the slice below.
+	if len(duplicateCrts) == 0 {
+		return false, nil, nil
+	}
+
 	// If there are no duplicates, return early.
 	if len(duplicateCrts) == 1 && duplicateCrts[0].Name == crt.Name {
 		return true, nil, nil

--- a/internal/controller/certificates/certificates_test.go
+++ b/internal/controller/certificates/certificates_test.go
@@ -56,9 +56,10 @@ func TestCertificateOwnsSecret(t *testing.T) {
 		secrets             []runtime.Object
 		certificates        []runtime.Object
 
-		expectedResult      bool
-		expectedOtherOwners []string
-		expectedError       error
+		expectedResult            bool
+		expectedOtherOwners       []string
+		expectedError             error
+		ignoreSelectedCertificate bool
 	}{
 		{
 			name: "Certificate is only cert referencing the secret",
@@ -129,6 +130,18 @@ func TestCertificateOwnsSecret(t *testing.T) {
 			expectedError:       nil,
 		},
 		{
+			name: "Certificate is not present in the lister cache (e.g. deleted mid-reconcile)",
+
+			selectedCertificate: "certificate-missing",
+			secrets:             []runtime.Object{},
+			certificates:        []runtime.Object{},
+
+			expectedResult:            false,
+			expectedOtherOwners:       nil,
+			expectedError:             nil,
+			ignoreSelectedCertificate: true,
+		},
+		{
 			name: "Certificate has conflict, is the oldest, but annotation marks another as the owner",
 
 			selectedCertificate: "certificate-3",
@@ -188,7 +201,10 @@ func TestCertificateOwnsSecret(t *testing.T) {
 				}
 			}
 			if selectedCrt == nil {
-				t.Fatal("failed to find selected Certificate")
+				if !tt.ignoreSelectedCertificate {
+					t.Fatal("failed to find selected Certificate")
+				}
+				selectedCrt = certificate(tt.selectedCertificate, testCreationTimestamp)
 			}
 
 			// Call the function under test


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

There's a race condition in `CertificateOwnsSecret`wherein if the Get from trigger controller gets the cert, then the cert is deleted which will result in list having 0 certs.. that means fetching duplicateCerts[0] will fail and this prevents that from happening. 

Fixes #8848

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fixed a rare panic in the trigger controller when a Certificate is deleted from the informer cache while a reconcile is in progress (e.g. during namespace teardown).
```