### PR TITLE
fix(acmeorders): reschedule Order when concurrent finalize returns 403 with processing ACME order

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -601,6 +601,18 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 			c.setOrderState(&o.Status, string(cmacme.Valid))
 			return c.syncCertificateDataWithOrder(ctx, cl, *acmeOrder, o, issuer)
 		}
+		//Another request is finalizing the same underlying ACME order. Requeue and retry when it completes.
+		if acmeOrder.Status == acmeapi.StatusProcessing {
+			log.V(logf.DebugLevel).Info("ACME order is still processing a concurrent finalize request, scheduling a retry")
+			c.setOrderState(&o.Status, string(cmacme.Pending))
+
+			c.scheduledWorkQueue.Add(types.NamespacedName{
+				Name:      o.Name,
+				Namespace: o.Namespace,
+			}, RequeuePeriod)
+
+			return nil
+		}
 
 	}
 

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -603,7 +603,7 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 		}
 		//Another request is finalizing the same underlying ACME order. Requeue and retry when it completes.
 		if acmeOrder.Status == acmeapi.StatusProcessing {
-			log.V(logf.DebugLevel).Info("ACME order is still processing a concurrent finalize request, scheduling a retry")
+			log.V(logf.DebugLevel).Info("ACME order is still processing a concurrent finalize request, scheduling a retry", "acme_order_url", acmeOrder.URI)
 			c.setOrderState(&o.Status, string(cmacme.Pending))
 
 			c.scheduledWorkQueue.Add(types.NamespacedName{

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -831,6 +831,35 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 			},
 			expectErr: false,
 		},
+		"call FinalizeOrder, reschedule rather than fail if a concurrent finalize request is still processing": {
+			order: testOrderReady,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestCom, testOrderReady, testAuthorizationChallengeValid},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("orders"),
+						"status",
+						testOrderPending.Namespace, testOrderPending)),
+				},
+				ExpectedEvents: []string{},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeGetOrder: func(_ context.Context, url string) (*acmeapi.Order, error) {
+					return &acmeapi.Order{
+						URI:         testOrderReady.Status.URL,
+						Status:      acmeapi.StatusProcessing,
+						FinalizeURL: testOrderReady.Status.FinalizeURL,
+					}, nil
+				},
+				FakeCreateOrderCert: func(_ context.Context, url string, csr []byte, bundle bool) ([][]byte, string, error) {
+					return nil, "", &acmeError403
+				},
+				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
+					return "key", nil
+				},
+			},
+			expectErr:      false,
+			shouldSchedule: true,
+		},
 		"call FinalizeOrder fetch alternate cert chain": {
 			order: testOrderReady.DeepCopy(),
 			builder: &testpkg.Builder{


### PR DESCRIPTION
## Pull Request Motivation

Fixes #8960

When two `Certificate` resources with identical DNS names but different `privateKey.algorithm` values (e.g. RSA and ECDSA) are reconciled simultaneously (e.g. by Flux), cert-manager creates two `Order` CRs that both submit `newOrder` to the ACME server with the same identifier set. Let's Encrypt coalesces these into a single pending ACME order and returns the same order URL to both.

Both Order controllers reach the `ready` state, pass DNS-01 validation, then call `CreateOrderCert` concurrently. The race winner transitions the shared ACME order to `processing`. The race loser receives `403 orderNotReady: Order was already processing` and re-fetches the ACME order, which is now in the `processing` state.

The existing 403 safety net (added for #2765) only recovers when the re-fetched order is `valid`. When it is `processing`, no branch matched, so the loser fell through to the generic 4xx handler and was permanently marked `Errored` cascading to a permanently failed `CertificateRequest`, despite no actual validation failure.

## Fix: 

add a `StatusProcessing` branch in `finalizeOrder` that sets the Order back to `Pending` and schedules a requeue via `scheduledWorkQueue`, matching the existing retry pattern in `sync.go`. On the next reconcile the shared ACME order will be in a final state and the existing `valid`/`invalid` logic handles it correctly.

## Changes:
- `pkg/controller/acmeorders/sync.go` - 19 lines added inside `finalizeOrder`, no logic removed or modified
- `pkg/controller/acmeorders/sync_test.go` - 1 new table-driven test case covering the new branch

/kind bug

```release-note
Fix permanent Order failure when two concurrent ACME finalize requests race on the same underlying ACME order (e.g. two Certificates with identical DNS names but different key algorithms reconciled simultaneously).
```