### PR TITLE
fix(keymanager): preserve current private key secret on stale informer cache

### DIFF
--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -204,11 +204,14 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 	// always clean up if multiple are found
 	if len(secrets) > 1 {
-		// Delete all secrets, optionally skipping the one specified in nextPrivateKeySecretName
+		latestName, err := c.latestNextPrivateKeySecretName(ctx, crt)
+		if err != nil {
+			return err
+		}
+
 		log.V(logf.DebugLevel).Info("Cleaning up Secret resources as multiple nextPrivateKeySecretName candidates found", "total_secrets", len(secrets))
 
-		// Use ptr.Deref to get the value or empty string if nil
-		return c.deleteSecretResources(ctx, secrets, ptr.Deref(crt.Status.NextPrivateKeySecretName, ""))
+		return c.deleteSecretResources(ctx, secrets, ptr.Deref(latestName, ""))
 	}
 
 	secret := secrets[0]
@@ -220,8 +223,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return c.setNextPrivateKeySecretName(ctx, crt, &secret.Name)
 	}
 	if *crt.Status.NextPrivateKeySecretName != secrets[0].Name {
-		log.V(logf.DebugLevel).Info("Deleting existing private key secret as name does not match status.nextPrivateKeySecretName")
-		return c.deleteSecretResources(ctx, secrets)
+		latestName, err := c.latestNextPrivateKeySecretName(ctx, crt)
+		if err != nil {
+			return err
+		}
+		if latestName == nil || *latestName != secret.Name {
+			log.V(logf.DebugLevel).Info("Deleting existing private key secret as name does not match status.nextPrivateKeySecretName")
+			return c.deleteSecretResources(ctx, secrets)
+		}
+		log.V(logf.DebugLevel).Info("Secret name matches API status.nextPrivateKeySecretName; informer cache was stale")
 	}
 
 	if secret.Data == nil || len(secret.Data[corev1.TLSPrivateKeyKey]) == 0 {
@@ -311,6 +321,15 @@ func (c *controller) deleteSecretResources(ctx context.Context, secrets []*corev
 		logf.WithRelatedResource(log, s).V(logf.DebugLevel).Info("Deleted 'next private key' Secret resource")
 	}
 	return nil
+}
+
+// latestNextPrivateKeySecretName avoids acting on stale informer data.
+func (c *controller) latestNextPrivateKeySecretName(ctx context.Context, crt *cmapi.Certificate) (*string, error) {
+	latestCrt, err := c.client.CertmanagerV1().Certificates(crt.Namespace).Get(ctx, crt.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return latestCrt.Status.NextPrivateKeySecretName, nil
 }
 
 func (c *controller) setNextPrivateKeySecretName(ctx context.Context, crt *cmapi.Certificate, name *string) error {

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -112,6 +112,8 @@ func TestProcessItem(t *testing.T) {
 
 		// err is the expected error text returned by the controller, if any.
 		err string
+
+		apiCertificate *cmapi.Certificate
 	}{
 		"do nothing if an empty 'key' is used": {},
 		"do nothing if an invalid 'key' is used": {
@@ -293,6 +295,11 @@ func TestProcessItem(t *testing.T) {
 				ownedSecretWithName("testns", "fixed-name-2", "test", nil),
 			},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewAction(coretesting.NewDeleteAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -324,6 +331,11 @@ func TestProcessItem(t *testing.T) {
 				ownedSecretWithName("testns", "fixed-name-3", "test", nil),
 			},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewAction(coretesting.NewDeleteAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -354,6 +366,11 @@ func TestProcessItem(t *testing.T) {
 				ownedSecretWithName("testns", "fixed-name-2", "test", nil),
 			},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewAction(coretesting.NewDeleteAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -442,6 +459,11 @@ func TestProcessItem(t *testing.T) {
 				ownedSecretWithName("testns", "fixed-name", "test", nil),
 			},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewAction(coretesting.NewDeleteAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -515,6 +537,84 @@ func TestProcessItem(t *testing.T) {
 				ownedSecretWithName("testns", "fixed-name", "test", map[string][]byte{"tls.key": mustGenerateRSA(t, 2048)}),
 			},
 		},
+		"preserve secret matching API status when informer cache is stale (single secret)": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: new("stale-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "current-name", "test", map[string][]byte{"tls.key": mustGenerateRSA(t, 2048)}),
+			},
+			apiCertificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: new("current-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
+			},
+		},
+		"preserve secret matching API status when informer cache is stale (multiple secrets)": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: new("stale-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "stale-name", "test", nil),
+				ownedSecretWithName("testns", "keep-name", "test", nil),
+			},
+			apiCertificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: new("keep-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"stale-name",
+				)),
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -535,6 +635,12 @@ func TestProcessItem(t *testing.T) {
 				builder.CertManagerObjects = append(builder.CertManagerObjects, req)
 			}
 			builder.Init()
+
+			if test.apiCertificate != nil {
+				builder.FakeCMClient().PrependReactor("get", "certificates", func(action coretesting.Action) (bool, runtime.Object, error) {
+					return true, test.apiCertificate, nil
+				})
+			}
 
 			// Register informers used by the controller using the registration wrapper
 			w := &controllerWrapper{}


### PR DESCRIPTION
### Pull Request Motivation

When two concurrent key-manager reconciliations race (e.g. triggered by both a Certificate and an Issuer creation event in the same cycle), each can create a different temporary private-key Secret and the second overwrites `status.nextPrivateKeySecretName` in the API. A subsequent reconciliation that still holds a stale informer cache then deletes the Secret that is actually the active next private key. This leaves the CertificateRequest's CSR signed by a now-deleted key, producing:

    Error generating certificate template: CSR not signed by referenced private key

The Certificate never recovers until the next backoff retry creates a new Secret and CertificateRequest from scratch.

Observed in production on cert-manager v1.21.1 with a self-signed Issuer (plugin-barman-cloud chart). The sibling Certificate issued through the same Issuer succeeded, confirming the chart and Issuer config are valid.

Both cleanup paths in `keymanager_controller.go` trusted `crt.Status.NextPrivateKeySecretName` from the informer cache to decide which Secret to preserve. A stale cache caused the controller to delete the wrong Secret.

The existing hardening in `createNewPrivateKeySecret` (live Get added in 7e27be86) narrowed but did not close this window: it prevents creating a duplicate-named Secret but does not prevent a stale-cache deletion of the current one.

This PR fetches the live `status.nextPrivateKeySecretName` from the API before either destructive cleanup decision. The live Get is only called when secrets exist and cleanup is about to happen; the steady-state path (zero secrets → create) is unaffected.

Two new table-driven regression tests simulate a stale informer cache (lister returns old status, API returns current status):

- **Single secret**: the Secret matching the API status is preserved instead of deleted.
- **Multiple secrets**: the Secret matching the API status is preserved and the stale-named duplicate is deleted.

Both tests fail without the fix (wrong Secret deleted) and pass with it. Existing tests updated to expect the additional Get action.

### Kind

/kind bug

### Release Note

```release-note
Fixed a race condition in the keymanager controller that could delete the active private key Secret when the informer cache was stale, causing Certificate issuance to fail with "CSR not signed by referenced private key".
```