### PR TITLE
fix(acme): treat 404 as retryable error for ACME server replication lag

### DIFF
--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -23,24 +23,36 @@ import (
 )
 
 const (
-	maxDelay   = 3 * time.Second
-	maxRetries = 5
+	maxDelay       = 3 * time.Second
+	maxRetries     = 5
+	maxRetries404  = 3
 )
 
 // RetryBackoff is the ACME client RetryBackoff which is modified
-// to act upon badNonce errors. all other retries will be handled by cert-manager.
+// to act upon badNonce and 404 errors. All other retries will be handled by cert-manager.
 // Since we cannot check the exact error this is best effort.
 func RetryBackoff(n int, r *http.Request, resp *http.Response) time.Duration {
 
 	// According to the spec badNonce is urn:ietf:params:acme:error:badNonce.
 	// However, we cannot use the request body in here as it is closed already.
 	// So we're using its status code instead: 400
-	if resp.StatusCode != http.StatusBadRequest {
+	//
+	// A 404 Not Found can also occur transiently due to ACME server replication lag
+	// (e.g. Let's Encrypt), where a resource created via POST is not yet visible on
+	// a read replica. See: https://github.com/cert-manager/cert-manager/issues/8939
+	retryable := resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound
+	if !retryable {
 		return -1
 	}
 
-	// don't retry more than 6 times, if we get 6 nonce mismatches something is quite wrong
-	if n > maxRetries {
+	// Differentiate retry limits based on error type.
+	// badNonce (400): more retries needed as nonce desync can persist.
+	// 404: fewer retries as replication lag is typically very short-lived.
+	if resp.StatusCode == http.StatusNotFound {
+		if n >= maxRetries404 {
+			return -1
+		}
+	} else if n > maxRetries {
 		return -1
 	}
 

--- a/pkg/acme/util/util_test.go
+++ b/pkg/acme/util/util_test.go
@@ -77,6 +77,39 @@ func TestRetryBackoff(t *testing.T) {
 				return duration == -1
 			},
 		},
+		{
+			name: "Retry a 404 error when the first time",
+			args: args{
+				n:    0,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			validateOutput: func(duration time.Duration) bool {
+				return duration > 0
+			},
+		},
+		{
+			name: "Retry a 404 error when less than 3 times",
+			args: args{
+				n:    2,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			validateOutput: func(duration time.Duration) bool {
+				return duration > 0
+			},
+		},
+		{
+			name: "Do not retry a 404 error after 3 tries",
+			args: args{
+				n:    3,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			validateOutput: func(duration time.Duration) bool {
+				return duration == -1
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/third_party/forked/acme/http.go
+++ b/third_party/forked/acme/http.go
@@ -318,8 +318,13 @@ func isBadNonce(err error) bool {
 //
 // Note that a "bad nonce" error is returned with a non-retriable 400 Bad Request code.
 // Callers should parse the response and check with isBadNonce.
+//
+// A 404 Not Found response is also considered retriable because some ACME servers
+// (e.g. Let's Encrypt) use replicated databases which can cause transient 404 errors
+// for recently created resources due to replication lag. See:
+// https://github.com/cert-manager/cert-manager/issues/8939
 func isRetriable(code int) bool {
-	return code <= 399 || code >= 500 || code == http.StatusTooManyRequests
+	return code <= 399 || code >= 500 || code == http.StatusTooManyRequests || code == http.StatusNotFound
 }
 
 // responseError creates an error of Error type from resp.

--- a/third_party/forked/acme/http_test.go
+++ b/third_party/forked/acme/http_test.go
@@ -239,6 +239,78 @@ func TestUserAgent(t *testing.T) {
 	}
 }
 
+func TestPostRetriesOnNotFound(t *testing.T) {
+	// Verify that 404 responses are retried on POST, simulating ACME server replication lag.
+	// See: https://github.com/cert-manager/cert-manager/issues/8939
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Replay-Nonce", "test-nonce")
+		if r.Method == "HEAD" {
+			return
+		}
+
+		postCount++
+		if postCount <= 2 {
+			// Return 404 for the first 2 POST attempts to simulate replication lag.
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"type":"urn:ietf:params:acme:error:malformed","detail":"Not Found"}`))
+			return
+		}
+		// Succeed on the 3rd POST attempt.
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"status":"valid"}`))
+	}))
+	defer ts.Close()
+
+	client := &Client{
+		Key:          testKey,
+		DirectoryURL: ts.URL,
+		dir:          &Directory{AuthzURL: ts.URL},
+	}
+
+	if _, err := client.Authorize(context.Background(), "example.com"); err != nil {
+		t.Errorf("client.Authorize: %v", err)
+	}
+	// Should have retried and eventually succeeded after 3 POST attempts.
+	if postCount != 3 {
+		t.Errorf("total POST requests count: %d; want 3", postCount)
+	}
+}
+
+func TestGetRetriesOnNotFound(t *testing.T) {
+	// Verify that 404 responses are retried on GET, simulating ACME server replication lag.
+	// See: https://github.com/cert-manager/cert-manager/issues/8939
+	var getCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getCount++
+		if getCount <= 2 {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"type":"urn:ietf:params:acme:error:malformed","detail":"Not Found"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"valid","identifier":{"type":"dns","value":"example.com"}}`))
+	}))
+	defer ts.Close()
+
+	client := &Client{
+		Key:          testKey,
+		RetryBackoff: func(n int, r *http.Request, res *http.Response) time.Duration {
+			return time.Millisecond // small delay for tests
+		},
+		dir: &Directory{AuthzURL: ts.URL},
+	}
+
+	_, err := client.GetAuthorization(context.Background(), ts.URL)
+	if err != nil {
+		t.Errorf("client.GetAuthorization: %v", err)
+	}
+	if getCount != 3 {
+		t.Errorf("total GET requests count: %d; want 3", getCount)
+	}
+}
+
 func TestAccountKidLoop(t *testing.T) {
 	// if Client.postNoRetry is called with a nil key argument
 	// then Client.Key must be set, otherwise we fall into an


### PR DESCRIPTION
## Summary

Fixes #8939

Let's Encrypt and other ACME servers use replicated databases which can cause transient 404 errors during the ACME flow. When a resource is created via POST (written to primary), a subsequent read may hit a replica that hasn't synced yet, resulting in a 404 Not Found.

This is a well-documented issue in the Let's Encrypt community:
- https://community.letsencrypt.org/t/acme-404-errors-for-existing-end-to-end-tests-no-such-authorization-certificate-not-found/247849
- https://community.letsencrypt.org/t/getting-intermittent-404-from-lets-encrypt-when-finalizing-an-order/248203
- https://github.com/letsencrypt/boulder/issues/6549

## Changes

1. **`third_party/forked/acme/http.go`**: Added `http.StatusNotFound` (404) to the `isRetriable` function so the ACME client retries on 404 responses.

2. **`pkg/acme/util/util.go`**: Updated `RetryBackoff` to handle 404 responses with a conservative retry limit of 3 attempts (vs 5 for badNonce), since replication lag is typically very short-lived.

3. **Tests**: Added `TestPostRetriesOnNotFound` and `TestGetRetriesOnNotFound` to verify retry behavior on both POST and GET requests. Added unit tests for `RetryBackoff` with 404 status code.

## Design Decisions

- **Retry limit**: 404 retries are capped at 3 (vs 5 for badNonce) because replication lag should resolve within seconds. If the 404 persists beyond 3 attempts, it's likely a genuine configuration error.
- **Backoff**: Uses the same exponential backoff as badNonce (1s base + jitter, capped at 3s).
- **Minimal change**: Only touches the retriable status code check and the backoff function — no changes to the ACME protocol logic.