### PR TITLE
[release-1.20] Update Go to v1.26.5

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -32,7 +32,7 @@ export GOVENDOR_DIR ?= $(default_shared_dir)/go_vendor
 
 # https://go.dev/dl/
 # renovate: datasource=golang-version packageName=go
-VENDORED_GO_VERSION := 1.26.4
+VENDORED_GO_VERSION := 1.26.5
 
 $(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
 	@mkdir -p $@
@@ -468,10 +468,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
-go_linux_arm64_SHA256SUM=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
-go_darwin_amd64_SHA256SUM=05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d
-go_darwin_arm64_SHA256SUM=b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53
+go_linux_amd64_SHA256SUM=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
+go_linux_arm64_SHA256SUM=fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49
+go_darwin_amd64_SHA256SUM=6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725
+go_darwin_arm64_SHA256SUM=efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
go1.26.5 (released 2026-07-07) includes security fixes to the `crypto/tls` and `os` packages, as well as bug fixes to the compiler, the runtime, the `go` command, the `net` package, the `os` package, and the `syscall` package. See the [Go 1.26.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.5+label%3ACherryPickApproved) on the issue tracker for details.
-- https://go.dev/doc/devel/release#go1.26.minor

Should fix testgrid failures in the release-1.20 branch:
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.20

Security fixes:
 * [CVE-2026-42505](https://pkg.go.dev/vuln/GO-2026-5856): `crypto/tls` — ECH de-anonymization via PSK identity leakage in unencrypted ClientHello
 * [CVE-2026-39822](https://github.com/golang/go/issues/79027): `os` — Root escape via symlink plus trailing slash

Checksums copied from `master` (which is already on Go 1.26.5) and verified locally with `make vendor-go`.

Prior art: cert-manager/cert-manager#8926

/kind cleanup

```release-note
Update Go to `v1.26.5` to fix CVE-2026-42505 and CVE-2026-39822
```