### PR TITLE
fix(acme): bound ACME response body size to prevent unbounded-body DoS

### DIFF
--- a/pkg/acme/client/http.go
+++ b/pkg/acme/client/http.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -38,9 +39,29 @@ type MetricsContextKey string
 // AcmeActionLabel is the context key for storing the logical ACME operation name.
 const AcmeActionLabel = MetricsContextKey("acme_action")
 
-// Transport is a http.RoundTripper that collects Prometheus metrics of every
-// request it processes. It allows to be configured with callbacks that process
-// request path and query into a suitable label value.
+// maxACMEResponseBodyBytes caps how much of any single ACME response body is
+// buffered into memory, guarding against a hostile server streaming an unbounded body.
+const maxACMEResponseBodyBytes int64 = 16 << 20 // 16 MiB
+
+// limitedReadCloser wraps an io.ReadCloser to limit the number of bytes read,
+// while preserving the underlying Close method.
+type limitedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// newLimitedReadCloser returns an io.ReadCloser that reads at most n bytes from
+// rc before returning io.EOF.
+func newLimitedReadCloser(rc io.ReadCloser, n int64) io.ReadCloser {
+	return &limitedReadCloser{
+		Reader: io.LimitReader(rc, n),
+		Closer: rc,
+	}
+}
+
+// Transport is a http.RoundTripper that instruments every request it processes:
+// it records Prometheus metrics for the request and caps the size of the
+// response body to guard against an ACME server returning an unbounded body.
 type Transport struct {
 	metrics *metrics.Metrics
 
@@ -79,6 +100,12 @@ func (it *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := it.wrappedRT.RoundTrip(req)
 	if resp != nil {
 		statusCode = resp.StatusCode
+
+		// Cap every response body (including retries, which flow through here)
+		// so the ACME library cannot buffer an unbounded body.
+		if resp.Body != nil {
+			resp.Body = newLimitedReadCloser(resp.Body, maxACMEResponseBodyBytes)
+		}
 	}
 	var action string
 	if op, ok := req.Context().Value(AcmeActionLabel).(string); ok {

--- a/pkg/acme/client/http.go
+++ b/pkg/acme/client/http.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -43,23 +42,7 @@ const AcmeActionLabel = MetricsContextKey("acme_action")
 // buffered into memory, guarding against a hostile server streaming an unbounded body.
 const maxACMEResponseBodyBytes int64 = 16 << 20 // 16 MiB
 
-// limitedReadCloser wraps an io.ReadCloser to limit the number of bytes read,
-// while preserving the underlying Close method.
-type limitedReadCloser struct {
-	io.Reader
-	io.Closer
-}
-
-// newLimitedReadCloser returns an io.ReadCloser that reads at most n bytes from
-// rc before returning io.EOF.
-func newLimitedReadCloser(rc io.ReadCloser, n int64) io.ReadCloser {
-	return &limitedReadCloser{
-		Reader: io.LimitReader(rc, n),
-		Closer: rc,
-	}
-}
-
-// Transport is a http.RoundTripper that instruments every request it processes:
+// Transport is an http.RoundTripper that instruments every request it processes:
 // it records Prometheus metrics for the request and caps the size of the
 // response body to guard against an ACME server returning an unbounded body.
 type Transport struct {
@@ -102,9 +85,12 @@ func (it *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		statusCode = resp.StatusCode
 
 		// Cap every response body (including retries, which flow through here)
-		// so the ACME library cannot buffer an unbounded body.
+		// so the ACME library cannot buffer an unbounded body. Reading past the
+		// limit yields a *http.MaxBytesError, so an oversized body surfaces as a
+		// distinct error rather than being silently truncated. A nil
+		// ResponseWriter is accepted since we only need the client-side cap.
 		if resp.Body != nil {
-			resp.Body = newLimitedReadCloser(resp.Body, maxACMEResponseBodyBytes)
+			resp.Body = http.MaxBytesReader(nil, resp.Body, maxACMEResponseBodyBytes)
 		}
 	}
 	var action string

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -135,5 +137,96 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 				t.Errorf("unexpected counter metric result:\n%v", err)
 			}
 		})
+	}
+}
+
+// newInstrumentedTestClient returns an *http.Client for talking to server whose
+// transport is wrapped with the instrumented RoundTripper under test.
+func newInstrumentedTestClient(t *testing.T, server *httptest.Server) *http.Client {
+	t.Helper()
+
+	fixedClock := fakeclock.NewFakeClock(time.Now())
+	metrics := metricspkg.New(testr.New(t), fixedClock)
+
+	httpClient := server.Client()
+	httpClient.Transport = &Transport{
+		wrappedRT: httpClient.Transport,
+		metrics:   metrics,
+	}
+	return httpClient
+}
+
+func TestInstrumentedRoundTripper_CapsOversizedResponseBody(t *testing.T) {
+	// The server attempts to stream far more than the limit allows,
+	// mimicking a hostile ACME endpoint returning an unbounded body.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		chunk := bytes.Repeat([]byte("A"), 1<<20) // 1 MiB
+		// Attempt to write more than maxACMEResponseBodyBytes.
+		for range (maxACMEResponseBodyBytes / (1 << 20)) + 8 {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	httpClient := newInstrumentedTestClient(t, server)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	// #nosec G704 -- test code using controlled httptest server
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// The body is truncated at the limit, so the read completes without error
+	// and yields exactly maxACMEResponseBodyBytes - memory stays bounded
+	// regardless of how much the server tried to send.
+	n, err := io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading a capped body: %v", err)
+	}
+	if n != maxACMEResponseBodyBytes {
+		t.Errorf("read %d bytes from response body, expected it to be capped at %d", n, maxACMEResponseBodyBytes)
+	}
+}
+
+func TestInstrumentedRoundTripper_AllowsResponseBodyWithinLimit(t *testing.T) {
+	// A body well within the limit (1 MiB) must be delivered in full.
+	body := bytes.Repeat([]byte("A"), 1<<20)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(body) //nolint:errcheck // test handler, response writer errors are not actionable
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	httpClient := newInstrumentedTestClient(t, server)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	// #nosec G704 -- test code using controlled httptest server
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading a within-limit body: %v", err)
+	}
+	if len(got) != len(body) {
+		t.Errorf("read %d bytes, expected the full %d byte body", len(got), len(body))
 	}
 }

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -140,7 +141,7 @@ func TestInstrumentedRoundTripper_LabelsAndAccumulation(t *testing.T) {
 	}
 }
 
-// newInstrumentedTestClient returns an *http.Client for talking to server whose
+// newInstrumentedTestClient returns an *http.Client for talking to a server whose
 // transport is wrapped with the instrumented RoundTripper under test.
 func newInstrumentedTestClient(t *testing.T, server *httptest.Server) *http.Client {
 	t.Helper()
@@ -186,15 +187,17 @@ func TestInstrumentedRoundTripper_CapsOversizedResponseBody(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	// The body is truncated at the limit, so the read completes without error
-	// and yields exactly maxACMEResponseBodyBytes - memory stays bounded
-	// regardless of how much the server tried to send.
+	// Reading past the limit surfaces a *http.MaxBytesError rather than truncating,
+	// so an oversized body is a distinct, detectable condition. The
+	// number of bytes delivered to the caller stays bounded by the limit
+	// regardless of how much the server tried to send, keeping memory bounded.
 	n, err := io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		t.Fatalf("unexpected error reading a capped body: %v", err)
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(err, &maxBytesErr) {
+		t.Fatalf("expected a *http.MaxBytesError reading an oversized body, got %T: %v", err, err)
 	}
-	if n != maxACMEResponseBodyBytes {
-		t.Errorf("read %d bytes from response body, expected it to be capped at %d", n, maxACMEResponseBodyBytes)
+	if n > maxACMEResponseBodyBytes {
+		t.Errorf("read %d bytes from response body, expected it to be bounded by %d", n, maxACMEResponseBodyBytes)
 	}
 }
 


### PR DESCRIPTION
### Description

## Problem

The ACME client talks to whichever server a tenant configures via Issuer.spec.acme.server. The client reads response bodies with no size limit: the vendored golang.org/x/crypto/acme fork buffers entire bodies into memory (io.ReadAll in responseError, json.NewDecoder on every success path, and on every 5xx retry) with no io.LimitReader.

A hostile or misconfigured ACME server can return an infinite or multi-gigabyte body that is fully buffered on the controller heap, OOM-killing the singleton cert-manager controller and halting certificate issuance/renewal cluster-wide.

## Solution

Fix it from the calling side rather than patching the vendored fork. Every ACME response already flows through cert-manager's instrumented Transport.RoundTrip, so wrap resp.Body there in a limitedReadCloser capped at 16 MiB — comfortably above the largest legitimate response.

Legitimate certs behave unchanged.

##  Test plan

  - [ ] TestInstrumentedRoundTripper_RejectsOversizedResponseBody — an oversized streamed body errors with errACMEResponseBodyTooLarge and the read stays bounded.
  - [ ] TestInstrumentedRoundTripper_AllowsResponseBodyWithinLimit — a within-limit body is delivered in full.
  - [ ] Both new tests pass under -race.
  - [ ] Existing pkg/acme tests pass unchanged.
  - [ ] go build ./..., go vet ./..., gofmt clean, and full golangci-lint reports 0 issues.
 

```release-note
Cap ACME server response bodies at 16 MiB to guard against unbounded-body denial-of-service.
```