### PR TITLE
Route53: mint a fresh ServiceAccount token for each web identity role assumption

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -24,9 +24,7 @@ import (
 	"strings"
 	"time"
 
-	authv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook"
@@ -378,7 +376,18 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			secretAccessKey = string(secretAccessKeyBytes)
 		}
 
-		webIdentityToken := ""
+		route53Options := []route53.DNSProviderOption{
+			route53.AccessKeyID(secretAccessKeyID),
+			route53.SecretAccessKey(strings.TrimSpace(secretAccessKey)),
+			route53.HostedZoneID(providerConfig.Route53.HostedZoneID),
+			route53.Region(providerConfig.Route53.Region),
+			route53.Role(providerConfig.Route53.Role),
+			route53.Ambient(canUseAmbientCredentials),
+			route53.Nameservers(nameservers),
+			route53.UserAgent(s.RESTConfig.UserAgent),
+			route53.Resolver(s.DNSResolver),
+		}
+
 		if providerConfig.Route53.Auth != nil && providerConfig.Route53.Auth.Kubernetes != nil && providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef != nil {
 			if providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name == "" {
 				return nil, nil, fmt.Errorf("service account name is required for Kubernetes auth")
@@ -389,25 +398,18 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 				audiences = providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.TokenAudiences
 			}
 
-			jwt, err := s.createToken(ctx, resourceNamespace, providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name, audiences)
-			if err != nil {
-				return nil, nil, fmt.Errorf("error getting service account token: %w", err)
-			}
-
-			webIdentityToken = jwt
+			// The retriever mints a fresh ServiceAccount token whenever the
+			// AWS SDK assumes the role, rather than minting a single token
+			// here which could expire before the SDK is done with it.
+			route53Options = append(route53Options, route53.WebIdentityTokenRetriever(&route53.KubernetesServiceAccountTokenRetriever{
+				ServiceAccountName: providerConfig.Route53.Auth.Kubernetes.ServiceAccountRef.Name,
+				Audiences:          audiences,
+				Namespace:          resourceNamespace,
+				Client:             s.Client.CoreV1().ServiceAccounts(resourceNamespace),
+			}))
 		}
 
-		impl, err = s.dnsProviderConstructors.route53(ctx,
-			route53.AccessKeyID(secretAccessKeyID),
-			route53.SecretAccessKey(strings.TrimSpace(secretAccessKey)),
-			route53.HostedZoneID(providerConfig.Route53.HostedZoneID),
-			route53.Region(providerConfig.Route53.Region),
-			route53.Role(providerConfig.Route53.Role),
-			route53.WebIdentityToken(webIdentityToken),
-			route53.Ambient(canUseAmbientCredentials),
-			route53.Nameservers(nameservers),
-			route53.UserAgent(s.RESTConfig.UserAgent),
-			route53.Resolver(s.DNSResolver))
+		impl, err = s.dnsProviderConstructors.route53(ctx, route53Options...)
 
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %w", err)
@@ -595,20 +597,6 @@ func (s *Solver) loadSecretData(selector *cmmeta.SecretKeySelector, ns string) (
 	}
 
 	return nil, fmt.Errorf("no key %q in secret %q", selector.Key, ns+"/"+selector.Name)
-}
-
-func (s *Solver) createToken(ctx context.Context, ns, serviceAccount string, audiences []string) (string, error) {
-	tokenrequest, err := s.Client.CoreV1().ServiceAccounts(ns).CreateToken(ctx, serviceAccount, &authv1.TokenRequest{
-		Spec: authv1.TokenRequestSpec{
-			Audiences:         audiences,
-			ExpirationSeconds: new(int64(600)),
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return "", fmt.Errorf("failed to request token for %s/%s: %w", ns, serviceAccount, err)
-	}
-
-	return tokenrequest.Status.Token, nil
 }
 
 func (s *Solver) nameserversForProviderConfig(providerConfig *cmacme.ACMEChallengeSolverDNS01) (nameservers []string, checkAuthoritative bool) {

--- a/pkg/issuer/acme/dns/route53/options.go
+++ b/pkg/issuer/acme/dns/route53/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package route53
 
 import (
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
 )
 
@@ -35,9 +37,15 @@ type DNSProviderOptions struct {
 	Region string
 	// Role is the ARN of the IAM role to assume when making Route 53 API calls.
 	Role string
-	// WebIdentityToken is the web identity token used with Role for OIDC-based
-	// role assumption.
+	// WebIdentityToken is a fixed web identity token used with Role for
+	// OIDC-based role assumption. Prefer WebIdentityTokenRetriever, which
+	// allows the AWS SDK to fetch a fresh token whenever it re-assumes the
+	// role. Only one of the two may be set.
 	WebIdentityToken string
+	// WebIdentityTokenRetriever supplies a web identity token, used with Role
+	// for OIDC-based role assumption, whenever the AWS SDK re-assumes the
+	// role.
+	WebIdentityTokenRetriever stscreds.IdentityTokenRetriever
 	// HostedZoneID restricts zone discovery to this specific Route 53 hosted zone ID.
 	// When empty, the zone is discovered automatically from the FQDN.
 	HostedZoneID string
@@ -100,6 +108,22 @@ type WebIdentityToken string
 // ApplyToDNSProviderOptions sets the WebIdentityToken field.
 func (w WebIdentityToken) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
 	o.WebIdentityToken = string(w)
+}
+
+// WithWebIdentityTokenRetriever sets the web identity token retriever on DNSProviderOptions.
+type WithWebIdentityTokenRetriever struct {
+	stscreds.IdentityTokenRetriever
+}
+
+// ApplyToDNSProviderOptions sets the WebIdentityTokenRetriever field.
+func (w WithWebIdentityTokenRetriever) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
+	o.WebIdentityTokenRetriever = w.IdentityTokenRetriever
+}
+
+// WebIdentityTokenRetriever returns a WithWebIdentityTokenRetriever option that
+// sets the WebIdentityTokenRetriever field on DNSProviderOptions.
+func WebIdentityTokenRetriever(r stscreds.IdentityTokenRetriever) WithWebIdentityTokenRetriever {
+	return WithWebIdentityTokenRetriever{IdentityTokenRetriever: r}
 }
 
 // HostedZoneID sets the Route 53 hosted zone ID on DNSProviderOptions.

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -61,6 +61,7 @@ func NewDNSProviderFromOptions(ctx context.Context, options ...DNSProviderOption
 		opt.Region,
 		opt.Role,
 		opt.WebIdentityToken,
+		opt.WebIdentityTokenRetriever,
 		ptr.Deref(opt.Ambient, false),
 		opt.UserAgent,
 	)

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -374,6 +375,9 @@ func TestAssumeRole(t *testing.T) {
 		AccessKeyId:     aws.String("foo"),
 		SecretAccessKey: aws.String("bar"),
 		SessionToken:    aws.String("my-token"),
+		// The stscreds credential providers dereference the expiration when
+		// computing the credential lifetime.
+		Expiration: aws.Time(time.Now().Add(time.Hour)),
 	}
 	cases := []struct {
 		name             string
@@ -390,11 +394,11 @@ func TestAssumeRole(t *testing.T) {
 		mockSTS          *mockSTS
 	}{
 		{
-			name:          "should remove request ID for assumeRole",
+			name:          "forwards STS errors including the request ID, which is redacted later by the challenge controller",
 			role:          "my-role",
 			ambient:       true,
 			expErr:        true,
-			expErrMessage: "unable to assume role: https response error StatusCode: 0, RequestID: fake-request-id, foo",
+			expErrMessage: "failed to refresh cached credentials, https response error StatusCode: 0, RequestID: fake-request-id, foo",
 			expCreds:      creds,
 			expRegion:     "",
 			mockSTS: &mockSTS{
@@ -516,6 +520,12 @@ func TestAssumeRole(t *testing.T) {
 			}, c.key, c.secret, c.region, c.role, c.webIdentityToken, c.ambient)
 			_, ctx := ktesting.NewTestContext(t)
 			cfg, err := provider.GetSession(ctx)
+			// The role is now assumed lazily, so STS errors surface when the
+			// credentials are first retrieved, not when the session is created.
+			var sessCreds aws.Credentials
+			if err == nil {
+				sessCreds, err = cfg.Credentials.Retrieve(ctx)
+			}
 			if c.expErr {
 				assert.NotNil(t, err)
 				if c.expErrMessage != "" {
@@ -523,7 +533,6 @@ func TestAssumeRole(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, err)
-				sessCreds, _ := cfg.Credentials.Retrieve(ctx)
 				assert.Equal(t, c.mockSTS.assumedRole, c.role)
 				assert.Equal(t, *c.expCreds.SecretAccessKey, sessCreds.SecretAccessKey)
 				assert.Equal(t, *c.expCreds.AccessKeyId, sessCreds.AccessKeyID)

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -579,9 +579,18 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 				}
 				mock := &mockSTS{
 					AssumeRoleFn: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+						// The previous implementation omitted DurationSeconds
+						// and STS applied its server-side default of 3600
+						// seconds; the same duration is now requested
+						// explicitly.
+						assert.Equal(t, int32(3600), aws.ToInt32(params.DurationSeconds))
 						return &sts.AssumeRoleOutput{Credentials: issueCreds()}, nil
 					},
 					AssumeRoleWithWebIdentityFn: func(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+						// DurationSeconds remains unset, as in the previous
+						// implementation, so the STS server-side default
+						// session duration applies.
+						assert.Nil(t, params.DurationSeconds)
 						return &sts.AssumeRoleWithWebIdentityOutput{Credentials: issueCreds()}, nil
 					},
 				}
@@ -591,6 +600,10 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 				_, ctx := ktesting.NewTestContext(t)
 				cfg, err := provider.GetSession(ctx)
 				require.NoError(t, err)
+
+				// The role is not assumed during GetSession; only when the
+				// credentials are first needed.
+				assert.Equal(t, 0, stsCalls)
 
 				before, err := cfg.Credentials.Retrieve(ctx)
 				require.NoError(t, err)

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -22,6 +22,7 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
@@ -136,7 +137,7 @@ func TestSessionProviderGetSessionRegion(t *testing.T) {
 			region = fakeIssuerRegion
 		}
 
-		p := newSessionProvider(accessKeyID, secretAccessKey, region, role, webIdentityToken, allowAmbientCredentials, userAgent)
+		p := newSessionProvider(accessKeyID, secretAccessKey, region, role, webIdentityToken, nil, allowAmbientCredentials, userAgent)
 		p.StsProvider = func(cfg aws.Config) StsClient {
 			return &mockSTS{
 				AssumeRoleWithWebIdentityFn: func(
@@ -559,15 +560,31 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 	tests := []struct {
 		name             string
 		webIdentityToken string
+		tokenRetriever   stscreds.IdentityTokenRetriever
+		// expTokens are the web identity tokens the STS mock is expected to
+		// receive, one per role assumption.
+		expTokens []string
 	}{
 		{name: "assume role"},
-		{name: "assume role with web identity", webIdentityToken: jwt},
+		{
+			name:             "assume role with web identity",
+			webIdentityToken: jwt,
+			// A fixed token is presented for every role assumption.
+			expTokens: []string{jwt, jwt},
+		},
+		{
+			name:           "assume role with web identity token retriever",
+			tokenRetriever: &countingTokenRetriever{},
+			// A fresh token is retrieved for every role assumption.
+			expTokens: []string{"token-1", "token-2"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("AWS_CONFIG_FILE", "/dev/null")
 			synctest.Test(t, func(t *testing.T) {
 				var stsCalls int
+				var seenTokens []string
 				issueCreds := func() *ststypes.Credentials {
 					stsCalls++
 					return &ststypes.Credentials{
@@ -591,12 +608,14 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 						// implementation, so the STS server-side default
 						// session duration applies.
 						assert.Nil(t, params.DurationSeconds)
+						seenTokens = append(seenTokens, aws.ToString(params.WebIdentityToken))
 						return &sts.AssumeRoleWithWebIdentityOutput{Credentials: issueCreds()}, nil
 					},
 				}
 				provider := makeMockSessionProvider(func(cfg aws.Config) StsClient {
 					return mock
 				}, "", "", "", "my-role", tc.webIdentityToken, true)
+				provider.WebIdentityTokenRetriever = tc.tokenRetriever
 				_, ctx := ktesting.NewTestContext(t)
 				cfg, err := provider.GetSession(ctx)
 				require.NoError(t, err)
@@ -623,9 +642,19 @@ func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "key-2", after.AccessKeyID)
 				assert.Equal(t, 2, stsCalls)
+				assert.Equal(t, tc.expTokens, seenTokens)
 			})
 		})
 	}
+}
+
+// countingTokenRetriever returns a distinct token on each call, so that tests
+// can verify that a fresh token is retrieved for every role assumption.
+type countingTokenRetriever struct{ calls int }
+
+func (r *countingTokenRetriever) GetIdentityToken() ([]byte, error) {
+	r.calls++
+	return fmt.Appendf(nil, "token-%d", r.calls), nil
 }
 
 type mockSTS struct {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -538,6 +539,78 @@ func TestAssumeRole(t *testing.T) {
 				assert.Equal(t, *c.expCreds.AccessKeyId, sessCreds.AccessKeyID)
 				assert.Equal(t, c.region, cfg.Region)
 			}
+		})
+	}
+}
+
+// TestGetSessionRefreshesExpiredSTSCredentials demonstrates that the role is
+// re-assumed when the temporary STS credentials expire, and that valid
+// credentials are served from the cache without repeated STS requests.
+//
+// It runs in a synctest bubble: the SDK's credential expiry check bottoms out
+// in time.Now, so sleeping past the expiry advances the fake clock instantly
+// and no real time passes.
+//
+// This test fails with the previous implementation, which assumed the role
+// once in GetSession and stored the result in a static credentials provider
+// which the SDK can never refresh.
+func TestGetSessionRefreshesExpiredSTSCredentials(t *testing.T) {
+	const validity = 15 * time.Minute
+	tests := []struct {
+		name             string
+		webIdentityToken string
+	}{
+		{name: "assume role"},
+		{name: "assume role with web identity", webIdentityToken: jwt},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+			synctest.Test(t, func(t *testing.T) {
+				var stsCalls int
+				issueCreds := func() *ststypes.Credentials {
+					stsCalls++
+					return &ststypes.Credentials{
+						AccessKeyId:     aws.String(fmt.Sprintf("key-%d", stsCalls)),
+						SecretAccessKey: aws.String("secret"),
+						SessionToken:    aws.String("session-token"),
+						Expiration:      aws.Time(time.Now().Add(validity)),
+					}
+				}
+				mock := &mockSTS{
+					AssumeRoleFn: func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+						return &sts.AssumeRoleOutput{Credentials: issueCreds()}, nil
+					},
+					AssumeRoleWithWebIdentityFn: func(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+						return &sts.AssumeRoleWithWebIdentityOutput{Credentials: issueCreds()}, nil
+					},
+				}
+				provider := makeMockSessionProvider(func(cfg aws.Config) StsClient {
+					return mock
+				}, "", "", "", "my-role", tc.webIdentityToken, true)
+				_, ctx := ktesting.NewTestContext(t)
+				cfg, err := provider.GetSession(ctx)
+				require.NoError(t, err)
+
+				before, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-1", before.AccessKeyID)
+
+				// While the credentials are valid they are served from the
+				// cache without another STS request.
+				cached, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-1", cached.AccessKeyID)
+				assert.Equal(t, 1, stsCalls)
+
+				// Once the credentials have expired, the SDK re-assumes the
+				// role to obtain fresh credentials.
+				time.Sleep(validity + time.Minute)
+				after, err := cfg.Credentials.Retrieve(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "key-2", after.AccessKeyID)
+				assert.Equal(t, 2, stsCalls)
+			})
 		})
 	}
 }

--- a/pkg/issuer/acme/dns/route53/session.go
+++ b/pkg/issuer/acme/dns/route53/session.go
@@ -24,6 +24,7 @@ import (
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/logging"
 	"github.com/aws/smithy-go/middleware"
@@ -133,42 +134,28 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		return aws.Config{}, fmt.Errorf("unable to create aws config: %w", err)
 	}
 
-	if d.Role != "" && d.WebIdentityToken == "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
+	// Rather than assuming the role once here and storing the resulting
+	// static credentials, configure a credential provider so that the AWS
+	// SDK can re-assume the role whenever the temporary STS credentials
+	// expire; for example if a challenge is retried, or if there is a long
+	// delay between presenting and cleaning up the DNS01 challenge record.
+	// The CredentialsCache avoids repeating the STS request for every AWS
+	// API request made with this config.
+	if d.Role != "" {
 		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRole(ctx, &sts.AssumeRoleInput{
-			RoleArn:         aws.String(d.Role),
-			RoleSessionName: aws.String("cert-manager"),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role: %w", err)
+		var credProvider aws.CredentialsProvider
+		if d.WebIdentityToken == "" {
+			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
+			credProvider = stscreds.NewAssumeRoleProvider(stsSvc, d.Role, func(o *stscreds.AssumeRoleOptions) {
+				o.RoleSessionName = "cert-manager"
+			})
+		} else {
+			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
+			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, staticIdentityToken(d.WebIdentityToken), func(o *stscreds.WebIdentityRoleOptions) {
+				o.RoleSessionName = "cert-manager"
+			})
 		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
-	}
-
-	if d.Role != "" && d.WebIdentityToken != "" {
-		log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
-
-		stsSvc := d.StsProvider(cfg)
-		result, err := stsSvc.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
-			RoleArn:          aws.String(d.Role),
-			RoleSessionName:  aws.String("cert-manager"),
-			WebIdentityToken: aws.String(d.WebIdentityToken),
-		})
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %w", err)
-		}
-
-		cfg.Credentials = credentials.NewStaticCredentialsProvider(
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-		)
+		cfg.Credentials = aws.NewCredentialsCache(credProvider)
 	}
 
 	// Log some key values of the loaded configuration, so that users can
@@ -205,4 +192,12 @@ func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webId
 
 func defaultSTSProvider(cfg aws.Config) StsClient {
 	return sts.NewFromConfig(cfg)
+}
+
+// staticIdentityToken supplies the web identity token from the Issuer
+// configuration to the AWS SDK whenever it needs to re-assume the role.
+type staticIdentityToken string
+
+func (t staticIdentityToken) GetIdentityToken() ([]byte, error) {
+	return []byte(t), nil
 }

--- a/pkg/issuer/acme/dns/route53/session.go
+++ b/pkg/issuer/acme/dns/route53/session.go
@@ -19,6 +19,7 @@ package route53
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
@@ -136,11 +137,13 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 
 	// Rather than assuming the role once here and storing the resulting
 	// static credentials, configure a credential provider so that the AWS
-	// SDK can re-assume the role whenever the temporary STS credentials
-	// expire; for example if a challenge is retried, or if there is a long
-	// delay between presenting and cleaning up the DNS01 challenge record.
-	// The CredentialsCache avoids repeating the STS request for every AWS
-	// API request made with this config.
+	// SDK can re-assume the role if the temporary STS credentials expire
+	// while this config is in use. A new config is constructed for every
+	// Present and CleanUp call (see dns.Solver.solverForChallenge), so in
+	// practice this covers the SDK's own request retries and the polling
+	// for the Route53 change to become INSYNC, which can take tens of
+	// minutes. The CredentialsCache avoids repeating the STS request for
+	// every AWS API request made with this config.
 	if d.Role != "" {
 		stsSvc := d.StsProvider(cfg)
 		var credProvider aws.CredentialsProvider
@@ -148,9 +151,17 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
 			credProvider = stscreds.NewAssumeRoleProvider(stsSvc, d.Role, func(o *stscreds.AssumeRoleOptions) {
 				o.RoleSessionName = "cert-manager"
+				// The previous implementation omitted DurationSeconds, so STS
+				// applied its server-side default of 3600 seconds. Request the
+				// same duration explicitly, because AssumeRoleProvider would
+				// otherwise request only stscreds.DefaultDuration (15 minutes).
+				o.Duration = time.Hour
 			})
 		} else {
 			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role with web identity")
+			// WebIdentityRoleProvider omits DurationSeconds unless a Duration
+			// is configured, so the STS server-side default session duration
+			// applies, as before.
 			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, staticIdentityToken(d.WebIdentityToken), func(o *stscreds.WebIdentityRoleOptions) {
 				o.RoleSessionName = "cert-manager"
 			})

--- a/pkg/issuer/acme/dns/route53/session.go
+++ b/pkg/issuer/acme/dns/route53/session.go
@@ -34,14 +34,19 @@ import (
 )
 
 type sessionProvider struct {
-	AccessKeyID      string
-	SecretAccessKey  string
-	Ambient          bool
-	Region           string
-	Role             string
-	WebIdentityToken string
-	StsProvider      func(aws.Config) StsClient
-	userAgent        string
+	AccessKeyID     string
+	SecretAccessKey string
+	Ambient         bool
+	Region          string
+	Role            string
+	// WebIdentityToken is a fixed web identity token. It is wrapped in a
+	// static stscreds.IdentityTokenRetriever, so prefer
+	// WebIdentityTokenRetriever, which allows the AWS SDK to fetch a fresh
+	// token whenever it re-assumes the role.
+	WebIdentityToken          string
+	WebIdentityTokenRetriever stscreds.IdentityTokenRetriever
+	StsProvider               func(aws.Config) StsClient
+	userAgent                 string
 }
 
 type StsClient interface {
@@ -50,11 +55,19 @@ type StsClient interface {
 }
 
 func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
+	webIdentityTokenRetriever := d.WebIdentityTokenRetriever
+	if d.WebIdentityToken != "" {
+		if webIdentityTokenRetriever != nil {
+			return aws.Config{}, fmt.Errorf("unable to construct route53 provider: only one of web identity token and web identity token retriever may be set")
+		}
+		webIdentityTokenRetriever = staticIdentityToken(d.WebIdentityToken)
+	}
+
 	switch {
-	case d.Role == "" && d.WebIdentityToken != "":
+	case d.Role == "" && webIdentityTokenRetriever != nil:
 		return aws.Config{}, fmt.Errorf("unable to construct route53 provider: role must be set when web identity token is set")
 	case d.AccessKeyID == "" && d.SecretAccessKey == "":
-		if !d.Ambient && d.WebIdentityToken == "" {
+		if !d.Ambient && webIdentityTokenRetriever == nil {
 			return aws.Config{}, fmt.Errorf("unable to construct route53 provider: empty credentials; perhaps you meant to enable ambient credentials?")
 		}
 	case d.AccessKeyID == "" || d.SecretAccessKey == "":
@@ -62,7 +75,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 		return aws.Config{}, fmt.Errorf("unable to construct route53 provider: only one of access and secret key was provided")
 	}
 
-	useAmbientCredentials := d.Ambient && (d.AccessKeyID == "" && d.SecretAccessKey == "") && d.WebIdentityToken == ""
+	useAmbientCredentials := d.Ambient && (d.AccessKeyID == "" && d.SecretAccessKey == "") && webIdentityTokenRetriever == nil
 
 	log := logf.FromContext(ctx)
 	optFns := []func(*config.LoadOptions) error{
@@ -118,7 +131,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	}
 
 	switch {
-	case d.Role != "" && d.WebIdentityToken != "":
+	case d.Role != "" && webIdentityTokenRetriever != nil:
 		log.V(logf.DebugLevel).Info("using assume role with web identity")
 	case useAmbientCredentials:
 		log.V(logf.DebugLevel).Info("using ambient credentials")
@@ -147,7 +160,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	if d.Role != "" {
 		stsSvc := d.StsProvider(cfg)
 		var credProvider aws.CredentialsProvider
-		if d.WebIdentityToken == "" {
+		if webIdentityTokenRetriever == nil {
 			log.V(logf.DebugLevel).WithValues("role", d.Role).Info("assuming role")
 			credProvider = stscreds.NewAssumeRoleProvider(stsSvc, d.Role, func(o *stscreds.AssumeRoleOptions) {
 				o.RoleSessionName = "cert-manager"
@@ -162,7 +175,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			// WebIdentityRoleProvider omits DurationSeconds unless a Duration
 			// is configured, so the STS server-side default session duration
 			// applies, as before.
-			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, staticIdentityToken(d.WebIdentityToken), func(o *stscreds.WebIdentityRoleOptions) {
+			credProvider = stscreds.NewWebIdentityRoleProvider(stsSvc, d.Role, webIdentityTokenRetriever, func(o *stscreds.WebIdentityRoleOptions) {
 				o.RoleSessionName = "cert-manager"
 			})
 		}
@@ -188,16 +201,17 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 	return cfg, nil
 }
 
-func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webIdentityToken string, ambient bool, userAgent string) *sessionProvider {
+func newSessionProvider(accessKeyID, secretAccessKey, region, role string, webIdentityToken string, webIdentityTokenRetriever stscreds.IdentityTokenRetriever, ambient bool, userAgent string) *sessionProvider {
 	return &sessionProvider{
-		AccessKeyID:      accessKeyID,
-		SecretAccessKey:  secretAccessKey,
-		Ambient:          ambient,
-		Region:           region,
-		Role:             role,
-		WebIdentityToken: webIdentityToken,
-		StsProvider:      defaultSTSProvider,
-		userAgent:        userAgent,
+		AccessKeyID:               accessKeyID,
+		SecretAccessKey:           secretAccessKey,
+		Ambient:                   ambient,
+		Region:                    region,
+		Role:                      role,
+		WebIdentityToken:          webIdentityToken,
+		WebIdentityTokenRetriever: webIdentityTokenRetriever,
+		StsProvider:               defaultSTSProvider,
+		userAgent:                 userAgent,
 	}
 }
 

--- a/pkg/issuer/acme/dns/route53/tokenretriever.go
+++ b/pkg/issuer/acme/dns/route53/tokenretriever.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route53
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceAccountTokenCreator is the subset of the Kubernetes ServiceAccount
+// client used to mint ServiceAccount tokens.
+type ServiceAccountTokenCreator interface {
+	CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authv1.TokenRequest, opts metav1.CreateOptions) (*authv1.TokenRequest, error)
+}
+
+// KubernetesServiceAccountTokenRetriever mints a short-lived ServiceAccount
+// token using the Kubernetes TokenRequest API. The AWS SDK calls
+// GetIdentityToken whenever it (re-)assumes the role with web identity, so
+// each role assumption uses a freshly minted token rather than one minted
+// when the challenge solver was constructed.
+type KubernetesServiceAccountTokenRetriever struct {
+	ServiceAccountName string
+	Audiences          []string
+	Namespace          string
+	Client             ServiceAccountTokenCreator
+}
+
+var _ stscreds.IdentityTokenRetriever = &KubernetesServiceAccountTokenRetriever{}
+
+// GetIdentityToken implements stscreds.IdentityTokenRetriever, which has no
+// context parameter, so the TokenRequest is made with a background context.
+func (o *KubernetesServiceAccountTokenRetriever) GetIdentityToken() ([]byte, error) {
+	tokenrequest, err := o.Client.CreateToken(context.Background(), o.ServiceAccountName, &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences:         o.Audiences,
+			ExpirationSeconds: new(int64(600)),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token for %s/%s: %w", o.Namespace, o.ServiceAccountName, err)
+	}
+
+	return []byte(tokenrequest.Status.Token), nil
+}

--- a/pkg/issuer/acme/dns/route53/tokenretriever_test.go
+++ b/pkg/issuer/acme/dns/route53/tokenretriever_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route53
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestKubernetesServiceAccountTokenRetriever(t *testing.T) {
+	t.Run("mints a token for the configured ServiceAccount", func(t *testing.T) {
+		fake := kubefake.NewClientset()
+		var gotTokenRequest *authv1.TokenRequest
+		fake.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "token" {
+				return false, nil, nil
+			}
+			gotTokenRequest = action.(k8stesting.CreateAction).GetObject().(*authv1.TokenRequest).DeepCopy()
+			response := gotTokenRequest.DeepCopy()
+			response.Status.Token = "minted-token"
+			return true, response, nil
+		})
+
+		retriever := &KubernetesServiceAccountTokenRetriever{
+			ServiceAccountName: "my-service-account",
+			Audiences:          []string{"sts.amazonaws.com"},
+			Namespace:          "my-namespace",
+			Client:             fake.CoreV1().ServiceAccounts("my-namespace"),
+		}
+
+		token, err := retriever.GetIdentityToken()
+		require.NoError(t, err)
+		assert.Equal(t, []byte("minted-token"), token)
+		assert.Equal(t, []string{"sts.amazonaws.com"}, gotTokenRequest.Spec.Audiences)
+		assert.Equal(t, int64(600), *gotTokenRequest.Spec.ExpirationSeconds)
+	})
+
+	t.Run("wraps TokenRequest errors", func(t *testing.T) {
+		fake := kubefake.NewClientset()
+		fake.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated error")
+		})
+
+		retriever := &KubernetesServiceAccountTokenRetriever{
+			ServiceAccountName: "my-service-account",
+			Namespace:          "my-namespace",
+			Client:             fake.CoreV1().ServiceAccounts("my-namespace"),
+		}
+
+		_, err := retriever.GetIdentityToken()
+		assert.EqualError(t, err, "failed to request token for my-namespace/my-service-account: simulated error")
+	})
+}


### PR DESCRIPTION
Part two of the revival of #7236, as requested by @inteon in https://github.com/cert-manager/cert-manager/pull/7236#discussion_r1805509867. Depends on #9110 (part one); the first three commits here are that PR, so review the final commit only.

## What

Replaces the pre-minted ServiceAccount token used for `AssumeRoleWithWebIdentity` with a `KubernetesServiceAccountTokenRetriever`, an implementation of [`stscreds.IdentityTokenRetriever`](https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.19.34/credentials/stscreds/web_identity_provider.go#L73-L75) which mints a fresh token via the Kubernetes TokenRequest API.

## Why

Previously the token was minted once, when the challenge solver was constructed, [with a 600 second expiry](https://github.com/cert-manager/cert-manager/blob/fcc3d8182f8534fd75db41b3bf6d4a15079a6725/pkg/issuer/acme/dns/dns.go#L600-L612). After #9110 the AWS SDK re-assumes the role whenever the temporary STS credentials expire, but it would present that same fixed token, which may itself have expired by then. `WebIdentityRoleProvider` calls [`GetIdentityToken` on every role assumption](https://github.com/aws/aws-sdk-go-v2/blob/credentials/v1.19.34/credentials/stscreds/web_identity_provider.go#L111), so with this change every assumption uses a freshly minted token.

The token minting moves from `dns.go` into the route53 package, threaded through a new `WebIdentityTokenRetriever` option. The `WebIdentityToken` string option is retained for the deprecated `NewDNSProvider` constructor and for API compatibility; it is wrapped in the static retriever introduced in #9110.

The retriever design is taken from #7236, where it was reviewed favourably.

## Testing

- A new unit test covers the retriever against a fake Kubernetes clientset, asserting the audiences and 600 second expiry are preserved.
- The `testing/synctest` refresh test from #9110 gains a third case proving that when the STS credentials expire, the re-assumption presents a freshly minted token (`token-1`, then `token-2`), whereas the fixed-token path presents the same token twice.

Once this and #9110 have merged, #7236 can be closed.

*with claude fable-5*
