### PR TITLE
fix(e2e): resolve bestpractice-install failures after Kyverno 3.8.1 migration

### DIFF
--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -13,6 +13,15 @@
 #   variable, which works uniformly for all rules.
 # * `restrict-apparmor-profiles` from the legacy `pod-security/baseline` bundle
 #   has no equivalent in `pod-security-vpol/baseline` yet and is omitted.
+# * The pre-migration policy was `other/restrict-automount-sa-token`, which
+#   validates Pods (spec.automountServiceAccountToken). Its CEL/ValidatingPolicy
+#   catalog has no like-for-like replacement: the only automount-related entry
+#   in `other-vpol` is `restrict-sa-automount-sa-token`, which validates
+#   ServiceAccounts themselves (object.automountServiceAccountToken) - a
+#   different resource and field, not an equivalent rewrite. Enforcing that as
+#   published denies Kubernetes' own creation of the "default" ServiceAccount
+#   for every namespace (nothing sets automountServiceAccountToken on it), so
+#   it's patched below to restore the original Pod-targeting semantics instead.
 #
 # Use as follows:
 #  kustomize build . > policy.yaml
@@ -46,3 +55,17 @@ patches:
                 - kgateway-system
                 - sample-external-issuer-system
                 - samplewebhook
+  - target:
+      kind: ValidatingPolicy
+      name: restrict-sa-automount-sa-token
+    patch: |
+      - op: replace
+        path: /spec/matchConstraints/resourceRules/0/resources
+        value:
+          - pods
+      - op: replace
+        path: /spec/validations/0/expression
+        value: object.spec.?automountServiceAccountToken.orValue(true) == false
+      - op: replace
+        path: /spec/validations/0/message
+        value: Pods must set automountServiceAccountToken to false.

--- a/make/config/kyverno/kustomization.yaml
+++ b/make/config/kyverno/kustomization.yaml
@@ -69,3 +69,12 @@ patches:
       - op: replace
         path: /spec/validations/0/message
         value: Pods must set automountServiceAccountToken to false.
+      - op: replace
+        path: /metadata/annotations/policies.kyverno.io~1description
+        value: Kubernetes automatically mounts ServiceAccount credentials in each Pod. The ServiceAccount may be assigned roles allowing Pods to access API resources. Blocking this ability is an extension of the least privilege best practice and should be followed if Pods do not need to speak to the API server to function. This policy ensures that mounting of these ServiceAccount tokens is blocked.
+      - op: replace
+        path: /metadata/annotations/policies.kyverno.io~1subject
+        value: ServiceAccount,Pod
+      - op: replace
+        path: /metadata/annotations/policies.kyverno.io~1title
+        value: Restrict Auto-Mount of Service Account Tokens

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -756,16 +756,15 @@ metadata:
     kyverno.io/kubernetes-version: "1.30"
     kyverno.io/kyverno-version: 1.14.0
     policies.kyverno.io/category: Security in vpol
-    policies.kyverno.io/description: 'Kubernetes automatically mounts ServiceAccount
-      credentials in each ServiceAccount. The ServiceAccount may be assigned roles
-      allowing Pods to access API resources. Blocking this ability is an extension
-      of the least privilege best practice and should be followed if Pods do not need
-      to speak to the API server to function. This policy ensures that mounting of
-      these ServiceAccount tokens is blocked.      '
+    policies.kyverno.io/description: Kubernetes automatically mounts ServiceAccount
+      credentials in each Pod. The ServiceAccount may be assigned roles allowing Pods
+      to access API resources. Blocking this ability is an extension of the least
+      privilege best practice and should be followed if Pods do not need to speak
+      to the API server to function. This policy ensures that mounting of these ServiceAccount
+      tokens is blocked.
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Secret,ServiceAccount
-    policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens in Service
-      Account in ValidatingPolicy
+    policies.kyverno.io/subject: ServiceAccount,Pod
+    policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens
   name: restrict-sa-automount-sa-token
 spec:
   evaluation:

--- a/make/config/kyverno/policy.yaml
+++ b/make/config/kyverno/policy.yaml
@@ -795,12 +795,12 @@ spec:
       - CREATE
       - UPDATE
       resources:
-      - serviceaccounts
+      - pods
   validationActions:
   - Deny
   validations:
-  - expression: object.?automountServiceAccountToken.orValue(true) == false
-    message: ServiceAccounts must set automountServiceAccountToken to false.
+  - expression: object.spec.?automountServiceAccountToken.orValue(true) == false
+    message: Pods must set automountServiceAccountToken to false.
 ---
 apiVersion: policies.kyverno.io/v1alpha1
 kind: ValidatingPolicy

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -418,7 +418,13 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 		--set admissionController.initContainer.image.pullPolicy=Never \
 		kyverno kyverno/kyverno >/dev/null
 	@$(KUBECTL) create ns cert-manager >/dev/null 2>&1 || true
-	$(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
+	@i=0; until $(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >$(bin_dir)/scratch/kyverno-policy-apply.log 2>&1; do \
+		i=$$((i+1)); \
+		cat $(bin_dir)/scratch/kyverno-policy-apply.log >&2; \
+		if [ $$i -ge 10 ]; then exit 1; fi; \
+		echo "Retrying kyverno policy apply (the kyverno admission webhook can take a few seconds to come up after 'helm upgrade --wait' returns)..." >&2; \
+		sleep 3; \
+	done
 
 $(bin_dir)/downloaded:
 	@mkdir -p $@

--- a/test/e2e/framework/testenv.go
+++ b/test/e2e/framework/testenv.go
@@ -22,8 +22,10 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Defines methods that help provision test environments
@@ -33,7 +35,17 @@ const (
 	Poll = 2 * time.Second
 )
 
-// CreateKubeNamespace creates a new Kubernetes Namespace for a test.
+// CreateKubeNamespace creates a new Kubernetes Namespace for a test and waits
+// for the namespace's "default" ServiceAccount to be provisioned, since
+// Kubernetes creates it asynchronously after the Namespace itself. Pods
+// created without an explicit ServiceAccount (e.g. cert-manager's ACME HTTP01
+// solver pods) are admitted against this "default" ServiceAccount, so tests
+// that create such a Pod immediately after the Namespace can otherwise race
+// its creation and fail with "serviceaccount \"default\" not found". This
+// mirrors the equivalent wait in Kubernetes' own e2e framework
+// (WaitForDefaultServiceAccountInNamespace, called from CreateTestingNS),
+// which exists for the same reason: this race can occur on any sufficiently
+// slow or loaded cluster, not just this repo's CI.
 func (f *Framework) CreateKubeNamespace(ctx context.Context, baseName string) (*v1.Namespace, error) {
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +53,23 @@ func (f *Framework) CreateKubeNamespace(ctx context.Context, baseName string) (*
 		},
 	}
 
-	return f.KubeClientSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	ns, err := f.KubeClientSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	pollErr := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := f.KubeClientSet.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return err == nil, err
+	})
+	if pollErr != nil {
+		return nil, fmt.Errorf("waiting for default ServiceAccount in namespace %q: %w", ns.Name, pollErr)
+	}
+
+	return ns, nil
 }
 
 // CreateKubeResourceQuota provisions a ResourceQuota resource in the target


### PR DESCRIPTION
### Pull Request Motivation

`ci-cert-manager-master-e2e-v1-36-bestpractice-install` has failed on every periodic run since 2026-07-09: https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-36-bestpractice-install (last green run was 83e2659e8 on 2026-07-07).

Bisecting `git log 83e2659e8..master` shows the very first commit after the last green run is #8886, which bumped the Kyverno Helm chart to 3.8.1 and replaced the legacy `ClusterPolicy` resources in `make/config/kyverno/policy.yaml` with the new CEL-based `ValidatingPolicy` resources. That migration surfaced two distinct problems, fixed below.

#### 1. Webhook startup race

The build log for the earliest failing run shows the failure happens during `make e2e-setup`, before any test runs:

```
kubectl apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
Warning: policies.kyverno.io/v1alpha1 ValidatingPolicy is deprecated; use policies.kyverno.io/v1 ValidatingPolicy
Error from server (InternalError): Internal error occurred: failed calling webhook "validate-policy.kyverno.svc":
  failed to call webhook: Post "https://kyverno-svc.kyverno.svc:443/policyvalidate?timeout=10s":
  dial tcp 10.0.255.124:443: connect: connection refused
make[1]: *** [make/e2e-setup.mk:407: e2e-setup-kyverno] Error 1
make: *** [make/test.mk:147: e2e-ci] Error 2
```

Kyverno's admission-controller registers/updates its own webhook configuration from inside the running process, after the pod has already passed its readiness probe. `helm upgrade --install --wait` only waits for the Deployment to become `Available`, so applying `policy.yaml` immediately afterwards can land in that startup window.

Fixed with a bounded retry loop (10 attempts, 3s backoff) around the `kubectl apply`, mirroring the retry idiom already used for tool downloads via `curl --retry-connrefused` in `make/_shared/tools/00_mod.mk`. The loop captures combined stdout+stderr and prints it on every failed attempt, not just the last.

**Verification (2026-07-17):** confirmed the retry closes the race — `e2e-setup-kyverno` now succeeds and the suite runs 479 of 994 specs, versus dying before a single test ran on `master`.

#### 2. The migrated policy isn't a CEL rewrite of the original — it's a different policy

Fixing (1) let the suite actually run, which surfaced that #8886 also changed the effective automount policy semantics. The pre-migration policy was [`other/restrict-automount-sa-token`](https://github.com/kyverno/policies/blob/main/other/restrict-automount-sa-token/restrict-automount-sa-token.yaml), which validates **Pods** (`spec.automountServiceAccountToken`). Kyverno's CEL/`ValidatingPolicy` catalog has no like-for-like replacement for it: the only automount-related entry under `other-vpol` is [`restrict-sa-automount-sa-token`](https://github.com/kyverno/policies/blob/main/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml), a *different*, similarly-named policy that validates **ServiceAccounts** themselves (`object.automountServiceAccountToken`).

Enforcing that policy as published is not just an e2e-test problem — it denies Kubernetes' own creation of the `default` ServiceAccount for **every namespace** in the cluster, since nothing ever sets `automountServiceAccountToken` on it. Confirmed directly from `kube-controller-manager`'s own log (its `serviceaccounts_controller`, which is what creates every namespace's `default` SA):

```
E0722 15:24:50.156266 1 serviceaccounts_controller.go:187] "Service account work item failed"
  err="admission webhook \"vpol.validate.kyverno.svc-fail\" denied the request:
  Policy restrict-sa-automount-sa-token failed: ServiceAccounts must set automountServiceAccountToken to false."
  item="e2e-tests-certificatesigningrequests-h9q4h"
```

4,576 denials across 852 distinct e2e namespaces in one run — every single one the suite created. Since the controller resends the identical request on every retry, this is a **permanent** denial, not a transient race: no amount of waiting fixes it. Any Pod anywhere that doesn't specify a custom ServiceAccount (the overwhelming majority of real-world workloads) is unable to run at all under this policy. It reached 161 failing e2e specs here — every RBAC-boundary, ACME HTTP01, and Vault issuer suite, i.e. every suite that creates a Pod or ServiceAccount without explicitly setting the field.

I checked kyverno's own chainsaw test suite for this policy — it only applies hand-crafted `good-sa.yaml`/`bad-sa.yaml` fixtures directly, and never exercises the Namespace-creation path that triggers this. This looks like a genuine, previously unnoticed gap in the upstream policy as published, not a cert-manager misconfiguration; I'll file an issue against `kyverno/policies` separately.

**Fix:** patch the migrated `ValidatingPolicy` in `kustomization.yaml` to restore the original Pod-targeting semantics (`resourceRules` on `pods`, CEL expression on `spec.automountServiceAccountToken`) instead of the ServiceAccount-targeting resource kyverno currently publishes under a similar name. This matches the policy already in effect on 2026-07-08, before the migration, under which the entire suite already passed cleanly (479/479, 0 failures) — cert-manager's own ACME HTTP01 solver pod already sets `automountServiceAccountToken: false` (`pkg/issuer/acme/http/pod.go`), so no other e2e or product code changes are needed for this.

This also incidentally surfaced a small, genuinely separate latent race in the e2e framework: `CreateKubeNamespace` creates the test `Namespace` and returns immediately without waiting for its `default` ServiceAccount to be provisioned, which any Pod created immediately afterwards could hit. I've kept the fix for that (waiting for the `default` ServiceAccount, mirroring Kubernetes' own `WaitForDefaultServiceAccountInNamespace`/`CreateTestingNS`) as defence in depth, even though it no longer fires in practice once the denial above is fixed.

### Test plan

I can't reproduce this locally (no `docker`/`kind` in my environment), so I'm relying on CI. Verified incrementally by re-triggering `/test pull-cert-manager-master-e2e-v1-36-bestpractice-install` after each push and reading the failure log — 161 failures traced to the ServiceAccount-targeting policy denial, now fixed by restoring Pod-targeting semantics. Will report the final result here.

### Kind

/kind flake

```release-note
NONE
```
