### PR TITLE
fix(acme): accept ECDSA account private keys in addition to RSA

### DIFF
--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -42,7 +42,7 @@ type NewClientOptions struct {
 	SkipTLSVerify bool
 	CABundle      []byte
 	Server        string
-	PrivateKey    *rsa.PrivateKey
+	PrivateKey    crypto.Signer
 }
 
 // NewClientFunc is a function type for building a new ACME client.

--- a/pkg/acme/accounts/registry.go
+++ b/pkg/acme/accounts/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package accounts
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -44,7 +44,7 @@ type Registry interface {
 
 	// IsKeyCheckSumCached checks if the private key checksum is cached with registered client.
 	// If not cached, the account is re-verified for the private key.
-	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 
 	Getter
 }
@@ -88,8 +88,7 @@ type stableOptions struct {
 	serverURL     string
 	skipVerifyTLS bool
 	issuerUID     string
-	publicKey     string
-	exponent      int
+	publicKeyDER  string
 	caBundle      string
 	keyChecksum   [sha256.Size]byte
 }
@@ -99,16 +98,17 @@ func (c stableOptions) equalTo(c2 stableOptions) bool {
 }
 
 func newStableOptions(uid string, options NewClientOptions) stableOptions {
-	// Encoding a big.Int cannot fail
-	publicNBytes, _ := options.PrivateKey.PublicKey.N.GobEncode()
-	checksum := sha256.Sum256(x509.MarshalPKCS1PrivateKey(options.PrivateKey))
+	// MarshalPKIXPublicKey supports RSA, ECDSA, and Ed25519 keys;
+	// encoding cannot fail for valid crypto.Signer implementations.
+	pubKeyDER, _ := x509.MarshalPKIXPublicKey(options.PrivateKey.Public())
+	privKeyDER, _ := x509.MarshalPKCS8PrivateKey(options.PrivateKey)
+	checksum := sha256.Sum256(privKeyDER)
 
 	return stableOptions{
 		serverURL:     options.Server,
 		skipVerifyTLS: options.SkipTLSVerify,
 		issuerUID:     uid,
-		publicKey:     string(publicNBytes),
-		exponent:      options.PrivateKey.PublicKey.E,
+		publicKeyDER:  string(pubKeyDER),
 		caBundle:      string(options.CABundle),
 		keyChecksum:   checksum,
 	}
@@ -197,12 +197,15 @@ func (r *registry) ListClients() map[string]acmecl.Interface {
 // IsKeyCheckSumCached returns true when there is no difference in private key checksum.
 // This can be used to identify if the private key has changed for the existing
 // registered client.
-func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (r *registry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
 	if privateKey != nil && lastPrivateKeyHash != "" {
-		privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return false
+		}
 		checksum := sha256.Sum256(privateKeyBytes)
 		checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 

--- a/pkg/acme/accounts/registry_test.go
+++ b/pkg/acme/accounts/registry_test.go
@@ -187,7 +187,10 @@ func TestRegistry_AddClient_UpdatesClientPKChecksum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkBytes := x509.MarshalPKCS1PrivateKey(pk)
+	pkBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %v", err)
+	}
 	pkChecksum := sha256.Sum256(pkBytes)
 	pkChecksumString := base64.StdEncoding.EncodeToString(pkChecksum[:])
 

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"crypto/rsa"
+	"crypto"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -31,7 +31,7 @@ type FakeRegistry struct {
 	RemoveClientFunc        func(uid string)
 	GetClientFunc           func(uid string) (acmecl.Interface, error)
 	ListClientsFunc         func() map[string]acmecl.Interface
-	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool
+	IsKeyCheckSumCachedFunc func(lastPrivateKeyHash string, privateKey crypto.Signer) bool
 }
 
 func (f *FakeRegistry) AddClient(uid string, options accounts.NewClientOptions) {
@@ -50,6 +50,6 @@ func (f *FakeRegistry) ListClients() map[string]acmecl.Interface {
 	return f.ListClientsFunc()
 }
 
-func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+func (f *FakeRegistry) IsKeyCheckSumCached(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 	return f.IsKeyCheckSumCachedFunc(lastPrivateKeyHash, privateKey)
 }

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -18,7 +18,7 @@ package acme
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -67,7 +67,6 @@ const (
 	messageInvalidPrivateKey             = "Account private key is invalid: "
 
 	messageTemplateUpdateToV2              = "Your ACME server URL is set to a v1 endpoint (%s). You should update the spec.acme.server field to %q"
-	messageTemplateNotRSA                  = "ACME private key in %q is not of type RSA"
 	messageTemplateFailedToParseURL        = "Failed to parse existing ACME server URI %q: %v"
 	messageTemplateFailedToParseAccountURL = "Failed to parse existing ACME account URI %q: %v"
 	messageTemplateFailedToGetEABKey       = "failed to get External Account Binding key from secret: %v"
@@ -176,19 +175,6 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			message: msg,
 		}
 	}
-	rsaPk, ok := pk.(*rsa.PrivateKey)
-	if !ok {
-		msg := fmt.Sprintf(messageTemplateNotRSA,
-			issuer.GetSpec().ACME.PrivateKey.Name)
-		return setupResult{
-			err: nil,
-
-			status:  cmmeta.ConditionFalse,
-			reason:  errorAccountVerificationFailed,
-			message: msg,
-		}
-	}
-
 	if warning := a.validateDNSSolvers(ctx, issuer); len(warning) > 0 {
 		return setupResult{
 			err:     nil,
@@ -198,7 +184,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		}
 	}
 
-	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, rsaPk)
+	isPKChecksumSame := a.accountRegistry.IsKeyCheckSumCached(issuer.GetStatus().ACMEStatus().LastPrivateKeyHash, pk)
 
 	// TODO: don't always clear the client cache.
 	//  In future we should intelligently manage items in the account cache
@@ -213,7 +199,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	// TODO: perform a complex check to determine whether we need to verify
@@ -275,7 +261,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 			CABundle:      issuer.GetSpec().ACME.CABundle,
 			Server:        issuer.GetSpec().ACME.Server,
-			PrivateKey:    rsaPk,
+			PrivateKey:    pk,
 		})
 
 		return setupResult{
@@ -423,7 +409,17 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 	}
 
 	log.V(logf.InfoLevel).Info("verified existing registration with ACME server")
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(rsaPk)
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		msg := messageAccountVerificationFailed + "failed to marshal account private key: " + err.Error()
+		return setupResult{
+			err: fmt.Errorf("%s", msg),
+
+			status:  cmmeta.ConditionFalse,
+			reason:  errorAccountVerificationFailed,
+			message: msg,
+		}
+	}
 	checksum := sha256.Sum256(privateKeyBytes)
 	checksumString := base64.StdEncoding.EncodeToString(checksum[:])
 	issuer.GetStatus().ACMEStatus().URI = account.URI
@@ -434,7 +430,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		SkipTLSVerify: issuer.GetSpec().ACME.SkipTLSVerify,
 		CABundle:      issuer.GetSpec().ACME.CABundle,
 		Server:        issuer.GetSpec().ACME.Server,
-		PrivateKey:    rsaPk,
+		PrivateKey:    pk,
 	})
 
 	return setupResult{
@@ -539,7 +535,7 @@ func (a *Acme) getEABKey(ctx context.Context, ns string, eab cmmeta.SecretKeySel
 
 // createAccountPrivateKey will generate a new RSA private key, and create it
 // as a secret resource in the apiserver.
-func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (*rsa.PrivateKey, error) {
+func (a *Acme) createAccountPrivateKey(ctx context.Context, sel cmmeta.SecretKeySelector, ns string) (crypto.Signer, error) {
 	sel = acme.PrivateKeySelector(sel)
 	accountPrivKey, err := pki.GenerateRSAPrivateKey(pki.MinRSAKeySize)
 	if err != nil {

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -19,7 +19,6 @@ package acme
 import (
 	"context"
 	"crypto"
-	"crypto/rsa"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -133,7 +132,7 @@ func TestAcme_Setup(t *testing.T) {
 		// Error returned when creating ACME account key.
 		acmePrivKeySecretCreateErr error
 		// ACME account key created by createAccountPrivateKey.
-		acmePrivKey *rsa.PrivateKey
+		acmePrivKey crypto.Signer
 
 		eabSecret       *corev1.Secret
 		eabSecretGetErr error
@@ -190,7 +189,7 @@ func TestAcme_Setup(t *testing.T) {
 		"ACME private key secret does not exist, account key generation is enabled, key creation succeeds": {
 			issuer:      gen.IssuerFrom(baseIssuer),
 			kfsErr:      notFoundErr,
-			acmePrivKey: rsaPrivKey.(*rsa.PrivateKey),
+			acmePrivKey: rsaPrivKey,
 			expectedConditions: []cmapi.IssuerCondition{
 				*gen.IssuerConditionFrom(readyTrueCondition)},
 			removeClientShouldBeCalled: true,
@@ -216,15 +215,15 @@ func TestAcme_Setup(t *testing.T) {
 			},
 			wantsErr: true,
 		},
-		"ACME account's key is not an RSA key": {
+		"ACME account key with ECDSA P-256 is accepted": {
 			issuer: gen.IssuerFrom(baseIssuer,
 				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
-			kfsKey: ecdsaPrivKey,
+			kfsKey:                     ecdsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
 			expectedConditions: []cmapi.IssuerCondition{
-				*gen.IssuerConditionFrom(readyFalseCondition,
-					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateNotRSA, issuerSecretKeyName))),
-			},
+				*gen.IssuerConditionFrom(readyTrueCondition)},
 		},
 		"ACME server URL is an invalid URL": {
 			issuer: gen.IssuerFrom(baseIssuer,
@@ -544,7 +543,7 @@ func TestAcme_Setup(t *testing.T) {
 				AddClientFunc: func(string, accounts.NewClientOptions) {
 					addClientWasCalled = true
 				},
-				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey *rsa.PrivateKey) bool {
+				IsKeyCheckSumCachedFunc: func(lastPrivateKeyHash string, privateKey crypto.Signer) bool {
 					return true
 				},
 			}


### PR DESCRIPTION
## What does this PR do?

Removes the hard-coded RSA-only restriction in the ACME issuer setup so that users who already have an ACME account with an ECDSA key (created via certbot, acme.sh, or any other ACME client) can reuse that account in cert-manager without regenerating it as RSA.

The account private key generation continues to produce RSA keys by default. This change only widens the accepted key types for **existing** keys supplied via `spec.acme.privateKeySecretRef`.

/kind bug

## Which issue(s) does this PR fix?

Fixes #8434

## How was this tested?

- Added unit tests for RSA (existing) and ECDSA P-256 (new) account keys
- All existing ACME setup tests continue to pass

## Release Note

\`\`\`release-note
The ACME issuer now accepts ECDSA account private keys in addition to RSA keys, allowing reuse of ACME accounts originally created with ECDSA keys by other clients.
\`\`\`