### PR TITLE
Fix nil pointer dereference in certificateRequestIdentity.Validate

### DIFF
--- a/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity.go
+++ b/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity.go
@@ -81,6 +81,14 @@ func (p *certificateRequestIdentity) Mutate(ctx context.Context, request admissi
 }
 
 func (p *certificateRequestIdentity) Validate(ctx context.Context, request admissionv1.AdmissionRequest, oldObj, obj runtime.Object) ([]string, error) {
+	// request.RequestResource is optional on the AdmissionRequest API and may
+	// be nil, for example if the caller posts an AdmissionReview directly to
+	// the webhook without populating it. Guard against that to avoid a nil
+	// pointer dereference.
+	if request.RequestResource == nil {
+		return nil, fmt.Errorf("internal error: admission request is missing requestResource")
+	}
+
 	// Only run this admission plugin for CertificateRequest resources
 	if request.RequestResource.Group != "cert-manager.io" ||
 		request.RequestResource.Resource != "certificaterequests" {

--- a/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity_test.go
+++ b/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity_test.go
@@ -239,6 +239,34 @@ func TestValidateCreate(t *testing.T) {
 	}
 }
 
+// TestValidate_NilRequestResource reproduces
+// https://github.com/cert-manager/cert-manager/issues/9064: when an
+// AdmissionRequest is received with a nil RequestResource (e.g. because the
+// caller posted a hand-crafted AdmissionReview payload directly to the
+// webhook without populating the optional "requestResource" field),
+// Validate must not panic with a nil pointer dereference. It should instead
+// return gracefully.
+func TestValidate_NilRequestResource(t *testing.T) {
+	p := NewPlugin().(*certificateRequestIdentity)
+	req := admissionv1.AdmissionRequest{
+		Operation:       admissionv1.Create,
+		RequestResource: nil,
+		UserInfo: authenticationv1.UserInfo{
+			UID:      "abc",
+			Username: "user-1",
+		},
+	}
+	cr := &certmanager.CertificateRequest{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Validate() panicked with nil RequestResource: %v", r)
+		}
+	}()
+
+	_, _ = p.Validate(t.Context(), req, nil, cr)
+}
+
 func compareErrors(t *testing.T, exp, act error) {
 	if exp == nil && act == nil {
 		return


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes #9064. `request.RequestResource` is optional on the `AdmissionRequest` API and can be nil, for example when an `AdmissionReview` is posted directly to the webhook without populating `requestResource`. `certificateRequestIdentity.Validate` dereferenced it unconditionally, causing a nil pointer panic instead of returning a clean validation error.

Added a regression test (`TestValidate_NilRequestResource`) that reproduces the panic before the fix and passes after it. Ran the full `internal/webhook/...` and `pkg/webhook/...` test suites with no regressions.

This same unguarded pattern also exists in a few other admission webhook functions in the codebase (`Mutate` in the same file, plus two other files) — left out of this PR to keep it scoped to exactly what #9064 reports; happy to follow up separately if useful.

AI-assisted (Claude) for investigation and implementation, reviewed by me before submission.

### Kind

/kind bug

### Release Note

```release-note
Fix a nil pointer panic in the CertificateRequest identity admission webhook when an AdmissionReview is received without `requestResource` populated.
```