### PR TITLE
Fix #8994 (approach C): adopt controller-runtime TypedEventHandler

### DIFF
--- a/cmd/controller/go.sum
+++ b/cmd/controller/go.sum
@@ -193,6 +193,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=

--- a/internal/informers/core.go
+++ b/internal/informers/core.go
@@ -68,9 +68,15 @@ type SecretLister interface {
 
 // Informer is a subset of client-go SharedIndexInformer https://github.com/kubernetes/client-go/blob/release-1.26/tools/cache/shared_informer.go#L35-L211
 type Informer interface {
-	// AddEventHandler allows the reconcile loop to register an event handler so
-	// it gets triggered when the informer has a new event
+	// AddEventHandler registers an event handler on the typed (full-object)
+	// informer. For the filtered Secret informer, this receives only
+	// cert-manager-labelled Secrets as *corev1.Secret.
 	AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
+	// AddMetadataEventHandler registers an event handler on the metadata-only
+	// informer. For the filtered Secret informer, this receives non-labelled
+	// Secrets as *v1.PartialObjectMetadata. For non-filtered informers this
+	// is a no-op.
+	AddMetadataEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
 	// HasSynced returns true if the informer's cache has synced (at least
 	// one LIST has been performed)
 	HasSynced() bool

--- a/internal/informers/core_basic.go
+++ b/internal/informers/core_basic.go
@@ -95,7 +95,19 @@ type baseSecretInformer struct {
 
 func (bsi *baseSecretInformer) Informer() Informer {
 	bsi.informer = bsi.f.InformerFor(&corev1.Secret{}, bsi.new)
-	return bsi.informer
+	return &singleInformer{bsi.informer}
+}
+
+// singleInformer wraps a cache.SharedIndexInformer to satisfy the Informer
+// interface. AddMetadataEventHandler is a no-op because the base (non-filtered)
+// Secret informer caches all Secrets fully — there is no separate metadata
+// informer.
+type singleInformer struct {
+	cache.SharedIndexInformer
+}
+
+func (s *singleInformer) AddMetadataEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
 }
 
 func (bsi *baseSecretInformer) Lister() SecretLister {

--- a/internal/informers/core_filteredsecrets.go
+++ b/internal/informers/core_filteredsecrets.go
@@ -195,11 +195,12 @@ func (i *informer) HasSynced() bool {
 }
 
 func (i *informer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	_, err := i.typedInformer.AddEventHandler(handler)
+	return nil, err
+}
+
+func (i *informer) AddMetadataEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	_, err := i.metadataInformer.AddEventHandler(handler)
-	if err != nil {
-		return nil, err
-	}
-	_, err = i.typedInformer.AddEventHandler(handler)
 	return nil, err
 }
 

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -93,10 +93,14 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						clusterIssuerLister,
 					)
-					if _, err := secretInformer.AddEventHandler(controllerpkg.BlockingEventHandler(
+					secretHandler := controllerpkg.BlockingEventHandler(
 						handleSecretReferenceWorkFunc(log, certificateRequestLister, helper, queue),
-					)); err != nil {
+					)
+					if _, err := secretInformer.AddEventHandler(secretHandler); err != nil {
 						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
+					if _, err := secretInformer.AddMetadataEventHandler(secretHandler); err != nil {
+						return nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 					}
 					return mustSync, nil
 				},

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned.go
@@ -87,10 +87,14 @@ func init() {
 						ctx.SharedInformerFactory.Certmanager().V1().Issuers().Lister(),
 						ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers().Lister(),
 					)
-					if _, err := secretInformer.AddEventHandler(controllerpkg.BlockingEventHandler(
+					secretHandler := controllerpkg.BlockingEventHandler(
 						handleSecretReferenceWorkFunc(log, certificateSigningRequestLister, helper, queue, ctx.IssuerOptions),
-					)); err != nil {
+					)
+					if _, err := secretInformer.AddEventHandler(secretHandler); err != nil {
 						return nil, fmt.Errorf("error setting up event handler: %v", err)
+					}
+					if _, err := secretInformer.AddMetadataEventHandler(secretHandler); err != nil {
+						return nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 					}
 					return []cache.InformerSynced{
 						secretInformer.HasSynced,

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -98,8 +98,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	if _, err := clusterIssuerInformer.Informer().AddEventHandler(controllerpkg.QueuingEventHandler(c.queue)); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
-	if _, err := secretInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(c.secretEvent)); err != nil {
+	secretHandler := controllerpkg.BlockingEventHandler(c.secretEvent)
+	if _, err := secretInformer.Informer().AddEventHandler(secretHandler); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretInformer.Informer().AddMetadataEventHandler(secretHandler); err != nil {
+		return nil, nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 	}
 
 	// instantiate additional helpers used by this controller

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -94,8 +94,12 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 	if _, err := issuerInformer.Informer().AddEventHandler(controllerpkg.QueuingEventHandler(c.queue)); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
 	}
-	if _, err := secretInformer.Informer().AddEventHandler(controllerpkg.BlockingEventHandler(c.secretEvent)); err != nil {
+	secretHandler := controllerpkg.BlockingEventHandler(c.secretEvent)
+	if _, err := secretInformer.Informer().AddEventHandler(secretHandler); err != nil {
 		return nil, nil, fmt.Errorf("error setting up event handler: %v", err)
+	}
+	if _, err := secretInformer.Informer().AddMetadataEventHandler(secretHandler); err != nil {
+		return nil, nil, fmt.Errorf("error setting up metadata event handler: %v", err)
 	}
 
 	// instantiate additional helpers used by this controller

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
+	"context"
 	"reflect"
 	"strings"
 	"time"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -111,69 +112,50 @@ func HandleOwnedResourceNamespacedFunc[T metav1.Object](
 func QueuingEventHandler(
 	queue workqueue.TypedRateLimitingInterface[types.NamespacedName],
 ) cache.ResourceEventHandler {
+	enqueue := func(obj metav1.Object) {
+		queue.Add(cache.MetaObjectToName(obj).AsNamespacedName())
+	}
 	return filteredEventHandler[metav1.Object]{
-		handler: blockingEventHandler[metav1.Object]{workFunc: func(obj metav1.Object) {
-			queue.Add(cache.MetaObjectToName(obj).AsNamespacedName())
-		}},
+		handler: handler.TypedFuncs[metav1.Object, types.NamespacedName]{
+			CreateFunc: func(_ context.Context, e event.TypedCreateEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				enqueue(e.Object)
+			},
+			UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				enqueue(e.ObjectNew)
+			},
+			DeleteFunc: func(_ context.Context, e event.TypedDeleteEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				enqueue(e.Object)
+			},
+		},
 		predicates: []predicate.TypedPredicate[metav1.Object]{
-			// prevent unnecessary reconciliations in case the resource did not update
 			onlyUpdateWhenResourceChanged[metav1.Object]{},
 		},
 	}
 }
 
-// blockingEventHandler is an implementation of cache.ResourceEventHandler that
-// simply synchronously calls its workFunc upon calls to OnAdd, OnUpdate or
-// OnDelete.
-// It skips update events in case the resource has not changed.
-type blockingEventHandler[T any] struct {
-	workFunc func(obj T)
-}
-
-var _ cache.ResourceEventHandler = blockingEventHandler[metav1.Object]{}
-
 // BlockingEventHandler returns a cache.ResourceEventHandler that
-// simply synchronously calls the workFunc upon calls to OnAdd, OnUpdate or
-// OnDelete. It skips update events in case the resource has not changed.
+// synchronously calls the workFunc upon calls to OnAdd, OnUpdate or
+// OnDelete. It uses controller-runtime's handler.TypedFuncs internally
+// and skips update events when the resource has not changed.
 func BlockingEventHandler[T metav1.Object](
 	workFunc func(obj T),
 ) cache.ResourceEventHandler {
 	return filteredEventHandler[T]{
-		handler: blockingEventHandler[T]{workFunc: workFunc},
+		handler: handler.TypedFuncs[T, types.NamespacedName]{
+			CreateFunc: func(_ context.Context, e event.TypedCreateEvent[T], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				workFunc(e.Object)
+			},
+			UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[T], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				workFunc(e.ObjectNew)
+			},
+			DeleteFunc: func(_ context.Context, e event.TypedDeleteEvent[T], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+				workFunc(e.Object)
+			},
+		},
 		predicates: []predicate.TypedPredicate[T]{
-			// prevent unnecessary reconciliations in case the resource did not update
 			onlyUpdateWhenResourceChanged[T]{},
 		},
 	}
-}
-
-func (b blockingEventHandler[T]) run(obj any) {
-	tObj, ok := obj.(T)
-	if !ok {
-		logf.Log.Error(nil, "Object could not be casted to type", "object", obj, "type", fmt.Sprintf("%T", obj), "expected_type", fmt.Sprintf("%T", *new(T)))
-		return
-	}
-
-	b.workFunc(tObj)
-}
-
-// OnAdd synchronously adds a newly created object to the workqueue.
-func (b blockingEventHandler[T]) OnAdd(obj any, isInInitialList bool) {
-	b.run(obj)
-}
-
-// OnUpdate synchronously adds an updated object to the workqueue.
-func (b blockingEventHandler[T]) OnUpdate(oldObj, newObj any) {
-	b.run(newObj)
-}
-
-// OnDelete synchronously adds a deleted object to the workqueue.
-func (b blockingEventHandler[T]) OnDelete(obj any) {
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		obj = tombstone.Obj
-	}
-	b.run(obj)
 }
 
 // onlyUpdateWhenResourceChanged implements a predicate function only
@@ -225,109 +207,80 @@ func isNil(arg any) bool {
 	return false
 }
 
-// filteredEventHandler is an implementation of cache.ResourceEventHandler that
-// only passes the event to the handler when all predicates return true
+// filteredEventHandler adapts a handler.TypedEventHandler to
+// cache.ResourceEventHandler, applying predicates before forwarding typed
+// events. This is the cert-manager equivalent of controller-runtime's
+// internal.EventHandler — it bridges client-go informers to the typed
+// handler interface.
 type filteredEventHandler[T metav1.Object] struct {
-	handler cache.ResourceEventHandler
-	// predicates is a list of predicates that must all pass
-	// for the object to be enqueued.
+	handler    handler.TypedEventHandler[T, types.NamespacedName]
 	predicates []predicate.TypedPredicate[T]
 }
 
 var _ cache.ResourceEventHandler = filteredEventHandler[metav1.Object]{}
 
-// FilterEventHandler returns a cache.ResourceEventHandler that
-// skips events based on the passed predicates and passes all other
-// events to the provided handler.
+// FilterEventHandler returns a cache.ResourceEventHandler that applies the
+// given predicates and delegates to the provided TypedEventHandler.
 func FilterEventHandler[T metav1.Object](
-	handler cache.ResourceEventHandler,
+	h handler.TypedEventHandler[T, types.NamespacedName],
 	predicates ...predicate.TypedPredicate[T],
 ) cache.ResourceEventHandler {
 	return filteredEventHandler[T]{
-		handler:    handler,
+		handler:    h,
 		predicates: predicates,
 	}
 }
 
-// OnAdd adds a newly created object to the workqueue.
 func (q filteredEventHandler[T]) OnAdd(obj any, isInInitialList bool) {
-	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnAdd")
-
-	c := event.TypedCreateEvent[T]{
-		IsInInitialList: isInInitialList,
-	}
-
-	// Pull Object out of the object
-	if o, ok := obj.(T); ok {
-		c.Object = o
-	} else {
-		log.Error(nil, "OnAdd missing Object", "object", obj, "type", fmt.Sprintf("%T", obj))
+	o, ok := obj.(T)
+	if !ok {
 		return
 	}
 
+	c := event.TypedCreateEvent[T]{Object: o, IsInInitialList: isInInitialList}
 	for _, p := range q.predicates {
 		if !p.Create(c) {
 			return
 		}
 	}
 
-	q.handler.OnAdd(obj, isInInitialList)
+	q.handler.Create(context.TODO(), c, nil)
 }
 
-// OnUpdate adds an updated object to the workqueue.
 func (q filteredEventHandler[T]) OnUpdate(oldObj, newObj any) {
-	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnUpdate")
-
-	u := event.TypedUpdateEvent[T]{}
-
-	if o, ok := oldObj.(T); ok {
-		u.ObjectOld = o
-	} else {
-		log.Error(nil, "OnUpdate missing ObjectOld", "object", oldObj, "type", fmt.Sprintf("%T", oldObj))
+	oOld, ok := oldObj.(T)
+	if !ok {
+		return
+	}
+	oNew, ok := newObj.(T)
+	if !ok {
 		return
 	}
 
-	// Pull Object out of the object
-	if o, ok := newObj.(T); ok {
-		u.ObjectNew = o
-	} else {
-		log.Error(nil, "OnUpdate missing ObjectNew", "object", newObj, "type", fmt.Sprintf("%T", newObj))
-		return
-	}
-
+	u := event.TypedUpdateEvent[T]{ObjectOld: oOld, ObjectNew: oNew}
 	for _, p := range q.predicates {
 		if !p.Update(u) {
 			return
 		}
 	}
 
-	q.handler.OnUpdate(oldObj, newObj)
+	q.handler.Update(context.TODO(), u, nil)
 }
 
-// OnDelete adds a deleted object to the workqueue for processing.
 func (q filteredEventHandler[T]) OnDelete(obj any) {
-	log := logf.Log.WithName("filteredEventHandler").WithValues("event", "OnDelete")
-
 	d := event.TypedDeleteEvent[T]{}
 
 	unwrappedObj := obj
-
-	// If the object doesn't have Metadata, assume it is a tombstone object of type DeletedFinalStateUnknown
-	tombstone, ok := unwrappedObj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		// Set DeleteStateUnknown to true
+	if tombstone, ok := unwrappedObj.(cache.DeletedFinalStateUnknown); ok {
 		d.DeleteStateUnknown = true
-
 		unwrappedObj = tombstone.Obj
 	}
 
-	// Pull Object out of the object
-	if o, ok := unwrappedObj.(T); ok {
-		d.Object = o
-	} else {
-		log.Error(nil, "OnDelete missing Object", "object", unwrappedObj, "type", fmt.Sprintf("%T", unwrappedObj))
+	o, ok := unwrappedObj.(T)
+	if !ok {
 		return
 	}
+	d.Object = o
 
 	for _, p := range q.predicates {
 		if !p.Delete(d) {
@@ -335,7 +288,7 @@ func (q filteredEventHandler[T]) OnDelete(obj any) {
 		}
 	}
 
-	q.handler.OnDelete(obj)
+	q.handler.Delete(context.TODO(), d, nil)
 }
 
 // BuildAnnotationsToCopy takes a map of annotations and a list of prefix

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -362,12 +364,23 @@ func TestFilterEventHandler(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			callCount := 0
-			handler := FilterEventHandler(
-				BlockingEventHandler(func(obj metav1.Object) { callCount++ }),
+			increment := func() { callCount++ }
+			h := FilterEventHandler(
+				handler.TypedFuncs[metav1.Object, types.NamespacedName]{
+					CreateFunc: func(_ context.Context, _ event.TypedCreateEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+						increment()
+					},
+					UpdateFunc: func(_ context.Context, _ event.TypedUpdateEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+						increment()
+					},
+					DeleteFunc: func(_ context.Context, _ event.TypedDeleteEvent[metav1.Object], _ workqueue.TypedRateLimitingInterface[types.NamespacedName]) {
+						increment()
+					},
+				},
 				test.predicate,
 			)
 
-			test.triggerEvent(handler)
+			test.triggerEvent(h)
 
 			if callCount != test.expectCalls {
 				t.Errorf("expected handler to be called %d times, got %d", test.expectCalls, callCount)


### PR DESCRIPTION
## Summary

Adopt controller-runtime's `handler.TypedEventHandler` for cert-manager's
informer event handling, fixing #8994 and aligning with the upstream
pattern.

- Replace `blockingEventHandler[T]` with `handler.TypedFuncs[T,
  types.NamespacedName]` from controller-runtime.
- Change `filteredEventHandler[T]` to wrap
  `handler.TypedEventHandler[T, types.NamespacedName]` instead of
  `cache.ResourceEventHandler`. This moves all type assertions into the
  adapter layer (`filteredEventHandler`) and delivers fully typed events
  downstream — no type casts in work functions.
- Split `AddEventHandler` into separate typed and metadata registration
  methods (same structural fix as approach B).
- The issuer and clusterissuer controllers register on both informers;
  certificate sub-controllers register only on the typed informer.

This is a stepping stone toward full controller-runtime adoption. The
`filteredEventHandler` is the cert-manager equivalent of
controller-runtime's `internal.EventHandler` — it bridges client-go
informers to the typed handler interface.

**See also:**
- **Approach A** (widen return type): cert-manager/cert-manager#9004
- **Approach B** (split informer interface): cert-manager/cert-manager#9005

All three PRs target `master` for review and CI; they are mutually
exclusive approaches to the same issue.

## Motivation

cert-manager/cert-manager#8994 — discovered shortly after the 1.21.0
release. The generics refactor in #8407 changed the handler signature
from `func(interface{})` to `func(U)`, which broke the dual-informer
Secret handler path.

## Test plan

- `go test ./pkg/controller/` — `TestBlockingEventHandler`,
  `TestQueuingEventHandler`, `TestFilterEventHandler`,
  `TestOnlyUpdateWhenResourceChanged` all pass
- `go test ./pkg/controller/certificates/...` — all pass
- `go test ./pkg/controller/issuers/...` — pass
- `go test ./pkg/controller/clusterissuers/...` — pass
- `go test ./internal/informers/...` — pass