### PR TITLE
Requeue Issuers/ClusterIssuers when ACME DNS-01 solver Secrets change

### DIFF
--- a/pkg/acme/secrets.go
+++ b/pkg/acme/secrets.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
+	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
+	"github.com/cert-manager/cert-manager/internal/apis/meta"
+	"github.com/cert-manager/cert-manager/pkg/api"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// RequiredDNS01SolverSecrets returns the Kubernetes Secret references required
+// by the ACME DNS-01 solvers configured on the given issuer. It is the single
+// source of truth for which Secrets an ACME issuer's DNS-01 solvers depend on,
+// shared by the code that validates those Secrets exist (pkg/issuer/acme) and
+// the code that decides whether a Secret event is relevant to a given
+// Issuer/ClusterIssuer (pkg/controller/issuers, pkg/controller/clusterissuers).
+func RequiredDNS01SolverSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
+	var secrets []*meta.SecretKeySelector
+	spec := issuer.GetSpec()
+	if spec.ACME == nil {
+		return secrets, nil
+	}
+
+	solvers := spec.ACME.Solvers
+	for i := range solvers {
+		sol := solvers[i]
+		if sol.DNS01 == nil {
+			continue
+		}
+
+		var out cmacme.ACMEChallengeSolver
+		if err := api.Scheme.Convert(&sol, &out, nil); err != nil {
+			return nil, fmt.Errorf("unable to convert ACME challenge solver to internal challenge type: %w", err)
+		}
+
+		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
+		if len(requiredSecrets) == 0 {
+			continue
+		}
+		secrets = append(secrets, requiredSecrets...)
+	}
+
+	return secrets, nil
+}

--- a/pkg/acme/secrets_test.go
+++ b/pkg/acme/secrets_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cert-manager/cert-manager/pkg/acme"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func TestRequiredDNS01SolverSecrets(t *testing.T) {
+	tests := map[string]struct {
+		issuer        gen.IssuerModifier
+		expectNames   []string
+		expectErr     bool
+		expectNoSlice bool
+	}{
+		"non-ACME issuer returns no secrets": {
+			issuer:        gen.SetIssuerCA(v1.CAIssuer{SecretName: "ca-secret"}),
+			expectNoSlice: true,
+		},
+		"ACME issuer with no solvers returns no secrets": {
+			issuer:      gen.SetIssuerACME(cmacme.ACMEIssuer{}),
+			expectNames: nil,
+		},
+		"ACME issuer with an HTTP-01-only solver returns no secrets": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{HTTP01: &cmacme.ACMEChallengeSolverHTTP01{}},
+			}),
+			expectNames: nil,
+		},
+		"ACME issuer with a Route53 DNS-01 solver returns its secret": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						SecretAccessKey: cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+							Key:                  "secret-access-key",
+						},
+					},
+				}},
+			}),
+			expectNames: []string{"route53-creds"},
+		},
+		"ACME issuer with multiple DNS-01 solvers returns all their secrets": {
+			issuer: gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+						SecretAccessKey: cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+							Key:                  "secret-access-key",
+						},
+					},
+				}},
+				{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+					CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
+						ServiceAccount: &cmmeta.SecretKeySelector{
+							LocalObjectReference: cmmeta.LocalObjectReference{Name: "clouddns-creds"},
+							Key:                  "service-account.json",
+						},
+					},
+				}},
+			}),
+			expectNames: []string{"route53-creds", "clouddns-creds"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			issuer := gen.Issuer("test", tc.issuer)
+
+			secrets, err := acme.RequiredDNS01SolverSecrets(issuer)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.expectNoSlice {
+				assert.Nil(t, secrets)
+				return
+			}
+
+			var names []string
+			for _, s := range secrets {
+				names = append(names, s.Name)
+			}
+			assert.Equal(t, tc.expectNames, names)
+		})
+	}
+}

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/cert-manager/cert-manager/pkg/acme"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -47,6 +48,16 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 				if iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
 					affected = append(affected, iss)
 					continue
+				}
+			}
+			solverSecrets, err := acme.RequiredDNS01SolverSecrets(iss)
+			if err != nil {
+				return nil, fmt.Errorf("error determining ACME DNS-01 solver secrets for issuer %s: %w", iss.Name, err)
+			}
+			for _, s := range solverSecrets {
+				if s.Name == secret.Name {
+					affected = append(affected, iss)
+					break
 				}
 			}
 		case iss.Spec.CA != nil:

--- a/pkg/controller/clusterissuers/checks_test.go
+++ b/pkg/controller/clusterissuers/checks_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterissuers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+// TestIssuersForSecret_ACMEDNS01Solver is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/9036: a ClusterIssuer
+// with an ACME DNS-01 solver referencing a Secret must be requeued when that
+// Secret is created or updated, the same way it already is for its
+// PrivateKey and ExternalAccountBinding Secrets.
+func TestIssuersForSecret_ACMEDNS01Solver(t *testing.T) {
+	const clusterResourceNamespace = "cert-manager"
+
+	route53Issuer := gen.ClusterIssuer("route53-issuer",
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+	eabIssuer := gen.ClusterIssuer("eab-issuer",
+		gen.SetIssuerACMEEAB("kid", "eab-creds"),
+	)
+	privateKeyIssuer := gen.ClusterIssuer("privatekey-issuer",
+		gen.SetIssuerACMEPrivKeyRef("privatekey-creds"),
+	)
+	caIssuer := gen.ClusterIssuer("ca-issuer",
+		gen.SetIssuerCASecretName("ca-creds"),
+	)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, iss := range []*v1.ClusterIssuer{route53Issuer, eabIssuer, privateKeyIssuer, caIssuer} {
+		require.NoError(t, indexer.Add(iss))
+	}
+
+	c := &controller{
+		clusterIssuerLister:      cmlisters.NewClusterIssuerLister(indexer),
+		clusterResourceNamespace: clusterResourceNamespace,
+	}
+
+	tests := map[string]struct {
+		secret        *corev1.Secret
+		expectIssuers []string
+	}{
+		"a Secret referenced by a DNS-01 solver requeues the matching ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "route53-creds"),
+			expectIssuers: []string{"route53-issuer"},
+		},
+		"a Secret referenced by ExternalAccountBinding still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "eab-creds"),
+			expectIssuers: []string{"eab-issuer"},
+		},
+		"a Secret referenced by the ACME PrivateKey still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "privatekey-creds"),
+			expectIssuers: []string{"privatekey-issuer"},
+		},
+		"a Secret referenced by a CA ClusterIssuer still requeues its ClusterIssuer": {
+			secret:        secretNamed(clusterResourceNamespace, "ca-creds"),
+			expectIssuers: []string{"ca-issuer"},
+		},
+		"a same-named Secret outside the cluster resource namespace does not requeue": {
+			secret:        secretNamed("some-other-namespace", "route53-creds"),
+			expectIssuers: nil,
+		},
+		"an unreferenced Secret requeues nothing": {
+			secret:        secretNamed(clusterResourceNamespace, "unrelated-secret"),
+			expectIssuers: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			affected, err := c.issuersForSecret(tc.secret)
+			require.NoError(t, err)
+
+			var names []string
+			for _, iss := range affected {
+				names = append(names, iss.Name)
+			}
+			assert.Equal(t, tc.expectIssuers, names)
+		})
+	}
+}
+
+func secretNamed(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/cert-manager/cert-manager/pkg/acme"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
 
@@ -49,6 +50,16 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 				if iss.Spec.ACME.ExternalAccountBinding.Key.Name == secret.Name {
 					affected = append(affected, iss)
 					continue
+				}
+			}
+			solverSecrets, err := acme.RequiredDNS01SolverSecrets(iss)
+			if err != nil {
+				return nil, fmt.Errorf("error determining ACME DNS-01 solver secrets for issuer %s/%s: %w", iss.Namespace, iss.Name, err)
+			}
+			for _, s := range solverSecrets {
+				if s.Name == secret.Name {
+					affected = append(affected, iss)
+					break
 				}
 			}
 		case iss.Spec.CA != nil:

--- a/pkg/controller/issuers/checks_test.go
+++ b/pkg/controller/issuers/checks_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package issuers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+// TestIssuersForSecret_ACMEDNS01Solver is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/9036: an Issuer with an
+// ACME DNS-01 solver referencing a Secret must be requeued when that Secret
+// is created or updated, the same way it already is for its PrivateKey and
+// ExternalAccountBinding Secrets.
+func TestIssuersForSecret_ACMEDNS01Solver(t *testing.T) {
+	const ns = "testns"
+
+	route53Issuer := gen.Issuer("route53-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+	eabIssuer := gen.Issuer("eab-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMEEAB("kid", "eab-creds"),
+	)
+	privateKeyIssuer := gen.Issuer("privatekey-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerACMEPrivKeyRef("privatekey-creds"),
+	)
+	caIssuer := gen.Issuer("ca-issuer",
+		gen.SetIssuerNamespace(ns),
+		gen.SetIssuerCASecretName("ca-creds"),
+	)
+	otherNamespaceIssuer := gen.Issuer("other-ns-issuer",
+		gen.SetIssuerNamespace("other"),
+		gen.SetIssuerACMESolvers([]cmacme.ACMEChallengeSolver{
+			{DNS01: &cmacme.ACMEChallengeSolverDNS01{
+				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+					SecretAccessKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "route53-creds"},
+						Key:                  "secret-access-key",
+					},
+				},
+			}},
+		}),
+	)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, iss := range []*v1.Issuer{route53Issuer, eabIssuer, privateKeyIssuer, caIssuer, otherNamespaceIssuer} {
+		require.NoError(t, indexer.Add(iss))
+	}
+
+	c := &controller{issuerLister: cmlisters.NewIssuerLister(indexer)}
+
+	tests := map[string]struct {
+		secret        *corev1.Secret
+		expectIssuers []string
+	}{
+		"a Secret referenced by a DNS-01 solver requeues the matching Issuer": {
+			secret:        secretNamed(ns, "route53-creds"),
+			expectIssuers: []string{"route53-issuer"},
+		},
+		"a Secret referenced by ExternalAccountBinding still requeues its Issuer": {
+			secret:        secretNamed(ns, "eab-creds"),
+			expectIssuers: []string{"eab-issuer"},
+		},
+		"a Secret referenced by the ACME PrivateKey still requeues its Issuer": {
+			secret:        secretNamed(ns, "privatekey-creds"),
+			expectIssuers: []string{"privatekey-issuer"},
+		},
+		"a Secret referenced by a CA Issuer still requeues its Issuer": {
+			secret:        secretNamed(ns, "ca-creds"),
+			expectIssuers: []string{"ca-issuer"},
+		},
+		"a same-named Secret in a different namespace does not requeue": {
+			secret:        secretNamed("other", "route53-creds"),
+			expectIssuers: []string{"other-ns-issuer"},
+		},
+		"an unreferenced Secret requeues nothing": {
+			secret:        secretNamed(ns, "unrelated-secret"),
+			expectIssuers: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			affected, err := c.issuersForSecret(tc.secret)
+			require.NoError(t, err)
+
+			var names []string
+			for _, iss := range affected {
+				names = append(names, iss.Name)
+			}
+			assert.Equal(t, tc.expectIssuers, names)
+		})
+	}
+}
+
+func secretNamed(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -29,15 +29,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	cmacme "github.com/cert-manager/cert-manager/internal/apis/acme"
-	"github.com/cert-manager/cert-manager/internal/apis/certmanager/validation"
-	"github.com/cert-manager/cert-manager/internal/apis/meta"
 	"github.com/cert-manager/cert-manager/pkg/acme"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	"github.com/cert-manager/cert-manager/pkg/acme/client"
-	"github.com/cert-manager/cert-manager/pkg/api"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -584,7 +579,7 @@ var acmev1ToV2Mappings = map[string]string{
 func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) []string {
 	var warning []string
 
-	secrets, err := extractSecrets(issuer)
+	secrets, err := acme.RequiredDNS01SolverSecrets(issuer)
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "error extracting secrets")
 		warning = append(warning, "unable to verify dns solvers")
@@ -608,33 +603,4 @@ func (a *Acme) validateDNSSolvers(ctx context.Context, issuer v1.GenericIssuer) 
 		}
 	}
 	return warning
-}
-
-func extractSecrets(issuer v1.GenericIssuer) ([]*meta.SecretKeySelector, error) {
-	var secrets []*meta.SecretKeySelector
-	spec := issuer.GetSpec()
-	if spec.ACME == nil {
-		return secrets, nil
-	}
-
-	solvers := spec.ACME.Solvers
-	for i := range solvers {
-		sol := solvers[i]
-		if sol.DNS01 == nil {
-			continue
-		}
-
-		var out cmacme.ACMEChallengeSolver
-		if err := api.Scheme.Convert(&sol, &out, nil); err != nil {
-			return nil, fmt.Errorf("unable to convert ACME challenge solver to internal challenge type: %w", err)
-		}
-
-		_, requiredSecrets := validation.ValidateACMEChallengeSolverDNS01(out.DNS01, field.NewPath("spec"))
-		if len(requiredSecrets) == 0 {
-			continue
-		}
-		secrets = append(secrets, requiredSecrets...)
-	}
-
-	return secrets, nil
 }


### PR DESCRIPTION
## Motivation

Fixes #9036.

Since 1.21.0, #8255 added eager validation of ACME DNS-01 solver Secrets, surfacing an `InvalidSolver` condition when a solver's Secret is missing or a required key is absent. However, `issuersForSecret()` in `pkg/controller/issuers` and `pkg/controller/clusterissuers` — which decides which Issuers/ClusterIssuers to requeue on a Secret informer event — was never extended to match solver `secretRef`s, only the ACME `PrivateKey`, `ExternalAccountBinding`, `CA`, Venafi and Vault credential secrets.

The result: once an Issuer/ClusterIssuer gets stuck at `Ready: False` / `InvalidSolver` because a solver Secret doesn't exist yet, creating that Secret never triggers a requeue. The issuer only recovers on the next informer resync (10h by default), a change to the Issuer/ClusterIssuer's own spec, or a controller restart.

This was discussed and deferred during review of #8255 (https://github.com/cert-manager/cert-manager/pull/8255#issuecomment-4128299694), and is also the flip side of an unanswered question raised on that PR about a Secret being invalidated *after* the issuer reaches `Ready` (https://github.com/cert-manager/cert-manager/pull/8255#issuecomment-4370169724) — same underlying gap, opposite direction.

@gecube independently reproduced the bug on both `v1.21.0` and `master`, and validated locally that extending `issuersForSecret()` to match DNS-01 solver secrets fixes it (see the issue for their full write-up).

## Change

Extracts the existing per-provider DNS-01 solver secret-reference walk — previously private to `pkg/issuer/acme`'s `Setup()` (`extractSecrets`), which already uses it to validate that solver Secrets exist and contain the expected key — into an exported `pkg/acme.RequiredDNS01SolverSecrets` helper, and calls it from `issuersForSecret()` in both `pkg/controller/issuers/checks.go` and `pkg/controller/clusterissuers/checks.go`.

Reusing this logic, rather than re-implementing the provider-by-provider secretRef list at the call site, means a newly added DNS-01 provider only needs its secretRef wired into `ValidateACMEChallengeSolverDNS01` once — as is already required for admission validation — for both call sites (validation and requeue) to pick it up automatically.

No import cycle is introduced: `pkg/acme` is a small, side-effect-free package with no dependency back into either controller package (verified with `go list -deps`), unlike importing the full `pkg/issuer/acme` package directly, which would also register the ACME issuer factory via its `init()` as an unwanted side effect.

## Test plan

- Added `pkg/acme/secrets_test.go`, unit-testing `RequiredDNS01SolverSecrets` against a non-ACME issuer, an ACME issuer with no solvers, an HTTP-01-only solver, a single DNS-01 solver (Route53), and multiple DNS-01 solvers (Route53 + CloudDNS).
- Added `pkg/controller/issuers/checks_test.go` and `pkg/controller/clusterissuers/checks_test.go` — `issuersForSecret()` had **no existing test coverage** for either package, so alongside the new DNS-01 solver match these also cover the pre-existing PrivateKey/EAB/CA match paths and cross-namespace isolation, as a regression guard.
- Manually reproduced the exact scenario from the issue (a ClusterIssuer with a Route53 DNS-01 solver referencing a not-yet-existing Secret) as a standalone test before applying the fix (0 issuers requeued) and after (1 issuer requeued), confirming the fix addresses the reported behaviour.
- `go build ./...` and `go test ./pkg/acme/... ./pkg/issuer/acme/... ./pkg/controller/issuers/... ./pkg/controller/clusterissuers/...` all pass, including the pre-existing `pkg/issuer/acme` suite covering `validateDNSSolvers`/`Setup()`, which now calls the extracted helper.

### Release Note

```release-note
Fix Issuers/ClusterIssuers with an ACME DNS-01 solver getting stuck at `Ready: False`/`InvalidSolver` and never recovering after the missing solver Secret is created
```
