### PR TITLE
fix(acme): don't reflect HTTP-01 self-check response body in Challenge

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -316,15 +316,16 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 	}
 
 	if string(presentedKey) != key {
-		// truncate the response before displaying it to avoid extra long strings
-		// being displayed to users
+		// truncate the response before logging it to avoid extra long strings
+		// being displayed to operators
 		keyToPrint := string(presentedKey)
 		if len(keyToPrint) > 24 {
 			// trim spaces to make output look right if it ends with whitespace
 			keyToPrint = strings.TrimSpace(keyToPrint[:24]) + "... (truncated)"
 		}
 		log.V(logf.DebugLevel).Info("key returned by server did not match expected", "actual", keyToPrint, "expected", key)
-		return fmt.Errorf("did not get expected response when querying endpoint, expected %q but got: %s", key, keyToPrint)
+		// The response body is deliberately kept out of the returned error
+		return fmt.Errorf("did not get expected response %q when querying endpoint", key)
 	}
 
 	log.V(logf.DebugLevel).Info("reachability test succeeded")

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -213,12 +213,27 @@ func errorLeaksBody(err error, body string) bool {
 	return strings.Contains(strings.ToLower(err.Error()), strings.ToLower(body))
 }
 
+// maxUntruncatedBodyLen is the length the old (removed) code truncated the
+// reflected body to. A sentinel has to be shorter than this for the tests to be
+// an effective regression test for the future: otherwise the old code would
+// only have leaked a prefix and the tests would pass against it too.
+// assertEffectiveSentinel enforces this.
+const maxUntruncatedBodyLen = 24
+
+func assertEffectiveSentinel(t *testing.T, sentinel string) {
+	t.Helper()
+	if len(sentinel) > maxUntruncatedBodyLen {
+		t.Fatalf("sentinel %q is %d chars; it must be <= %d to be an effective regression test", sentinel, len(sentinel), maxUntruncatedBodyLen)
+	}
+}
+
 // TestReachabilityDoesNotReflectResponseBody ensures that when the endpoint
 // returns a body that does not match the expected key, the contents of that
 // body are not included in the returned error.
 func TestReachabilityDoesNotReflectResponseBody(t *testing.T) {
 	const responseBody = "SENTINEL-BODY"
 	const key = "the-expected-challenge-key"
+	assertEffectiveSentinel(t, responseBody)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, responseBody)
@@ -244,6 +259,7 @@ func TestReachabilityDoesNotReflectResponseBody(t *testing.T) {
 func TestReachabilityDoesNotReflectRedirectedResponseBody(t *testing.T) {
 	const internalBody = "SENTINEL-REDIRECT"
 	const key = "the-expected-challenge-key"
+	assertEffectiveSentinel(t, internalBody)
 
 	// internal represents an internal-only endpoint reachable from the
 	// controller pod but not intended to be exposed to tenants.

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -203,5 +205,70 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 		default:
 			t.Errorf("Unexpected error: %v", err)
 		}
+	}
+}
+
+// errorLeaksBody reports whether err's message contains body.
+func errorLeaksBody(err error, body string) bool {
+	return strings.Contains(strings.ToLower(err.Error()), strings.ToLower(body))
+}
+
+// TestReachabilityDoesNotReflectResponseBody ensures that when the endpoint
+// returns a body that does not match the expected key, the contents of that
+// body are not included in the returned error.
+func TestReachabilityDoesNotReflectResponseBody(t *testing.T) {
+	const responseBody = "SENTINEL-BODY"
+	const key = "the-expected-challenge-key"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, responseBody)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL %q: %v", server.URL, err)
+	}
+
+	err = testReachability(t.Context(), u, key, nil, "cert-manager-test")
+	if err == nil {
+		t.Fatal("expected testReachability to return an error for a mismatched response, but got none")
+	}
+	if errorLeaksBody(err, responseBody) {
+		t.Errorf("expected error not to contain the response body %q, but it did: %v", responseBody, err)
+	}
+}
+
+// TestReachabilityDoesNotReflectRedirectedResponseBody ensures that a response
+// body reached by following a redirect is not reflected in the returned error.
+func TestReachabilityDoesNotReflectRedirectedResponseBody(t *testing.T) {
+	const internalBody = "SENTINEL-REDIRECT"
+	const key = "the-expected-challenge-key"
+
+	// internal represents an internal-only endpoint reachable from the
+	// controller pod but not intended to be exposed to tenants.
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, internalBody)
+	}))
+	defer internal.Close()
+
+	// public is the host being validated; it redirects the self-check to the
+	// internal endpoint.
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer public.Close()
+
+	u, err := url.Parse(public.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL %q: %v", public.URL, err)
+	}
+
+	err = testReachability(t.Context(), u, key, nil, "cert-manager-test")
+	if err == nil {
+		t.Fatal("expected testReachability to return an error, but got none")
+	}
+	if errorLeaksBody(err, internalBody) {
+		t.Errorf("response body reached via a redirect must not be reflected in the error, but got: %v", err)
 	}
 }


### PR DESCRIPTION
# Description

##  Problem

The HTTP-01 self-check (testReachability) fetches http://<dnsName>/.well-known/acme-challenge/<token> to confirm the challenge token is served. Because the ACME spec requires following redirects, the response may come from a host other than the one being validated. 

On a token mismatch, the first 24 bytes of that response body were embedded verbatim in the returned error, which is persisted to Challenge.Status.Reason — a field readable by any tenant with access to the Challenge in its namespace. This disclosed fragments of internal responses.

##  Solution
Keep the response body out of the returned error, replacing it with a static message that points operators to the controller logs. The body is still logged at debug level for legitimate propagation debugging. Redirect-following and InsecureSkipVerify are intentionally left unchanged — both are spec-required behaviour that matches Let's Encrypt/Boulder. Legitimate certs behave unchanged.

## Test plan

  - [ ] Existing pkg/issuer/acme/http tests (TestReachabilityCustomDnsServers, TestCheck) pass unchanged — the error still contains the expected key, just not the response body.
  - [ ] go build ./... and go vet ./... clean.

```release-note
The ACME HTTP-01 self-check no longer reflects the fetched response body in `Challenge.status.reason`, preventing disclosure of internal response contents reachable via redirects. The response is still available in the controller's debug logs.
```
