### PR TITLE
Fix nil pointer panic on renewal-window errors in the trigger controller

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -488,6 +488,8 @@ func validateCertificateRenewalWindows(window internalcmapi.CertificateRenewalWi
 
 	if window.WindowDuration == nil {
 		el = append(el, field.Required(fldPath.Child("windowDuration"), "windowDuration must be specified and should be greater than 0"))
+	} else if window.WindowDuration.Duration <= 0 {
+		el = append(el, field.Invalid(fldPath.Child("windowDuration"), window.WindowDuration.Duration.String(), "windowDuration must be greater than 0"))
 	}
 
 	if _, err := time.LoadLocation(window.Timezone); err != nil && window.Timezone != "" {

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -934,6 +934,30 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
+		"invalid renewal window with zero windowDuration": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					PrivateKey: &internalcmapi.CertificatePrivateKey{
+						RotationPolicy: internalcmapi.RotationPolicyNever,
+					},
+					Renewal: &internalcmapi.CertificateRenewal{
+						Policy: internalcmapi.RenewBefore,
+						Windows: []internalcmapi.CertificateRenewalWindows{
+							{
+								WindowDuration: &metav1.Duration{Duration: 0},
+								Cron:           "0 12 * * *",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("renewal", "windows").Index(0).Child("windowDuration"), "0s", "windowDuration must be greater than 0"),
+			},
+		},
 		"invalid renewal cron with timezone prefix and no schedule": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -313,6 +313,10 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 			message = err.Error()
 		}
 
+		if renewalTime == nil {
+			return "", "", false
+		}
+
 		renewIn := renewalTime.Time.Sub(c.Now())
 		if renewIn > 0 {
 			// renewal time is in the future, no need to renew

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -307,19 +307,22 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 			return reason, message, true
 		}
 
-		// pki.RenewalTime always returns a non-nil renewal time here: the only
-		// nil case is the Disabled policy, which is handled by the early return
-		// above. On a renewal-window misconfiguration it returns the
-		// deterministic renewBefore-based time together with an error, so we can
-		// keep gating renewal on that time while surfacing the error as the
-		// WindowError reason once renewal is actually due. This avoids both the
-		// nil pointer panic and immediately re-issuing certificates that are
-		// nowhere near expiry (which would spam re-issuance while the window
-		// config stays invalid).
 		renewalTime, err := pki.RenewalTime(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore, crt.Spec.RenewBeforePercentage, crt.Spec.Renewal)
 		if err != nil {
+			// On a renewal-window misconfiguration RenewalTime still returns the
+			// deterministic renewBefore-based time, so we gate renewal on it and
+			// surface the error as the WindowError reason once renewal is due,
+			// rather than re-issuing a certificate that is nowhere near expiry.
 			reason = WindowError
 			message = err.Error()
+		}
+
+		// A nil renewal time means renewal is disabled for this Certificate, so
+		// it is never nearing expiry. RenewalTime only returns nil for the
+		// Disabled policy (also short-circuited by the early return above); a
+		// window error always comes with the fallback time handled above.
+		if renewalTime == nil {
+			return "", "", false
 		}
 
 		renewIn := renewalTime.Time.Sub(c.Now())

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -313,8 +313,13 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 			message = err.Error()
 		}
 
+		// pki.RenewalTime returns a nil time together with an error for renewal
+		// window errors (bad cron expression, unknown timezone, non-positive
+		// windowDuration). The Disabled policy is already handled above, so a
+		// nil renewalTime here always means err != nil. Surface it as a
+		// WindowError violation rather than dereferencing nil below.
 		if renewalTime == nil {
-			return "", "", false
+			return reason, message, true
 		}
 
 		renewIn := renewalTime.Time.Sub(c.Now())

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -307,19 +307,19 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 			return reason, message, true
 		}
 
+		// pki.RenewalTime always returns a non-nil renewal time here: the only
+		// nil case is the Disabled policy, which is handled by the early return
+		// above. On a renewal-window misconfiguration it returns the
+		// deterministic renewBefore-based time together with an error, so we can
+		// keep gating renewal on that time while surfacing the error as the
+		// WindowError reason once renewal is actually due. This avoids both the
+		// nil pointer panic and immediately re-issuing certificates that are
+		// nowhere near expiry (which would spam re-issuance while the window
+		// config stays invalid).
 		renewalTime, err := pki.RenewalTime(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore, crt.Spec.RenewBeforePercentage, crt.Spec.Renewal)
 		if err != nil {
 			reason = WindowError
 			message = err.Error()
-		}
-
-		// pki.RenewalTime returns a nil time together with an error for renewal
-		// window errors (bad cron expression, unknown timezone, non-positive
-		// windowDuration). The Disabled policy is already handled above, so a
-		// nil renewalTime here always means err != nil. Surface it as a
-		// WindowError violation rather than dereferencing nil below.
-		if renewalTime == nil {
-			return reason, message, true
 		}
 
 		renewIn := renewalTime.Time.Sub(c.Now())

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -320,8 +320,13 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 		// A nil renewal time means renewal is disabled for this Certificate, so
 		// it is never nearing expiry. RenewalTime only returns nil for the
 		// Disabled policy (also short-circuited by the early return above); a
-		// window error always comes with the fallback time handled above.
+		// window error always comes with the fallback time handled above. If a
+		// regression ever reintroduces a (nil, error) return, fail loudly
+		// rather than silently never renewing until the certificate expires.
 		if renewalTime == nil {
+			if err != nil {
+				return reason, message, true
+			}
 			return "", "", false
 		}
 

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2354,3 +2354,28 @@ func Test_SecretCertificateNameAnnotationsMismatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_CurrentCertificateNearingExpiry_RenewalDisabled(t *testing.T) {
+	clock := &fakeclock.FakeClock{}
+	pk := testcrypto.MustCreatePEMPrivateKey(t)
+	certPEM := testcrypto.MustCreateCert(t, pk, &cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{CommonName: "example.com"},
+	})
+	input := Input{
+		Certificate: &cmapi.Certificate{
+			Spec: cmapi.CertificateSpec{
+				Renewal: &cmapi.CertificateRenewal{
+					Policy: cmapi.CertificateRenewalPolicyDisabled,
+				},
+			},
+		},
+		Secret: &corev1.Secret{
+			Data: map[string][]byte{corev1.TLSCertKey: certPEM},
+		},
+	}
+
+	reason, message, violation := CurrentCertificateNearingExpiry(clock)(input)
+	assert.Equal(t, "", reason)
+	assert.Equal(t, "", message)
+	assert.False(t, violation)
+}

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2388,13 +2388,13 @@ func Test_CurrentCertificateNearingExpiry_RenewalDisabled(t *testing.T) {
 // surfaces as a WindowError violation only once renewal is actually due; a
 // certificate nowhere near expiry must not be flagged for re-issuance.
 func Test_CurrentCertificateNearingExpiry_WindowError(t *testing.T) {
-	now := time.Now()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	notBefore := now
+	notAfter := now.Add(30 * 24 * time.Hour)
 	pk := testcrypto.MustCreatePEMPrivateKey(t)
-	// Default validity is ~90 days from now, so the renewBefore-based renewal
-	// time lands well inside that range.
-	certPEM := testcrypto.MustCreateCert(t, pk, &cmapi.Certificate{
+	certPEM := testcrypto.MustCreateCertWithNotBeforeAfter(t, pk, &cmapi.Certificate{
 		Spec: cmapi.CertificateSpec{CommonName: "example.com"},
-	})
+	}, notBefore, notAfter)
 	input := Input{
 		Certificate: &cmapi.Certificate{
 			Spec: cmapi.CertificateSpec{
@@ -2422,7 +2422,7 @@ func Test_CurrentCertificateNearingExpiry_WindowError(t *testing.T) {
 
 	t.Run("due: surface the window error as a violation", func(t *testing.T) {
 		// Past the certificate's NotAfter, so renewal is unambiguously due.
-		clock := fakeclock.NewFakeClock(now.Add(91 * 24 * time.Hour))
+		clock := fakeclock.NewFakeClock(notAfter.Add(time.Hour))
 		reason, _, violation := CurrentCertificateNearingExpiry(clock)(input)
 		assert.True(t, violation)
 		assert.Equal(t, WindowError, reason)

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2379,3 +2379,35 @@ func Test_CurrentCertificateNearingExpiry_RenewalDisabled(t *testing.T) {
 	assert.Equal(t, "", message)
 	assert.False(t, violation)
 }
+
+// Test_CurrentCertificateNearingExpiry_WindowError covers the renewal-window
+// error path: pki.RenewalTime returns a nil time with an error (here for an
+// invalid cron expression), which previously caused a nil pointer panic in the
+// trigger controller. The error must surface as a WindowError violation.
+func Test_CurrentCertificateNearingExpiry_WindowError(t *testing.T) {
+	clock := &fakeclock.FakeClock{}
+	pk := testcrypto.MustCreatePEMPrivateKey(t)
+	certPEM := testcrypto.MustCreateCert(t, pk, &cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{CommonName: "example.com"},
+	})
+	input := Input{
+		Certificate: &cmapi.Certificate{
+			Spec: cmapi.CertificateSpec{
+				Renewal: &cmapi.CertificateRenewal{
+					Policy: cmapi.CertificateRenewalPolicyRenewBefore,
+					Windows: []cmapi.CertificateRenewalWindows{{
+						Cron:           "not a valid cron",
+						WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+					}},
+				},
+			},
+		},
+		Secret: &corev1.Secret{
+			Data: map[string][]byte{corev1.TLSCertKey: certPEM},
+		},
+	}
+
+	reason, _, violation := CurrentCertificateNearingExpiry(clock)(input)
+	assert.Equal(t, WindowError, reason)
+	assert.True(t, violation)
+}

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -2381,12 +2381,17 @@ func Test_CurrentCertificateNearingExpiry_RenewalDisabled(t *testing.T) {
 }
 
 // Test_CurrentCertificateNearingExpiry_WindowError covers the renewal-window
-// error path: pki.RenewalTime returns a nil time with an error (here for an
-// invalid cron expression), which previously caused a nil pointer panic in the
-// trigger controller. The error must surface as a WindowError violation.
+// error path (here an invalid cron expression). pki.RenewalTime previously
+// returned a nil time with an error, which crash-looped the trigger controller
+// with a nil pointer panic. It now returns the deterministic renewBefore-based
+// time alongside the error, so renewal is gated on that time and the error
+// surfaces as a WindowError violation only once renewal is actually due; a
+// certificate nowhere near expiry must not be flagged for re-issuance.
 func Test_CurrentCertificateNearingExpiry_WindowError(t *testing.T) {
-	clock := &fakeclock.FakeClock{}
+	now := time.Now()
 	pk := testcrypto.MustCreatePEMPrivateKey(t)
+	// Default validity is ~90 days from now, so the renewBefore-based renewal
+	// time lands well inside that range.
 	certPEM := testcrypto.MustCreateCert(t, pk, &cmapi.Certificate{
 		Spec: cmapi.CertificateSpec{CommonName: "example.com"},
 	})
@@ -2407,7 +2412,19 @@ func Test_CurrentCertificateNearingExpiry_WindowError(t *testing.T) {
 		},
 	}
 
-	reason, _, violation := CurrentCertificateNearingExpiry(clock)(input)
-	assert.Equal(t, WindowError, reason)
-	assert.True(t, violation)
+	t.Run("not yet due: no premature re-issuance despite the window error", func(t *testing.T) {
+		clock := fakeclock.NewFakeClock(now)
+		reason, message, violation := CurrentCertificateNearingExpiry(clock)(input)
+		assert.False(t, violation)
+		assert.Equal(t, "", reason)
+		assert.Equal(t, "", message)
+	})
+
+	t.Run("due: surface the window error as a violation", func(t *testing.T) {
+		// Past the certificate's NotAfter, so renewal is unambiguously due.
+		clock := fakeclock.NewFakeClock(now.Add(91 * 24 * time.Hour))
+		reason, _, violation := CurrentCertificateNearingExpiry(clock)(input)
+		assert.True(t, violation)
+		assert.Equal(t, WindowError, reason)
+	})
 }

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -356,6 +356,12 @@ func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificat
 				ariStatus.LastError = err.Error()
 				ariStatus.NextCheck = &metav1.Time{Time: c.computeNextCheck(now, defaultARIPoll)}
 
+				// Discard the fallback time returned alongside the error: it is
+				// a random time in the ARI window. Returning nil makes the
+				// caller recalculate deterministically and surface the error as
+				// a WindowError Ready condition, the same as on reconciles that
+				// do not fetch ARI.
+				renewalTime = nil
 				break
 			}
 		}

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -256,7 +256,7 @@ func TestProcessItem(t *testing.T) {
 			secretShouldExist: true,
 			certShouldUpdate:  false,
 		},
-		"update status as not ready (Ready=False) with invalid renewal time": {
+		"update status as not ready (Ready=False) with the fallback renewal time on a window error": {
 			condition: cmapi.CertificateCondition{
 				Type:               cmapi.CertificateConditionReady,
 				Status:             cmmeta.ConditionFalse,
@@ -269,8 +269,11 @@ func TestProcessItem(t *testing.T) {
 			secretShouldExist: true,
 			notAfter:          func(m metav1.Time) *metav1.Time { return &m }(metav1.NewTime(now.Add(time.Hour * 2).Truncate(time.Second))),
 			notBefore:         func(m metav1.Time) *metav1.Time { return &m }(metav1.NewTime(now.Truncate(time.Second))),
-			renewalTime:       func() *metav1.Time { return nil }(),
-			renewalTimeError:  fmt.Errorf("cannot find a time with the given windows"),
+			// RenewalTime returns a usable fallback time alongside a window
+			// error; the controller must record it in Status.RenewalTime while
+			// still setting Ready=False with WindowError.
+			renewalTime:      func(m metav1.Time) *metav1.Time { return &m }(metav1.NewTime(now.Add(time.Hour))),
+			renewalTimeError: fmt.Errorf("cannot find a time with the given windows"),
 		},
 	}
 	for name, test := range tests {

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -222,8 +222,12 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	reason, message, reissue := c.shouldReissue(input)
 	if reason == policies.WindowError {
-		c.recorder.Event(crt, corev1.EventTypeWarning, reason, fmt.Sprintf("Renewing certificate without satisfying renewal windows due to %s", message))
-		message = fmt.Sprintf("Renewing certificate without satisfying renewal windows at: %s", crt.Status.RenewalTime)
+		// The message deliberately contains no renewal time:
+		// crt.Status.RenewalTime is written by the readiness controller and
+		// may be nil (e.g. during a rolling upgrade) or an ARI-derived time
+		// unrelated to the fallback schedule that gated this decision.
+		message = fmt.Sprintf("Renewing certificate on the default schedule because the renewal configuration could not be honored: %s", message)
+		c.recorder.Event(crt, corev1.EventTypeWarning, reason, message)
 		reason = policies.Renewing
 	}
 

--- a/pkg/controller/certificates/trigger/trigger_controller_test.go
+++ b/pkg/controller/certificates/trigger/trigger_controller_test.go
@@ -398,15 +398,15 @@ func Test_controller_ProcessItem(t *testing.T) {
 				}
 			},
 			wantEvent: []string{
-				"Warning WindowError Renewing certificate without satisfying renewal windows due to cannot find renewal time in window",
-				"Normal Issuing Renewing certificate without satisfying renewal windows at: <nil>",
+				"Warning WindowError Renewing certificate on the default schedule because the renewal configuration could not be honored: cannot find renewal time in window",
+				"Normal Issuing Renewing certificate on the default schedule because the renewal configuration could not be honored: cannot find renewal time in window",
 			},
 			wantConditions: []cmapi.CertificateCondition{{
 				Type:               "Issuing",
 				ObservedGeneration: 42,
 				Status:             "True",
 				Reason:             "Renewing",
-				Message:            "Renewing certificate without satisfying renewal windows at: <nil>",
+				Message:            "Renewing certificate on the default schedule because the renewal configuration could not be honored: cannot find renewal time in window",
 				LastTransitionTime: &fixedNow,
 			}},
 		},

--- a/pkg/util/pki/renewaltime.go
+++ b/pkg/util/pki/renewaltime.go
@@ -41,7 +41,10 @@ func WithARIInfo(ariInfo *acmeapi.RenewalInfoResponse) RenewalTimeOptions {
 	}
 }
 
-// RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
+// RenewalTimeFunc is a custom function type for calculating renewal time of a
+// certificate. Implementations must follow the RenewalTime contract: a nil
+// time is returned only when renewal is disabled, and a usable fallback time
+// is returned alongside every error.
 type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration, *int32, *apiv1.CertificateRenewal, ...RenewalTimeOptions) (*metav1.Time, error)
 
 // RenewalTime calculates renewal time for a certificate.
@@ -51,6 +54,13 @@ type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration, *int32, *apiv1
 // will be the computed period before expiry based on the renewBeforePercentage
 // value and certificate lifetime.
 // Default renewal time is 2/3 through certificate's lifetime.
+//
+// A nil time is returned only when the renewal policy is Disabled. On any
+// error a usable fallback time is returned alongside it, so callers must not
+// discard the returned time when err != nil. Without ARI info the fallback is
+// the deterministic renewBefore-based time; with ARI info it is a random time
+// in the ARI suggested window, so callers wanting a deterministic fallback
+// should recalculate without ARI options.
 //
 // NB: If ARI is provided and the feature gate is enabled, the renewal time will be calculated based on the ARI suggested window instead of the renewBefore and renewBeforePercentage values. Cron windows will be applied on top of the ARI suggested window if provided.
 func RenewalTime(notBefore, notAfter time.Time, renewBefore *metav1.Duration, renewBeforePercentage *int32, renewalSpec *apiv1.CertificateRenewal, opts ...RenewalTimeOptions) (*metav1.Time, error) {
@@ -94,6 +104,10 @@ func RenewalTime(notBefore, notAfter time.Time, renewBefore *metav1.Duration, re
 	case apiv1.CertificateRenewalPolicyRenewBefore:
 		return applyRenewBeforeWithWindows(notAfter, notBefore, rt.Time, renewalSpec.Windows)
 	default:
+		// An unrecognized policy can only occur on version skew (the CRD and
+		// webhook validate the enum). Deliberately fail open: keep renewing on
+		// the default schedule so certificates do not silently expire, and
+		// surface the error so the operator notices the skew.
 		return &rt, fmt.Errorf("unsupported renewal policy: %s", renewalSpec.Policy)
 	}
 }
@@ -151,15 +165,15 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 		bestAfter  *time.Time
 	)
 
+	// On any window misconfiguration the fallback is returned alongside the
+	// error, so callers can keep scheduling renewal on the sane default while
+	// surfacing the error, rather than being handed a nil time to dereference.
+	fallback := metav1.NewTime(desiredRenewalTime)
+
 	if len(windows) == 0 {
-		return &metav1.Time{Time: desiredRenewalTime}, nil
+		return &fallback, nil
 	}
 
-	// On any window misconfiguration we still return the deterministic
-	// renewBefore-based desiredRenewalTime alongside the error (as the
-	// "cannot find a time" case below already does). Callers can then keep
-	// scheduling renewal on the sane default while surfacing the error,
-	// rather than being handed a nil time to dereference.
 	for _, w := range windows {
 		loc := time.UTC
 		if w.Timezone != "" {
@@ -167,17 +181,17 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 				loc = tz
 			} else {
 				// This shouldn't get triggered as we validate timezones in the validation webhook.
-				return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("error parsing timezone in window %s", err.Error())
+				return &fallback, fmt.Errorf("error parsing timezone in window %s", err.Error())
 			}
 		}
 
 		cronSched, err := util.CronParse(w.Cron, loc.String())
 		if err != nil {
-			return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("error parsing cron in window %s", err.Error())
+			return &fallback, fmt.Errorf("error parsing cron in window %s", err.Error())
 		}
 
 		if w.WindowDuration == nil || w.WindowDuration.Duration <= 0 {
-			return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("windowDuration must be a positive duration in window %v", w)
+			return &fallback, fmt.Errorf("windowDuration must be a positive duration in window %v", w)
 		}
 
 		// Any renewal logic should only start after notBefore and before notAfter. Bounds are [notBefore - dur, notAfter + dur)
@@ -196,7 +210,7 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 		return &metav1.Time{Time: *bestAfter}, nil
 	}
 
-	return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("cannot find a time with the given windows between %s and %s for: %s", notBefore, notAfter, desiredRenewalTime)
+	return &fallback, fmt.Errorf("cannot find a time with the given windows between %s and %s for: %s", notBefore, notAfter, desiredRenewalTime)
 }
 
 // bsFindEarliestWindowBeforeDesired performs a binary search over time to find

--- a/pkg/util/pki/renewaltime.go
+++ b/pkg/util/pki/renewaltime.go
@@ -94,7 +94,7 @@ func RenewalTime(notBefore, notAfter time.Time, renewBefore *metav1.Duration, re
 	case apiv1.CertificateRenewalPolicyRenewBefore:
 		return applyRenewBeforeWithWindows(notAfter, notBefore, rt.Time, renewalSpec.Windows)
 	default:
-		return nil, fmt.Errorf("unsupported renewal policy: %s", renewalSpec.Policy)
+		return &rt, fmt.Errorf("unsupported renewal policy: %s", renewalSpec.Policy)
 	}
 }
 
@@ -155,6 +155,11 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 		return &metav1.Time{Time: desiredRenewalTime}, nil
 	}
 
+	// On any window misconfiguration we still return the deterministic
+	// renewBefore-based desiredRenewalTime alongside the error (as the
+	// "cannot find a time" case below already does). Callers can then keep
+	// scheduling renewal on the sane default while surfacing the error,
+	// rather than being handed a nil time to dereference.
 	for _, w := range windows {
 		loc := time.UTC
 		if w.Timezone != "" {
@@ -162,17 +167,17 @@ func applyRenewBeforeWithWindows(notAfter, notBefore, desiredRenewalTime time.Ti
 				loc = tz
 			} else {
 				// This shouldn't get triggered as we validate timezones in the validation webhook.
-				return nil, fmt.Errorf("error parsing timezone in window %s", err.Error())
+				return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("error parsing timezone in window %s", err.Error())
 			}
 		}
 
 		cronSched, err := util.CronParse(w.Cron, loc.String())
 		if err != nil {
-			return nil, fmt.Errorf("error parsing cron in window %s", err.Error())
+			return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("error parsing cron in window %s", err.Error())
 		}
 
 		if w.WindowDuration == nil || w.WindowDuration.Duration <= 0 {
-			return nil, fmt.Errorf("windowDuration must be a positive duration in window %v", w)
+			return &metav1.Time{Time: desiredRenewalTime}, fmt.Errorf("windowDuration must be a positive duration in window %v", w)
 		}
 
 		// Any renewal logic should only start after notBefore and before notAfter. Bounds are [notBefore - dur, notAfter + dur)

--- a/pkg/util/pki/renewaltime_test.go
+++ b/pkg/util/pki/renewaltime_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -406,4 +407,66 @@ func TestRenewalWithDisable(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Nil(t, res)
+}
+
+// TestRenewalWindowErrorReturnsFallbackTime asserts that a renewal-window
+// misconfiguration returns an error together with the deterministic
+// renewBefore-based renewal time (rather than a nil time). A nil time here
+// previously caused a nil pointer panic that crash-looped the trigger
+// controller; returning the fallback lets callers keep scheduling renewal on
+// the sane default while surfacing the error.
+func TestRenewalWindowErrorReturnsFallbackTime(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	notBefore := now.Add(-10 * 24 * time.Hour)
+	notAfter := now.Add(10 * 24 * time.Hour)
+	renewBefore := &metav1.Duration{Duration: 5 * 24 * time.Hour}
+	// desiredRenewalTime respects renewBefore, so the fallback is notAfter-renewBefore.
+	wantFallback := notAfter.Add(-renewBefore.Duration)
+
+	tests := map[string]apiv1.CertificateRenewalWindows{
+		"invalid cron": {
+			Cron:           "not a valid cron",
+			WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+		},
+		"non-positive windowDuration": {
+			Cron:           "0 10 * * *",
+			WindowDuration: &metav1.Duration{Duration: 0},
+		},
+		"invalid timezone": {
+			Timezone:       "Not/AZone",
+			Cron:           "0 10 * * *",
+			WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+		},
+	}
+
+	for name, window := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := RenewalTime(notBefore, notAfter, renewBefore, nil, &apiv1.CertificateRenewal{
+				Policy:  apiv1.CertificateRenewalPolicyRenewBefore,
+				Windows: []apiv1.CertificateRenewalWindows{window},
+			})
+
+			assert.NotNil(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, wantFallback, res.Time)
+		})
+	}
+}
+
+// TestRenewalUnsupportedPolicyReturnsFallbackTime asserts that an unrecognized
+// renewal policy also returns the fallback renewal time alongside the error,
+// keeping RenewalTime's contract "non-nil time for every non-Disabled path".
+func TestRenewalUnsupportedPolicyReturnsFallbackTime(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	notBefore := now.Add(-10 * 24 * time.Hour)
+	notAfter := now.Add(10 * 24 * time.Hour)
+	renewBefore := &metav1.Duration{Duration: 5 * 24 * time.Hour}
+
+	res, err := RenewalTime(notBefore, notAfter, renewBefore, nil, &apiv1.CertificateRenewal{
+		Policy: apiv1.CertificateRenewalPolicy("Bogus"),
+	})
+
+	assert.ErrorContains(t, err, "unsupported renewal policy")
+	require.NotNil(t, res)
+	assert.Equal(t, notAfter.Add(-renewBefore.Duration), res.Time)
 }

--- a/pkg/util/pki/renewaltime_test.go
+++ b/pkg/util/pki/renewaltime_test.go
@@ -409,13 +409,13 @@ func TestRenewalWithDisable(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-// TestRenewalWindowErrorReturnsFallbackTime asserts that a renewal-window
-// misconfiguration returns an error together with the deterministic
-// renewBefore-based renewal time (rather than a nil time). A nil time here
-// previously caused a nil pointer panic that crash-looped the trigger
-// controller; returning the fallback lets callers keep scheduling renewal on
-// the sane default while surfacing the error.
-func TestRenewalWindowErrorReturnsFallbackTime(t *testing.T) {
+// TestRenewalErrorReturnsFallbackTime asserts that a renewal misconfiguration
+// (a bad window or an unrecognized policy) returns an error together with the
+// deterministic renewBefore-based renewal time (rather than a nil time). A
+// nil time here previously caused a nil pointer panic that crash-looped the
+// trigger controller; returning the fallback lets callers keep scheduling
+// renewal on the sane default while surfacing the error.
+func TestRenewalErrorReturnsFallbackTime(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	notBefore := now.Add(-10 * 24 * time.Hour)
 	notAfter := now.Add(10 * 24 * time.Hour)
@@ -423,50 +423,41 @@ func TestRenewalWindowErrorReturnsFallbackTime(t *testing.T) {
 	// desiredRenewalTime respects renewBefore, so the fallback is notAfter-renewBefore.
 	wantFallback := notAfter.Add(-renewBefore.Duration)
 
-	tests := map[string]apiv1.CertificateRenewalWindows{
+	tests := map[string]*apiv1.CertificateRenewal{
 		"invalid cron": {
-			Cron:           "not a valid cron",
-			WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+			Policy: apiv1.CertificateRenewalPolicyRenewBefore,
+			Windows: []apiv1.CertificateRenewalWindows{{
+				Cron:           "not a valid cron",
+				WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+			}},
 		},
 		"non-positive windowDuration": {
-			Cron:           "0 10 * * *",
-			WindowDuration: &metav1.Duration{Duration: 0},
+			Policy: apiv1.CertificateRenewalPolicyRenewBefore,
+			Windows: []apiv1.CertificateRenewalWindows{{
+				Cron:           "0 10 * * *",
+				WindowDuration: &metav1.Duration{Duration: 0},
+			}},
 		},
 		"invalid timezone": {
-			Timezone:       "Not/AZone",
-			Cron:           "0 10 * * *",
-			WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+			Policy: apiv1.CertificateRenewalPolicyRenewBefore,
+			Windows: []apiv1.CertificateRenewalWindows{{
+				Timezone:       "Not/AZone",
+				Cron:           "0 10 * * *",
+				WindowDuration: &metav1.Duration{Duration: 5 * time.Minute},
+			}},
+		},
+		"unsupported policy": {
+			Policy: apiv1.CertificateRenewalPolicy("Bogus"),
 		},
 	}
 
-	for name, window := range tests {
+	for name, renewal := range tests {
 		t.Run(name, func(t *testing.T) {
-			res, err := RenewalTime(notBefore, notAfter, renewBefore, nil, &apiv1.CertificateRenewal{
-				Policy:  apiv1.CertificateRenewalPolicyRenewBefore,
-				Windows: []apiv1.CertificateRenewalWindows{window},
-			})
+			res, err := RenewalTime(notBefore, notAfter, renewBefore, nil, renewal)
 
 			assert.NotNil(t, err)
 			require.NotNil(t, res)
 			assert.Equal(t, wantFallback, res.Time)
 		})
 	}
-}
-
-// TestRenewalUnsupportedPolicyReturnsFallbackTime asserts that an unrecognized
-// renewal policy also returns the fallback renewal time alongside the error,
-// keeping RenewalTime's contract "non-nil time for every non-Disabled path".
-func TestRenewalUnsupportedPolicyReturnsFallbackTime(t *testing.T) {
-	now := time.Now().Truncate(time.Second)
-	notBefore := now.Add(-10 * 24 * time.Hour)
-	notAfter := now.Add(10 * 24 * time.Hour)
-	renewBefore := &metav1.Duration{Duration: 5 * 24 * time.Hour}
-
-	res, err := RenewalTime(notBefore, notAfter, renewBefore, nil, &apiv1.CertificateRenewal{
-		Policy: apiv1.CertificateRenewalPolicy("Bogus"),
-	})
-
-	assert.ErrorContains(t, err, "unsupported renewal policy")
-	require.NotNil(t, res)
-	assert.Equal(t, notAfter.Add(-renewBefore.Duration), res.Time)
 }


### PR DESCRIPTION
### Pull Request Motivation

The trigger controller panics with a nil pointer dereference at `internal/controller/certificates/policies/checks.go` whenever `pki.RenewalTime` returns an error for a Certificate using `spec.renewal.windows` (invalid cron, unknown timezone, non-positive `windowDuration`). In those cases `RenewalTime` returned a `nil` time alongside the error, but `CurrentCertificateNearingExpiry` recorded the error and then dereferenced the nil time, crash-looping the controller. See #9100 for a reproduction on a live v1.21.1 cluster.

This supersedes #9067 by @archy-rock3t-cloud. That PR added a `renewalTime == nil` guard but was based on code from before #9032 merged (~280 commits behind `master`), and I could not push a rebase to it because the fork is organization-owned, where GitHub's "allow edits from maintainers" does not grant push access. So this PR carries the original commit (authorship preserved) rebased onto `master`, plus follow-up commits.

### The fix

Rather than guarding the nil at the point of the dereference, this fixes the inconsistency at the source. `pki.RenewalTime` already returned the deterministic renewBefore-based renewal time alongside the error for its "cannot find a time" case; it now does the same for every other non-`Disabled` path — the window-config errors and the unsupported-policy default. The only remaining `nil` return is the `Disabled` policy, which the trigger controller handles with an early return before it ever calls `RenewalTime`.

As a result:

- The nil dereference (#9100) is gone: a nil renewal time is now handled locally for what it means — the `Disabled` policy, so the certificate is never nearing expiry — rather than dereferenced on the assumption it can't occur.
- The trigger controller gates renewal on the fallback time and surfaces the `WindowError` reason only once renewal is actually due. A certificate nowhere near expiry is not flagged, so a persistently invalid window config no longer spams re-issuance (thanks @copilot for catching this).
- The readiness controller now records a real `Status.RenewalTime` and continues to set `Ready=False` with `WindowError`, so the misconfiguration is still surfaced immediately.

Tests:

- `renewaltime_test` asserts the fallback time is returned for invalid cron, non-positive `windowDuration`, invalid timezone, and unsupported policy.
- The trigger-controller test covers both the not-yet-due case (no premature re-issuance) and the due case (`WindowError` surfaced). Both panic against the pre-fix code.

Closes #9100.

### Kind

/kind bug

### Release Note

```release-note
Fix a nil pointer panic in the trigger controller that could crash-loop cert-manager when a Certificate used `spec.renewal.windows` with an invalid cron expression, unknown timezone, or non-positive `windowDuration`. Such window errors are now surfaced as a `WindowError` on the Certificate instead.
```

---

*with claude opus 4.8*
