### PR TITLE
fix: de-duplicate dnsNames when multiple Gateway/ListenerSet listeners share a Secret

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -387,14 +387,7 @@ func buildCertificates(
 			controllerGVK = gatewayGVK
 		}
 
-		var ipAddress, dnsNames []string
-		for _, h := range hosts {
-			if ip := net.ParseIP(h); ip != nil {
-				ipAddress = append(ipAddress, h)
-			} else {
-				dnsNames = append(dnsNames, h)
-			}
-		}
+		dnsNames, ipAddress := splitHosts(hosts)
 
 		labels := ingLike.GetLabels()
 
@@ -533,6 +526,26 @@ func handleGatewayAPIListeners[L gwapi.Listener | gwapi.ListenerEntry](listeners
 			tlsHosts[secretRef] = append(tlsHosts[secretRef], string(*l.Hostname))
 		}
 	}
+}
+
+// splitHosts de-duplicates hosts and splits them into DNS names and IP
+// addresses, preserving first-seen order. Duplicates arise when several
+// listeners reference the same Secret and hostname; dropping them keeps the
+// Certificate's SAN count in sync with the ACME order's identifiers.
+func splitHosts(hosts []string) (dnsNames, ipAddresses []string) {
+	seen := sets.New[string]()
+	for _, h := range hosts {
+		if seen.Has(h) {
+			continue
+		}
+		seen.Insert(h)
+		if ip := net.ParseIP(h); ip != nil {
+			ipAddresses = append(ipAddresses, h)
+		} else {
+			dnsNames = append(dnsNames, h)
+		}
+	}
+	return dnsNames, ipAddresses
 }
 
 func findCertificatesToBeRemoved(certs []*cmapi.Certificate, ingLike metav1.Object) []string {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -2465,6 +2465,97 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: multiple listeners referencing the same Secret
+			// and hostname must yield a single dnsName, otherwise the CSR has
+			// more SANs than the ACME order has identifiers and finalize fails.
+			Name:   "de-duplicates the same hostname referenced by multiple listeners for one Secret",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Name:     "listener-1",
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: new(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+						{
+							Name:     "listener-2",
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: new(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+						{
+							Name:     "listener-3",
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: new(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: func() *gwapi.Group { g := gwapi.Group("core"); return &g }(),
+										Kind:  func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						Annotations:     buildParentRefAnnotations(),
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
 			Name:   "return a single Certificate for a Gateway with a single valid TLS entry and common-name annotation (TLS)",
 			Issuer: acmeClusterIssuer,
 			IngressLike: &gwapi.Gateway{
@@ -5393,6 +5484,50 @@ func TestMergeAnnotations(t *testing.T) {
 			result := mergeAnnotations(tt.existing, tt.update)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("mergeAnnotations() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_splitHosts(t *testing.T) {
+	tests := []struct {
+		name            string
+		hosts           []string
+		wantDNSNames    []string
+		wantIPAddresses []string
+	}{
+		{
+			name:         "de-duplicates repeated DNS names, keeping first-seen order",
+			hosts:        []string{"example.com", "www.example.com", "example.com", "www.example.com"},
+			wantDNSNames: []string{"example.com", "www.example.com"},
+		},
+		{
+			name:            "splits DNS names from IPv4 and IPv6 addresses",
+			hosts:           []string{"example.com", "192.0.2.1", "2001:db8::1"},
+			wantDNSNames:    []string{"example.com"},
+			wantIPAddresses: []string{"192.0.2.1", "2001:db8::1"},
+		},
+		{
+			name:            "de-duplicates across both DNS names and IP addresses",
+			hosts:           []string{"example.com", "192.0.2.1", "example.com", "192.0.2.1"},
+			wantDNSNames:    []string{"example.com"},
+			wantIPAddresses: []string{"192.0.2.1"},
+		},
+		{
+			name:         "empty input yields nil slices",
+			hosts:        nil,
+			wantDNSNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDNSNames, gotIPAddresses := splitHosts(tt.hosts)
+			if !reflect.DeepEqual(gotDNSNames, tt.wantDNSNames) {
+				t.Errorf("dnsNames = %#v, want %#v", gotDNSNames, tt.wantDNSNames)
+			}
+			if !reflect.DeepEqual(gotIPAddresses, tt.wantIPAddresses) {
+				t.Errorf("ipAddresses = %#v, want %#v", gotIPAddresses, tt.wantIPAddresses)
 			}
 		})
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Listeners referencing the same Secret and hostname produced repeated entries in Certificate.spec.dnsNames, so the CSR carried more SANs than the ACME order had identifiers and finalize failed. De-duplicate hosts before building dnsNames/ipAddresses.

```
Failed to finalize Order: 400 urn:ietf:params:acme:error:badCSR: Unexpected number of identifiers found in CSR. 3 instead of 1 
 ```

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
De-duplicate dnsNames when multiple Gateway/ListenerSet listeners share a Secret
```
