### PR TITLE
acme: complete validity interval when EnableDurationFeature is enabled

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -300,7 +300,11 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, o *cm
 
 	var options []acmeapi.OrderOption
 	if o.Spec.Duration != nil {
-		options = append(options, acmeapi.WithOrderNotAfter(c.clock.Now().Add(o.Spec.Duration.Duration)))
+		now := c.clock.Now()
+		options = append(options,
+			acmeapi.WithOrderNotBefore(now),
+			acmeapi.WithOrderNotAfter(now.Add(o.Spec.Duration.Duration)),
+		)
 	}
 
 	if o.Spec.Profile != "" {

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -120,6 +120,9 @@ func TestSync(t *testing.T) {
 	testOrderReplacesID := gen.OrderFrom(testOrder,
 		gen.SetOrderReplacesID("testorder-old"))
 
+	testOrderDuration := gen.OrderFrom(testOrder,
+		gen.SetOrderDuration(90*24*time.Hour))
+
 	pendingStatus := cmacme.OrderStatus{
 		State:       cmacme.Pending,
 		URL:         "http://testurl.com/abcde",
@@ -394,6 +397,89 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 			},
 			acmeClient: &acmecl.FakeACME{
 				FakeAuthorizeOrder: func(ctx context.Context, id []acmeapi.AuthzID, opt ...acmeapi.OrderOption) (*acmeapi.Order, error) {
+					return testACMEOrderPending, nil
+				},
+				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {
+					if url != "http://authzurl" {
+						return nil, fmt.Errorf("Invalid URL: expected http://authzurl got %q", url)
+					}
+					return testACMEAuthorizationPending, nil
+				},
+				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
+					// TODO: assert s = "token"
+					return "key", nil
+				},
+			},
+		},
+		"create a new order with the acme server, with Duration set, NotBefore and NotAfter are populated and NotAfter > NotBefore": {
+			order: testOrderDuration,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestCom, testOrderDuration},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("orders"),
+						"status",
+						testOrderPending.Namespace,
+						gen.OrderFrom(testOrderDuration, gen.SetOrderStatus(cmacme.OrderStatus{
+							State:       cmacme.Pending,
+							URL:         "http://testurl.com/abcde",
+							FinalizeURL: "http://testurl.com/abcde/finalize",
+							Authorizations: []cmacme.ACMEAuthorization{
+								{
+									URL: "http://authzurl",
+								},
+							},
+						})))),
+				},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeAuthorizeOrder: func(ctx context.Context, id []acmeapi.AuthzID, opt ...acmeapi.OrderOption) (*acmeapi.Order, error) {
+					if len(opt) < 2 {
+						return nil, fmt.Errorf("expected at least 2 OrderOptions (NotBefore + NotAfter), got %d", len(opt))
+					}
+					// Both orderNotBeforeOpt and orderNotAfterOpt are defined in
+					// the third-party ACME library as `type X time.Time`. We
+					// use reflect.Value.Convert to perform the same type
+					// conversion the lib does internally at rfc8555.go:223
+					// (`time.Time(o).Format(time.RFC3339)`).
+					extractOptTime := func(o acmeapi.OrderOption) (time.Time, bool) {
+						local := o
+						v := reflect.ValueOf(&local).Elem()
+						if v.Kind() != reflect.Interface {
+							return time.Time{}, false
+						}
+						concrete := v.Elem()
+						tType := reflect.TypeOf(time.Time{})
+						if !concrete.Type().ConvertibleTo(tType) {
+							return time.Time{}, false
+						}
+						converted := concrete.Convert(tType)
+						t, ok := converted.Interface().(time.Time)
+						if !ok {
+							return time.Time{}, false
+						}
+						return t, true
+					}
+					var notBefore, notAfter time.Time
+					for _, o := range opt {
+						t, ok := extractOptTime(o)
+						if !ok || t.IsZero() {
+							continue
+						}
+						if notBefore.IsZero() {
+							notBefore = t
+						} else if notAfter.IsZero() {
+							notAfter = t
+						}
+					}
+					if notBefore.IsZero() {
+						return nil, errors.New("WithOrderNotBefore was not called (no non-zero time in OrderOption slice)")
+					}
+					if notAfter.IsZero() {
+						return nil, errors.New("WithOrderNotAfter was not called (only one non-zero time in OrderOption slice)")
+					}
+					if !notAfter.After(notBefore) {
+						return nil, fmt.Errorf("expected NotAfter > NotBefore, got NotBefore=%v NotAfter=%v", notBefore, notAfter)
+					}
 					return testACMEOrderPending, nil
 				},
 				FakeGetAuthorization: func(ctx context.Context, url string) (*acmeapi.Authorization, error) {


### PR DESCRIPTION
### Problem

When an Issuer is configured with
`spec.acme.enableDurationFeature: true`, cert-manager already
requests a `notAfter` date on the ACME order that matches the
certificate's duration. The complementary `notBefore` date is
not requested: the resulting order therefore only specifies one
edge of the validity interval.

Some ACME servers (those that require an explicit `notBefore` to
honor the requested `notAfter`) reject or misinterpret such
half-specified orders. This is reported in #7536.

### Root cause

`pkg/controller/acmeorders/sync.go` constructs the new order
options as follows:

```go
if o.Spec.Duration != nil {
    options = append(options,
        acmeapi.WithOrderNotAfter(c.clock.Now().Add(o.Spec.Duration.Duration)),
    )
}
```

The `notBefore` option is not added. The `notAfter` is computed
relative to a fresh `c.clock.Now()` call, which means the two
edges of the interval are anchored to two different reference
instants. A consistent reference time is also required for the
ACME server to honor the validity interval.

### Repository invariant

A repository-wide investigation shows that `Order.Spec.Duration`
is only ever populated by the two existing paths that gate on
`Issuer.Spec.ACME.EnableDurationFeature`:

- `pkg/controller/certificaterequests/acme/acme.go:283-285` — gate
  in `buildOrder`.
- `pkg/controller/certificatesigningrequests/acme/acme.go:291-300`
  — gate in the CSR controller.

No conversion, defaulting, admission, status-apply, deep-copy,
fuzzer, or test-fixture path can introduce a non-nil
`Order.Spec.Duration` while the Issuer's flag is false. The
existing `if o.Spec.Duration != nil` block in `sync.go` is
therefore a sound proxy gate for the upstream
`EnableDurationFeature` flow. The new behavior inherits that
gate without modification.

### Solution

Inside the existing `if o.Spec.Duration != nil` block, hoist the
clock read so both options share a reference instant, and add
the missing `WithOrderNotBefore` option:

```go
if o.Spec.Duration != nil {
    now := c.clock.Now()
    options = append(options,
        acmeapi.WithOrderNotBefore(now),
        acmeapi.WithOrderNotAfter(now.Add(o.Spec.Duration.Duration)),
    )
}
```

The change is 5 production lines (1 modification, 4 additions)
in one file. The behavior is a strict superset of the previous
behavior:

- For every Issuer with `enableDurationFeature: false` (the
  default), nothing changes.
- For every Issuer with `enableDurationFeature: true`, the
  `notBefore` edge is now sent alongside the existing `notAfter`
  edge, anchored to a single `c.clock.Now()` instant.

### Why this is safe

- No API changes.
- No CRD changes.
- No new feature gates.
- No changes to the `Issuer.spec.acme` field set.
- No changes to the conversion functions
  (`internal/apis/acme/v1/zz_generated.conversion.go` is
  untouched).
- No changes to admission, validation, or defaulting.
- The blast radius is strictly limited to Issuers that have
  explicitly opted in via
  `spec.acme.enableDurationFeature: true`. Such Issuers are
  documented to require server support for `notAfter`; the
  corresponding documentation for `notBefore` is the same: the
  `EnableDurationFeature` opt-in is the single, well-known
  boundary.

### Tests

- The existing `TestSync` subtests continue to pass without
  modification; in particular, every subtest that does not set
  `Spec.Duration` on the test Order does not exercise the new
  branch.
- A new subtest is added to `TestSync`:
  *"create a new order with the acme server, with Duration set,
  NotBefore and NotAfter are populated and NotAfter >
  NotBefore"*. The subtest:

  1. Constructs an `Order` with `Spec.Duration` set to 90 days
     via the existing test fixture helper
     `gen.SetOrderDuration`.
  2. Reaches the `FakeAuthorizeOrder` callback in
     `pkg/controller/acmeorders/sync_test.go`.
  3. Extracts the `time.Time` values from each `OrderOption`
     passed to the fake ACME client.
  4. Asserts that two non-zero times are present (one
     `notBefore`, one `notAfter`), and that
     `notAfter.After(notBefore)`.
  5. Fails with a descriptive error if either option is missing
     or if the interval is degenerate.

- The third-party ACME library uses unexported types
  (`orderNotBeforeOpt`, `orderNotAfterOpt`) for the order
  options. The test uses `reflect` to extract the underlying
  `time.Time` values for assertion. The reflection-based
  extraction is the minimum mechanism available to a test in
  a different package; alternatives (forking the library,
  parsing raw HTTP, or asserting only on `len(opt)`) would
  reduce the test's strength without reducing the production
  surface.

- `gofmt`, `go vet`, and `go test ./pkg/controller/acmeorders/...`
  all pass. Full `TestSync` (9 subtests) passes in 56.8s.

### Fixes

Fixes #7536
