### PR TITLE
Fix nil RequestResource panics in sibling admission webhooks

### DIFF
--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
@@ -80,6 +80,11 @@ func NewPlugin(authz authorizer.Authorizer, discoveryClient discovery.DiscoveryI
 }
 
 func (c *certificateRequestApproval) Validate(ctx context.Context, request admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (warnings []string, err error) {
+	// request.RequestResource is optional and may be nil.
+	if request.RequestResource == nil {
+		return nil, nil
+	}
+
 	if request.RequestResource.Group != "cert-manager.io" ||
 		request.RequestResource.Resource != "certificaterequests" ||
 		request.RequestSubResource != "status" {

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
@@ -40,6 +40,30 @@ var (
 	expNoDiscovery = discovery.DiscoveryInterface(nil)
 )
 
+func TestValidate_NilRequestResource(t *testing.T) {
+	c := NewPlugin(nil, expNoDiscovery).(*certificateRequestApproval)
+	req := admissionv1.AdmissionRequest{
+		Operation:           admissionv1.Update,
+		RequestResource:     nil,
+		RequestSubResource:  "status",
+	}
+	cr := &certmanager.CertificateRequest{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Validate() panicked with nil RequestResource: %v", r)
+		}
+	}()
+
+	warnings, err := c.Validate(context.Background(), req, cr, cr)
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if warnings != nil {
+		t.Fatalf("Validate() unexpected warnings: %v", warnings)
+	}
+}
+
 func TestValidate(t *testing.T) {
 	baseCR := &certmanager.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "testns"},

--- a/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity.go
+++ b/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity.go
@@ -46,7 +46,12 @@ func NewPlugin() admission.Interface {
 }
 
 func (p *certificateRequestIdentity) Mutate(ctx context.Context, request admissionv1.AdmissionRequest, obj *unstructured.Unstructured) error {
-	// Only run this admission plugin for the certificaterequests/status sub-resource
+	// request.RequestResource is optional and may be nil (same as Validate).
+	if request.RequestResource == nil {
+		return nil
+	}
+
+	// Only run this admission plugin for CertificateRequest creates
 	if request.RequestResource.Group != "cert-manager.io" ||
 		request.RequestResource.Resource != "certificaterequests" ||
 		request.Operation != admissionv1.Create {

--- a/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity_test.go
+++ b/internal/webhook/admission/certificaterequest/identity/certificaterequest_identity_test.go
@@ -157,6 +157,29 @@ func TestMutate_Ignores(t *testing.T) {
 	}
 }
 
+func TestMutate_NilRequestResource(t *testing.T) {
+	p := NewPlugin().(*certificateRequestIdentity)
+	req := admissionv1.AdmissionRequest{
+		Operation:       admissionv1.Create,
+		RequestResource: nil,
+		UserInfo: authenticationv1.UserInfo{
+			UID:      "abc",
+			Username: "user-1",
+		},
+	}
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Mutate() panicked with nil RequestResource: %v", r)
+		}
+	}()
+
+	if err := p.Mutate(t.Context(), req, obj); err != nil {
+		t.Fatalf("Mutate() unexpected error: %v", err)
+	}
+}
+
 func TestValidateCreate(t *testing.T) {
 	fldPath := field.NewPath("spec")
 

--- a/internal/webhook/admission/resourcevalidation/resourcevalidation.go
+++ b/internal/webhook/admission/resourcevalidation/resourcevalidation.go
@@ -74,6 +74,11 @@ func NewPlugin() admission.Interface {
 }
 
 func (p resourceValidation) Validate(_ context.Context, request admissionv1.AdmissionRequest, oldObj, obj runtime.Object) ([]string, error) {
+	// request.RequestResource is optional and may be nil.
+	if request.RequestResource == nil {
+		return nil, nil
+	}
+
 	requestResource := schema.GroupVersionResource{
 		Group:    request.RequestResource.Group,
 		Version:  request.RequestResource.Version,

--- a/internal/webhook/admission/resourcevalidation/resourcevalidation_test.go
+++ b/internal/webhook/admission/resourcevalidation/resourcevalidation_test.go
@@ -52,6 +52,28 @@ var (
 	}
 )
 
+func TestValidate_NilRequestResource(t *testing.T) {
+	p := NewPlugin().(*resourceValidation)
+	req := admissionv1.AdmissionRequest{
+		Operation:       admissionv1.Create,
+		RequestResource: nil,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Validate() panicked with nil RequestResource: %v", r)
+		}
+	}()
+
+	warnings, err := p.Validate(t.Context(), req, nil, nil)
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if warnings != nil {
+		t.Fatalf("Validate() unexpected warnings: %v", warnings)
+	}
+}
+
 func TestResourceValidation(t *testing.T) {
 	tests := map[string]struct {
 		mapping     map[schema.GroupVersionResource]validationPair


### PR DESCRIPTION
### Pull Request Motivation

Follow-up to #9081 / #9064. The same unguarded request.RequestResource dereference exists in certificateRequestIdentity.Mutate, certificateRequestApproval.Validate, and resourceValidation.Validate. Each panics if an AdmissionReview arrives without requestResource populated. Adds nil guards and regression tests (fail-before/pass-after verified locally).

### Kind

/kind bug

### Release Note

```release-note
Fix nil pointer panics in admission webhooks when AdmissionRequest.requestResource is unset.
```
