### PR TITLE
Re-queue Issuer/ClusterIssuer on ACME DNS-01 solver Secret events

### DIFF
--- a/pkg/acme/secrets.go
+++ b/pkg/acme/secrets.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
+	"github.com/cert-manager/cert-manager/internal/apis/meta"
+	"github.com/cert-manager/cert-manager/pkg/api"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// RequiredDNS01SolverSecrets returns the Kubernetes Secret references required
+// by the ACME DNS-01 solvers configured on the given issuer. It is the single
+// source of truth for which Secrets an ACME issuer's DNS-01 solvers depend on,
+// shared by the code that validates those Secrets exist (pkg/issuer/acme) and
+// the code that decides whether a Secret event is relevant to a given
+// Issuer/ClusterIssuer (pkg/controller/issuers, pkg/controller/clusterissuers).
+func RequiredDNS01SolverSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
+	var secrets []*meta.SecretKeySelector
+	spec := issuer.GetSpec()
+	if spec.ACME == nil {
+		return secrets, nil
+	}
+
+	solvers := spec.ACME.Solvers
+	for i := range solvers {
+		sol := solvers[i]
+		if sol.DNS01 == nil {
+			continue
+		}
+
+		var out cmacme.ACMEChallengeSolver
+		if err := api.Scheme.Convert(&sol, &out, nil); err != nil {
+			return nil, fmt.Errorf("unable to convert ACME challenge solver to internal challenge type: %w", err)
+		}
+
+		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
+		if len(requiredSecrets) == 0 {
+			continue
+		}
+		secrets = append(secrets, requiredSecrets...)
+	}
+
+	return secrets, nil
+}

--- a/pkg/acme/secrets.go
+++ b/pkg/acme/secrets.go
@@ -23,9 +23,9 @@ import (
 
 	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
 	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
-	"github.com/cert-manager/cert-manager/internal/apis/meta"
 	"github.com/cert-manager/cert-manager/pkg/api"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
 // RequiredDNS01SolverSecrets returns the Kubernetes Secret references required
@@ -34,8 +34,8 @@ import (
 // shared by the code that validates those Secrets exist (pkg/issuer/acme) and
 // the code that decides whether a Secret event is relevant to a given
 // Issuer/ClusterIssuer (pkg/controller/issuers, pkg/controller/clusterissuers).
-func RequiredDNS01SolverSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
-	var secrets []*meta.SecretKeySelector
+func RequiredDNS01SolverSecrets(issuer v1.GenericIssuer) ([]cmmeta.SecretKeySelector, error) {
+	var secrets []cmmeta.SecretKeySelector
 	spec := issuer.GetSpec()
 	if spec.ACME == nil {
 		return secrets, nil
@@ -54,10 +54,16 @@ func RequiredDNS01SolverSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelec
 		}
 
 		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
-		if len(requiredSecrets) == 0 {
-			continue
+		for _, s := range requiredSecrets {
+			// Convert back to the external type: this is a public function in a
+			// non-internal package, so it must not leak internal/... types into
+			// callers outside this module.
+			var external cmmeta.SecretKeySelector
+			if err := api.Scheme.Convert(s, &external, nil); err != nil {
+				return nil, fmt.Errorf("unable to convert required secret reference to external type: %w", err)
+			}
+			secrets = append(secrets, external)
 		}
-		secrets = append(secrets, requiredSecrets...)
 	}
 
 	return secrets, nil

--- a/pkg/acme/secrets_test.go
+++ b/pkg/acme/secrets_test.go
@@ -30,10 +30,15 @@ import (
 )
 
 func TestRequiredDNS01SolverSecrets(t *testing.T) {
+	// RequiredDNS01SolverSecrets can only return an error if api.Scheme.Convert
+	// fails converting the external ACMEChallengeSolver to its internal type.
+	// That conversion is entirely generated field-copying (no parsing or
+	// validation), so it cannot fail for any value of the external Go struct
+	// type - there is no test case for it here because there is no reachable
+	// way to construct one.
 	tests := map[string]struct {
 		issuer        gen.IssuerModifier
 		expectNames   []string
-		expectErr     bool
 		expectNoSlice bool
 	}{
 		"non-ACME issuer returns no secrets": {
@@ -156,10 +161,6 @@ func TestRequiredDNS01SolverSecrets(t *testing.T) {
 			issuer := gen.Issuer("test", tc.issuer)
 
 			secrets, err := acme.RequiredDNS01SolverSecrets(issuer)
-			if tc.expectErr {
-				require.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 
 			if tc.expectNoSlice {

--- a/pkg/acme/secrets_test.go
+++ b/pkg/acme/secrets_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cert-manager/cert-manager/pkg/acme"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func TestRequiredDNS01SolverSecrets(t *testing.T) {
+	tests := map[string]struct {
+		issuer        gen.IssuerModifier
+		expectNames   []string
+		expectErr     bool
+		expectNoSlice bool
+	}{
+		"non-ACME issuer returns no secrets": {
+			issuer:        gen.SetIssuerCA(v1.CAIssuer{SecretName: "ca-secret"}),
+			expectNoSlice: true,
+		},
+		"ACME issuer with no solvers returns no secrets": {
+			issuer:      gen.SetIssuerACME(cmacme.ACMEIssuer{}),
+			expectNames: nil,
+		},
+		"ACME issuer with an HTTP-01-only solver returns no secrets": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{HTTP01: &cmacme.ACMEChallengeSolverHTTP01{}},
+			}),
+			expectNames: nil,
+		},
+		"ACME issuer with a Route53 DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						SecretAccessKey: cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+							Key:                  "secret-access-key",
+						},
+					},
+				}},
+			}),
+			expectNames: []string{"route53-creds"},
+		},
+		"ACME issuer with multiple DNS-01 solvers returns all their secrets": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						SecretAccessKey: cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+							Key:                  "secret-access-key",
+						},
+					},
+				}},
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+						ServiceAccount: &cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "clouddns-creds"},
+							Key:                  "service-account.json",
+						},
+					},
+				}},
+			}),
+			expectNames: []string{"route53-creds", "clouddns-creds"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			issuer := gen.Issuer("test", tc.issuer)
+
+			secrets, err := acme.RequiredDNS01SolverSecrets(issuer)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.expectNoSlice {
+				assert.Nil(t, secrets)
+				return
+			}
+
+			var names []string
+			for _, s := range secrets {
+				names = append(names, s.Name)
+			}
+			assert.Equal(t, tc.expectNames, names)
+		})
+	}
+}

--- a/pkg/acme/secrets_test.go
+++ b/pkg/acme/secrets_test.go
@@ -63,6 +63,71 @@ func TestRequiredDNS01SolverSecrets(t *testing.T) {
 			}),
 			expectNames: []string{"route53-creds"},
 		},
+		"ACME issuer with an Akamai DNS-01 solver returns its secrets": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{
+						ServiceConsumerDomain: "example.com",
+						AccessToken:           cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "akamai-access-token"}},
+						ClientSecret:          cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "akamai-client-secret"}},
+						ClientToken:           cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "akamai-client-token"}},
+					},
+				}},
+			}),
+			expectNames: []string{"akamai-access-token", "akamai-client-secret", "akamai-client-token"},
+		},
+		"ACME issuer with an AzureDNS DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+						ClientSecret: &cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "azuredns-creds"}},
+					},
+				}},
+			}),
+			expectNames: []string{"azuredns-creds"},
+		},
+		"ACME issuer with a Cloudflare DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
+						APIToken: &cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "cloudflare-token"}},
+					},
+				}},
+			}),
+			expectNames: []string{"cloudflare-token"},
+		},
+		"ACME issuer with an AcmeDNS DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{
+						Host:          "https://auth.example.com",
+						AccountSecret: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "acmedns-creds"}},
+					},
+				}},
+			}),
+			expectNames: []string{"acmedns-creds"},
+		},
+		"ACME issuer with a DigitalOcean DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					DigitalOcean: &cmacme.ACMEIssuerDNS01ProviderDigitalOcean{
+						Token: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "digitalocean-token"}},
+					},
+				}},
+			}),
+			expectNames: []string{"digitalocean-token"},
+		},
+		"ACME issuer with an RFC2136 DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
+						Nameserver: "ns.example.com:53",
+						TSIGSecret: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "rfc2136-tsig"}},
+					},
+				}},
+			}),
+			expectNames: []string{"rfc2136-tsig"},
+		},
 		"ACME issuer with multiple DNS-01 solvers returns all their secrets": {
 			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
 				{DNS01: &cmacme.ACMEChallengeSolverDNS01{

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -55,7 +55,7 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 			if err != nil {
 				// Don't let one issuer's conversion error stop every other
 				// issuer from being matched against this Secret event.
-				runtime.HandleError(fmt.Errorf("error determining ACME DNS-01 solver secrets for issuer %s: %w", iss.Name, err))
+				runtime.HandleError(fmt.Errorf("error determining ACME DNS-01 solver secrets for ClusterIssuer %s: %w", iss.Name, err))
 				continue
 			}
 			for _, s := range solverSecrets {

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -21,8 +21,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
 
-	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/cert-manager/cert-manager/pkg/acme"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -40,11 +41,28 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 		}
 		switch {
 		case iss.Spec.ACME != nil:
-			// Match account key, EAB key, and DNS-01 solver secrets so creating
-			// a missing solver Secret re-queues the ClusterIssuer (see #9036).
-			if acmeIssuerReferencesSecret(iss.Spec.ACME, secret.Name) {
+			if iss.Spec.ACME.PrivateKey.Name == secret.Name {
 				affected = append(affected, iss)
 				continue
+			}
+			if iss.Spec.ACME.ExternalAccountBinding != nil && iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
+				affected = append(affected, iss)
+				continue
+			}
+			// Match DNS-01 solver secrets so creating a missing solver Secret
+			// re-queues the ClusterIssuer (see #9036).
+			solverSecrets, err := acme.RequiredDNS01SolverSecrets(iss)
+			if err != nil {
+				// Don't let one issuer's conversion error stop every other
+				// issuer from being matched against this Secret event.
+				runtime.HandleError(fmt.Errorf("error determining ACME DNS-01 solver secrets for issuer %s: %w", iss.Name, err))
+				continue
+			}
+			for _, s := range solverSecrets {
+				if s.Name == secret.Name {
+					affected = append(affected, iss)
+					break
+				}
 			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
@@ -105,70 +123,4 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 	}
 
 	return affected, nil
-}
-
-// acmeIssuerReferencesSecret reports whether the ACME issuer config references
-// the given Secret name via the account private key, EAB key, or any DNS-01
-// solver provider secret.
-func acmeIssuerReferencesSecret(acme *cmacme.ACMEIssuer, secretName string) bool {
-	if acme.PrivateKey.Name == secretName {
-		return true
-	}
-	if acme.ExternalAccountBinding != nil && acme.ExternalAccountBinding.Key.Name == secretName {
-		return true
-	}
-	for i := range acme.Solvers {
-		if dns01SolverReferencesSecret(acme.Solvers[i].DNS01, secretName) {
-			return true
-		}
-	}
-	return false
-}
-
-// dns01SolverReferencesSecret matches the secret names collected by
-// validation.ValidateACMEChallengeSolverDNS01 so creating or updating a solver
-// Secret re-queues the ClusterIssuer that depends on it (see #9036).
-func dns01SolverReferencesSecret(dns *cmacme.ACMEChallengeSolverDNS01, secretName string) bool {
-	if dns == nil {
-		return false
-	}
-	if dns.Akamai != nil {
-		if dns.Akamai.AccessToken.Name == secretName ||
-			dns.Akamai.ClientSecret.Name == secretName ||
-			dns.Akamai.ClientToken.Name == secretName {
-			return true
-		}
-	}
-	if dns.AzureDNS != nil && dns.AzureDNS.ClientSecret != nil && dns.AzureDNS.ClientSecret.Name == secretName {
-		return true
-	}
-	if dns.CloudDNS != nil && dns.CloudDNS.ServiceAccount != nil && dns.CloudDNS.ServiceAccount.Name == secretName {
-		return true
-	}
-	if dns.Cloudflare != nil {
-		if dns.Cloudflare.APIKey != nil && dns.Cloudflare.APIKey.Name == secretName {
-			return true
-		}
-		if dns.Cloudflare.APIToken != nil && dns.Cloudflare.APIToken.Name == secretName {
-			return true
-		}
-	}
-	if dns.Route53 != nil {
-		if dns.Route53.SecretAccessKey.Name == secretName {
-			return true
-		}
-		if dns.Route53.SecretAccessKeyID != nil && dns.Route53.SecretAccessKeyID.Name == secretName {
-			return true
-		}
-	}
-	if dns.AcmeDNS != nil && dns.AcmeDNS.AccountSecret.Name == secretName {
-		return true
-	}
-	if dns.DigitalOcean != nil && dns.DigitalOcean.Token.Name == secretName {
-		return true
-	}
-	if dns.RFC2136 != nil && dns.RFC2136.TSIGSecret.Name == secretName {
-		return true
-	}
-	return false
 }

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -39,15 +40,11 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 		}
 		switch {
 		case iss.Spec.ACME != nil:
-			if iss.Spec.ACME.PrivateKey.Name == secret.Name {
+			// Match account key, EAB key, and DNS-01 solver secrets so creating
+			// a missing solver Secret re-queues the ClusterIssuer (see #9036).
+			if acmeIssuerReferencesSecret(iss.Spec.ACME, secret.Name) {
 				affected = append(affected, iss)
 				continue
-			}
-			if iss.Spec.ACME.ExternalAccountBinding != nil {
-				if iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
-					affected = append(affected, iss)
-					continue
-				}
 			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
@@ -108,4 +105,70 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 	}
 
 	return affected, nil
+}
+
+// acmeIssuerReferencesSecret reports whether the ACME issuer config references
+// the given Secret name via the account private key, EAB key, or any DNS-01
+// solver provider secret.
+func acmeIssuerReferencesSecret(acme *cmacme.ACMEIssuer, secretName string) bool {
+	if acme.PrivateKey.Name == secretName {
+		return true
+	}
+	if acme.ExternalAccountBinding != nil && acme.ExternalAccountBinding.Key.Name == secretName {
+		return true
+	}
+	for i := range acme.Solvers {
+		if dns01SolverReferencesSecret(acme.Solvers[i].DNS01, secretName) {
+			return true
+		}
+	}
+	return false
+}
+
+// dns01SolverReferencesSecret matches the secret names collected by
+// validation.ValidateACMEChallengeSolverDNS01 so creating or updating a solver
+// Secret re-queues the ClusterIssuer that depends on it (see #9036).
+func dns01SolverReferencesSecret(dns *cmacme.ACMEChallengeSolverDNS01, secretName string) bool {
+	if dns == nil {
+		return false
+	}
+	if dns.Akamai != nil {
+		if dns.Akamai.AccessToken.Name == secretName ||
+			dns.Akamai.ClientSecret.Name == secretName ||
+			dns.Akamai.ClientToken.Name == secretName {
+			return true
+		}
+	}
+	if dns.AzureDNS != nil && dns.AzureDNS.ClientSecret != nil && dns.AzureDNS.ClientSecret.Name == secretName {
+		return true
+	}
+	if dns.CloudDNS != nil && dns.CloudDNS.ServiceAccount != nil && dns.CloudDNS.ServiceAccount.Name == secretName {
+		return true
+	}
+	if dns.Cloudflare != nil {
+		if dns.Cloudflare.APIKey != nil && dns.Cloudflare.APIKey.Name == secretName {
+			return true
+		}
+		if dns.Cloudflare.APIToken != nil && dns.Cloudflare.APIToken.Name == secretName {
+			return true
+		}
+	}
+	if dns.Route53 != nil {
+		if dns.Route53.SecretAccessKey.Name == secretName {
+			return true
+		}
+		if dns.Route53.SecretAccessKeyID != nil && dns.Route53.SecretAccessKeyID.Name == secretName {
+			return true
+		}
+	}
+	if dns.AcmeDNS != nil && dns.AcmeDNS.AccountSecret.Name == secretName {
+		return true
+	}
+	if dns.DigitalOcean != nil && dns.DigitalOcean.Token.Name == secretName {
+		return true
+	}
+	if dns.RFC2136 != nil && dns.RFC2136.TSIGSecret.Name == secretName {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -27,6 +27,14 @@ import (
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
+// issuersForSecret returns ClusterIssuers that reference the given Secret so
+// Secret events can re-queue the right cluster issuers.
+//
+// TODO(hjoshi123, wallrj): This walks every ClusterIssuer on each Secret event
+// (O(numClusterIssuers)). ACME DNS-01 matching also runs RequiredDNS01SolverSecrets
+// per ClusterIssuer (extra conversion). Under high Secret churn that is expensive;
+// index ClusterIssuers by referenced Secret names for O(1)/O(related) lookup.
+// Deferred so the Ready=False re-queue fix (#9036) can land first.
 func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssuer, error) {
 	issuers, err := c.clusterIssuerLister.List(labels.NewSelector())
 

--- a/pkg/controller/clusterissuers/checks_test.go
+++ b/pkg/controller/clusterissuers/checks_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterissuers
+
+import (
+	"testing"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestACMEIssuerReferencesSecret(t *testing.T) {
+	solverSecret := "dns-solver-creds"
+	eabSecret := "eab-creds"
+	accountSecret := "account-key"
+
+	tests := []struct {
+		name       string
+		acme       *cmacme.ACMEIssuer
+		secretName string
+		want       bool
+	}{
+		{
+			name: "private key",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+			},
+			secretName: accountSecret,
+			want:       true,
+		},
+		{
+			name: "eab key",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
+					Key: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: eabSecret}},
+				},
+			},
+			secretName: eabSecret,
+			want:       true,
+		},
+		{
+			name: "route53 solver secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+								SecretAccessKey: cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+									Key:                  "secret-access-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: solverSecret,
+			want:       true,
+		},
+		{
+			name: "clouddns solver secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+								ServiceAccount: &cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+									Key:                  "key.json",
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: solverSecret,
+			want:       true,
+		},
+		{
+			name: "unrelated secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+								SecretAccessKey: cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: "other",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acmeIssuerReferencesSecret(tt.acme, tt.secretName); got != tt.want {
+				t.Fatalf("acmeIssuerReferencesSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/clusterissuers/checks_test.go
+++ b/pkg/controller/clusterissuers/checks_test.go
@@ -19,106 +19,108 @@ package clusterissuers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func TestACMEIssuerReferencesSecret(t *testing.T) {
-	solverSecret := "dns-solver-creds"
-	eabSecret := "eab-creds"
-	accountSecret := "account-key"
+// TestIssuersForSecret_ACMEDNS01Solver is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/9036: a ClusterIssuer
+// with an ACME DNS-01 solver referencing a Secret must be requeued when that
+// Secret is created or updated, the same way it already is for its
+// PrivateKey and ExternalAccountBinding Secrets.
+func TestIssuersForSecret_ACMEDNS01Solver(t *testing.T) {
+	const clusterResourceNamespace = "cert-manager"
 
-	tests := []struct {
-		name       string
-		acme       *cmacme.ACMEIssuer
-		secretName string
-		want       bool
+	route53Issuer := gen.ClusterIssuer("route53-issuer",
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+	eabIssuer := gen.ClusterIssuer("eab-issuer",
+		gen.SetIssuerACMEEAB("kid", "eab-creds"),
+	)
+	privateKeyIssuer := gen.ClusterIssuer("privatekey-issuer",
+		gen.SetIssuerACMEPrivKeyRef("privatekey-creds"),
+	)
+	caIssuer := gen.ClusterIssuer("ca-issuer",
+		gen.SetIssuerCASecretName("ca-creds"),
+	)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, iss := range []*v1.ClusterIssuer{route53Issuer, eabIssuer, privateKeyIssuer, caIssuer} {
+		require.NoError(t, indexer.Add(iss))
+	}
+
+	c := &controller{
+		clusterIssuerLister:      cmlisters.NewClusterIssuerLister(indexer),
+		clusterResourceNamespace: clusterResourceNamespace,
+	}
+
+	tests := map[string]struct {
+		secret        *corev1.Secret
+		expectIssuers []string
 	}{
-		{
-			name: "private key",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-			},
-			secretName: accountSecret,
-			want:       true,
+		"a Secret referenced by a DNS-01 solver requeues the matching ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "route53-creds"),
+			expectIssuers: []string{"route53-issuer"},
 		},
-		{
-			name: "eab key",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
-					Key: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: eabSecret}},
-				},
-			},
-			secretName: eabSecret,
-			want:       true,
+		"a Secret referenced by ExternalAccountBinding still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "eab-creds"),
+			expectIssuers: []string{"eab-issuer"},
 		},
-		{
-			name: "route53 solver secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-								SecretAccessKey: cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-									Key:                  "secret-access-key",
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: solverSecret,
-			want:       true,
+		"a Secret referenced by the ACME PrivateKey still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "privatekey-creds"),
+			expectIssuers: []string{"privatekey-issuer"},
 		},
-		{
-			name: "clouddns solver secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
-								ServiceAccount: &cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-									Key:                  "key.json",
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: solverSecret,
-			want:       true,
+		"a Secret referenced by a CA ClusterIssuer still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "ca-creds"),
+			expectIssuers: []string{"ca-issuer"},
 		},
-		{
-			name: "unrelated secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-								SecretAccessKey: cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: "other",
-			want:       false,
+		"a same-named Secret outside the cluster resource namespace does not requeue": {
+			secret:        secretNamed("some-other-namespace", "route53-creds"),
+			expectIssuers: nil,
+		},
+		"an unreferenced Secret requeues nothing": {
+			secret:        secretNamed(clusterResourceNamespace, "unrelated-secret"),
+			expectIssuers: nil,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := acmeIssuerReferencesSecret(tt.acme, tt.secretName); got != tt.want {
-				t.Fatalf("acmeIssuerReferencesSecret() = %v, want %v", got, tt.want)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			affected, err := c.issuersForSecret(tc.secret)
+			require.NoError(t, err)
+
+			var names []string
+			for _, iss := range affected {
+				names = append(names, iss.Name)
 			}
+			assert.Equal(t, tc.expectIssuers, names)
 		})
+	}
+}
+
+func secretNamed(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
 	}
 }

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -21,8 +21,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
 
-	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/cert-manager/cert-manager/pkg/acme"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -42,11 +43,28 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 
 		switch {
 		case iss.Spec.ACME != nil:
-			// Match account key, EAB key, and DNS-01 solver secrets so creating
-			// a missing solver Secret re-queues the Issuer (see #9036).
-			if acmeIssuerReferencesSecret(iss.Spec.ACME, secret.Name) {
+			if iss.Spec.ACME.PrivateKey.Name == secret.Name {
 				affected = append(affected, iss)
 				continue
+			}
+			if iss.Spec.ACME.ExternalAccountBinding != nil && iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
+				affected = append(affected, iss)
+				continue
+			}
+			// Match DNS-01 solver secrets so creating a missing solver Secret
+			// re-queues the Issuer (see #9036).
+			solverSecrets, err := acme.RequiredDNS01SolverSecrets(iss)
+			if err != nil {
+				// Don't let one issuer's conversion error stop every other
+				// issuer from being matched against this Secret event.
+				runtime.HandleError(fmt.Errorf("error determining ACME DNS-01 solver secrets for issuer %s/%s: %w", iss.Namespace, iss.Name, err))
+				continue
+			}
+			for _, s := range solverSecrets {
+				if s.Name == secret.Name {
+					affected = append(affected, iss)
+					break
+				}
 			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
@@ -107,70 +125,4 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 	}
 
 	return affected, nil
-}
-
-// acmeIssuerReferencesSecret reports whether the ACME issuer config references
-// the given Secret name via the account private key, EAB key, or any DNS-01
-// solver provider secret.
-func acmeIssuerReferencesSecret(acme *cmacme.ACMEIssuer, secretName string) bool {
-	if acme.PrivateKey.Name == secretName {
-		return true
-	}
-	if acme.ExternalAccountBinding != nil && acme.ExternalAccountBinding.Key.Name == secretName {
-		return true
-	}
-	for i := range acme.Solvers {
-		if dns01SolverReferencesSecret(acme.Solvers[i].DNS01, secretName) {
-			return true
-		}
-	}
-	return false
-}
-
-// dns01SolverReferencesSecret matches the secret names collected by
-// validation.ValidateACMEChallengeSolverDNS01 so creating or updating a solver
-// Secret re-queues the Issuer that depends on it (see #9036).
-func dns01SolverReferencesSecret(dns *cmacme.ACMEChallengeSolverDNS01, secretName string) bool {
-	if dns == nil {
-		return false
-	}
-	if dns.Akamai != nil {
-		if dns.Akamai.AccessToken.Name == secretName ||
-			dns.Akamai.ClientSecret.Name == secretName ||
-			dns.Akamai.ClientToken.Name == secretName {
-			return true
-		}
-	}
-	if dns.AzureDNS != nil && dns.AzureDNS.ClientSecret != nil && dns.AzureDNS.ClientSecret.Name == secretName {
-		return true
-	}
-	if dns.CloudDNS != nil && dns.CloudDNS.ServiceAccount != nil && dns.CloudDNS.ServiceAccount.Name == secretName {
-		return true
-	}
-	if dns.Cloudflare != nil {
-		if dns.Cloudflare.APIKey != nil && dns.Cloudflare.APIKey.Name == secretName {
-			return true
-		}
-		if dns.Cloudflare.APIToken != nil && dns.Cloudflare.APIToken.Name == secretName {
-			return true
-		}
-	}
-	if dns.Route53 != nil {
-		if dns.Route53.SecretAccessKey.Name == secretName {
-			return true
-		}
-		if dns.Route53.SecretAccessKeyID != nil && dns.Route53.SecretAccessKeyID.Name == secretName {
-			return true
-		}
-	}
-	if dns.AcmeDNS != nil && dns.AcmeDNS.AccountSecret.Name == secretName {
-		return true
-	}
-	if dns.DigitalOcean != nil && dns.DigitalOcean.Token.Name == secretName {
-		return true
-	}
-	if dns.RFC2136 != nil && dns.RFC2136.TSIGSecret.Name == secretName {
-		return true
-	}
-	return false
 }

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -41,15 +42,11 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 
 		switch {
 		case iss.Spec.ACME != nil:
-			if iss.Spec.ACME.PrivateKey.Name == secret.Name {
+			// Match account key, EAB key, and DNS-01 solver secrets so creating
+			// a missing solver Secret re-queues the Issuer (see #9036).
+			if acmeIssuerReferencesSecret(iss.Spec.ACME, secret.Name) {
 				affected = append(affected, iss)
 				continue
-			}
-			if iss.Spec.ACME.ExternalAccountBinding != nil {
-				if iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
-					affected = append(affected, iss)
-					continue
-				}
 			}
 		case iss.Spec.CA != nil:
 			if iss.Spec.CA.SecretName == secret.Name {
@@ -110,4 +107,70 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 	}
 
 	return affected, nil
+}
+
+// acmeIssuerReferencesSecret reports whether the ACME issuer config references
+// the given Secret name via the account private key, EAB key, or any DNS-01
+// solver provider secret.
+func acmeIssuerReferencesSecret(acme *cmacme.ACMEIssuer, secretName string) bool {
+	if acme.PrivateKey.Name == secretName {
+		return true
+	}
+	if acme.ExternalAccountBinding != nil && acme.ExternalAccountBinding.Key.Name == secretName {
+		return true
+	}
+	for i := range acme.Solvers {
+		if dns01SolverReferencesSecret(acme.Solvers[i].DNS01, secretName) {
+			return true
+		}
+	}
+	return false
+}
+
+// dns01SolverReferencesSecret matches the secret names collected by
+// validation.ValidateACMEChallengeSolverDNS01 so creating or updating a solver
+// Secret re-queues the Issuer that depends on it (see #9036).
+func dns01SolverReferencesSecret(dns *cmacme.ACMEChallengeSolverDNS01, secretName string) bool {
+	if dns == nil {
+		return false
+	}
+	if dns.Akamai != nil {
+		if dns.Akamai.AccessToken.Name == secretName ||
+			dns.Akamai.ClientSecret.Name == secretName ||
+			dns.Akamai.ClientToken.Name == secretName {
+			return true
+		}
+	}
+	if dns.AzureDNS != nil && dns.AzureDNS.ClientSecret != nil && dns.AzureDNS.ClientSecret.Name == secretName {
+		return true
+	}
+	if dns.CloudDNS != nil && dns.CloudDNS.ServiceAccount != nil && dns.CloudDNS.ServiceAccount.Name == secretName {
+		return true
+	}
+	if dns.Cloudflare != nil {
+		if dns.Cloudflare.APIKey != nil && dns.Cloudflare.APIKey.Name == secretName {
+			return true
+		}
+		if dns.Cloudflare.APIToken != nil && dns.Cloudflare.APIToken.Name == secretName {
+			return true
+		}
+	}
+	if dns.Route53 != nil {
+		if dns.Route53.SecretAccessKey.Name == secretName {
+			return true
+		}
+		if dns.Route53.SecretAccessKeyID != nil && dns.Route53.SecretAccessKeyID.Name == secretName {
+			return true
+		}
+	}
+	if dns.AcmeDNS != nil && dns.AcmeDNS.AccountSecret.Name == secretName {
+		return true
+	}
+	if dns.DigitalOcean != nil && dns.DigitalOcean.Token.Name == secretName {
+		return true
+	}
+	if dns.RFC2136 != nil && dns.RFC2136.TSIGSecret.Name == secretName {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -27,6 +27,14 @@ import (
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
+// issuersForSecret returns Issuers that reference the given Secret so Secret
+// events can re-queue the right issuers.
+//
+// TODO(hjoshi123, wallrj): This walks every Issuer on each Secret event
+// (O(numIssuers)). ACME DNS-01 matching also runs RequiredDNS01SolverSecrets
+// per Issuer (extra conversion). Under high Secret churn that is expensive;
+// index Issuers by referenced Secret names for O(1)/O(related) lookup.
+// Deferred so the Ready=False re-queue fix (#9036) can land first.
 func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, error) {
 	issuers, err := c.issuerLister.List(labels.NewSelector())
 

--- a/pkg/controller/issuers/checks_test.go
+++ b/pkg/controller/issuers/checks_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package issuers
+
+import (
+	"testing"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestACMEIssuerReferencesSecret(t *testing.T) {
+	solverSecret := "dns-solver-creds"
+	eabSecret := "eab-creds"
+	accountSecret := "account-key"
+
+	tests := []struct {
+		name       string
+		acme       *cmacme.ACMEIssuer
+		secretName string
+		want       bool
+	}{
+		{
+			name: "private key",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+			},
+			secretName: accountSecret,
+			want:       true,
+		},
+		{
+			name: "eab key",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
+					Key: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: eabSecret}},
+				},
+			},
+			secretName: eabSecret,
+			want:       true,
+		},
+		{
+			name: "route53 solver secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+								SecretAccessKey: cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+									Key:                  "secret-access-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: solverSecret,
+			want:       true,
+		},
+		{
+			name: "clouddns solver secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+								ServiceAccount: &cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+									Key:                  "key.json",
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: solverSecret,
+			want:       true,
+		},
+		{
+			name: "unrelated secret",
+			acme: &cmacme.ACMEIssuer{
+				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+								SecretAccessKey: cmmeta.SecretKeySelector{
+									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
+								},
+							},
+						},
+					},
+				},
+			},
+			secretName: "other",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acmeIssuerReferencesSecret(tt.acme, tt.secretName); got != tt.want {
+				t.Fatalf("acmeIssuerReferencesSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/issuers/checks_test.go
+++ b/pkg/controller/issuers/checks_test.go
@@ -19,106 +19,122 @@ package issuers
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func TestACMEIssuerReferencesSecret(t *testing.T) {
-	solverSecret := "dns-solver-creds"
-	eabSecret := "eab-creds"
-	accountSecret := "account-key"
+// TestIssuersForSecret_ACMEDNS01Solver is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/9036: an Issuer with an
+// ACME DNS-01 solver referencing a Secret must be requeued when that Secret
+// is created or updated, the same way it already is for its PrivateKey and
+// ExternalAccountBinding Secrets.
+func TestIssuersForSecret_ACMEDNS01Solver(t *testing.T) {
+	const ns = "testns"
 
-	tests := []struct {
-		name       string
-		acme       *cmacme.ACMEIssuer
-		secretName string
-		want       bool
+	route53Issuer := gen.Issuer("route53-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+	eabIssuer := gen.Issuer("eab-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMEEAB("kid", "eab-creds"),
+	)
+	privateKeyIssuer := gen.Issuer("privatekey-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMEPrivKeyRef("privatekey-creds"),
+	)
+	caIssuer := gen.Issuer("ca-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerCASecretName("ca-creds"),
+	)
+	otherNamespaceIssuer := gen.Issuer("other-ns-issuer",
+		gen.SetIssuerNamespace("other"),
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, iss := range []*v1.Issuer{route53Issuer, eabIssuer, privateKeyIssuer, caIssuer, otherNamespaceIssuer} {
+		require.NoError(t, indexer.Add(iss))
+	}
+
+	c := &controller{issuerLister: cmlisters.NewIssuerLister(indexer)}
+
+	tests := map[string]struct {
+		secret        *corev1.Secret
+		expectIssuers []string
 	}{
-		{
-			name: "private key",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-			},
-			secretName: accountSecret,
-			want:       true,
+		"a Secret referenced by a DNS-01 solver requeues the matching Issuer": {
+			secret:        secretNamed(ns, "route53-creds"),
+			expectIssuers: []string{"route53-issuer"},
 		},
-		{
-			name: "eab key",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
-					Key: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: eabSecret}},
-				},
-			},
-			secretName: eabSecret,
-			want:       true,
+		"a Secret referenced by ExternalAccountBinding still requeues its Issuer": {
+			secret:        secretNamed(ns, "eab-creds"),
+			expectIssuers: []string{"eab-issuer"},
 		},
-		{
-			name: "route53 solver secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-								SecretAccessKey: cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-									Key:                  "secret-access-key",
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: solverSecret,
-			want:       true,
+		"a Secret referenced by the ACME PrivateKey still requeues its Issuer": {
+			secret:        secretNamed(ns, "privatekey-creds"),
+			expectIssuers: []string{"privatekey-issuer"},
 		},
-		{
-			name: "clouddns solver secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
-								ServiceAccount: &cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-									Key:                  "key.json",
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: solverSecret,
-			want:       true,
+		"a Secret referenced by a CA Issuer still requeues its Issuer": {
+			secret:        secretNamed(ns, "ca-creds"),
+			expectIssuers: []string{"ca-issuer"},
 		},
-		{
-			name: "unrelated secret",
-			acme: &cmacme.ACMEIssuer{
-				PrivateKey: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: accountSecret}},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-								SecretAccessKey: cmmeta.SecretKeySelector{
-									LocalObjectReference: cmmeta.LocalObjectReference{Name: solverSecret},
-								},
-							},
-						},
-					},
-				},
-			},
-			secretName: "other",
-			want:       false,
+		"a same-named Secret in a different namespace does not requeue": {
+			secret:        secretNamed("other", "route53-creds"),
+			expectIssuers: []string{"other-ns-issuer"},
+		},
+		"an unreferenced Secret requeues nothing": {
+			secret:        secretNamed(ns, "unrelated-secret"),
+			expectIssuers: nil,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := acmeIssuerReferencesSecret(tt.acme, tt.secretName); got != tt.want {
-				t.Fatalf("acmeIssuerReferencesSecret() = %v, want %v", got, tt.want)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			affected, err := c.issuersForSecret(tc.secret)
+			require.NoError(t, err)
+
+			var names []string
+			for _, iss := range affected {
+				names = append(names, iss.Name)
 			}
+			assert.Equal(t, tc.expectIssuers, names)
 		})
+	}
+}
+
+func secretNamed(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
 	}
 }

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -29,15 +29,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
-	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
-	"github.com/cert-manager/cert-manager/internal/apis/meta"
 	"github.com/cert-manager/cert-manager/pkg/acme"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/acme/client"
-	"github.com/cert-manager/cert-manager/pkg/api"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -584,7 +579,7 @@ var acmev1ToV2Mappings = map[string]string{
 func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) []string {
 	var warning []string
 
-	secrets, err := extractSecrets(issuer)
+	secrets, err := acme.RequiredDNS01SolverSecrets(issuer)
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "error extracting secrets")
 		warning = append(warning, "unable to verify dns solvers")
@@ -608,33 +603,4 @@ func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) 
 		}
 	}
 	return warning
-}
-
-func extractSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
-	var secrets []*meta.SecretKeySelector
-	spec := issuer.GetSpec()
-	if spec.ACME == nil {
-		return secrets, nil
-	}
-
-	solvers := spec.ACME.Solvers
-	for i := range solvers {
-		sol := solvers[i]
-		if sol.DNS01 == nil {
-			continue
-		}
-
-		var out cmacme.ACMEChallengeSolver
-		if err := api.Scheme.Convert(&sol, &out, nil); err != nil {
-			return nil, fmt.Errorf("unable to convert ACME challenge solver to internal challenge type: %w", err)
-		}
-
-		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
-		if len(requiredSecrets) == 0 {
-			continue
-		}
-		secrets = append(secrets, requiredSecrets...)
-	}
-
-	return secrets, nil
 }


### PR DESCRIPTION
## Pull Request Motivation

Fixes #9036

Since #8255, ACME Issuer/ClusterIssuer `Setup()` validates DNS-01 solver Secrets and can leave the issuer at `Ready: False` / `InvalidSolver` when a Secret is missing. Creating that Secret later never re-queued the issuer because `issuersForSecret` only matched the ACME account private key and EAB key, not solver secretRefs. Recovery required a 10h resync, a spec change, or a restart.

## Changes

- Extend `issuersForSecret` in both `pkg/controller/issuers` and `pkg/controller/clusterissuers` to match DNS-01 solver secrets (same set of secret names collected by `ValidateACMEChallengeSolverDNS01`: Route53, CloudDNS, Cloudflare, Akamai, AzureDNS, AcmeDNS, DigitalOcean, RFC2136, etc.).
- Keep matching private key and EAB secrets as before.
- Unit tests for the pure matcher (account key, EAB, Route53, CloudDNS, unrelated secret).

## Kind

/kind bug

## Release Note

```release-note
Fix Issuer/ClusterIssuer stuck at Ready=False/InvalidSolver after a missing ACME DNS-01 solver Secret is created
```

## Verification

```
go test ./pkg/controller/issuers/ ./pkg/controller/clusterissuers/ -count=1
```

Both packages: pass (including new `TestACMEIssuerReferencesSecret`).

## Related

- Issue #9036 (repro with envtest ProcessItem counters)
- Introduced user-visible gap by #8255 (DNS solver validation at Ready time)
- Gap discussed during #8255 review (solver secrets not in requeue path)
