### PR TITLE
fix(renew): Do not renew a certificate if its renewPolicy=Disabled

### DIFF
--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -273,8 +273,7 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 
 		// If the certificate renewal policy is set to Disabled, do not renew.
 		if crt.Spec.Renewal != nil && crt.Spec.Renewal.Policy == cmapi.CertificateRenewalPolicyDisabled {
-			// renewal policy is set to disabled, do not renew
-			return RenewalDisabled, fmt.Sprintf("The certificate renewal policy is set to %s", cmapi.CertificateRenewalPolicyDisabled), true
+			return RenewalDisabled, fmt.Sprintf("The certificate renewal policy is set to %s", cmapi.CertificateRenewalPolicyDisabled), false
 		}
 
 		reason := Renewing

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -271,6 +271,12 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 		notAfter := metav1.NewTime(x509Cert.NotAfter)
 		crt := input.Certificate
 
+		// If the certificate renewal policy is set to Disabled, do not renew.
+		if crt.Spec.Renewal != nil && crt.Spec.Renewal.Policy == cmapi.CertificateRenewalPolicyDisabled {
+			// renewal policy is set to disabled, do not renew
+			return RenewalDisabled, fmt.Sprintf("The certificate renewal policy is set to %s", cmapi.CertificateRenewalPolicyDisabled), true
+		}
+
 		reason := Renewing
 		message := fmt.Sprintf("Renewing certificate as renewal was scheduled at %s", input.Certificate.Status.RenewalTime)
 

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -273,7 +273,7 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 
 		// If the certificate renewal policy is set to Disabled, do not renew.
 		if crt.Spec.Renewal != nil && crt.Spec.Renewal.Policy == cmapi.CertificateRenewalPolicyDisabled {
-			return RenewalDisabled, fmt.Sprintf("The certificate renewal policy is set to %s", cmapi.CertificateRenewalPolicyDisabled), false
+			return "", "", false
 		}
 
 		reason := Renewing

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -543,6 +543,42 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				},
 			},
 		},
+		"does not trigger renewal if renewal policy is disabled": {
+			certificate: &cmapi.Certificate{
+				Spec: cmapi.CertificateSpec{
+					CommonName: "example.com",
+					IssuerRef: cmmeta.IssuerReference{
+						Name:  "testissuer",
+						Kind:  "IssuerKind",
+						Group: "group.example.com",
+					},
+					Renewal: &cmapi.CertificateRenewal{
+						Policy: cmapi.CertificateRenewalPolicyDisabled,
+					},
+				},
+				Status: cmapi.CertificateStatus{
+					RenewalTime: nil,
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "something",
+					Annotations: map[string]string{
+						cmapi.IssuerNameAnnotationKey:  "testissuer",
+						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+					},
+				},
+				Data: map[string][]byte{
+					corev1.TLSPrivateKeyKey: staticFixedPrivateKey,
+					corev1.TLSCertKey: testcrypto.MustCreateCertWithNotBeforeAfter(t, staticFixedPrivateKey,
+						&cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.com"}},
+						clock.Now().Add(time.Minute*-30),
+						// expires in 5 minutes time
+						clock.Now().Add(time.Minute*5),
+					),
+				},
+			},
+		},
 	}
 	policyChain := NewTriggerPolicyChain(clock)
 	for name, test := range tests {

--- a/internal/controller/certificates/policies/constants.go
+++ b/internal/controller/certificates/policies/constants.go
@@ -66,6 +66,9 @@ const (
 	// SecretManagedMetadataMismatch is a policy violation whereby the Secret is
 	// missing labels that should have been added by cert-manager
 	SecretManagedMetadataMismatch string = "SecretManagedMetadataMismatch"
+	// RenewalDisabled is a policy violation whereby the Certificate's
+	// Renewal Policy is set to RenewalDisabled.
+	RenewalDisabled string = "Disabled"
 
 	// AdditionalOutputFormatsMismatch is a policy violation whereby the
 	// Certificate's AdditionalOutputFormats is not reflected on the target

--- a/internal/controller/certificates/policies/constants.go
+++ b/internal/controller/certificates/policies/constants.go
@@ -67,7 +67,7 @@ const (
 	// missing labels that should have been added by cert-manager
 	SecretManagedMetadataMismatch string = "SecretManagedMetadataMismatch"
 	// RenewalDisabled is a policy violation whereby the Certificate's
-	// Renewal Policy is set to RenewalDisabled.
+	// Renewal Policy is set to Disabled.
 	RenewalDisabled string = "Disabled"
 
 	// AdditionalOutputFormatsMismatch is a policy violation whereby the


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/9031

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Avoid controller panic if a Certificate sets spec.renewal.policy=Disabled
```
