### PR TITLE
Fix CertificateRequest approval event reason

### DIFF
--- a/pkg/controller/certificaterequests/approver/approver_test.go
+++ b/pkg/controller/certificaterequests/approver/approver_test.go
@@ -139,7 +139,7 @@ func TestProcessItem(t *testing.T) {
 					LastTransitionTime: &metaNow,
 				},
 			},
-			expectedEvent: "Normal cert-manager.io Certificate request has been approved by cert-manager.io",
+			expectedEvent: "Normal AutoApproved Certificate request has been approved by cert-manager.io",
 		},
 		"approve CertificateRequest has 'Ready' Pending condition": {
 			request: &cmapi.CertificateRequest{
@@ -168,7 +168,7 @@ func TestProcessItem(t *testing.T) {
 					LastTransitionTime: &metaNow,
 				},
 			},
-			expectedEvent: "Normal cert-manager.io Certificate request has been approved by cert-manager.io",
+			expectedEvent: "Normal AutoApproved Certificate request has been approved by cert-manager.io",
 		},
 	}
 	for name, test := range tests {

--- a/pkg/controller/certificaterequests/approver/sync.go
+++ b/pkg/controller/certificaterequests/approver/sync.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	ApprovedMessage = "Certificate request has been approved by cert-manager.io"
+	ApprovedMessage         = "Certificate request has been approved by cert-manager.io"
+	eventReasonAutoApproved = "AutoApproved"
 )
 
 // Sync will set the "Approved" condition to True on synced
@@ -68,7 +69,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	if err := c.updateStatusOrApply(ctx, cr); err != nil {
 		return err
 	}
-	c.recorder.Event(cr, corev1.EventTypeNormal, "cert-manager.io", ApprovedMessage)
+	c.recorder.Event(cr, corev1.EventTypeNormal, eventReasonAutoApproved, ApprovedMessage)
 
 	log.V(logf.DebugLevel).Info("approved certificate request")
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes #7522.

The CertificateRequest approver emitted a Normal Event with `cert-manager.io` as its reason, which does not follow the Kubernetes UpperCamelCase Event reason convention. This changes only the Event reason to `AutoApproved`; the CertificateRequest Approved condition reason and message remain unchanged for compatibility.

Tests:

- `go test -race ./pkg/controller/certificaterequests/approver -run '^TestProcessItem$' -count=1`
- `go test ./pkg/controller/certificaterequests/... -count=1`
- `go vet ./pkg/controller/certificaterequests/approver`

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Fix CertificateRequest approval Events to use the standard `AutoApproved` reason.
```
