### PR TITLE
Use %w for error wrapping instead of %s with err.Error()

### DIFF
--- a/internal/apis/certmanager/validation/util/nameserver.go
+++ b/internal/apis/certmanager/validation/util/nameserver.go
@@ -51,7 +51,7 @@ func ValidNameserver(nameserver string) (string, error) {
 			// net.JoinHostPort expect IPv6 address to be unenclosed
 			host = strings.Trim(nameserver, "[]")
 		} else {
-			return "", fmt.Errorf("RFC2136 nameserver is invalid: %s", err.Error())
+			return "", fmt.Errorf("RFC2136 nameserver is invalid: %w", err)
 		}
 	}
 

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -52,7 +52,7 @@ func ordersForGenericIssuer(iss cmapi.GenericIssuer, orderLister cmacmelisters.O
 	orders, err := orderLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing certificates: %s", err.Error())
+		return nil, fmt.Errorf("error listing certificates: %w", err)
 	}
 
 	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -34,15 +34,15 @@ func handleGenericIssuerFunc(
 	orderLister cmacmelisters.OrderLister,
 ) func(cmapi.GenericIssuer) {
 	return func(iss cmapi.GenericIssuer) {
-		certs, err := ordersForGenericIssuer(iss, orderLister)
+		orders, err := ordersForGenericIssuer(iss, orderLister)
 		if err != nil {
-			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetNamespace(), iss.GetName()))
+			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s: %w", iss.GetNamespace(), iss.GetName(), err))
 			return
 		}
-		for _, crt := range certs {
+		for _, order := range orders {
 			queue.Add(types.NamespacedName{
-				Namespace: crt.Namespace,
-				Name:      crt.Name,
+				Namespace: order.Namespace,
+				Name:      order.Name,
 			})
 		}
 	}
@@ -52,7 +52,7 @@ func ordersForGenericIssuer(iss cmapi.GenericIssuer, orderLister cmacmelisters.O
 	orders, err := orderLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing certificates: %s", err.Error())
+		return nil, fmt.Errorf("error listing orders: %w", err)
 	}
 
 	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -47,7 +47,7 @@ func (c *Controller) certificatesRequestsForGenericIssuer(iss cmapi.GenericIssue
 	crts, err := c.certificateRequestLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing certificates: %s", err.Error())
+		return nil, fmt.Errorf("error listing certificates: %w", err)
 	}
 
 	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -47,7 +47,7 @@ func (c *Controller) certificatesRequestsForGenericIssuer(iss cmapi.GenericIssue
 	crts, err := c.certificateRequestLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing certificates: %s", err.Error())
+		return nil, fmt.Errorf("error listing certificate requests: %w", err)
 	}
 
 	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)

--- a/pkg/controller/certificatesigningrequests/checks.go
+++ b/pkg/controller/certificatesigningrequests/checks.go
@@ -49,7 +49,7 @@ func (c *Controller) handleGenericIssuer(iss cmapi.GenericIssuer) {
 func (c *Controller) certificateSigningRequestsForGenericIssuer(iss cmapi.GenericIssuer) ([]*certificatesv1.CertificateSigningRequest, error) {
 	csrs, err := c.csrLister.List(labels.NewSelector())
 	if err != nil {
-		return nil, fmt.Errorf("error listing certificates signing requests: %s", err.Error())
+		return nil, fmt.Errorf("error listing certificates signing requests: %w", err)
 	}
 
 	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -39,7 +39,7 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 	issuers, err := c.clusterIssuerLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing issuers: %s", err.Error())
+		return nil, fmt.Errorf("error listing issuers: %w", err)
 	}
 
 	var affected []*v1.ClusterIssuer

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -29,7 +29,7 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.ClusterIssue
 	issuers, err := c.clusterIssuerLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing issuers: %s", err.Error())
+		return nil, fmt.Errorf("error listing issuers: %w", err)
 	}
 
 	var affected []*v1.ClusterIssuer

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -39,7 +39,7 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 	issuers, err := c.issuerLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing issuers: %s", err.Error())
+		return nil, fmt.Errorf("error listing issuers: %w", err)
 	}
 
 	var affected []*v1.Issuer

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -29,7 +29,7 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1.Issuer, erro
 	issuers, err := c.issuerLister.List(labels.NewSelector())
 
 	if err != nil {
-		return nil, fmt.Errorf("error listing issuers: %s", err.Error())
+		return nil, fmt.Errorf("error listing issuers: %w", err)
 	}
 
 	var affected []*v1.Issuer

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -322,7 +322,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			digitalocean.Resolver(s.DNSResolver))
 
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating digitalocean challenge solver: %s", err.Error())
+			return nil, nil, fmt.Errorf("error instantiating digitalocean challenge solver: %w", err)
 		}
 	case providerConfig.Route53 != nil:
 		dbg.Info("preparing to create Route53 provider")

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -243,7 +243,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 		if providerConfig.CloudDNS.ServiceAccount != nil {
 			saSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.CloudDNS.ServiceAccount.Name)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error getting clouddns service account: %s", err)
+				return nil, nil, fmt.Errorf("error getting clouddns service account: %w", err)
 			}
 
 			saKey := providerConfig.CloudDNS.ServiceAccount.Key
@@ -263,7 +263,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			clouddns.Resolver(s.DNSResolver))
 
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating google clouddns challenge solver: %s", err)
+			return nil, nil, fmt.Errorf("error instantiating google clouddns challenge solver: %w", err)
 		}
 	case providerConfig.Cloudflare != nil:
 		dbg.Info("preparing to create Cloudflare provider")
@@ -282,7 +282,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 
 		saSecret, err := s.secretLister.Secrets(resourceNamespace).Get(saSecretName)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting cloudflare secret: %s", err)
+			return nil, nil, fmt.Errorf("error getting cloudflare secret: %w", err)
 		}
 
 		keyData, ok := saSecret.Data[saSecretKey]
@@ -304,13 +304,13 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			cloudflare.APIToken(apiToken),
 			cloudflare.UserAgent(s.RESTConfig.UserAgent))
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err)
+			return nil, nil, fmt.Errorf("error instantiating cloudflare challenge solver: %w", err)
 		}
 	case providerConfig.DigitalOcean != nil:
 		dbg.Info("preparing to create DigitalOcean provider")
 		apiTokenSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.DigitalOcean.Token.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting digitalocean token: %s", err)
+			return nil, nil, fmt.Errorf("error getting digitalocean token: %w", err)
 		}
 
 		apiToken := strings.TrimSpace(string(apiTokenSecret.Data[providerConfig.DigitalOcean.Token.Key]))
@@ -322,7 +322,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			digitalocean.Resolver(s.DNSResolver))
 
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating digitalocean challenge solver: %s", err.Error())
+			return nil, nil, fmt.Errorf("error instantiating digitalocean challenge solver: %w", err)
 		}
 	case providerConfig.Route53 != nil:
 		dbg.Info("preparing to create Route53 provider")
@@ -351,7 +351,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 
 			secretAccessKeyIDSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.Route53.SecretAccessKeyID.Name)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error getting route53 secret access key id: %s", err)
+				return nil, nil, fmt.Errorf("error getting route53 secret access key id: %w", err)
 			}
 
 			secretAccessKeyIDBytes, ok := secretAccessKeyIDSecret.Data[providerConfig.Route53.SecretAccessKeyID.Key]
@@ -368,7 +368,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 		if providerConfig.Route53.SecretAccessKey.Name != "" {
 			secretAccessKeySecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.Route53.SecretAccessKey.Name)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error getting route53 secret access key: %s", err)
+				return nil, nil, fmt.Errorf("error getting route53 secret access key: %w", err)
 			}
 
 			secretAccessKeyBytes, ok := secretAccessKeySecret.Data[providerConfig.Route53.SecretAccessKey.Key]
@@ -420,7 +420,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 		if providerConfig.AzureDNS.ClientID != "" {
 			clientSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.AzureDNS.ClientSecret.Name)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error getting azuredns client secret: %s", err)
+				return nil, nil, fmt.Errorf("error getting azuredns client secret: %w", err)
 			}
 
 			clientSecretBytes, ok := clientSecret.Data[providerConfig.AzureDNS.ClientSecret.Key]
@@ -445,13 +445,13 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			azuredns.Resolver(s.DNSResolver))
 
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating azuredns challenge solver: %s", err)
+			return nil, nil, fmt.Errorf("error instantiating azuredns challenge solver: %w", err)
 		}
 	case providerConfig.AcmeDNS != nil:
 		dbg.Info("preparing to create ACMEDNS provider")
 		accountSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.AcmeDNS.AccountSecret.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting acmedns accounts secret: %s", err)
+			return nil, nil, fmt.Errorf("error getting acmedns accounts secret: %w", err)
 		}
 
 		accountSecretBytes, ok := accountSecret.Data[providerConfig.AcmeDNS.AccountSecret.Key]
@@ -464,7 +464,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			acmedns.AccountJSON(accountSecretBytes))
 
 		if err != nil {
-			return nil, providerConfig, fmt.Errorf("error instantiating acmedns challenge solver: %s", err)
+			return nil, providerConfig, fmt.Errorf("error instantiating acmedns challenge solver: %w", err)
 		}
 	default:
 		return nil, providerConfig, fmt.Errorf("no dns provider config specified for challenge")

--- a/pkg/issuer/factory.go
+++ b/pkg/issuer/factory.go
@@ -71,7 +71,7 @@ func NewFactory(ctx *controller.Context) Factory {
 func (f *factory) IssuerFor(issuer v1.GenericIssuer) (Interface, error) {
 	issuerType, err := apiutil.NameForIssuer(issuer)
 	if err != nil {
-		return nil, fmt.Errorf("could not get issuer type: %s", err.Error())
+		return nil, fmt.Errorf("could not get issuer type: %w", err)
 	}
 
 	constructorsLock.RLock()

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -133,7 +133,7 @@ func New(namespace string, secretsLister internalinformers.SecretLister, issuer 
 	// has been created.
 	vcertClient, err := vcert.NewClient(cfg, false)
 	if err != nil {
-		return nil, fmt.Errorf("error creating vcert client: %s", err.Error())
+		return nil, fmt.Errorf("error creating vcert client: %w", err)
 	}
 
 	var tppc *tpp.Connector

--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -253,7 +253,7 @@ func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators 
 		} else {
 			asn1Subject, err = asn1.Marshal(cert.Subject.ToRDNSequence())
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal subject to ASN.1 DER: %s", err.Error())
+				return nil, fmt.Errorf("failed to marshal subject to ASN.1 DER: %w", err)
 			}
 		}
 

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -382,18 +382,18 @@ func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, p
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuerCert, publicKey, signerKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating x509 certificate: %s", err.Error())
+		return nil, nil, fmt.Errorf("error creating x509 certificate: %w", err)
 	}
 
 	cert, err := x509.ParseCertificate(derBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error decoding DER certificate bytes: %s", err.Error())
+		return nil, nil, fmt.Errorf("error decoding DER certificate bytes: %w", err)
 	}
 
 	pemBytes := bytes.NewBuffer([]byte{})
 	err = pem.Encode(pemBytes, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	if err != nil {
-		return nil, nil, fmt.Errorf("error encoding certificate PEM: %s", err.Error())
+		return nil, nil, fmt.Errorf("error encoding certificate PEM: %w", err)
 	}
 
 	return pemBytes.Bytes(), cert, err
@@ -428,7 +428,7 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caPrivateKey crypto.Signer, te
 func EncodeCSR(template *x509.CertificateRequest, key crypto.Signer) ([]byte, error) {
 	derBytes, err := x509.CreateCertificateRequest(rand.Reader, template, key)
 	if err != nil {
-		return nil, fmt.Errorf("error creating x509 certificate: %s", err.Error())
+		return nil, fmt.Errorf("error creating x509 certificate: %w", err)
 	}
 
 	return derBytes, nil

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -166,7 +166,7 @@ func EncodePKCS8PrivateKey(pk any) ([]byte, error) {
 func EncodeECPrivateKey(pk *ecdsa.PrivateKey) ([]byte, error) {
 	asnBytes, err := x509.MarshalECPrivateKey(pk)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding private key: %s", err.Error())
+		return nil, fmt.Errorf("error encoding private key: %w", err)
 	}
 
 	block := &pem.Block{Type: "EC PRIVATE KEY", Bytes: asnBytes}

--- a/pkg/util/pki/renewaltime.go
+++ b/pkg/util/pki/renewaltime.go
@@ -162,13 +162,13 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 				loc = tz
 			} else {
 				// This shouldn't get triggered as we validate timezones in the validation webhook.
-				return nil, fmt.Errorf("error parsing timezone in window %s", err.Error())
+				return nil, fmt.Errorf("error parsing timezone in window: %w", err)
 			}
 		}
 
 		cronSched, err := util.CronParse(w.Cron, loc.String())
 		if err != nil {
-			return nil, fmt.Errorf("error parsing cron in window %s", err.Error())
+			return nil, fmt.Errorf("error parsing cron in window: %w", err)
 		}
 
 		if w.WindowDuration == nil || w.WindowDuration.Duration <= 0 {


### PR DESCRIPTION
## Summary

- Replace `fmt.Errorf("...: %s", err.Error())` and `fmt.Errorf("...: %s", err)` with `fmt.Errorf("...: %w", err)` across 13 production files (28 instances)
- Preserves error chains so callers can use [`errors.Is()`](https://pkg.go.dev/errors#Is) and [`errors.As()`](https://pkg.go.dev/errors#As) to inspect wrapped errors ([Go blog: Working with Errors in Go 1.13](https://go.dev/blog/go1.13-errors))

**Excluded:** `internal/vault/vault.go` remains unchanged. Callers of `vault.New()` use `k8sErrors.IsNotFound()` and `cmerrors.IsInvalidData()` for control flow. Only the `ServiceAccounts().CreateToken` paths (lines 633 and 795) can return a Kubernetes `NotFound`; the other 18 excluded sites wrap Vault HTTP/JSON/PEM errors. The full file is excluded to avoid re-debate on scope.

**Venafi:** `venaficlient.New` is converted despite `IsNotFound` callers — vcert errors do not implement `APIStatus`, so wrapping is safe.

**Review feedback addressed:**
- `renewaltime.go`: colon separator before `%w` for user-facing readiness messages
- `acmeorders/checks.go`: "orders" noun fix, err propagated through `HandleError`
- `certificaterequests/checks.go`: "certificate requests" noun fix
- `dns.go`: all 12 `solverForChallenge` error wraps converted

All `golangci-lint` checks pass. This is a mechanical change with intentional message fixes noted above.

### Similar Items

The same fix has been applied across several other Go projects:

- [redhat-best-practices-for-k8s/certsuite#3730](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3730) (merged)
- [openshift/tls-scanner#70](https://github.com/openshift/tls-scanner/pull/70) (merged)
- [openshift-kni/commatrix#482](https://github.com/openshift-kni/commatrix/pull/482) (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) (open)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) (merged)

```release-note
NONE
```