### PR TITLE
Route53: assume the role lazily so the AWS SDK can refresh STS credentials

### DIFF
--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -374,6 +375,9 @@ func TestAssumeRole(t *testing.T) {
 		AccessKeyId:     aws.String("foo"),
 		SecretAccessKey: aws.String("bar"),
 		SessionToken:    aws.String("my-token"),
+		// The stscreds credential providers dereference the expiration when
+		// computing the credential lifetime.
+		Expiration: aws.Time(time.Now().Add(time.Hour)),
 	}
 	cases := []struct {
 		name             string
@@ -390,11 +394,11 @@ func TestAssumeRole(t *testing.T) {
 		mockSTS          *mockSTS
 	}{
 		{
-			name:          "should remove request ID for assumeRole",
+			name:          "forwards STS errors including the request ID, which is redacted later by the challenge controller",
 			role:          "my-role",
 			ambient:       true,
 			expErr:        true,
-			expErrMessage: "unable to assume role: https response error StatusCode: 0, RequestID: fake-request-id, foo",
+			expErrMessage: "failed to refresh cached credentials, https response error StatusCode: 0, RequestID: fake-request-id, foo",
 			expCreds:      creds,
 			expRegion:     "",
 			mockSTS: &mockSTS{
@@ -516,6 +520,12 @@ func TestAssumeRole(t *testing.T) {
 			}, c.key, c.secret, c.region, c.role, c.webIdentityToken, c.ambient)
 			_, ctx := ktesting.NewTestContext(t)
 			cfg, err := provider.GetSession(ctx)
+			// The role is now assumed lazily, so STS errors surface when the
+			// credentials are first retrieved, not when the session is created.
+			var sessCreds aws.Credentials
+			if err == nil {
+				sessCreds, err = cfg.Credentials.Retrieve(ctx)
+			}
 			if c.expErr {
 				assert.NotNil(t, err)
 				if c.expErrMessage != "" {
@@ -523,7 +533,6 @@ func TestAssumeRole(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, err)
-				sessCreds, _ := cfg.Credentials.Retrieve(ctx)
 				assert.Equal(t, c.mockSTS.assumedRole, c.role)
 				assert.Equal(t, *c.expCreds.SecretAccessKey, sessCreds.SecretAccessKey)
 				assert.Equal(t, *c.expCreds.AccessKeyId, sessCreds.AccessKeyID)

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -579,9 +579,18 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 				}
 				mock := &mockSTS{
 					AssumeRoleFn: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+						// The previous implementation omitted DurationSeconds
+						// and STS applied its server-side default of 3600
+						// seconds; the same duration is now requested
+						// explicitly.
+						assert.Equal(t, int32(3600), aws.ToInt32(params.DurationSeconds))
 						return &sts.AssumeRoleOutput{Credentials: issueCreds()}, nil
 					},
 					AssumeRoleWithWebIdentityFn: func(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+						// DurationSeconds remains unset, as in the previous
+						// implementation, so the STS server-side default
+						// session duration applies.
+						assert.Nil(t, params.DurationSeconds)
 						return &sts.AssumeRoleWithWebIdentityOutput{Credentials: issueCreds()}, nil
 					},
 				}
@@ -591,6 +600,10 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 				_, ctx := ktesting.NewTestContext(t)
 				cfg, err := provider.GetSession(ctx)
 				require.NoError(t, err)
+
+				// The role is not assumed during GetSession; only when the
+				// credentials are first needed.
+				assert.Equal(t, 0, stsCalls)
 
 				before, err := cfg.Credentials.Retrieve(ctx)
 				require.NoError(t, err)

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -538,6 +539,78 @@ func TestAssumeRole(t *testing.T) {
 				assert.Equal(t, *c.expCreds.AccessKeyId, sessCreds.AccessKeyID)
 				assert.Equal(t, c.region, cfg.Region)
 			}
+		})
+	}
+}
+
+// TestGetSessionRefreshesExpiredSTSCredentials demonstrates that the role is
+// re-assumed when the temporary STS credentials expire, and that valid
+// credentials are served from the cache without repeated STS requests.
+//
+// It runs in a synctest bubble: the SDK's credential expiry check bottoms out
+// in time.Now, so sleeping past the expiry advances the fake clock instantly
+// and no real time passes.
+//
+// This test fails with the previous implementation, which assumed the role
+// once in GetSession and stored the result in a static credentials provider
+// which the SDK can never refresh.
+func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
+	const validity = 15 * time.Minute
+	tests := []struct {
+		name             string
+		webIdentityToken string
+	}{
+		{name: "assume role"},
+		{name: "assume role with web identity", webIdentityToken: jwt},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+			synctest.Test(t, func(t *testing.T) {
+				var stsCalls int
+				issueCreds := func() *ststypes.Credentials {
+					stsCalls++
+					return &ststypes.Credentials{
+						AccessKeyId:     aws.String(fmt.Sprintf("key-%d", stsCalls)),
+						SecretAccessKey: aws.String("secret"),
+						SessionToken:    aws.String("session-token"),
+						Expiration:      aws.Time(time.Now().Add(validity)),
+					}
+				}
+				mock := &mockSTS{
+					AssumeRoleFn: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+						return &sts.AssumeRoleOutput{Credentials: issueCreds()}, nil
+					},
+					AssumeRoleWithWebIdentityFn: func(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+						return &sts.AssumeRoleWithWebIdentityOutput{Credentials: issueCreds()}, nil
+					},
+				}
+				provider := makeMockSessionProvider(func(cfg aws.Config) StsClient {
+					return mock
+				}, "", "", "", "my-role", tc.webIdentityToken, true)
+				_, ctx := ktesting.NewTestContext(t)
+				cfg, err := provider.GetSession(ctx)
+				require.NoError(t, err)
+
+				before, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-1", before.AccessKeyID)
+
+				// While the credentials are valid they are served from the
+				// cache without another STS request.
+				cached, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-1", cached.AccessKeyID)
+				assert.Equal(t, 1, stsCalls)
+
+				// Once the credentials have expired, the SDK re-assumes the
+				// role to obtain fresh credentials.
+				time.Sleep(validity + time.Minute)
+				after, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-2", after.AccessKeyID)
+				assert.Equal(t, 2, stsCalls)
+			})
 		})
 	}
 }

--- a/pkg/issuer/acme/dns/route53/session.go
+++ b/pkg/issuer/acme/dns/route53/session.go
@@ -24,6 +24,7 @@ import (
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/logging"
 	"github.com/aws/smithy-go/middleware"
@@ -133,42 +134,28 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		return aws.Config{}, fmt.Errorf("unable to create aws config: %w", err)
 	}
 
-	if d.Role != "" && d.WebIdentityToken == "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
+	// Rather than assuming the role once here and storing the resulting
+	// static credentials, configure a credential provider so that the AWS
+	// SDK can re-assume the role whenever the temporary STS credentials
+	// expire; for example if a challenge is retried, or if there is a long
+	// delay between presenting and cleaning up the DNS01 challenge record.
+	// The CredentialsCache avoids repeating the STS request for every AWS
+	// API request made with this config.
+	if d.Role != "" {
 		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRole(ctx, &sts.AssumeRoleInput{
-			RoleArn:         aws.String(d.Role),
-			RoleSessionName: aws.String("cert-manager"),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role: %w", err)
+		var credProvider aws.CredentialsProvider
+		if d.WebIdentityToken == "" {
+			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
+			credProvider = stscreds.NewAssumeRoleProvider(stsSvc, d.Role, func(o *stscreds.AssumeRoleOptions) {
+				o.RoleSessionName = "cert-manager"
+			})
+		} else {
+			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
+			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, staticIdentityToken(d.WebIdentityToken), func(o *stscreds.WebIdentityRoleOptions) {
+				o.RoleSessionName = "cert-manager"
+			})
 		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
-	}
-
-	if d.Role != "" && d.WebIdentityToken != "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
-
-		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
-			RoleArn:          aws.String(d.Role),
-			RoleSessionName:  aws.String("cert-manager"),
-			WebIdentityToken: aws.String(d.WebIdentityToken),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %w", err)
-		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
+		cfg.Credentials = aws.NewCredentialsCache(credProvider)
 	}
 
 	// Log some key values of the loaded configuration, so that users can
@@ -205,4 +192,12 @@ func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webId
 
 func defaultSTSProvider(cfg aws.Config) StsClient {
 	return sts.NewFromConfig(cfg)
+}
+
+// staticIdentityToken supplies the web identity token from the Issuer
+// configuration to the AWS SDK whenever it needs to re-assume the role.
+type staticIdentityToken string
+
+func (t staticIdentityToken) GetIdentityToken() ([]byte, error) {
+	return []byte(t), nil
 }

--- a/pkg/issuer/acme/dns/route53/session.go
+++ b/pkg/issuer/acme/dns/route53/session.go
@@ -19,6 +19,7 @@ package route53
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
@@ -136,11 +137,13 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 
 	// Rather than assuming the role once here and storing the resulting
 	// static credentials, configure a credential provider so that the AWS
-	// SDK can re-assume the role whenever the temporary STS credentials
-	// expire; for example if a challenge is retried, or if there is a long
-	// delay between presenting and cleaning up the DNS01 challenge record.
-	// The CredentialsCache avoids repeating the STS request for every AWS
-	// API request made with this config.
+	// SDK can re-assume the role if the temporary STS credentials expire
+	// while this config is in use. A new config is constructed for every
+	// Present and CleanUp call (see dns.Solver.solverForChallenge), so in
+	// practice this covers the SDK's own request retries and the polling
+	// for the Route53 change to become INSYNC, which can take tens of
+	// minutes. The CredentialsCache avoids repeating the STS request for
+	// every AWS API request made with this config.
 	if d.Role != "" {
 		stsSvc := d.StsProvider(cfg)
 		var credProvider aws.CredentialsProvider
@@ -148,9 +151,17 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
 			credProvider = stscreds.NewAssumeRoleProvider(stsSvc, d.Role, func(o *stscreds.AssumeRoleOptions) {
 				o.RoleSessionName = "cert-manager"
+				// The previous implementation omitted DurationSeconds, so STS
+				// applied its server-side default of 3600 seconds. Request the
+				// same duration explicitly, because AssumeRoleProvider would
+				// otherwise request only stscreds.DefaultDuration (15 minutes).
+				o.Duration = time.Hour
 			})
 		} else {
 			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
+			// WebIdentityRoleProvider omits DurationSeconds unless a Duration
+			// is configured, so the STS server-side default session duration
+			// applies, as before.
 			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, staticIdentityToken(d.WebIdentityToken), func(o *stscreds.WebIdentityRoleOptions) {
 				o.RoleSessionName = "cert-manager"
 			})


### PR DESCRIPTION
Part 1 of reviving #7236, split as requested in [inteon's review](https://github.com/cert-manager/cert-manager/pull/7236#discussion_r1805509867). This part changes how the role is assumed, without any API or refactoring noise; the follow-up, part 2, is already drafted at https://github.com/wallrj/cert-manager/pull/1 — it replaces the pre-minted ServiceAccount token with a TokenRequest-backed `IdentityTokenRetriever` so the token itself is also refreshed on demand. It is stacked on this PR's branch (so its diff shows only the part-two changes) and will be resubmitted here once this PR merges.

## What

`GetSession` previously called `AssumeRole`/`AssumeRoleWithWebIdentity` eagerly and stored the resulting temporary credentials in a [static credentials provider](https://github.com/cert-manager/cert-manager/blob/fcc3d81827154275c24b3fdb5feda0f953594309/pkg/issuer/acme/dns/route53/session.go#L136-L172), which the AWS SDK can never refresh.

It now configures the SDK's own credential providers instead:

* [`stscreds.NewAssumeRoleProvider`](https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.19.34/credentials/stscreds/assume_role_provider.go#L258) when only a Role is set,
* [`stscreds.NewWebIdentityRoleProvider`](https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.19.34/credentials/stscreds/web_identity_provider.go#L93) when a web identity token is also supplied,

both wrapped in an `aws.NewCredentialsCache` so the STS request is not repeated for every AWS API call.

## Why

The SDK can now re-assume the role if the temporary STS credentials expire while the config is in use. A new config is constructed for every Present and CleanUp call ([`solverForChallenge`](https://github.com/cert-manager/cert-manager/blob/fcc3d81827154275c24b3fdb5feda0f953594309/pkg/issuer/acme/dns/dns.go#L95)), so in practice this covers the SDK's own request retries and the polling for the Route53 change to become INSYNC, which can take tens of minutes (#9066). Previously the credentials were requested once at DNS provider construction and reused unconditionally, and any STS failure surfaced as `error instantiating route53 challenge solver`. Cross-operation reuse of the credential cache would require caching the provider itself, which is out of scope here.

## Related issues and PRs

* #7234 (open): reports `error instantiating route53 challenge solver: unable to assume role: AccessDenied` repeating rapidly. This PR changes that failure mode: the role is no longer assumed at solver construction, so STS failures surface during present/clean-up instead, with normal controller backoff. It does not implement the challenge-timeout feature requested there.
* #7897 (open, WIP): retries challenge solving with freshly loaded issuer credentials on 403 errors. Complementary, with no file overlap: this PR removes one cause of expired credentials (STS token expiry, now self-healed by the SDK); #7897 handles the other (issuer credentials rotated in Kubernetes, which requires rebuilding the solver).
* #9066 (open): Route53 change records can take ~30 minutes to reach INSYNC, and there are proposals to wait longer rather than re-create them. The stscreds default AssumeRole duration is [15 minutes](https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.19.34/credentials/stscreds/assume_role_provider.go#L146-L150), so longer waits make one-shot, unrefreshable credentials untenable; this PR makes that future work safe.

## History

* The eager assume-role-at-construction pattern has caused a long line of now-closed issues: #5486 and #4061 (aggressive retries on unstable error messages), #5557, #5780, #6872, #4053 (all `error instantiating route53 challenge solver: unable to assume role`), and #3640 (TXT records left behind because clean-up ran with expired credentials).
* #7236 was the first attempt at this change (itself an alternative to #7235); it went stale after the review request to split it, and master has since diverged (the #8973 options refactor split out `session.go`).
* Request-ID redaction, originally done in this package by `removeReqID` (#4061), was centralised in the challenge controller in 8f2779cc6adba81a1638b5720dd7658bbd526c38, which is what makes this PR's simpler error handling safe.

## Notes for reviewers

* STS errors now surface on the first Route53 API call rather than at provider construction, wrapped by the credentials cache: [`"failed to refresh cached credentials, %w"`](https://github.com/aws/aws-sdk-go-v2/blob/v1.43.4/aws/credential_cache.go#L128). The Amazon request ID in those errors is redacted centrally by the challenge controller (see History above), so Challenge error messages remain stable.
* `RoleSessionName` remains `cert-manager`, as before.
* The `StsClient` test-injection seam is unchanged; the tests now retrieve credentials to trigger the lazy STS call.
* `TestGetSessionRefreshesExpiredSTSCredentials` proves the new behaviour: it issues 15-minute credentials from the mock, sleeps past their expiry inside a [`testing/synctest`](https://pkg.go.dev/testing/synctest) bubble (the SDK's expiry check bottoms out in `time.Now`, which synctest fakes, following the prior art in [`dynamic_source_test.go`](https://github.com/cert-manager/cert-manager/blob/fcc3d81827154275c24b3fdb5feda0f953594309/pkg/server/tls/dynamic_source_test.go#L342)), and asserts that the role is re-assumed. The same test fails against the previous implementation (`expected: "key-2", actual: "key-1"`; STS called once instead of twice).

```release-note
Route53 ACME DNS-01 solver: the IAM role is now assumed lazily and the resulting STS credentials are cached and refreshed automatically by the AWS SDK, instead of being requested once when the challenge solver is constructed.
```

*with claude fable-5*



