### PR TITLE
feat(release): sign staged metadata.json with cosign

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -84,6 +84,9 @@ $(bin_dir)/release/metadata.json: $(wildcard $(bin_dir)/metadata/*.json) | $(bin
 # pipeline (which holds the KMS key), not by anyone who can write to the staging
 # bucket. upload-release copies the whole release dir, so the .sig ships too.
 $(bin_dir)/release/metadata.json.sig: $(bin_dir)/release/metadata.json | $(NEEDS_COSIGN)
+ifeq ($(strip $(CMREL_KEY)),)
+	$(error Trying to sign metadata.json but CMREL_KEY is empty)
+endif
 	$(COSIGN) sign-blob --yes --tlog-upload=false --key $(COSIGN_KMS_KEY) --output-signature $@ $<
 
 .PHONY: release-containers

--- a/make/release.mk
+++ b/make/release.mk
@@ -25,6 +25,10 @@ CMREL_KEY ?=
 ## @category Release
 RELEASE_TARGET_BUCKET ?=
 
+## cosign wants the KMS key as "versions" (not "cryptoKeyVersions") with a
+## gcpkms:// scheme. Derive it from CMREL_KEY so callers only set one key.
+COSIGN_KMS_KEY := gcpkms://$(subst cryptoKeyVersions,versions,$(CMREL_KEY))
+
 .PHONY: release-artifacts
 ## Build all release artifacts which might be run or used locally, except
 ## for anything which requires signing. Note that since the manifests bundle
@@ -54,6 +58,7 @@ release-artifacts-signed: release-artifacts release-manifests-signed
 ## @category Release
 release: release-artifacts-signed
 	$(MAKE) --no-print-directory $(bin_dir)/release/metadata.json
+	$(MAKE) --no-print-directory $(bin_dir)/release/metadata.json.sig
 
 .PHONY: upload-release
 ## Create a complete release and then upload it to a target GCS bucket specified by
@@ -74,6 +79,12 @@ $(bin_dir)/release/metadata.json: $(wildcard $(bin_dir)/metadata/*.json) | $(bin
 		--arg buildSource "make" \
 		--arg gitCommitRef "$(GITCOMMIT)" \
 		'.releaseVersion = $$releaseVersion | .gitCommitRef = $$gitCommitRef | .buildSource = $$buildSource | .artifacts += [inputs]' $^ > $@
+
+# Sign metadata.json so the publish step can verify it was produced by this
+# pipeline (which holds the KMS key), not by anyone who can write to the staging
+# bucket. upload-release copies the whole release dir, so the .sig ships too.
+$(bin_dir)/release/metadata.json.sig: $(bin_dir)/release/metadata.json | $(NEEDS_COSIGN)
+	$(COSIGN) sign-blob --yes --tlog-upload=false --key $(COSIGN_KMS_KEY) --output-signature $@ $<
 
 .PHONY: release-containers
 release-containers: release-container-bundles release-container-metadata


### PR DESCRIPTION
```Backport to release-1.21 of the master change (same edit; make/release.mk is identical across these branches).```

# Description

## Problem

cmrel gcb publish now verifies a cosign signature over the staged metadata.json and, once enforcement is switched on, fails closed if there's no valid metadata.json.sig next to it in gs://cert-manager-release. metadata.json lists every release artifact and its checksum, and it's read back from the same bucket it was uploaded to — so signing it with the release KMS key (which random bucket writers don't hold) is what makes it trustworthy.

The staging job — make upload-release — never produced that signature:
  - Broken publish: upload-release is a plain `rclone copyto` of the release dir; it never installed cosign or signed anything, so no .sig was ever staged. With the enforcing default shipped, cmrel gcb publish refuses every release (this broke the v1.21.1 patch release).
  - Untrustworthy metadata: without a signature over metadata.json, anyone who can write to the staging bucket could alter the artifact list or checksums and the publish step had no way to detect it.

## Solution

Sign $(bin_dir)/release/metadata.json with cosign (sign-blob) in make/release.mk, producing metadata.json.sig. The key is derived from the existing CMREL_KEY — rewritten to the gcpkms://…/versions/N form cosign expects — so callers still set only one key. --tlog-upload=false keeps this private staging artifact out of the public Rekor log and keeps verification offline. upload-release already copies the whole release dir, so the .sig ships alongside metadata.json with no rclone change, and cosign is already a make tool, so no cloudbuild change is needed. Local make release-artifacts is unaffected — signing only runs in the paths that already require CMREL_KEY.

## Test plan

  - [ ] make --dry-run … metadata.json.sig expands to cosign sign-blob --yes --tlog-upload=false --key gcpkms://…/versions/1 --output-signature … metadata.json and the Makefile parses clean (recipe lines tab-indented, no missing separator).
  - [ ] KMS key derivation verified: CMREL_KEY ending …/cryptoKeyVersions/1 becomes gcpkms://…/versions/1, matching what cosign verify-blob --key gcpkms://… uses on the publish side.
  - [ ] Dependency wiring confirmed: the .sig target builds metadata.json first and pulls in $(NEEDS_COSIGN) (pinned cosign=v2.6.3).
  - [ ] Cross-version check to run before enforcement is flipped on: one cmrel publish --nomock against a freshly-signed staged release, confirming publish-side cosign v1.13.6 verify-blob accepts the v2.6.3-produced detached signature.

## Release note

  ```release-note
  The release staging process now signs metadata.json with cosign so the publish step can verify its authenticity.
  ```