### PR TITLE
chore(acme): forbid direct construction of the forked ACME client

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,22 @@ linters:
       max-blank-identifiers: 4
     exhaustive:
       default-signifies-exhaustive: true
+    forbidigo:
+      # Resolve each expression's real type so rules can match by import path
+      # regardless of the local import alias
+      analyze-types: true
+      forbid:
+        # golangci-lint only applies its built-in "forbid" list when none is
+        # configured; defining our own replaces it, so the default rule banning
+        # stray debug prints is repeated here.
+        - pattern: ^(fmt\.Print(|f|ln)|print|println)$
+          msg: Do not commit print statements.
+        # Ban naming the forked ACME client type (e.g. constructing acme.Client)
+        # so clients can only be created via pkg/acme/accounts.NewClient.
+        - pattern: \.Client$
+          pkg: ^github\.com/cert-manager/cert-manager/third_party/forked/acme$
+          msg: >-
+            Do not construct the forked ACME client directly; obtain one via pkg/acme/accounts.NewClient.
     gosec:
       excludes:
         - G101 # Look for hardcoded credentials

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -60,7 +60,9 @@ func NewClient(
 }
 
 func newClientFromHTTPClient(httpClient *http.Client, userAgent string, options NewClientOptions) acmecl.Interface {
-	return middleware.NewLogger(&acmeapi.Client{
+	// The only sanctioned place to construct the ACME client,
+	// forbidigo forces all other callers through NewClient.
+	return middleware.NewLogger(&acmeapi.Client{ //nolint:forbidigo // sanctioned ACME client constructor
 		Key:          options.PrivateKey,
 		HTTPClient:   httpClient,
 		DirectoryURL: options.Server,

--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -65,6 +65,7 @@ type Interface interface { //nolint:interfacebloat
 	GetRenewalInfo(ctx context.Context, cert *x509.Certificate) (*acme.RenewalInfoResponse, error)
 }
 
-var _ Interface = &acme.Client{
+// Compile-time assertion that *acme.Client satisfies Interface.
+var _ Interface = &acme.Client{ //nolint:forbidigo // compile-time interface assertion, not a client instance
 	RetryBackoff: acmeutil.RetryBackoff,
 }


### PR DESCRIPTION
# Description

## Problem

The forked golang.org/x/crypto/acme client is only safe to use when built through pkg/acme/accounts.NewClient — that constructor is what wires in the hardened HTTP client (custom TLS config, Prometheus instrumentation, and the response-body size cap added in [#9010](https://github.com/cert-manager/cert-manager/pull/9010)). 

Nothing currently stops a developer from constructing a raw acme.Client{} elsewhere, which bypasses all of those protections and could reintroduce issues like the unbounded-body DoS. This was out-of-scope for that fix, so it's split out here.

## Solution

Add a forbidigo rule that bans naming the forked acme.Client type. With analyze-types: true the rule matches by import path, so it catches any import alias (acme, acmeapi, …) and ignores unrelated types such as net/http.Client. The two legitimate sites — the NewClient constructor and the compile-time var _ Interface = &acme.Client{} assertion — are exempted with an inline //nolint:forbidigo. No runtime behaviour changes; this is a lint-only guardrail.

## Test plan

  - [ ] forbidigo flags direct acme.Client construction — verified by temporarily adding a rogue &acmeapi.Client{} in pkg/controller/acmeorders, running the linter (reported as an error, exit non-zero), then removing the file.
  - [ ] The two sanctioned sites carry //nolint:forbidigo, and nolintlint confirms both directives are valid and in use.
  - [ ] verify-generate-golangci-lint-config passes; golangci-lint config verify is clean.
  - [ ] Existing pkg/acme tests pass unchanged; go build ./..., go vet ./..., gofmt clean, and full golangci-lint reports 0 issues.
  
## Release Note

​```release-note
NONE
​```