### PR TITLE
chart: add global tolerations support

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -100,8 +100,19 @@ imagePullSecrets:
 Global node selector  
   
 The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).  
-  
+
 If a component-specific nodeSelector is also set, it will be merged and take precedence.
+#### **global.tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Global tolerations  
+
+A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).  
+
+If a component-specific tolerations list is also set, it will be appended to the global list.
 
 #### **global.commonLabels** ~ `object`
 > Default value:

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -156,7 +156,8 @@ spec:
       {{- else if .Values.global.runtimeClassName }}
       runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.cainjector.tolerations }}
+      {{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.cainjector.tolerations | default (list)) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -235,7 +235,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.tolerations | default (list)) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -103,7 +103,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.startupapicheck.tolerations }}
+      {{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.startupapicheck.tolerations | default (list)) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -209,7 +209,8 @@ spec:
       {{- else if .Values.global.runtimeClassName }}
       runtimeClassName: {{ .Values.global.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.webhook.tolerations }}
+      {{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.webhook.tolerations | default (list)) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
+++ b/deploy/charts/cert-manager/tests/controller/deployment_test.yaml
@@ -281,6 +281,31 @@ tests:
             global-key: global-value
             component-key: component-value
 
+  - it: should merge global and component tolerations
+    set:
+      global:
+        tolerations:
+          - key: global-key
+            operator: Exists
+            effect: NoSchedule
+      tolerations:
+        - key: component-key
+          operator: Exists
+          effect: NoExecute
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: component-key
+            operator: Exists
+            effect: NoExecute
+
   - it: should set tolerations
     set:
       tolerations:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -825,6 +825,9 @@
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.global.nodeSelector"
         },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.global.tolerations"
+        },
         "podSecurityPolicy": {
           "$ref": "#/$defs/helm-values.global.podSecurityPolicy"
         },
@@ -901,6 +904,12 @@
       "default": {},
       "description": "Global node selector\n\nThe nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).\n\nIf a component-specific nodeSelector is also set, it will be merged and take precedence.",
       "type": "object"
+    },
+    "helm-values.global.tolerations": {
+      "default": [],
+      "description": "Global tolerations\n\nA list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nIf a component-specific tolerations list is also set, it will be appended to the global list.",
+      "items": {},
+      "type": "array"
     },
     "helm-values.global.podSecurityPolicy": {
       "properties": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -22,6 +22,14 @@ global:
   # +docs:property
   nodeSelector: {}
 
+  # Global tolerations
+  #
+  # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
+  #
+  # If a component-specific tolerations list is also set, it will be appended to the global list.
+  # +docs:property
+  tolerations: []
+
   # Labels to apply to all resources.
   # These labels are also applied to dynamically-created ACME HTTP01 solver resources
   # (pods, services, ingresses, or Gateway API HTTPRoutes).


### PR DESCRIPTION
### Pull Request Motivation

Add support for `global.tolerations` in the cert-manager Helm chart, matching the existing `global.nodeSelector` pattern. This lets users define tolerations once and apply them across chart workloads without repeating the same configuration per component.

### Kind

/kind feature

### Release Note

```release-note
Added support for `global.tolerations` in the cert-manager Helm chart and merged it into component pod specs.