### PR TITLE
test: add regression coverage for deep-subdomain zone lookup (#4749)

### DIFF
--- a/pkg/issuer/acme/dns/util/cache_test.go
+++ b/pkg/issuer/acme/dns/util/cache_test.go
@@ -43,6 +43,26 @@ func TestCachingResolver_FindZoneByFQDN(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for cert-manager/cert-manager#4749: a certificate
+			// for a deep subdomain (multiple labels below the real zone apex)
+			// must climb past every intermediate NXDOMAIN label to find the
+			// zone, rather than stopping at the first one queried.
+			name:       "multiple NXDOMAIN labels: climbs past deep subdomains to zone apex",
+			givenFQDN:  "_acme-challenge.baz.bar.foo.example.com.",
+			expectZone: "foo.example.com.",
+			mockDNS: []interaction{
+				{"SOA _acme-challenge.baz.bar.foo.example.com.", &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError}}},
+				{"SOA baz.bar.foo.example.com.", &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError}}},
+				{"SOA bar.foo.example.com.", &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError}}},
+				{"SOA foo.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.SOA{Hdr: dns.RR_Header{Name: "foo.example.com.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300}},
+					},
+				}},
+			},
+		},
+		{
 			// Per RFC 2181, CNAME cannot exist at a zone apex, so a SOA alongside a
 			// CNAME is not authoritative for that label. The search continues up the tree.
 			name:       "CNAME at label is skipped per RFC 2181",


### PR DESCRIPTION
Motivation:
cert-manager/cert-manager#4749 reports that requesting a certificate for
a deep subdomain (e.g. baz.bar.foo.com) causes the DNS zone lookup used
by the rfc2136 (and other) DNS-01 solvers to pick the wrong zone, which
is then rejected by the authoritative nameserver with NOTAUTH.

Investigating the current FindZoneByFQDN implementation
(pkg/issuer/acme/dns/util/cache.go), I found it already climbs the DNS
label tree one label at a time, correctly continuing past NXDOMAIN and
RFC 2181 CNAME-at-apex responses until it reaches the real zone apex.
That loop has no special-casing for depth, but was only ever exercised
by a single-hop test case (sub.example.com. -> example.com.), so the
multi-hop scenario described in the issue had no direct regression
coverage of its own.

Approach:
Add one new table-driven case to TestCachingResolver_FindZoneByFQDN in
pkg/issuer/acme/dns/util/cache_test.go reproducing the issue's scenario:
an FQDN 4 labels below the real zone apex, where 3 consecutive
intermediate labels return NXDOMAIN before the SOA is found. No
production code is changed by this commit.

I confirmed the new case exercises behavior the old single-hop test
did not: temporarily shrinking the zone-walking loop to stop climbing
after 2 hops (reverted before committing) made this new test fail
while the pre-existing single-hop test kept passing.

Impact:
This is a test-only change; behavior is unchanged before and after.
The zone-lookup scenario reported in the issue already resolves to the
correct zone on current master, most likely due to earlier, unrelated
work on FindZoneByFQDN's tree-climbing algorithm. This commit does not
claim to fix a bug - it adds regression coverage tying that already-
correct behavior to the exact case described in #4749.

Note that later comments on #4749 (e.g. 2025-03-18) describe a distinct
situation: the SOA-resolved zone is genuinely correct, but the
configured TSIG key isn't authorized to update it. That is a separate
authorization/configuration concern this commit does not address, so
the issue should remain open for that rather than being auto-closed.

Validation:
- go build ./...
- go test ./pkg/issuer/acme/dns/...  (passes, including the new case)
- gofmt -l and go vet ./pkg/issuer/acme/dns/util/...  (clean)

Relates to #4749

/kind cleanup

```release-note
NONE
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>