### PR TITLE
fix: don't count terminating HTTP01 solver pods when deciding to create/clean up

### DIFF
--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -79,11 +79,24 @@ func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) error {
 	if err != nil {
 		return err
 	}
-	if len(existingPods) == 1 {
-		logf.WithRelatedResource(log, existingPods[0]).Info("found one existing HTTP01 solver pod")
+
+	// Pods that are already terminating (e.g. deleted on a previous sync, or
+	// stuck terminating on a drained/unreachable node) are ignored here: they
+	// are already on their way out, and waiting for them to disappear from
+	// the lister cache before making progress can block forever. See
+	// https://github.com/cert-manager/cert-manager/issues/7768.
+	var activePods []*metav1.PartialObjectMetadata
+	for _, pod := range existingPods {
+		if pod.DeletionTimestamp == nil {
+			activePods = append(activePods, pod)
+		}
+	}
+
+	if len(activePods) == 1 {
+		logf.WithRelatedResource(log, activePods[0]).Info("found one existing HTTP01 solver pod")
 		return nil
 	}
-	if len(existingPods) > 1 {
+	if len(activePods) > 1 {
 		log.V(logf.InfoLevel).Info("multiple challenge solver pods found for challenge. cleaning up all existing pods.")
 		err := s.cleanupPods(ctx, ch)
 		if err != nil {

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -85,12 +85,16 @@ func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) error {
 	// are already on their way out, and waiting for them to disappear from
 	// the lister cache before making progress can block forever. See
 	// https://github.com/cert-manager/cert-manager/issues/7768.
-	var activePods []*metav1.PartialObjectMetadata
-	for _, pod := range existingPods {
-		if pod.DeletionTimestamp == nil {
-			activePods = append(activePods, pod)
-		}
-	}
+	//
+	// This is a deliberate trade-off: if one active pod remains alongside
+	// stuck-terminating ones, this func no-ops below and no further Delete
+	// calls are issued for the terminating pods, so they are left as-is
+	// rather than retried; and nothing here bounds how many terminating
+	// pods can accumulate if the underlying cause (e.g. repeated node
+	// drains) keeps recurring. Both are considered acceptable because every
+	// listed pod already carries a DeletionTimestamp and serves the same
+	// token/key as any active pod.
+	activePods, _ := partitionPodsByTermination(existingPods)
 
 	if len(activePods) == 1 {
 		logf.WithRelatedResource(log, activePods[0]).Info("found one existing HTTP01 solver pod")
@@ -146,6 +150,20 @@ func (s *Solver) getPodsForChallenge(ctx context.Context, ch *cmacme.Challenge) 
 	}
 
 	return relevantPods, nil
+}
+
+// partitionPodsByTermination splits pods into those that are still active
+// (no DeletionTimestamp set) and those that are already terminating, so
+// callers have a single, shared definition of "active" to work from.
+func partitionPodsByTermination(pods []*metav1.PartialObjectMetadata) (active, terminating []*metav1.PartialObjectMetadata) {
+	for _, pod := range pods {
+		if pod.DeletionTimestamp == nil {
+			active = append(active, pod)
+		} else {
+			terminating = append(terminating, pod)
+		}
+	}
+	return active, terminating
 }
 
 func (s *Solver) cleanupPods(ctx context.Context, ch *cmacme.Challenge) error {

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -298,6 +298,29 @@ func TestEnsurePod(t *testing.T) {
 			chal:        chal,
 			expectedErr: true,
 		},
+		"should create a new pod if the only existing pod is terminating": {
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{func(p metav1.PartialObjectMetadata) *metav1.PartialObjectMetadata {
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return &p
+				}(*podMeta)},
+				ExpectedActions: []testpkg.Action{testpkg.NewAction(coretesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("pods"), testNamespace, pod))},
+			},
+			chal: chal,
+		},
+		"should do nothing if one pod is active and another is terminating": {
+			builder: &testpkg.Builder{
+				PartialMetadataObjects: []runtime.Object{podMeta, func(p metav1.PartialObjectMetadata) *metav1.PartialObjectMetadata {
+					p.Name = "foobar"
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return &p
+				}(*podMeta)},
+				ExpectedActions: []testpkg.Action{},
+			},
+			chal: chal,
+		},
 	}
 	for name, scenario := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Motivation:
The HTTP01 solver's ensurePod could get stuck permanently retrying
"multiple existing challenge solver pods found and cleaned up.
retrying challenge sync" instead of making progress. getPodsForChallenge
lists all pods owned by the Challenge with no filtering on deletion
state, and a pod that has been sent a graceful Delete (e.g. by a
previous cleanup, or by node draining/eviction) keeps appearing in
that list - with a DeletionTimestamp set - until its node's kubelet
confirms termination. If a node is drained, evicted, or its kubelet
becomes unreachable, that confirmation may never arrive, so the pod
stays "Terminating" indefinitely. Every reconcile then saw ">1
existing pods" (the same stuck one(s) plus, potentially, itself
after a prior no-op re-delete), re-ran cleanup, and returned the same
retry error forever, never reaching the "create a new pod" branch.
This matches the behaviour reported in #7768: a handful of Challenges
stuck in a create/delete loop for weeks after a suspected node
eviction, blocking ACME validation and certificate issuance/renewal
for those Challenges until a human manually intervened (e.g.
force-deleting the stuck pod).

Approach:
In ensurePod, partition the pods returned by getPodsForChallenge into
"active" pods (DeletionTimestamp == nil) and use that count, rather
than the raw count, to decide whether to do nothing, clean up, or
create. Pods that are already terminating no longer block forward
progress: if the only existing pods are terminating, cert-manager now
creates a fresh solver pod instead of looping forever on the retry
error. cleanupPods and getPodsForChallenge are otherwise unchanged;
cleanup is still triggered whenever more than one active pod exists,
and still re-deletes anything matching the challenge (a harmless
no-op for pods already terminating).

This is a targeted fix for the specific stuck-loop symptom described
in the issue; it does not change behaviour when there are 0 or 1
active pods and no terminating stragglers, which remains the common
case.

Validation:
Added two new table-driven cases to TestEnsurePod in
pkg/issuer/acme/http/pod_test.go: one where the only existing pod is
terminating (expects a new pod to be created, no delete calls), and
one where one active pod coexists with a terminating one (expects no
action at all, i.e. the healthy pod is left alone rather than being
deleted as part of a false "multiple pods" cleanup - this reproduces
a related latent bug in the old code where a legitimate active pod
would have been deleted alongside a stuck-terminating one).

Ran:
  go build ./...
  go test ./pkg/issuer/acme/http/...
Both pass, including the new and pre-existing cases in that package.
This was verified by re-running the fix and tests independently
through two rounds of adversarial review; no correctness, convention,
or fork-safety blockers were found.

Note: this fix is verified against the reconciler logic and unit
tests only; it was not reproduced end-to-end against a live cluster
with an actually-stuck/unreachable node, since that requires
infrastructure not available here.

/kind bug

```release-note
Fixed a bug in the ACME HTTP01 solver where a challenge could get stuck
permanently retrying "multiple existing challenge solver pods found"
if a solver pod became stuck in a Terminating state (for example due
to node draining, eviction, or an unreachable kubelet), blocking
certificate issuance/renewal for the affected challenge.
```

Fixes #7768

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
