### PR TITLE
fix(acme): retry newOrder without `replaces` on generic ARI `malformed` rejection

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -846,6 +847,13 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, order *cmacme.Orde
 // RFC 9773, servers signal this with the `alreadyReplaced` problem type.
 // We also treat ErrCADoesNotSupportARI as a rejection so renewal can fall
 // back gracefully if the directory changes between Discover and newOrder.
+//
+// RFC 9773 does not mandate a problem type for a `replaces` value the server
+// cannot otherwise validate, e.g. when the Certificate's issuerRef has been
+// switched to a different CA and the CertID's Authority Key Identifier is no
+// longer recognised. Servers we've observed (e.g. Let's Encrypt) report this
+// as a generic `malformed` problem whose detail mentions the `replaces`
+// field, so we also treat that as a rejection.
 func isARIReplacesRejection(err error) bool {
 	if errors.Is(err, acmeapi.ErrCADoesNotSupportARI) {
 		return true
@@ -853,6 +861,9 @@ func isARIReplacesRejection(err error) bool {
 	var ae *acmeapi.Error
 	if errors.As(err, &ae) {
 		if ae.ProblemType == "urn:ietf:params:acme:error:alreadyReplaced" {
+			return true
+		}
+		if ae.ProblemType == "urn:ietf:params:acme:error:malformed" && strings.Contains(strings.ToLower(ae.Detail), "replaces") {
 			return true
 		}
 	}

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -1133,6 +1133,62 @@ func runTest(t *testing.T, test testT) {
 	test.builder.CheckAndFinish(err)
 }
 
+func TestIsARIReplacesRejection(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"CA does not support ARI": {
+			err:  acmeapi.ErrCADoesNotSupportARI,
+			want: true,
+		},
+		"wrapped CA does not support ARI": {
+			err:  fmt.Errorf("authorizing order: %w", acmeapi.ErrCADoesNotSupportARI),
+			want: true,
+		},
+		"alreadyReplaced problem type": {
+			err: &acmeapi.Error{
+				ProblemType: "urn:ietf:params:acme:error:alreadyReplaced",
+				Detail:      "Certificate has already been replaced",
+			},
+			want: true,
+		},
+		"malformed problem mentioning replaces field": {
+			err: &acmeapi.Error{
+				ProblemType: "urn:ietf:params:acme:error:malformed",
+				Detail:      "Could not validate ARI 'replaces' field :: path contained an Authority Key Identifier that did not match a known issuer",
+			},
+			want: true,
+		},
+		"malformed problem mentioning replaces field with different casing": {
+			err: &acmeapi.Error{
+				ProblemType: "urn:ietf:params:acme:error:malformed",
+				Detail:      "Could not validate ARI 'Replaces' field",
+			},
+			want: true,
+		},
+		"malformed problem unrelated to replaces": {
+			err: &acmeapi.Error{
+				ProblemType: "urn:ietf:params:acme:error:malformed",
+				Detail:      "Error creating new order :: invalid DNS name",
+			},
+			want: false,
+		},
+		"unrelated error": {
+			err:  fmt.Errorf("connection refused"),
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isARIReplacesRejection(test.err)
+			if got != test.want {
+				t.Errorf("isARIReplacesRejection(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}
+
 func TestFinalizeOrder(t *testing.T) {
 	tests := map[string]struct {
 		cl               acmecl.Interface


### PR DESCRIPTION
Motivation:
When a Certificate's issuerRef is switched to a different ACME CA while
the ACMEUseARI feature gate is enabled, cert-manager derives an ARI
(RFC 9773) CertID from the currently-installed leaf certificate and sends
it as the `replaces` field on the newOrder request. That CertID's
Authority Key Identifier belongs to the old CA, so the new CA's ACME
server cannot validate it. Some servers (e.g. Let's Encrypt) reject this
with a generic `urn:ietf:params:acme:error:malformed` problem instead of
the RFC-defined `alreadyReplaced` problem, e.g.:

  404 urn:ietf:params:acme:error:malformed: Could not validate ARI
  'replaces' field :: path contained an Authority Key Identifier that did
  not match a known issuer

cert-manager already has a fallback in pkg/controller/acmeorders/sync.go
that retries the newOrder call without the `replaces` option when
isARIReplacesRejection(err) returns true, but that function only matched
ErrCADoesNotSupportARI and the `alreadyReplaced` problem type. It did not
match this `malformed` case, so the retry never fired: the Order was
marked as a terminal Errored state and the issuer switch could never
complete while ARI was enabled. Fixes #9074.

Approach:
Broaden isARIReplacesRejection to also treat an ACME error as an ARI
`replaces` rejection when its ProblemType is `malformed` and its Detail
(case-insensitively) mentions "replaces". This is narrow enough to avoid
retrying on unrelated `malformed` errors (e.g. a bad CSR), since those
won't mention the `replaces` field, while covering the CA behaviour
observed in the issue. No behaviour changes for CAs that don't send this
error, and the pre-existing single-retry-without-replaces flow is
otherwise unchanged.

Validation:
  go build ./pkg/controller/acmeorders/...
  go test ./pkg/controller/acmeorders/...
Both pass, including a new TestIsARIReplacesRejection covering the
`alreadyReplaced` case, the new `malformed`+"replaces" case (with a
different-casing variant), a `malformed` case unrelated to `replaces`
(to confirm it is NOT retried), and the pre-existing ErrCADoesNotSupportARI
cases.

/kind bug

```release-note
Fixed a bug where switching a Certificate's ACME issuer while the
ACMEUseARI feature gate was enabled could permanently fail re-issuance,
because the new CA rejected the ARI `replaces` hint derived from the
certificate issued by the previous CA.
```

Fixes #9074

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>