### PR TITLE
[release-1.21] Disable generate-klone

### DIFF
--- a/make/_shared/klone/01_mod.mk
+++ b/make/_shared/klone/01_mod.mk
@@ -18,7 +18,10 @@
 generate-klone: | $(NEEDS_KLONE)
 	$(KLONE) sync
 
-shared_generate_targets += generate-klone
+# MANUAL CHANGE!
+# generate-klone is removed so we can manually update versions
+# and diverge from upstream klone
+# shared_generate_targets += generate-klone
 
 .PHONY: upgrade-klone
 ## Upgrade klone Makefile modules to latest version


### PR DESCRIPTION
Prevents future Go version bumps on the release branch from being reverted by `make generate`.

See the [release process docs](https://cert-manager.io/docs/contributing/release-process/) for context. Example PR from release-1.20: cert-manager/cert-manager#8578.

```release-note
NONE
```