### PR TITLE
Add workqueue keys to controller logs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -138,8 +138,9 @@ func (c *controller) worker(ctx context.Context) {
 		// use an inlined function so we can use defer
 		func() {
 			defer c.queue.Done(obj)
+			itemLog := log.WithValues("key", obj)
 
-			log.V(logf.DebugLevel).Info("syncing item")
+			itemLog.V(logf.DebugLevel).Info("syncing item")
 
 			// Increase sync count for this controller
 			c.metrics.IncrementSyncCallCount(c.name)
@@ -147,19 +148,19 @@ func (c *controller) worker(ctx context.Context) {
 			err := c.syncHandler(ctx, obj)
 			if err != nil {
 				if strings.Contains(err.Error(), genericregistry.OptimisticLockErrorMsg) {
-					log.Info("re-queuing item due to optimistic locking on resource", "error", err.Error())
+					itemLog.Info("re-queuing item due to optimistic locking on resource", "error", err.Error())
 					// These errors are not counted towards the controllerSyncErrorCount metric on purpose
 					// as they will go way with
 					// https://github.com/cert-manager/cert-manager/blob/master/design/20220118.server-side-apply.md
 				} else {
-					log.Error(err, "re-queuing item due to error processing")
+					itemLog.Error(err, "re-queuing item due to error processing")
 					c.metrics.IncrementSyncErrorCount(c.name)
 				}
 
 				c.queue.AddRateLimited(obj)
 				return
 			}
-			log.V(logf.DebugLevel).Info("finished processing work item")
+			itemLog.V(logf.DebugLevel).Info("finished processing work item")
 			c.queue.Forget(obj)
 		}()
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Partially addresses #7551.

Generic controller worker messages did not include the dequeued resource key, so repeated sync and requeue logs could not be tied to the affected object. This restores item-scoped logging context with a `key` field on the sync, optimistic-lock requeue, error requeue, and completion paths.

This change does not alter queue behavior, retry timing, metrics, or reconciliation results. The other independent logging concerns tracked in #7551 remain out of scope.

Tests:

- `go test ./pkg/controller/... -count=1`
- `go test -race ./pkg/controller -count=1`
- `go vet ./pkg/controller`

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Controller workqueue log messages now include the affected resource key.
```
