### PR TITLE
Remove manual GOMAXPROCS configuration from Webhook

### DIFF
--- a/pkg/acme/webhook/cmd/cmd.go
+++ b/pkg/acme/webhook/cmd/cmd.go
@@ -44,10 +44,6 @@ func RunWebhookServer(groupName string, hooks ...webhook.Solver) {
 	ctrl.SetLogger(logf.Log)
 	ctx = logf.NewContext(ctx, logf.Log, "acme-dns-webhook")
 
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	cmd := server.NewCommandStartWebhookServer(ctx, groupName, hooks...)
 
 	if err := cmd.ExecuteContext(ctx); err != nil {

--- a/pkg/acme/webhook/cmd/cmd.go
+++ b/pkg/acme/webhook/cmd/cmd.go
@@ -18,8 +18,6 @@ package cmd
 
 import (
 	"context"
-	"os"
-	"runtime"
 
 	"k8s.io/component-base/logs"
 	ctrl "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

GOMAXPROCS is handled by the runtime since go 1.5 or so. This gets in the way of runtime automatic configuration.

### Kind

/kind cleanup 

### Release Note

```release-note
Restore GOMAXPROCS handling to the default go runtime.
```
