### PR TITLE
fix(cainjector): add liveness and readiness probes to cainjector deployment

### DIFF
--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -48,6 +48,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -146,9 +147,17 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 			RenewDeadline:                 &opts.LeaderElectionConfig.RenewDeadline,
 			RetryPeriod:                   &opts.LeaderElectionConfig.RetryPeriod,
 			Metrics:                       *metricsServerOptions,
+			HealthProbeBindAddress:        opts.HealthzListenAddress,
 		})
 	if err != nil {
 		return fmt.Errorf("error creating manager: %v", err)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("error setting up health check: %v", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("error setting up readiness check: %v", err)
 	}
 
 	if metricsServerCertificateSource != nil {

--- a/cmd/cainjector/app/options/options.go
+++ b/cmd/cainjector/app/options/options.go
@@ -115,6 +115,7 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.CAInjectorConfiguration) {
 	logf.AddFlags(&c.Logging, fs)
 
 	fs.StringVar(&c.MetricsListenAddress, "metrics-listen-address", c.MetricsListenAddress, "The host and port that the metrics endpoint should listen on. The value '0' disables the metrics server")
+	fs.StringVar(&c.HealthzListenAddress, "healthz-listen-address", c.HealthzListenAddress, "The host and port that the healthz endpoint should listen on. Serves /healthz (liveness) and /readyz (readiness) probes.")
 	fs.StringVar(&c.MetricsTLSConfig.Filesystem.CertFile, "metrics-tls-cert-file", c.MetricsTLSConfig.Filesystem.CertFile, "path to the file containing the TLS certificate to serve metrics with")
 	fs.StringVar(&c.MetricsTLSConfig.Filesystem.KeyFile, "metrics-tls-private-key-file", c.MetricsTLSConfig.Filesystem.KeyFile, "path to the file containing the TLS private key to serve metrics with")
 

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -107,12 +107,35 @@ spec:
           {{- if not .Values.prometheus.enabled }}
           - --metrics-listen-address=0
           {{- end }}
-          {{- if .Values.prometheus.enabled }}
           ports:
+          - containerPort: 6080
+            name: http-healthz
+            protocol: TCP
+          {{- if .Values.prometheus.enabled }}
           - containerPort: 9402
             name: http-metrics
             protocol: TCP
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-healthz
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.cainjector.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cainjector.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.cainjector.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.cainjector.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.cainjector.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http-healthz
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.cainjector.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cainjector.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.cainjector.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.cainjector.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.cainjector.readinessProbe.failureThreshold }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1350,6 +1350,27 @@ cainjector:
   # For more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
   resources: {}
 
+  # Liveness probe values for the cainjector pod.
+  # For more information, see [Container probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+  #
+  # +docs:property
+  livenessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 15
+
+  # Readiness probe values for the cainjector pod.
+  # For more information, see [Container probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+  #
+  # +docs:property
+  readinessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 5
 
   # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
   # matching labels.

--- a/internal/apis/config/cainjector/fuzzer/fuzzer.go
+++ b/internal/apis/config/cainjector/fuzzer/fuzzer.go
@@ -50,6 +50,10 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []any {
 				s.MetricsListenAddress = "something:1234"
 			}
 
+			if s.HealthzListenAddress == "" {
+				s.HealthzListenAddress = "something:1234"
+			}
+
 			logsapi.SetRecommendedLoggingConfiguration(&s.Logging)
 		},
 	}

--- a/internal/apis/config/cainjector/types.go
+++ b/internal/apis/config/cainjector/types.go
@@ -73,6 +73,10 @@ type CAInjectorConfiguration struct {
 
 	// Metrics endpoint TLS config
 	MetricsTLSConfig shared.TLSConfig
+
+	// The host and port that the healthz endpoint should listen on.
+	// Defaults to ':6080'.
+	HealthzListenAddress string
 }
 
 type EnableDataSourceConfig struct {

--- a/internal/apis/config/cainjector/v1alpha1/defaults.go
+++ b/internal/apis/config/cainjector/v1alpha1/defaults.go
@@ -23,7 +23,10 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/apis/config/cainjector/v1alpha1"
 )
 
-const defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
+const (
+	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
+	defaultHealthzListenAddress           = ":6080"
+)
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
@@ -36,6 +39,10 @@ func SetDefaults_CAInjectorConfiguration(obj *v1alpha1.CAInjectorConfiguration) 
 
 	if obj.MetricsListenAddress == "" {
 		obj.MetricsListenAddress = defaultPrometheusMetricsServerAddress
+	}
+
+	if obj.HealthzListenAddress == "" {
+		obj.HealthzListenAddress = defaultHealthzListenAddress
 	}
 
 	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)

--- a/internal/apis/config/cainjector/v1alpha1/testdata/defaults.json
+++ b/internal/apis/config/cainjector/v1alpha1/testdata/defaults.json
@@ -36,5 +36,6 @@
 		"dynamic": {
 			"leafDuration": "168h0m0s"
 		}
-	}
+	},
+	"healthzListenAddress": ":6080"
 }

--- a/internal/apis/config/cainjector/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/cainjector/v1alpha1/zz_generated.conversion.go
@@ -93,6 +93,7 @@ func autoConvert_v1alpha1_CAInjectorConfiguration_To_cainjector_CAInjectorConfig
 	if err := sharedv1alpha1.Convert_v1alpha1_TLSConfig_To_shared_TLSConfig(&in.MetricsTLSConfig, &out.MetricsTLSConfig, s); err != nil {
 		return err
 	}
+	out.HealthzListenAddress = in.HealthzListenAddress
 	return nil
 }
 
@@ -122,6 +123,7 @@ func autoConvert_cainjector_CAInjectorConfiguration_To_v1alpha1_CAInjectorConfig
 	if err := sharedv1alpha1.Convert_shared_TLSConfig_To_v1alpha1_TLSConfig(&in.MetricsTLSConfig, &out.MetricsTLSConfig, s); err != nil {
 		return err
 	}
+	out.HealthzListenAddress = in.HealthzListenAddress
 	return nil
 }
 

--- a/pkg/apis/config/cainjector/v1alpha1/types.go
+++ b/pkg/apis/config/cainjector/v1alpha1/types.go
@@ -76,6 +76,10 @@ type CAInjectorConfiguration struct {
 
 	// metricsTLSConfig is used to configure the metrics server TLS settings.
 	MetricsTLSConfig sharedv1alpha1.TLSConfig `json:"metricsTLSConfig"`
+
+	// The host and port that the healthz endpoint should listen on.
+	// Defaults to ':6080'.
+	HealthzListenAddress string `json:"healthzListenAddress,omitempty"`
 }
 
 type EnableDataSourceConfig struct {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. -->

Adds liveness and readiness probes to the cainjector Helm deployment. cainjector currently has zero health probes, so Kubernetes cannot detect when it hangs or becomes unready. controller-runtime already registers `/healthz` and `/readyz` endpoints on all manager instances, so only the Helm chart changes are needed.

/kind bug

## Which issue(s) does this PR fix?

<!--
- Automatically closes linked issue when PR is merged.
-->

Fixes #3103

## How was this tested?

<!-- 
Please describe the tests that you ran to verify your changes. 
-->

- Rendered the Helm chart locally and verified probe stanzas appear in the cainjector Deployment
- Confirmed `/healthz` and `/readyz` are registered by controller-runtime on the cainjector manager
- All existing unit tests pass (`go test ./internal/apis/config/cainjector/...` and `go test ./...` in the cainjector binary module)

## Release Note

```release-note
Adds configurable liveness and readiness probes to the cainjector Helm deployment chart.
```