### PR TITLE
docs: clarify that ACME solvers may be omitted for pre-authorized issuance

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -215,9 +215,13 @@ spec:
                         Solvers is a list of challenge solvers that will be used to solve
                         ACME challenges for the matching domains.
                         Solver configurations must be provided in order to obtain certificates
-                        from an ACME server, unless the ACME server authorizes the requested
-                        identifiers out of band (e.g. pre-validated domains), in which case
-                        solvers may be omitted and no Challenge resources will be created.
+                        from an ACME server, unless the ACME server pre-authorizes every
+                        identifier on every order, including renewals, out of band
+                        (e.g. pre-validated domains), in which case solvers may be omitted
+                        and no Challenge resources will be created. If any identifier on an
+                        order is not pre-authorized and no solver matches it, the order will
+                        remain pending indefinitely, with only a Warning event recorded
+                        against it.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
                       items:
                         description: |-

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -215,7 +215,9 @@ spec:
                         Solvers is a list of challenge solvers that will be used to solve
                         ACME challenges for the matching domains.
                         Solver configurations must be provided in order to obtain certificates
-                        from an ACME server.
+                        from an ACME server, unless the ACME server authorizes the requested
+                        identifiers out of band (e.g. pre-validated domains), in which case
+                        solvers may be omitted and no Challenge resources will be created.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
                       items:
                         description: |-

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -214,9 +214,13 @@ spec:
                         Solvers is a list of challenge solvers that will be used to solve
                         ACME challenges for the matching domains.
                         Solver configurations must be provided in order to obtain certificates
-                        from an ACME server, unless the ACME server authorizes the requested
-                        identifiers out of band (e.g. pre-validated domains), in which case
-                        solvers may be omitted and no Challenge resources will be created.
+                        from an ACME server, unless the ACME server pre-authorizes every
+                        identifier on every order, including renewals, out of band
+                        (e.g. pre-validated domains), in which case solvers may be omitted
+                        and no Challenge resources will be created. If any identifier on an
+                        order is not pre-authorized and no solver matches it, the order will
+                        remain pending indefinitely, with only a Warning event recorded
+                        against it.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
                       items:
                         description: |-

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -214,7 +214,9 @@ spec:
                         Solvers is a list of challenge solvers that will be used to solve
                         ACME challenges for the matching domains.
                         Solver configurations must be provided in order to obtain certificates
-                        from an ACME server.
+                        from an ACME server, unless the ACME server authorizes the requested
+                        identifiers out of band (e.g. pre-validated domains), in which case
+                        solvers may be omitted and no Challenge resources will be created.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
                       items:
                         description: |-

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -215,9 +215,13 @@ spec:
                       Solvers is a list of challenge solvers that will be used to solve
                       ACME challenges for the matching domains.
                       Solver configurations must be provided in order to obtain certificates
-                      from an ACME server, unless the ACME server authorizes the requested
-                      identifiers out of band (e.g. pre-validated domains), in which case
-                      solvers may be omitted and no Challenge resources will be created.
+                      from an ACME server, unless the ACME server pre-authorizes every
+                      identifier on every order, including renewals, out of band
+                      (e.g. pre-validated domains), in which case solvers may be omitted
+                      and no Challenge resources will be created. If any identifier on an
+                      order is not pre-authorized and no solver matches it, the order will
+                      remain pending indefinitely, with only a Warning event recorded
+                      against it.
                       For more information, see: https://cert-manager.io/docs/configuration/acme/
                     items:
                       description: |-

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -215,7 +215,9 @@ spec:
                       Solvers is a list of challenge solvers that will be used to solve
                       ACME challenges for the matching domains.
                       Solver configurations must be provided in order to obtain certificates
-                      from an ACME server.
+                      from an ACME server, unless the ACME server authorizes the requested
+                      identifiers out of band (e.g. pre-validated domains), in which case
+                      solvers may be omitted and no Challenge resources will be created.
                       For more information, see: https://cert-manager.io/docs/configuration/acme/
                     items:
                       description: |-

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -214,9 +214,13 @@ spec:
                       Solvers is a list of challenge solvers that will be used to solve
                       ACME challenges for the matching domains.
                       Solver configurations must be provided in order to obtain certificates
-                      from an ACME server, unless the ACME server authorizes the requested
-                      identifiers out of band (e.g. pre-validated domains), in which case
-                      solvers may be omitted and no Challenge resources will be created.
+                      from an ACME server, unless the ACME server pre-authorizes every
+                      identifier on every order, including renewals, out of band
+                      (e.g. pre-validated domains), in which case solvers may be omitted
+                      and no Challenge resources will be created. If any identifier on an
+                      order is not pre-authorized and no solver matches it, the order will
+                      remain pending indefinitely, with only a Warning event recorded
+                      against it.
                       For more information, see: https://cert-manager.io/docs/configuration/acme/
                     items:
                       description: |-

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -214,7 +214,9 @@ spec:
                       Solvers is a list of challenge solvers that will be used to solve
                       ACME challenges for the matching domains.
                       Solver configurations must be provided in order to obtain certificates
-                      from an ACME server.
+                      from an ACME server, unless the ACME server authorizes the requested
+                      identifiers out of band (e.g. pre-validated domains), in which case
+                      solvers may be omitted and no Challenge resources will be created.
                       For more information, see: https://cert-manager.io/docs/configuration/acme/
                     items:
                       description: |-

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -85,9 +85,13 @@ type ACMEIssuer struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server, unless the ACME server authorizes the requested
-	// identifiers out of band (e.g. pre-validated domains), in which case
-	// solvers may be omitted and no Challenge resources will be created.
+	// from an ACME server, unless the ACME server pre-authorizes every
+	// identifier on every order, including renewals, out of band
+	// (e.g. pre-validated domains), in which case solvers may be omitted
+	// and no Challenge resources will be created. If any identifier on an
+	// order is not pre-authorized and no solver matches it, the order will
+	// remain pending indefinitely, with only a Warning event recorded
+	// against it.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	Solvers []ACMEChallengeSolver
 

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -85,7 +85,9 @@ type ACMEIssuer struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server.
+	// from an ACME server, unless the ACME server authorizes the requested
+	// identifiers out of band (e.g. pre-validated domains), in which case
+	// solvers may be omitted and no Challenge resources will be created.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	Solvers []ACMEChallengeSolver
 

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1417,7 +1417,7 @@ func schema_pkg_apis_acme_v1_ACMEIssuer(ref common.ReferenceCallback) common.Ope
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+							Description: "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server, unless the ACME server authorizes the requested identifiers out of band (e.g. pre-validated domains), in which case solvers may be omitted and no Challenge resources will be created. For more information, see: https://cert-manager.io/docs/configuration/acme/",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1417,7 +1417,7 @@ func schema_pkg_apis_acme_v1_ACMEIssuer(ref common.ReferenceCallback) common.Ope
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server, unless the ACME server authorizes the requested identifiers out of band (e.g. pre-validated domains), in which case solvers may be omitted and no Challenge resources will be created. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+							Description: "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server, unless the ACME server pre-authorizes every identifier on every order, including renewals, out of band (e.g. pre-validated domains), in which case solvers may be omitted and no Challenge resources will be created. If any identifier on an order is not pre-authorized and no solver matches it, the order will remain pending indefinitely, with only a Warning event recorded against it. For more information, see: https://cert-manager.io/docs/configuration/acme/",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -94,9 +94,13 @@ type ACMEIssuer struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server, unless the ACME server authorizes the requested
-	// identifiers out of band (e.g. pre-validated domains), in which case
-	// solvers may be omitted and no Challenge resources will be created.
+	// from an ACME server, unless the ACME server pre-authorizes every
+	// identifier on every order, including renewals, out of band
+	// (e.g. pre-validated domains), in which case solvers may be omitted
+	// and no Challenge resources will be created. If any identifier on an
+	// order is not pre-authorized and no solver matches it, the order will
+	// remain pending indefinitely, with only a Warning event recorded
+	// against it.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	// +listType=atomic

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -94,7 +94,9 @@ type ACMEIssuer struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server.
+	// from an ACME server, unless the ACME server authorizes the requested
+	// identifiers out of band (e.g. pre-validated domains), in which case
+	// solvers may be omitted and no Challenge resources will be created.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	// +listType=atomic

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
@@ -81,7 +81,9 @@ type ACMEIssuerApplyConfiguration struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server.
+	// from an ACME server, unless the ACME server authorizes the requested
+	// identifiers out of band (e.g. pre-validated domains), in which case
+	// solvers may be omitted and no Challenge resources will be created.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	Solvers []ACMEChallengeSolverApplyConfiguration `json:"solvers,omitempty"`
 	// Enables or disables generating a new ACME account key.

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuer.go
@@ -81,9 +81,13 @@ type ACMEIssuerApplyConfiguration struct {
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
 	// Solver configurations must be provided in order to obtain certificates
-	// from an ACME server, unless the ACME server authorizes the requested
-	// identifiers out of band (e.g. pre-validated domains), in which case
-	// solvers may be omitted and no Challenge resources will be created.
+	// from an ACME server, unless the ACME server pre-authorizes every
+	// identifier on every order, including renewals, out of band
+	// (e.g. pre-validated domains), in which case solvers may be omitted
+	// and no Challenge resources will be created. If any identifier on an
+	// order is not pre-authorized and no solver matches it, the order will
+	// remain pending indefinitely, with only a Warning event recorded
+	// against it.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	Solvers []ACMEChallengeSolverApplyConfiguration `json:"solvers,omitempty"`
 	// Enables or disables generating a new ACME account key.


### PR DESCRIPTION
### Pull Request Motivation

AWS ACM's ACME endpoint authorizes identifiers out of band: once a domain is pre-validated, orders arrive with their authorizations already `valid` and cert-manager issues certificates without creating any `Challenge` resources. cert-manager already supports this correctly, but the `ACMEIssuer.spec.solvers` doc comment says solver configurations "must be provided in order to obtain certificates from an ACME server," directly contradicting the `+optional` marker a few lines below. That makes this a supported-but-undocumented configuration.

This PR is docs-only: it updates the field comment to state that solvers may be omitted when the ACME server authorizes identifiers out of band, and propagates the wording to the generated CRDs, Helm chart CRDs, applyconfiguration, and openapi spec. No behavior changes.

Verified against AWS ACM: orders for a prevalidated domain arrive with authorizations already `valid`, and certificates issue with zero `Challenge` objects created.

Fixes #9095

### Kind

/kind documentation

```release-note
NONE
```