### PR TITLE
Register Secret event handlers only on informers whose object type they handle

### DIFF
--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -68,9 +68,15 @@ type SecretLister interface {
 
 // Informer is a subset of client-go SharedIndexInformer https://github.com/kubernetes/client-go/blob/release-1.26/tools/cache/shared_informer.go#L35-L211
 type Informer interface {
-	// AddEventHandler allows the reconcile loop to register an event handler so
-	// it gets triggered when the informer has a new event
+	// AddEventHandler registers an event handler on the typed (full-object)
+	// informer. For the filtered Secret informer, this receives only
+	// cert-manager-labelled Secrets as *corev1.Secret.
 	AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
+	// AddMetadataEventHandler registers an event handler on the metadata-only
+	// informer. For the filtered Secret informer, this receives non-labelled
+	// Secrets as *v1.PartialObjectMetadata. For non-filtered informers this
+	// is a no-op.
+	AddMetadataEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
 	// HasSynced returns true if the informer's cache has synced (at least
 	// one LIST has been performed)
 	HasSynced() bool

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -95,7 +95,19 @@ type baseSecretInformer struct {
 
 func (bsi *baseSecretInformer) Informer() Informer {
 	bsi.informer = bsi.f.InformerFor(&corev1.Secret{}, bsi.new)
-	return bsi.informer
+	return &singleInformer{bsi.informer}
+}
+
+// singleInformer wraps a cache.SharedIndexInformer to satisfy the Informer
+// interface. AddMetadataEventHandler is a no-op because the base (non-filtered)
+// Secret informer caches all Secrets fully — there is no separate metadata
+// informer.
+type singleInformer struct {
+	cache.SharedIndexInformer
+}
+
+func (s *singleInformer) AddMetadataEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
 }
 
 func (bsi *baseSecretInformer) Lister() SecretLister {

--- a/internal/informers/core_basic_test.go
+++ b/internal/informers/core_basic_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/cache"
+)
+
+// The base (non-filtered) Secret informer has no separate metadata informer,
+// so AddMetadataEventHandler must be a no-op: it must not register the handler
+// on the wrapped informer, which AddEventHandler already covers.
+func Test_singleInformer_AddMetadataEventHandler_noop(t *testing.T) {
+	wrapped := &stubSharedIndexInformer{}
+	s := &singleInformer{wrapped}
+
+	reg, err := s.AddMetadataEventHandler(cache.ResourceEventHandlerFuncs{})
+	assert.NoError(t, err)
+	assert.Nil(t, reg)
+	assert.Equal(t, 0, wrapped.addEventHandlerCalls, "AddMetadataEventHandler on the base informer must not register the handler anywhere")
+
+	_, err = s.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, wrapped.addEventHandlerCalls)
+}

--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -195,11 +195,12 @@ func (i *informer) HasSynced() bool {
 }
 
 func (i *informer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	_, err := i.typedInformer.AddEventHandler(handler)
+	return nil, err
+}
+
+func (i *informer) AddMetadataEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	_, err := i.metadataInformer.AddEventHandler(handler)
-	if err != nil {
-		return nil, err
-	}
-	_, err = i.typedInformer.AddEventHandler(handler)
 	return nil, err
 }
 

--- a/internal/informers/core_filteredsecrets_test.go
+++ b/internal/informers/core_filteredsecrets_test.go
@@ -31,6 +31,7 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/metadata/metadatalister"
+	"k8s.io/client-go/tools/cache"
 )
 
 func Test_secretNamespaceLister_Get(t *testing.T) {
@@ -448,4 +449,38 @@ func Test_secretNamespaceLister_List(t *testing.T) {
 			assert.ElementsMatch(t, got, scenario.want)
 		})
 	}
+}
+
+// stubSharedIndexInformer counts AddEventHandler registrations. All other
+// methods of the embedded interface are unimplemented and panic if called.
+type stubSharedIndexInformer struct {
+	cache.SharedIndexInformer
+	addEventHandlerCalls int
+}
+
+func (s *stubSharedIndexInformer) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	s.addEventHandlerCalls++
+	return nil, nil
+}
+
+// Regression test for https://github.com/cert-manager/cert-manager/issues/8994:
+// a handler must only be registered on the informer whose object type it
+// handles. AddEventHandler must register on the typed informer only, and
+// AddMetadataEventHandler on the metadata informer only; registering one
+// handler on both delivers *v1.PartialObjectMetadata to handlers typed for
+// *corev1.Secret.
+func Test_informer_handlerRegistrationSplit(t *testing.T) {
+	typed := &stubSharedIndexInformer{}
+	metadata := &stubSharedIndexInformer{}
+	i := &informer{typedInformer: typed, metadataInformer: metadata}
+
+	_, err := i.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, typed.addEventHandlerCalls, "AddEventHandler must register on the typed informer")
+	assert.Equal(t, 0, metadata.addEventHandlerCalls, "AddEventHandler must not register on the metadata informer")
+
+	_, err = i.AddMetadataEventHandler(cache.ResourceEventHandlerFuncs{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, typed.addEventHandlerCalls, "AddMetadataEventHandler must not register on the typed informer")
+	assert.Equal(t, 1, metadata.addEventHandlerCalls, "AddMetadataEventHandler must register on the metadata informer")
 }

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -93,10 +93,14 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						clusterIssuerLister,
 					)
-					if _, err := secretInformer.AddEventHandler(controllerpkg.BlockingEventHandler(
+					secretHandler := controllerpkg.BlockingEventHandler(
 						handleSecretReferenceWorkFunc(log, certificateRequestLister, helper, queue),
-					)); err != nil {
+					)
+					if _, err := secretInformer.AddEventHandler(secretHandler); err != nil {
 						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
+					if _, err := secretInformer.AddMetadataEventHandler(secretHandler); err != nil {
+						return nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 					}
 					return mustSync, nil
 				},

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -87,10 +87,14 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
 					)
-					if _, err := secretInformer.AddEventHandler(controllerpkg.BlockingEventHandler(
+					secretHandler := controllerpkg.BlockingEventHandler(
 						handleSecretReferenceWorkFunc(log, certificateSigningRequestLister, helper, queue, ctx.IssuerOptions),
-					)); err != nil {
+					)
+					if _, err := secretInformer.AddEventHandler(secretHandler); err != nil {
 						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
+					if _, err := secretInformer.AddMetadataEventHandler(secretHandler); err != nil {
+						return nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 					}
 					return []cache.InformerSynced{
 						secretInformer.HasSynced,

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -98,8 +98,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	if _, err := clusterIssuerInformer.Informer().AddEventHandler(controllerpkg.QueuingEventHandler(c.queue)); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
-	if _, err := secretInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(c.secretEvent)); err != nil {
+	secretHandler := controllerpkg.BlockingEventHandler(c.secretEvent)
+	if _, err := secretInformer.Informer().AddEventHandler(secretHandler); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretInformer.Informer().AddMetadataEventHandler(secretHandler); err != nil {
+		return nil, nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 	}
 
 	// instantiate additional helpers used by this controller

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -94,8 +94,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	if _, err := issuerInformer.Informer().AddEventHandler(controllerpkg.QueuingEventHandler(c.queue)); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
-	if _, err := secretInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(c.secretEvent)); err != nil {
+	secretHandler := controllerpkg.BlockingEventHandler(c.secretEvent)
+	if _, err := secretInformer.Informer().AddEventHandler(secretHandler); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretInformer.Informer().AddMetadataEventHandler(secretHandler); err != nil {
+		return nil, nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 	}
 
 	// instantiate additional helpers used by this controller


### PR DESCRIPTION
## Summary

Stop registering a single Secret event handler on both the typed informer and the metadata informer. `AddEventHandler` now registers only on the typed informer (cert-manager-labelled Secrets, delivered as `*corev1.Secret`), and a new `AddMetadataEventHandler` method on the `Informer` interface registers only on the metadata informer (all other Secrets, delivered as `*v1.PartialObjectMetadata`). A handler is therefore only ever called with the object type it was written for.

- The issuer and clusterissuer controllers register on **both** informers: they react to any Secret change, including external credential Secrets.
- The certificate sub-controllers register only on the typed informer: they only watch cert-manager-managed Secrets.
- The non-filtered `baseSecretInformer` has no separate metadata informer, so its `AddMetadataEventHandler` is a no-op.

## Background

#8994 (handler log spam and dropped events, found shortly after the 1.21.0 release): the generics refactor in #8407 changed handler signatures from `func(interface{})` to `func(U)`, so a handler typed for `*corev1.Secret` failed its type assertion whenever the metadata informer delivered a `*v1.PartialObjectMetadata`.

That bug is already fixed on `master` by #9004 (cherry-picked to `release-1.21` as #9037), which widened the handler's return type so the assertion tolerates deliveries from either informer. This PR is a follow-up built on top of that fix: it removes the underlying flaw #9004 worked around, by making it impossible to register a handler on an informer whose object type it can't handle.

#9006 explored a larger controller-runtime alignment that included this same split; it was closed in favour of this PR (its closing comment sketches a path for the controller-runtime migration).

## Testing

- `go test` passes in `./internal/informers/...`, `./pkg/controller/certificates/...`, `./pkg/controller/issuers/...` and `./pkg/controller/clusterissuers/...`.
- This PR's own [e2e run](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/9005/pull-cert-manager-master-e2e-v1-36/2075622753154633728) (succeeded) contains **0** of the `OnAdd`/`OnUpdate`/`OnDelete` missing-object errors reported in #8994 — and not because the run was idle: the Secret metadata informer is active (`"Caches populated" type="*v1.PartialObjectMetadata"`) and 4,390 of the 13,007 log lines are Secret-related.

### Release Note

```release-note
Separate Secret informer event handler registration into typed and metadata-only paths, so a handler is only registered on the informer whose object type it can actually handle.
```
