### PR TITLE
Ignore GO-2026-5932 in trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,3 +2,8 @@
 # the version detection is wrongly looking at apiserver packages with versions < 1 - but all apiserver packages have
 # a major version of 0. In any case this is a vuln in Kubernetes clusters, not in our code.
 CVE-2020-8559
+
+# GO-2026-5932 flags golang.org/x/crypto/openpgp as unmaintained. cert-manager does not import the openpgp
+# sub-package; we only use x/crypto for SSH and other unrelated packages. No fixed version exists because the
+# advisory is a permanent deprecation notice, not a code bug.
+GO-2026-5932


### PR DESCRIPTION
## Motivation

[GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932), published 2026-07-07, permanently flags `golang.org/x/crypto/openpgp` as unmaintained and unsafe. Since it was published, all periodic trivy scan jobs have been failing across every branch (master, release-1.19, release-1.20, release-1.21).

cert-manager does not import the `openpgp` sub-package — it only uses `golang.org/x/crypto` for SSH, nacl, and other unrelated packages. Trivy flags the advisory because the module `golang.org/x/crypto` appears in the compiled binary, regardless of which sub-packages are actually imported.

There is no fixed version of `golang.org/x/crypto` that resolves the advisory because it is a deprecation notice for the `openpgp` sub-package, not a code bug.

## Changes

Adds `GO-2026-5932` to `.trivyignore`, following the same pattern as the existing `CVE-2020-8559` entry.

## Testing

Verified that cert-manager does not import `golang.org/x/crypto/openpgp`:

```
$ grep -r "openpgp" --include="*.go" .
(no results)
```

Confirmed the advisory affects all branches equally by checking `.trivyignore` and trivy scan logs across master, release-1.19, release-1.20, and release-1.21.

## Release Note

```release-note
Ignore GO-2026-5932 in Trivy scans: the advisory flags `golang.org/x/crypto/openpgp` as unmaintained, but cert-manager does not use the `openpgp` sub-package
```

Once merged, cherry-pick PRs will be created for release-1.19, release-1.20, and release-1.21 via `/cherry-pick`.

/cherry-pick release-1.21
/cherry-pick release-1.20
/cherry-pick release-1.19