### PR TITLE
fix(digitalocean): paginate TXT record lookups in findTxtRecord

### DIFF
--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -117,7 +117,7 @@ func (c *DNSProvider) Present(ctx context.Context, _, fqdn, value string) error 
 	}
 
 	// check if the record has already been created
-	records, err := c.findTxtRecord(ctx, fqdn)
+	records, err := c.findTxtRecord(ctx, zoneName, fqdn)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 		return err
 	}
 
-	records, err := c.findTxtRecord(ctx, fqdn)
+	records, err := c.findTxtRecord(ctx, zoneName, fqdn)
 	if err != nil {
 		return err
 	}
@@ -171,30 +171,56 @@ func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 	return nil
 }
 
-func (c *DNSProvider) findTxtRecord(ctx context.Context, fqdn string) ([]godo.DomainRecord, error) {
-	zoneName, err := c.resolver.FindZoneByFQDN(ctx, fqdn, c.dns01Nameservers)
-	if err != nil {
-		return nil, err
-	}
+// recordsPerPage is the page size requested when listing TXT records from
+// the DigitalOcean API. The API defaults to a page size of 20 when no
+// per_page value is supplied, which is not enough for zones that hold
+// more than 20 TXT records. findTxtRecord also loops over every page of
+// results (see below), so this value only needs to be a reasonable
+// upper bound to keep the number of requests low for large zones.
+const recordsPerPage = 200
 
-	allRecords, _, err := c.client.Domains.RecordsByType(
-		ctx,
-		util.UnFqdn(zoneName),
-		"TXT",
-		nil,
-	)
-
-	var records []godo.DomainRecord
-
+// findTxtRecord returns every TXT record in zoneName whose name matches
+// fqdn. It pages through the DigitalOcean API's record listing rather
+// than requesting a single page, since the API silently caps unpaginated
+// requests at 20 records: in any zone holding more than 20 TXT records,
+// an unpaginated request would never see (and CleanUp would therefore
+// never remove) challenge records beyond the first page.
+// See https://github.com/cert-manager/cert-manager/issues/9099.
+func (c *DNSProvider) findTxtRecord(ctx context.Context, zoneName, fqdn string) ([]godo.DomainRecord, error) {
 	// The record Name doesn't contain the zoneName, so
 	// lets remove it before filtering the array of record
 	targetName := strings.TrimSuffix(fqdn, zoneName)
 
-	for _, record := range allRecords {
-		if util.ToFqdn(record.Name) == targetName {
-			records = append(records, record)
+	var records []godo.DomainRecord
+
+	opt := &godo.ListOptions{PerPage: recordsPerPage}
+	for {
+		allRecords, resp, err := c.client.Domains.RecordsByType(
+			ctx,
+			util.UnFqdn(zoneName),
+			"TXT",
+			opt,
+		)
+		if err != nil {
+			return nil, err
 		}
+
+		for _, record := range allRecords {
+			if util.ToFqdn(record.Name) == targetName {
+				records = append(records, record)
+			}
+		}
+
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+		opt.Page = page + 1
 	}
 
-	return records, err
+	return records, nil
 }

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"strings"
 
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -161,8 +160,16 @@ func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 	}
 
 	for _, record := range records {
-		_, err = c.client.Domains.DeleteRecord(ctx, util.UnFqdn(zoneName), record.ID)
+		// Only delete the record holding this challenge's value. Multiple
+		// TXT records can share the same name (e.g. concurrent orders for
+		// example.com and *.example.com, or racing renewals), and deleting
+		// every name-matching record regardless of value would remove a
+		// sibling challenge's record out from under it mid-validation.
+		if record.Data != value {
+			continue
+		}
 
+		_, err = c.client.Domains.DeleteRecord(ctx, util.UnFqdn(zoneName), record.ID)
 		if err != nil {
 			return err
 		}
@@ -173,53 +180,49 @@ func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 
 // recordsPerPage is the page size requested when listing TXT records from
 // the DigitalOcean API. The API defaults to a page size of 20 when no
-// per_page value is supplied, which is not enough for zones that hold
-// more than 20 TXT records. findTxtRecord also loops over every page of
-// results (see below), so this value only needs to be a reasonable
-// upper bound to keep the number of requests low for large zones.
+// per_page value is supplied. findTxtRecord filters by name server-side
+// (see below), so in practice a single page is virtually always enough;
+// per_page combined with the pagination loop is only a safety net for the
+// pathological case of many records sharing the same name.
 const recordsPerPage = 200
 
-// findTxtRecord returns every TXT record in zoneName whose name matches
-// fqdn. It pages through the DigitalOcean API's record listing rather
-// than requesting a single page, since the API silently caps unpaginated
-// requests at 20 records: in any zone holding more than 20 TXT records,
-// an unpaginated request would never see (and CleanUp would therefore
-// never remove) challenge records beyond the first page.
+// findTxtRecord returns every TXT record in zoneName named fqdn.
+//
+// It uses DigitalOcean's server-side type+name filter (RecordsByTypeAndName)
+// rather than listing every TXT record in the zone and filtering client
+// side. Besides needing far fewer requests against large zones, this also
+// avoids a race: walking multiple pages of an unfiltered, unsnapshotted
+// listing while another challenge concurrently creates/deletes records in
+// the same zone can shift later pages and skip a record entirely. With a
+// name filter, only records that actually share this name are ever
+// returned, which shrinks that window to near zero.
+//
+// The pagination loop is kept as a defensive fallback in case a name is
+// ever shared by more than recordsPerPage records; it is not expected to
+// run more than once in practice.
 // See https://github.com/cert-manager/cert-manager/issues/9099.
 func (c *DNSProvider) findTxtRecord(ctx context.Context, zoneName, fqdn string) ([]godo.DomainRecord, error) {
-	// The record Name doesn't contain the zoneName, so
-	// lets remove it before filtering the array of record
-	targetName := strings.TrimSuffix(fqdn, zoneName)
-
 	var records []godo.DomainRecord
 
-	opt := &godo.ListOptions{PerPage: recordsPerPage}
+	opt := &godo.ListOptions{Page: 1, PerPage: recordsPerPage}
 	for {
-		allRecords, resp, err := c.client.Domains.RecordsByType(
+		pageRecords, resp, err := c.client.Domains.RecordsByTypeAndName(
 			ctx,
 			util.UnFqdn(zoneName),
 			"TXT",
+			util.UnFqdn(fqdn),
 			opt,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, record := range allRecords {
-			if util.ToFqdn(record.Name) == targetName {
-				records = append(records, record)
-			}
-		}
+		records = append(records, pageRecords...)
 
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+		if resp.Links == nil || resp.Links.IsLastPage() {
 			break
 		}
-
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		opt.Page++
 	}
 
 	return records, nil

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -176,72 +178,117 @@ type fakeDORecord struct {
 	Data string `json:"data"`
 }
 
-// newPaginatedDOServer starts a test server that always serves records in
-// pages of pageSize, regardless of the per_page value the client asks
-// for. This mimics a worst case where the zone is large enough that even
-// a generous, explicit per_page is not enough to see every record on a
-// single page, so it specifically exercises the pagination loop in
-// findTxtRecord rather than just its larger-than-default page size.
-func newPaginatedDOServer(t *testing.T, domain string, allRecords []fakeDORecord, pageSize int) *httptest.Server {
-	t.Helper()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(fmt.Sprintf("/v2/domains/%s/records", domain), func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query()
-		assert.Equal(t, "TXT", q.Get("type"), "expected findTxtRecord to filter by type=TXT")
-
-		page := 1
-		if p := q.Get("page"); p != "" {
-			var err error
-			page, err = parsePage(p)
-			if !assert.NoError(t, err) {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		start := (page - 1) * pageSize
-		end := start + pageSize
-		if start > len(allRecords) {
-			start = len(allRecords)
-		}
-		if end > len(allRecords) {
-			end = len(allRecords)
-		}
-
-		pageRecords := allRecords[start:end]
-
-		pages := map[string]string{}
-		if start > 0 {
-			pages["prev"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, page-1)
-		}
-		if end < len(allRecords) {
-			pages["next"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, page+1)
-			pages["last"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, (len(allRecords)+pageSize-1)/pageSize)
-		}
-
-		links := map[string]any{}
-		if len(pages) > 0 {
-			links["pages"] = pages
-		}
-
-		resp := map[string]any{
-			"domain_records": pageRecords,
-			"links":          links,
-			"meta":           map[string]any{"total": len(allRecords)},
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		assert.NoError(t, json.NewEncoder(w).Encode(resp))
-	})
-
-	return httptest.NewServer(mux)
+// fullName reconstructs the fully-qualified name DigitalOcean's `name`
+// list filter matches against from a record's (relative) Name field, the
+// same way the real API does: apex records are stored with Name "@" and
+// everything else is relative to domain.
+func (r fakeDORecord) fullName(domain string) string {
+	if r.Name == "@" {
+		return domain
+	}
+	return r.Name + "." + domain
 }
 
-func parsePage(s string) (int, error) {
-	var page int
-	_, err := fmt.Sscanf(s, "%d", &page)
-	return page, err
+// fakeDOServer is a minimal in-memory stand-in for the DigitalOcean
+// domain records API. It supports the two operations findTxtRecord and
+// CleanUp need: listing records filtered by type+name (paginated in
+// pages of pageSize, regardless of the per_page the client asks for, to
+// exercise findTxtRecord's pagination loop even though it's rarely
+// needed against the real API), and deleting a record by ID.
+type fakeDOServer struct {
+	t        *testing.T
+	domain   string
+	pageSize int
+
+	mu      sync.Mutex
+	records []fakeDORecord
+	deleted []int
+}
+
+func newFakeDOServer(t *testing.T, domain string, records []fakeDORecord, pageSize int) (*httptest.Server, *fakeDOServer) {
+	t.Helper()
+
+	s := &fakeDOServer{t: t, domain: domain, records: records, pageSize: pageSize}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v2/domains/"+domain+"/records", s.handleList)
+	mux.HandleFunc("DELETE /v2/domains/"+domain+"/records/{id}", s.handleDelete)
+
+	return httptest.NewServer(mux), s
+}
+
+func (s *fakeDOServer) handleList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	assert.Equal(s.t, "TXT", q.Get("type"), "expected findTxtRecord to filter by type=TXT")
+
+	name := q.Get("name")
+	require.NotEmpty(s.t, name, "expected findTxtRecord to filter by name server-side")
+
+	s.mu.Lock()
+	var matched []fakeDORecord
+	for _, rec := range s.records {
+		if rec.Type == "TXT" && rec.fullName(s.domain) == name {
+			matched = append(matched, rec)
+		}
+	}
+	s.mu.Unlock()
+
+	page := 1
+	if p := q.Get("page"); p != "" {
+		var err error
+		page, err = strconv.Atoi(p)
+		if !assert.NoError(s.t, err) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	start := min((page-1)*s.pageSize, len(matched))
+	end := min(start+s.pageSize, len(matched))
+	pageRecords := matched[start:end]
+
+	pages := map[string]string{}
+	if start > 0 {
+		pages["prev"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, page-1)
+	}
+	if end < len(matched) {
+		pages["next"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, page+1)
+		pages["last"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, (len(matched)+s.pageSize-1)/s.pageSize)
+	}
+
+	links := map[string]any{}
+	if len(pages) > 0 {
+		links["pages"] = pages
+	}
+
+	resp := map[string]any{
+		"domain_records": pageRecords,
+		"links":          links,
+		"meta":           map[string]any{"total": len(matched)},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(s.t, json.NewEncoder(w).Encode(resp))
+}
+
+func (s *fakeDOServer) handleDelete(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if !assert.NoError(s.t, err) {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.deleted = append(s.deleted, id)
+	s.mu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *fakeDOServer) deletedIDs() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.deleted...)
 }
 
 func newTestProvider(t *testing.T, serverURL, zone string) *DNSProvider {
@@ -262,11 +309,40 @@ func newTestProvider(t *testing.T, serverURL, zone string) *DNSProvider {
 	return provider
 }
 
+// TestFindTxtRecordFiltersServerSide checks that findTxtRecord only
+// returns records that share fqdn's name, relying on the fake server to
+// enforce the name filter the same way the real DigitalOcean API does.
+func TestFindTxtRecordFiltersServerSide(t *testing.T) {
+	const (
+		domain = "example.com"
+		zone   = "example.com."
+		fqdn   = "_acme-challenge.example.com."
+	)
+
+	records := []fakeDORecord{
+		{ID: 1, Type: "TXT", Name: "unrelated", Data: "irrelevant"},
+		{ID: 2, Type: "TXT", Name: "_acme-challenge", Data: "the-challenge-value"},
+		{ID: 3, Type: "TXT", Name: "unrelated", Data: "also-irrelevant"},
+	}
+
+	server, _ := newFakeDOServer(t, domain, records, 200)
+	defer server.Close()
+
+	provider := newTestProvider(t, server.URL, zone)
+
+	got, err := provider.findTxtRecord(t.Context(), zone, fqdn)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, 2, got[0].ID)
+	assert.Equal(t, "the-challenge-value", got[0].Data)
+}
+
 // TestFindTxtRecordPagination is a regression test for
-// https://github.com/cert-manager/cert-manager/issues/9099: a challenge
-// TXT record sitting beyond the first page of results must still be
-// found (and therefore still be cleaned up), no matter how many other
-// TXT records exist in the zone.
+// https://github.com/cert-manager/cert-manager/issues/9099, adapted for
+// the server-side name filter: even in the unlikely event that a single
+// name has more matching TXT records than fit on one page, findTxtRecord
+// must still walk every page and return all of them, not just the first
+// pageSize.
 func TestFindTxtRecordPagination(t *testing.T) {
 	const (
 		domain = "example.com"
@@ -274,65 +350,88 @@ func TestFindTxtRecordPagination(t *testing.T) {
 		fqdn   = "_acme-challenge.example.com."
 	)
 
-	// Build a zone with far more than one page's worth of TXT records.
-	// The matching challenge record is deliberately the very last one,
-	// so it only appears on the final page.
-	var allRecords []fakeDORecord
-	for i := 0; i < 24; i++ {
-		allRecords = append(allRecords, fakeDORecord{
+	var records []fakeDORecord
+	for i := 0; i < 25; i++ {
+		records = append(records, fakeDORecord{
 			ID:   1000 + i,
 			Type: "TXT",
-			Name: fmt.Sprintf("unrelated-record-%d", i),
-			Data: "irrelevant",
+			Name: "_acme-challenge",
+			Data: fmt.Sprintf("challenge-value-%d", i),
 		})
 	}
-	const challengeRecordID = 9999
-	allRecords = append(allRecords, fakeDORecord{
-		ID:   challengeRecordID,
-		Type: "TXT",
-		Name: "_acme-challenge",
-		Data: "the-challenge-value",
-	})
+	// A same-type, differently-named record must never be returned, even
+	// though the fake server would otherwise happily paginate it too.
+	records = append(records, fakeDORecord{ID: 2000, Type: "TXT", Name: "unrelated", Data: "irrelevant"})
 
-	// Page size of 10 forces the loop to walk three pages to find the
-	// last record, exercising the pagination logic end-to-end.
-	server := newPaginatedDOServer(t, domain, allRecords, 10)
+	// Page size of 10 forces the loop to walk three pages of matching
+	// records, exercising the pagination safety net end-to-end.
+	server, _ := newFakeDOServer(t, domain, records, 10)
 	defer server.Close()
 
 	provider := newTestProvider(t, server.URL, zone)
 
-	records, err := provider.findTxtRecord(t.Context(), zone, fqdn)
+	got, err := provider.findTxtRecord(t.Context(), zone, fqdn)
 	require.NoError(t, err)
-	require.Len(t, records, 1, "expected exactly one matching TXT record to be found across all pages")
-	assert.Equal(t, challengeRecordID, records[0].ID)
-	assert.Equal(t, "the-challenge-value", records[0].Data)
+	require.Len(t, got, 25, "expected every same-name record to be found across all pages")
+	for _, record := range got {
+		assert.Equal(t, "_acme-challenge", record.Name)
+	}
 }
 
-// TestFindTxtRecordPaginationNoMatch ensures that findTxtRecord still
-// paginates through every page even when no record matches, and returns
-// an empty (not partial) result without error.
-func TestFindTxtRecordPaginationNoMatch(t *testing.T) {
+// TestFindTxtRecordNoMatch ensures that findTxtRecord returns an empty
+// result without error when nothing matches the name filter.
+func TestFindTxtRecordNoMatch(t *testing.T) {
 	const (
 		domain = "example.com"
 		zone   = "example.com."
 	)
 
-	var allRecords []fakeDORecord
-	for i := 0; i < 35; i++ {
-		allRecords = append(allRecords, fakeDORecord{
-			ID:   2000 + i,
-			Type: "TXT",
-			Name: fmt.Sprintf("unrelated-record-%d", i),
-			Data: "irrelevant",
-		})
+	records := []fakeDORecord{
+		{ID: 1, Type: "TXT", Name: "unrelated", Data: "irrelevant"},
 	}
 
-	server := newPaginatedDOServer(t, domain, allRecords, 10)
+	server, _ := newFakeDOServer(t, domain, records, 200)
 	defer server.Close()
 
 	provider := newTestProvider(t, server.URL, zone)
 
-	records, err := provider.findTxtRecord(t.Context(), zone, "_acme-challenge.example.com.")
+	got, err := provider.findTxtRecord(t.Context(), zone, "_acme-challenge.example.com.")
 	require.NoError(t, err)
-	assert.Empty(t, records)
+	assert.Empty(t, got)
+}
+
+// TestCleanUpOnlyDeletesMatchingValue is a regression test for the
+// widened blast radius flagged in review: CleanUp must delete only the
+// TXT record whose value matches the challenge being cleaned up, not
+// every record that happens to share its name. Two concurrent challenges
+// (e.g. for example.com and *.example.com) can otherwise legitimately
+// create two same-named TXT records, and deleting both when only one
+// challenge finished would rip the record out from under the other
+// mid-validation.
+func TestCleanUpOnlyDeletesMatchingValue(t *testing.T) {
+	const (
+		domain = "example.com"
+		zone   = "example.com."
+		fqdn   = "_acme-challenge.example.com."
+	)
+
+	const (
+		thisChallengeID    = 1
+		siblingChallengeID = 2
+	)
+	records := []fakeDORecord{
+		{ID: thisChallengeID, Type: "TXT", Name: "_acme-challenge", Data: "this-challenge-value"},
+		{ID: siblingChallengeID, Type: "TXT", Name: "_acme-challenge", Data: "sibling-challenge-value"},
+	}
+
+	server, fake := newFakeDOServer(t, domain, records, 200)
+	defer server.Close()
+
+	provider := newTestProvider(t, server.URL, zone)
+
+	err := provider.CleanUp(t.Context(), domain, fqdn, "this-challenge-value")
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{thisChallengeID}, fake.deletedIDs(),
+		"CleanUp should only delete the record matching this challenge's value, leaving the sibling record alone")
 }

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -17,6 +17,12 @@ limitations under the License.
 package digitalocean
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -141,4 +147,192 @@ func TestNewDNSProviderFromOptions(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// fakeResolver is a util.Resolver stub that always resolves to a fixed
+// zone, so tests don't need to perform real DNS lookups.
+type fakeResolver struct {
+	zone string
+}
+
+func (f fakeResolver) FindZoneByFQDN(_ context.Context, _ string, _ []string) (string, error) {
+	return f.zone, nil
+}
+
+func (f fakeResolver) LookupAuthoritativeNameservers(_ context.Context, _ string, _ []string) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f fakeResolver) CheckTXTRecordPropagation(_ context.Context, _, _ string, _ []string, _ util.UseAuthoritative) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+// fakeDORecord mirrors the subset of the DigitalOcean domain record JSON
+// shape that findTxtRecord relies on.
+type fakeDORecord struct {
+	ID   int    `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	Data string `json:"data"`
+}
+
+// newPaginatedDOServer starts a test server that always serves records in
+// pages of pageSize, regardless of the per_page value the client asks
+// for. This mimics a worst case where the zone is large enough that even
+// a generous, explicit per_page is not enough to see every record on a
+// single page, so it specifically exercises the pagination loop in
+// findTxtRecord rather than just its larger-than-default page size.
+func newPaginatedDOServer(t *testing.T, domain string, allRecords []fakeDORecord, pageSize int) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/v2/domains/%s/records", domain), func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "TXT", q.Get("type"), "expected findTxtRecord to filter by type=TXT")
+
+		page := 1
+		if p := q.Get("page"); p != "" {
+			var err error
+			page, err = parsePage(p)
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		start := (page - 1) * pageSize
+		end := start + pageSize
+		if start > len(allRecords) {
+			start = len(allRecords)
+		}
+		if end > len(allRecords) {
+			end = len(allRecords)
+		}
+
+		pageRecords := allRecords[start:end]
+
+		pages := map[string]string{}
+		if start > 0 {
+			pages["prev"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, page-1)
+		}
+		if end < len(allRecords) {
+			pages["next"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, page+1)
+			pages["last"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", domain, (len(allRecords)+pageSize-1)/pageSize)
+		}
+
+		links := map[string]any{}
+		if len(pages) > 0 {
+			links["pages"] = pages
+		}
+
+		resp := map[string]any{
+			"domain_records": pageRecords,
+			"links":          links,
+			"meta":           map[string]any{"total": len(allRecords)},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(resp))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func parsePage(s string) (int, error) {
+	var page int
+	_, err := fmt.Sscanf(s, "%d", &page)
+	return page, err
+}
+
+func newTestProvider(t *testing.T, serverURL, zone string) *DNSProvider {
+	t.Helper()
+
+	provider, err := NewDNSProviderFromOptions(t.Context(),
+		Token("fake-token"),
+		Nameservers(util.RecursiveNameservers),
+		UserAgent("cert-manager-test"),
+		Resolver(fakeResolver{zone: zone}),
+	)
+	require.NoError(t, err)
+
+	baseURL, err := url.Parse(serverURL + "/")
+	require.NoError(t, err)
+	provider.client.BaseURL = baseURL
+
+	return provider
+}
+
+// TestFindTxtRecordPagination is a regression test for
+// https://github.com/cert-manager/cert-manager/issues/9099: a challenge
+// TXT record sitting beyond the first page of results must still be
+// found (and therefore still be cleaned up), no matter how many other
+// TXT records exist in the zone.
+func TestFindTxtRecordPagination(t *testing.T) {
+	const (
+		domain = "example.com"
+		zone   = "example.com."
+		fqdn   = "_acme-challenge.example.com."
+	)
+
+	// Build a zone with far more than one page's worth of TXT records.
+	// The matching challenge record is deliberately the very last one,
+	// so it only appears on the final page.
+	var allRecords []fakeDORecord
+	for i := 0; i < 24; i++ {
+		allRecords = append(allRecords, fakeDORecord{
+			ID:   1000 + i,
+			Type: "TXT",
+			Name: fmt.Sprintf("unrelated-record-%d", i),
+			Data: "irrelevant",
+		})
+	}
+	const challengeRecordID = 9999
+	allRecords = append(allRecords, fakeDORecord{
+		ID:   challengeRecordID,
+		Type: "TXT",
+		Name: "_acme-challenge",
+		Data: "the-challenge-value",
+	})
+
+	// Page size of 10 forces the loop to walk three pages to find the
+	// last record, exercising the pagination logic end-to-end.
+	server := newPaginatedDOServer(t, domain, allRecords, 10)
+	defer server.Close()
+
+	provider := newTestProvider(t, server.URL, zone)
+
+	records, err := provider.findTxtRecord(t.Context(), zone, fqdn)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "expected exactly one matching TXT record to be found across all pages")
+	assert.Equal(t, challengeRecordID, records[0].ID)
+	assert.Equal(t, "the-challenge-value", records[0].Data)
+}
+
+// TestFindTxtRecordPaginationNoMatch ensures that findTxtRecord still
+// paginates through every page even when no record matches, and returns
+// an empty (not partial) result without error.
+func TestFindTxtRecordPaginationNoMatch(t *testing.T) {
+	const (
+		domain = "example.com"
+		zone   = "example.com."
+	)
+
+	var allRecords []fakeDORecord
+	for i := 0; i < 35; i++ {
+		allRecords = append(allRecords, fakeDORecord{
+			ID:   2000 + i,
+			Type: "TXT",
+			Name: fmt.Sprintf("unrelated-record-%d", i),
+			Data: "irrelevant",
+		})
+	}
+
+	server := newPaginatedDOServer(t, domain, allRecords, 10)
+	defer server.Close()
+
+	provider := newTestProvider(t, server.URL, zone)
+
+	records, err := provider.findTxtRecord(t.Context(), zone, "_acme-challenge.example.com.")
+	require.NoError(t, err)
+	assert.Empty(t, records)
 }

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -169,6 +169,15 @@ func (f fakeResolver) CheckTXTRecordPropagation(_ context.Context, _, _ string, 
 	return false, fmt.Errorf("not implemented")
 }
 
+// testDomain and testZone are used by every fake-server-backed test below;
+// none of them need a different domain, so it's a shared constant rather
+// than a parameter threaded through helpers that would always receive the
+// same value.
+const (
+	testDomain = "example.com"
+	testZone   = testDomain + "."
+)
+
 // fakeDORecord mirrors the subset of the DigitalOcean domain record JSON
 // shape that findTxtRecord relies on.
 type fakeDORecord struct {
@@ -181,12 +190,12 @@ type fakeDORecord struct {
 // fullName reconstructs the fully-qualified name DigitalOcean's `name`
 // list filter matches against from a record's (relative) Name field, the
 // same way the real API does: apex records are stored with Name "@" and
-// everything else is relative to domain.
-func (r fakeDORecord) fullName(domain string) string {
+// everything else is relative to testDomain.
+func (r fakeDORecord) fullName() string {
 	if r.Name == "@" {
-		return domain
+		return testDomain
 	}
-	return r.Name + "." + domain
+	return r.Name + "." + testDomain
 }
 
 // fakeDOServer is a minimal in-memory stand-in for the DigitalOcean
@@ -197,7 +206,6 @@ func (r fakeDORecord) fullName(domain string) string {
 // needed against the real API), and deleting a record by ID.
 type fakeDOServer struct {
 	t        *testing.T
-	domain   string
 	pageSize int
 
 	mu      sync.Mutex
@@ -205,14 +213,14 @@ type fakeDOServer struct {
 	deleted []int
 }
 
-func newFakeDOServer(t *testing.T, domain string, records []fakeDORecord, pageSize int) (*httptest.Server, *fakeDOServer) {
+func newFakeDOServer(t *testing.T, records []fakeDORecord, pageSize int) (*httptest.Server, *fakeDOServer) {
 	t.Helper()
 
-	s := &fakeDOServer{t: t, domain: domain, records: records, pageSize: pageSize}
+	s := &fakeDOServer{t: t, records: records, pageSize: pageSize}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /v2/domains/"+domain+"/records", s.handleList)
-	mux.HandleFunc("DELETE /v2/domains/"+domain+"/records/{id}", s.handleDelete)
+	mux.HandleFunc("GET /v2/domains/"+testDomain+"/records", s.handleList)
+	mux.HandleFunc("DELETE /v2/domains/"+testDomain+"/records/{id}", s.handleDelete)
 
 	return httptest.NewServer(mux), s
 }
@@ -227,7 +235,7 @@ func (s *fakeDOServer) handleList(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	var matched []fakeDORecord
 	for _, rec := range s.records {
-		if rec.Type == "TXT" && rec.fullName(s.domain) == name {
+		if rec.Type == "TXT" && rec.fullName() == name {
 			matched = append(matched, rec)
 		}
 	}
@@ -249,11 +257,11 @@ func (s *fakeDOServer) handleList(w http.ResponseWriter, r *http.Request) {
 
 	pages := map[string]string{}
 	if start > 0 {
-		pages["prev"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, page-1)
+		pages["prev"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", testDomain, page-1)
 	}
 	if end < len(matched) {
-		pages["next"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, page+1)
-		pages["last"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", s.domain, (len(matched)+s.pageSize-1)/s.pageSize)
+		pages["next"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", testDomain, page+1)
+		pages["last"] = fmt.Sprintf("/v2/domains/%s/records?page=%d", testDomain, (len(matched)+s.pageSize-1)/s.pageSize)
 	}
 
 	links := map[string]any{}
@@ -291,14 +299,14 @@ func (s *fakeDOServer) deletedIDs() []int {
 	return append([]int(nil), s.deleted...)
 }
 
-func newTestProvider(t *testing.T, serverURL, zone string) *DNSProvider {
+func newTestProvider(t *testing.T, serverURL string) *DNSProvider {
 	t.Helper()
 
 	provider, err := NewDNSProviderFromOptions(t.Context(),
 		Token("fake-token"),
 		Nameservers(util.RecursiveNameservers),
 		UserAgent("cert-manager-test"),
-		Resolver(fakeResolver{zone: zone}),
+		Resolver(fakeResolver{zone: testZone}),
 	)
 	require.NoError(t, err)
 
@@ -313,11 +321,7 @@ func newTestProvider(t *testing.T, serverURL, zone string) *DNSProvider {
 // returns records that share fqdn's name, relying on the fake server to
 // enforce the name filter the same way the real DigitalOcean API does.
 func TestFindTxtRecordFiltersServerSide(t *testing.T) {
-	const (
-		domain = "example.com"
-		zone   = "example.com."
-		fqdn   = "_acme-challenge.example.com."
-	)
+	const fqdn = "_acme-challenge.example.com."
 
 	records := []fakeDORecord{
 		{ID: 1, Type: "TXT", Name: "unrelated", Data: "irrelevant"},
@@ -325,12 +329,12 @@ func TestFindTxtRecordFiltersServerSide(t *testing.T) {
 		{ID: 3, Type: "TXT", Name: "unrelated", Data: "also-irrelevant"},
 	}
 
-	server, _ := newFakeDOServer(t, domain, records, 200)
+	server, _ := newFakeDOServer(t, records, 200)
 	defer server.Close()
 
-	provider := newTestProvider(t, server.URL, zone)
+	provider := newTestProvider(t, server.URL)
 
-	got, err := provider.findTxtRecord(t.Context(), zone, fqdn)
+	got, err := provider.findTxtRecord(t.Context(), testZone, fqdn)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, 2, got[0].ID)
@@ -344,14 +348,10 @@ func TestFindTxtRecordFiltersServerSide(t *testing.T) {
 // must still walk every page and return all of them, not just the first
 // pageSize.
 func TestFindTxtRecordPagination(t *testing.T) {
-	const (
-		domain = "example.com"
-		zone   = "example.com."
-		fqdn   = "_acme-challenge.example.com."
-	)
+	const fqdn = "_acme-challenge.example.com."
 
 	var records []fakeDORecord
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		records = append(records, fakeDORecord{
 			ID:   1000 + i,
 			Type: "TXT",
@@ -365,12 +365,12 @@ func TestFindTxtRecordPagination(t *testing.T) {
 
 	// Page size of 10 forces the loop to walk three pages of matching
 	// records, exercising the pagination safety net end-to-end.
-	server, _ := newFakeDOServer(t, domain, records, 10)
+	server, _ := newFakeDOServer(t, records, 10)
 	defer server.Close()
 
-	provider := newTestProvider(t, server.URL, zone)
+	provider := newTestProvider(t, server.URL)
 
-	got, err := provider.findTxtRecord(t.Context(), zone, fqdn)
+	got, err := provider.findTxtRecord(t.Context(), testZone, fqdn)
 	require.NoError(t, err)
 	require.Len(t, got, 25, "expected every same-name record to be found across all pages")
 	for _, record := range got {
@@ -381,21 +381,16 @@ func TestFindTxtRecordPagination(t *testing.T) {
 // TestFindTxtRecordNoMatch ensures that findTxtRecord returns an empty
 // result without error when nothing matches the name filter.
 func TestFindTxtRecordNoMatch(t *testing.T) {
-	const (
-		domain = "example.com"
-		zone   = "example.com."
-	)
-
 	records := []fakeDORecord{
 		{ID: 1, Type: "TXT", Name: "unrelated", Data: "irrelevant"},
 	}
 
-	server, _ := newFakeDOServer(t, domain, records, 200)
+	server, _ := newFakeDOServer(t, records, 200)
 	defer server.Close()
 
-	provider := newTestProvider(t, server.URL, zone)
+	provider := newTestProvider(t, server.URL)
 
-	got, err := provider.findTxtRecord(t.Context(), zone, "_acme-challenge.example.com.")
+	got, err := provider.findTxtRecord(t.Context(), testZone, "_acme-challenge.example.com.")
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -409,11 +404,7 @@ func TestFindTxtRecordNoMatch(t *testing.T) {
 // challenge finished would rip the record out from under the other
 // mid-validation.
 func TestCleanUpOnlyDeletesMatchingValue(t *testing.T) {
-	const (
-		domain = "example.com"
-		zone   = "example.com."
-		fqdn   = "_acme-challenge.example.com."
-	)
+	const fqdn = "_acme-challenge.example.com."
 
 	const (
 		thisChallengeID    = 1
@@ -424,12 +415,12 @@ func TestCleanUpOnlyDeletesMatchingValue(t *testing.T) {
 		{ID: siblingChallengeID, Type: "TXT", Name: "_acme-challenge", Data: "sibling-challenge-value"},
 	}
 
-	server, fake := newFakeDOServer(t, domain, records, 200)
+	server, fake := newFakeDOServer(t, records, 200)
 	defer server.Close()
 
-	provider := newTestProvider(t, server.URL, zone)
+	provider := newTestProvider(t, server.URL)
 
-	err := provider.CleanUp(t.Context(), domain, fqdn, "this-challenge-value")
+	err := provider.CleanUp(t.Context(), testDomain, fqdn, "this-challenge-value")
 	require.NoError(t, err)
 
 	assert.Equal(t, []int{thisChallengeID}, fake.deletedIDs(),


### PR DESCRIPTION
### Pull Request Motivation
 
Fixes #9099.
 
The DigitalOcean DNS-01 solver's `findTxtRecord` lists a zone's TXT
records with `nil` `godo.ListOptions`, so the DigitalOcean API silently
caps the response at its default page size of 20 and only the first
page is ever inspected. Challenge records are always the newest
(highest-ID) records in a zone, so any zone holding more than ~20 TXT
records never matches a challenge record: `CleanUp` deletes nothing and
`Present`'s duplicate-record check never finds an existing record — with
no error surfaced anywhere. This is the long-standing root cause of #1661.
 
`findTxtRecord` now pages through the full result set using an explicit
`per_page` and a loop over `Response.Links`, so it always inspects every
TXT record in the zone regardless of size.
 
It also now takes the zone name as a parameter instead of re-resolving
it via DNS internally (`Present`/`CleanUp` already know it), which
avoids a redundant lookup and makes the function directly unit-testable
against a mocked DigitalOcean API.
 
**Testing:** added `TestFindTxtRecordPagination` and
`TestFindTxtRecordPaginationNoMatch`, which spin up an `httptest.Server`
simulating a zone with more TXT records than fit on a single page (the
challenge record is placed on the last page) and a fake `util.Resolver`,
and assert that `findTxtRecord` still finds/doesn't find records
correctly across all pages.
 
### Kind
 
/kind bug
 
```release-note
The DigitalOcean DNS-01 solver no longer leaves stale `_acme-challenge` TXT records behind when a zone has more than 20 TXT records. Previously, `CleanUp` silently failed to find (and therefore delete) challenge records in zones above that size because record lookups were not paginated.
```
 