### PR TITLE
fix: avoid overflow in renewBeforePercentage renewal time

### DIFF
--- a/pkg/util/pki/renewaltime_test.go
+++ b/pkg/util/pki/renewaltime_test.go
@@ -104,6 +104,12 @@ func TestRenewalTime(t *testing.T) {
 				},
 			},
 		},
+		"very long lived cert, spec.renewBeforePercentage does not overflow": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 87600), // 10 years
+			renewBeforePct:      new(int32(30)),
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 61320)}, // 70% of 10 years
+		},
 	}
 	for n, s := range tests {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
### Pull Request Motivation

`RenewalTime` computes the percentage offset as `actualDuration * renewBeforePercentage / 100`, multiplying before dividing. `actualDuration` is an int64 nanosecond count, so the product overflows once the certificate lifetime passes roughly `MaxInt64 / percentage`: about 9.7 years at 30%, 5.8 years at 50%. Past that the product wraps negative and the renewal time lands after the certificate has expired, so it is never renewed. The validating webhook does not constrain multi-year certificates, so such a Certificate is admitted. Dividing before multiplying cannot overflow for any valid duration and gives the same result after the existing truncate-to-second step.

### Kind

/kind bug

### Release Note

```release-note
Fixed an integer overflow in the renewal time calculation that could stop very long-lived certificates using `renewBeforePercentage` from being renewed before expiry.
```