### PR TITLE
Add Expiration print column to Certificate CRD

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -38,6 +38,10 @@ spec:
           name: Status
           priority: 1
           type: string
+        - jsonPath: .status.notAfter
+          name: Expiration
+          priority: 1
+          type: string
         - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
           jsonPath: .metadata.creationTimestamp
           name: Age

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -34,6 +34,10 @@ spec:
       name: Status
       priority: 1
       type: string
+    - jsonPath: .status.notAfter
+      name: Expiration
+      priority: 1
+      type: string
     - description: CreationTimestamp is a timestamp representing the server time when
         this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -31,6 +31,7 @@ import (
 // +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=`.spec.secretName`
 // +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=`.spec.issuerRef.name`,priority=1
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "Ready")].message`,priority=1
+// +kubebuilder:printcolumn:name="Expiration",type="string",JSONPath=`.status.notAfter`,priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
 // +kubebuilder:resource:scope=Namespaced,shortName={cert,certs},categories=cert-manager
 // +kubebuilder:selectablefield:JSONPath=.spec.issuerRef.group


### PR DESCRIPTION
Adds a `priority=1` (wide-only) print column showing `.status.notAfter` on the Certificate CRD, so operators can see certificate expiration dates at a glance:

```
$ kubectl get certificate -o wide
NAMESPACE   NAME       READY   SECRET       ISSUER            STATUS                                          EXPIRATION             AGE
default     my-cert    True    my-cert-tls  selfsigned-test   Certificate is up to date and has not expired   2026-10-26T17:42:51Z   5d
```

Previously, viewing expiration required `-o yaml` or a jsonpath query like:
```
kubectl get certificate -ojsonpath="{range .items[*]}{.metadata.name} {.status.notAfter}{'\n'}{end}"
```

The default `kubectl get certificate` output is unchanged — the new column only appears with `-o wide`, consistent with the existing Issuer and Status columns.

Uses `type: string` rather than `type: date` because kubectl renders date columns as relative past time ("5h ago"), which displays `<invalid>` for future timestamps like expiration dates.

Closes #4927

```release-note
Added an EXPIRATION column to `kubectl get certificate -o wide` output, showing the certificate's `status.notAfter` time.
```
