### PR TITLE
fix(vault): gate AWS IAM auth ambient credentials for namespaced Issuers

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -53,7 +53,7 @@ var _ Interface = &Vault{}
 
 // ClientBuilder is a function type that returns a new Interface.
 // Can be used in tests to create a mock signer of Vault certificate requests.
-type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer) (Interface, error)
+type ClientBuilder func(ctx context.Context, namespace string, _ func(ns string) CreateToken, _ internalinformers.SecretLister, _ v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error)
 
 // Interface implements various high level functionality related to connecting
 // with a Vault server, verifying its status and signing certificate request for
@@ -87,10 +87,11 @@ type CreateToken func(ctx context.Context, saName string, req *authv1.TokenReque
 // Vault implements Interface and holds a Vault issuer, secrets lister and a
 // Vault client.
 type Vault struct {
-	createToken   CreateToken // Uses the same namespace as below.
-	secretsLister internalinformers.SecretLister
-	issuer        v1.GenericIssuer
-	namespace     string
+	createToken              CreateToken // Uses the same namespace as below.
+	secretsLister            internalinformers.SecretLister
+	issuer                   v1.GenericIssuer
+	namespace                string
+	canUseAmbientCredentials bool
 
 	// The pattern below, of namespaced and non-namespaced Vault clients, is copied from Hashicorp Nomad:
 	// https://github.com/hashicorp/nomad/blob/6e4410a9b13ce167bc7ef53da97c621b5c9dcd12/nomad/vault.go#L180-L190
@@ -114,12 +115,13 @@ type Vault struct {
 // secrets lister.
 // Returned errors may be network failures and should be considered for
 // retrying.
-func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer) (Interface, error) {
+func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error) {
 	v := &Vault{
-		createToken:   createTokenFn(namespace),
-		secretsLister: secretsLister,
-		namespace:     namespace,
-		issuer:        issuer,
+		createToken:              createTokenFn(namespace),
+		secretsLister:            secretsLister,
+		namespace:                namespace,
+		issuer:                   issuer,
+		canUseAmbientCredentials: canUseAmbientCredentials,
 	}
 
 	cfg, err := v.newConfig()
@@ -664,6 +666,12 @@ func (v *Vault) requestTokenWithAWSAuth(ctx context.Context, client Client, awsA
 	// When using ambient credentials and a region is found from environment
 	// variables, the environment region takes precedence.
 	useAmbientCredentials := awsAuth.ServiceAccountRef == nil
+
+	// An Issuer/ClusterIssuer must never borrow the controller's ambient AWS identity
+	// unless the operator has explicitly opted in via the appropriate ambient-credentials flag.
+	if useAmbientCredentials && !v.canUseAmbientCredentials {
+		return "", fmt.Errorf("cannot authenticate to Vault using ambient AWS credentials: set auth.aws.serviceAccountRef, or enable ambient credentials via --issuer-ambient-credentials / --cluster-issuer-ambient-credentials")
+	}
 
 	var envRegionFound bool
 	{

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -439,9 +439,10 @@ func TestSetToken(t *testing.T) {
 		expectedToken string
 		expectedErr   error
 
-		issuer          cmapiv1.GenericIssuer
-		fakeLister      *listers.FakeSecretLister
-		mockCreateToken func(t *testing.T) CreateToken
+		issuer                   cmapiv1.GenericIssuer
+		canUseAmbientCredentials bool
+		fakeLister               *listers.FakeSecretLister
+		mockCreateToken          func(t *testing.T) CreateToken
 
 		fakeClient *vaultfake.FakeClient
 	}{
@@ -456,6 +457,25 @@ func TestSetToken(t *testing.T) {
 			expectedToken: "",
 			expectedErr: errors.New(
 				"error initializing Vault client: unable to load credentials. One of: tokenSecretRef, appRoleSecretRef, clientCertificate, Kubernetes, or AWS auth must be set",
+			),
+		},
+
+		"if aws auth omits serviceAccountRef and ambient credentials are not permitted, should error without using ambient credentials": {
+			issuer: gen.Issuer("vault-issuer",
+				gen.SetIssuerVault(cmapiv1.VaultIssuer{
+					CABundle: []byte(testLeafCertificate),
+					Auth: cmapiv1.VaultAuth{
+						AWS: &cmapiv1.VaultAWSAuth{
+							Role: "vault-aws-role",
+						},
+					},
+				}),
+			),
+			canUseAmbientCredentials: false,
+			fakeLister:               listers.FakeSecretListerFrom(listers.NewFakeSecretLister()),
+			expectedToken:            "",
+			expectedErr: errors.New(
+				"while requesting a Vault token using the AWS auth: cannot authenticate to Vault using ambient AWS credentials: set auth.aws.serviceAccountRef, or enable ambient credentials via --issuer-ambient-credentials / --cluster-issuer-ambient-credentials",
 			),
 		},
 
@@ -958,10 +978,11 @@ func TestSetToken(t *testing.T) {
 			}
 
 			v := &Vault{
-				namespace:     "test-namespace",
-				secretsLister: test.fakeLister,
-				createToken:   mockCreateToken,
-				issuer:        test.issuer,
+				namespace:                "test-namespace",
+				secretsLister:            test.fakeLister,
+				createToken:              mockCreateToken,
+				issuer:                   test.issuer,
+				canUseAmbientCredentials: test.canUseAmbientCredentials,
 			}
 
 			err := v.setToken(t.Context(), test.fakeClient)
@@ -978,6 +999,34 @@ func TestSetToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Verifies that the Vault AWS IAM auth path refuses to fall back to the controller's
+// ambient AWS credentials unless the issuer is permitted to use them.
+func TestRequestTokenWithAWSAuthAmbientCredentialsGate(t *testing.T) {
+	awsIssuer := gen.Issuer("vault-issuer",
+		gen.SetIssuerVault(cmapiv1.VaultIssuer{
+			CABundle: []byte(testLeafCertificate),
+			Auth: cmapiv1.VaultAuth{
+				AWS: &cmapiv1.VaultAWSAuth{
+					Role: "vault-aws-role",
+				},
+			},
+		}),
+	)
+
+	v := &Vault{
+		namespace:                "test-namespace",
+		issuer:                   awsIssuer,
+		canUseAmbientCredentials: false,
+	}
+
+	// The fake client errors on any Write call; the gate must fire before the
+	// login request is ever sent, so a Write error would indicate the gate was
+	// bypassed.
+	_, err := v.requestTokenWithAWSAuth(t.Context(), &vaultfake.FakeClient{T: t}, awsIssuer.GetSpec().Vault.Auth.AWS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot authenticate to Vault using ambient AWS credentials")
 }
 
 type testAppRoleRefT struct {
@@ -1658,7 +1707,7 @@ func TestNewWithVaultNamespaces(t *testing.T) {
 							},
 						},
 					},
-				})
+				}, false)
 			require.NoError(t, err)
 			assert.Equal(t, tc.vaultNS, c.(*Vault).client.(*vaultClientWrapper).Client.Namespace(),
 				"The vault client should have the namespace provided in the Issuer resource")
@@ -1715,7 +1764,7 @@ func TestIsVaultInitiatedAndUnsealedIntegration(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, false)
 	require.NoError(t, err)
 
 	err = v.IsVaultInitializedAndUnsealed()
@@ -1782,7 +1831,7 @@ func TestSignIntegration(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, false)
 	require.NoError(t, err)
 
 	certPEM, caPEM, err := v.Sign(csrPEM, time.Hour)

--- a/pkg/controller/certificaterequests/vault/fuzz_test.go
+++ b/pkg/controller/certificaterequests/vault/fuzz_test.go
@@ -173,7 +173,7 @@ func FuzzVaultCRController(f *testing.F) {
 
 			fakeVault := fakevault.New().WithSign(rsaPEMCert, rsaPEMCert, nil)
 			vault.vaultClientBuilder = func(_ context.Context, ns string, _ func(ns string) internalvault.CreateToken, sl internalinformers.SecretLister,
-				iss cmapi.GenericIssuer) (internalvault.Interface, error) {
+				iss cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakeVault.New(ns, sl, iss)
 			}
 		}

--- a/pkg/controller/certificaterequests/vault/vault.go
+++ b/pkg/controller/certificaterequests/vault/vault.go
@@ -79,7 +79,7 @@ func (v *Vault) Sign(ctx context.Context, cr *v1.CertificateRequest, issuerObj v
 
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
-	client, err := v.vaultClientBuilder(ctx, resourceNamespace, v.createTokenFn, v.secretsLister, issuerObj)
+	client, err := v.vaultClientBuilder(ctx, resourceNamespace, v.createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
 	if k8sErrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -563,7 +563,7 @@ func runTest(t *testing.T, test testT) {
 
 	if test.fakeVault != nil {
 		vault.vaultClientBuilder = func(_ context.Context, ns string, _ func(ns string) internalvault.CreateToken, sl internalinformers.SecretLister,
-			iss cmapi.GenericIssuer) (internalvault.Interface, error) {
+			iss cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 			return test.fakeVault.New(ns, sl, iss)
 		}
 	}

--- a/pkg/controller/certificatesigningrequests/vault/vault.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault.go
@@ -89,7 +89,7 @@ func (v *Vault) Sign(ctx context.Context, csr *certificatesv1.CertificateSigning
 	resourceNamespace := v.issuerOptions.ResourceNamespace(issuerObj)
 
 	createTokenFn := func(ns string) internalvault.CreateToken { return v.kclient.CoreV1().ServiceAccounts(ns).CreateToken }
-	client, err := v.clientBuilder(ctx, resourceNamespace, createTokenFn, v.secretsLister, issuerObj)
+	client, err := v.clientBuilder(ctx, resourceNamespace, createTokenFn, v.secretsLister, issuerObj, v.issuerOptions.CanUseAmbientCredentials(issuerObj))
 	if apierrors.IsNotFound(err) {
 		message := "Required secret resource not found"
 		log.Error(err, message)

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -131,7 +131,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{}, "test-secret")
 			},
 			builder: &testpkg.Builder{
@@ -192,7 +192,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return nil, errors.New("generic error")
 			},
 			expectedErr: true,
@@ -236,7 +236,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New(), nil
 			},
 			builder: &testpkg.Builder{
@@ -298,7 +298,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New().WithSign(nil, nil, errors.New("sign error")), nil
 			},
 			builder: &testpkg.Builder{
@@ -359,7 +359,7 @@ func TestProcessItem(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}),
 			),
-			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer) (internalvault.Interface, error) {
+			clientBuilder: func(_ context.Context, _ string, _ func(ns string) internalvault.CreateToken, _ internalinformers.SecretLister, _ cmapi.GenericIssuer, _ bool) (internalvault.Interface, error) {
 				return fakevault.New().WithSign([]byte("signed-cert"), []byte("signing-ca"), nil), nil
 			},
 			builder: &testpkg.Builder{

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -146,7 +146,7 @@ func (v *Vault) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 		return nil
 	}
 
-	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer)
+	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer))
 	if err != nil {
 		logf.FromContext(ctx).V(logf.WarnLevel).Info(messageVaultClientInitFailed, "err", err, "issuer", klog.KObj(issuer))
 		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultClientInitFailed, err.Error()))


### PR DESCRIPTION
## Description

### Problem

The Vault issuer can authenticate to a HashiCorp Vault server using AWS IAM: it signs a sts:GetCallerIdentity request with AWS credentials and sends that signature to Vault, which returns a Vault token. cert-manager has a deliberate safety rule for this — a tenant-created namespaced Issuer must **_never_** borrow the controller's own cloud identity unless the operator opts in via --issuer-ambient-credentials (defaulted false for Issuers, true for ClusterIssuers). Every other ambient-credential path honours this gate (e.g. the Route53 DNS-01 solver), however the Vault AWS IAM auth path did not.

This raised three issues:

  - Missing ambient-credentials gate: the path selected the controller's ambient AWS credential chain (IRSA / IMDS / EKS Pod Identity) whenever awsAuth.ServiceAccountRef == nil, without ever consulting IssuerOptions.CanUseAmbientCredentials(issuer). The gate was also unreachable, as IssuerOptions was never plumbed into the Vault client.
  - Identity disclosure: because the tenant also controls spec.vault.server, a low-privilege tenant could point a namespaced Vault Issuer at a server they control and receive a SigV4-signed GetCallerIdentity assertion of the controller's IAM identity (AccessKeyID + session token in the headers).
  - Privilege escalation: that signed assertion can be replayed within the SigV4 window against a real Vault AWS-IAM backend that trusts the controller's IAM role, minting a Vault token at controller privilege.

### Solution

- Thread the ambient-credentials decision from the issuer and CSR controllers (where the issuer type and IssuerOptions are known) through New / ClientBuilder into the Vault client, and refuse the ambient fallback when the issuer is not permitted to use ambient credentials. The explicit IRSA path (serviceAccountRef set) and ClusterIssuer behaviour are unchanged. Legitimate configurations behave identically.

### Test plan

  - [ ] TestRequestTokenWithAWSAuthAmbientCredentialsGate — an AWS-auth Issuer with no serviceAccountRef and ambient credentials not permitted errors out before
  any login request is sent (fake client would error on Write), confirming the gate fires ahead of the sink.
  - [ ] TestSetToken/"if aws auth omits serviceAccountRef and ambient credentials are not permitted…" — table case asserting the same denial surfaces through setToken.
  - [ ] Verified the gate is load-bearing: with the check removed, TestRequestTokenWithAWSAuthAmbientCredentialsGate fails (falls through to ambient/IMDS retrieval); restored, it passes.
  - [ ] Existing internal/vault, pkg/issuer/vault, pkg/controller/certificaterequests/vault, and pkg/controller/certificatesigningrequests/vault tests pass
  unchanged (signature updates only).
  - [ ] go build ./..., go vet ./..., and gofmt clean.

## release-note

```release-note
  The `vault` issuer no longer authenticates to Vault using the cert-manager controller's ambient AWS credentials
  for AWS IAM auth on a namespaced `Issuer`, unless ambient credentials are explicitly enabled via
  `--issuer-ambient-credentials`. `ClusterIssuer` and explicit `serviceAccountRef` (IRSA) configurations are
  unaffected.```