### PR TITLE
fix: prevent nil pointer panic when renewal policy is Disabled

### DIFF
--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -280,6 +280,10 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 			message = err.Error()
 		}
 
+		if renewalTime == nil {
+			return "", "", false
+		}
+
 		renewIn := renewalTime.Time.Sub(c.Now())
 		if renewIn > 0 {
 			// renewal time is in the future, no need to renew

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2318,3 +2318,28 @@ func Test_SecretCertificateNameAnnotationsMismatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_CurrentCertificateNearingExpiry_RenewalDisabled(t *testing.T) {
+	clock := &fakeclock.FakeClock{}
+	pk := testcrypto.MustCreatePEMPrivateKey(t)
+	certPEM := testcrypto.MustCreateCert(t, pk, &cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{CommonName: "example.com"},
+	})
+	input := Input{
+		Certificate: &cmapi.Certificate{
+			Spec: cmapi.CertificateSpec{
+				Renewal: &cmapi.CertificateRenewal{
+					Policy: cmapi.CertificateRenewalPolicyDisabled,
+				},
+			},
+		},
+		Secret: &corev1.Secret{
+			Data: map[string][]byte{corev1.TLSCertKey: certPEM},
+		},
+	}
+
+	reason, message, violation := CurrentCertificateNearingExpiry(clock)(input)
+	assert.Equal(t, "", reason)
+	assert.Equal(t, "", message)
+	assert.False(t, violation)
+}


### PR DESCRIPTION
### Pull Request Motivation

`pki.RenewalTime` returns a nil renewal time for `spec.renewal.policy: Disabled`. The `CurrentCertificateNearingExpiry` trigger policy only checks the returned error and then dereferences `renewalTime.Time`, so an issued Certificate that sets `renewal.policy: Disabled` triggers a nil-pointer dereference in the trigger controller. The panic is not recovered anywhere on the reconcile path, so it crashes the controller and the pod crash-loops as the Certificate is re-processed on restart. This returns early with no renewal when the renewal time is nil, matching the intent that `Disabled` never schedules a renewal.

### Kind

/kind bug

### Release Note

```release-note
Fixed a panic in the certificates controller when a Certificate has `spec.renewal.policy` set to `Disabled`.
```