### PR TITLE
fix(issuing): do not fail issuance for a request built from a replaced key

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -271,6 +271,23 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return nil
 	}
 
+	// If public key does not match, do nothing (requestmanager will handle this).
+	// Settle this before any terminal state is acted on: a request built from a key
+	// we have since replaced is one the requestmanager deletes and rebuilds, so its
+	// denial, invalidity or failure says nothing about the current issuance.
+	csr, err := utilpki.DecodeX509CertificateRequestBytes(req.Spec.Request)
+	if err != nil {
+		return err
+	}
+	publicKeyMatchesCSR, err := utilpki.PublicKeyMatchesCSR(pk.Public(), csr)
+	if err != nil {
+		return err
+	}
+	if !publicKeyMatchesCSR {
+		logf.WithResource(log, nextPrivateKeySecret).Info("next private key does not match CSR public key, waiting for requestmanager controller")
+		return nil
+	}
+
 	certIssuingCond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionIssuing)
 	crReadyCond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
 	if certIssuingCond == nil {
@@ -329,20 +346,6 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	// to False.
 	if crReadyCond.Reason == cmapi.CertificateRequestReasonFailed {
 		return c.failIssueCertificate(ctx, log, crt, apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady))
-	}
-
-	// If public key does not match, do nothing (requestmanager will handle this).
-	csr, err := utilpki.DecodeX509CertificateRequestBytes(req.Spec.Request)
-	if err != nil {
-		return err
-	}
-	publicKeyMatchesCSR, err := utilpki.PublicKeyMatchesCSR(pk.Public(), csr)
-	if err != nil {
-		return err
-	}
-	if !publicKeyMatchesCSR {
-		logf.WithResource(log, nextPrivateKeySecret).Info("next private key does not match CSR public key, waiting for requestmanager controller")
-		return nil
 	}
 
 	// If the CertificateRequest is valid and ready, verify its status and issue

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -446,6 +446,69 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"if certificate is in Issuing state, one CertificateRequest that failed, but the private key stored in the Secret does not match that creating the CSR, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestFailed,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+						// After the Issuing transition, so this is not the earlier
+						// "failed during a previous issuance" case.
+						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Second)}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							// Replaced after this request's CSR was built.
+							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
+			},
+			expectedErr: false,
+		},
+		"if certificate is in Issuing state, one CertificateRequest that was denied, but the private key stored in the Secret does not match that creating the CSR, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequest,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:    cmapi.CertificateRequestConditionDenied,
+							Status:  cmmeta.ConditionTrue,
+							Reason:  "Denied",
+							Message: "denied by policy",
+						}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							// Replaced after this request's CSR was built.
+							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
+			},
+			expectedErr: false,
+		},
 		"if certificate is in Issuing state, one CertificateRequest, and is ready, but the CertificateRequest contains a violation, do nothing": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{


### PR DESCRIPTION
### Pull Request Motivation

Fixes #6331

That issue has been open since 2023 and people keep arriving on it with the same pair of log lines:

```
"next private key does not match CSR public key, waiting for requestmanager controller"
"Error generating certificate template" err="CSR not signed by referenced private key"
```

The two lines say opposite things about the same request, and that turns out to be the whole bug.

`ProcessItem` acts on a CertificateRequest's terminal state before it checks whether the request's CSR still matches the Certificate's current next private key. When the key is replaced while a request is in flight, the self-signed issuer marks that request `Failed` with `ErrorKeyMatch`, and this controller reads the failure first: it bumps the issuance attempts and drops the Issuing condition, so the certificate sits out a backoff for a request the requestmanager is about to delete and rebuild against the new key.

The mismatch check already exists a few lines below and already does the right thing by waiting. It was simply unreachable once the request had failed. This moves it above `Denied`, `InvalidRequest` and `Failed`, so the "is this request stale?" question is settled before any terminal state is acted on. The requestmanager deletes a mismatched request regardless of its condition, so none of those verdicts describe the current issuance.

There is a related guard a little earlier that catches a request which failed *before* the Issuing condition was last set, a leftover from a previous issuance. It does not help here, because in this race the request fails part way through the current issuance, so its `FailureTime` is newer than the Issuing transition.

#### Known limitation

The reports on #6331 describe certificates "never renewing again". The only concrete logs on the issue (a v1.13 cluster) show the certificate recovering automatically after the failed-issuance backoff, so that description is the bounded backoff (1h by default, up to the 32h cap) read as permanent, rather than a separate never-recovers stall. This PR removes that backoff.

One residual window remains. This controller reads the next private key through its secret informer, so if that cache still holds the old key when it reconciles the failed request, the mismatch check passes and issuance fails exactly as before. The race is narrowed, not eliminated.

Two behaviour changes worth stating:

1. A genuine issuer failure that coincides with a key rotation is no longer counted towards `failedIssuanceAttempts`, so the rebuilt request is retried without backoff. That is the intended trade-off.
2. A failed request whose CSR carries an unsupported public key type now makes `PublicKeyMatchesCSR` return an error and requeue, where previously issuance failed. It needs a hand-crafted request, and the requestmanager already errors on the same input, so I have left it alone.

#### What does not change

A request that fails for a real reason still fails. Its CSR matches the current key, so it reaches the failure branch exactly as before, which the existing "has failed for the first time / fifth time during this series of attempts" cases cover. If the underlying problem persists, the rebuilt request fails again with a matching key and issuance is marked failed then.

An undecodable CSR cannot reach the moved check either: `RequestMatchesSpec` decodes the request earlier in the same function and returns that error.

#### Testing

The new case carries a `FailureTime` set after the Certificate's `Issuing` transition, so it is not absorbed by the earlier "failed during a previous issuance" branch and matches the timing in the issue, where the request fails part way through the current issuance. It otherwise mirrors the existing "is ready, but the private key stored in the Secret does not match that creating the CSR" case, with the request failed instead of ready. That combination was the one gap in the table. Reverting only `issuing_controller.go` makes it fail with the symptom from the issue:

```
got unexpected events, exp='[]'
got='[Warning Failed The certificate request has failed to complete and will be retried:
      CSR not signed by referenced private key]'
```

along with the `update status certificates` call that bumps the failed issuance attempt, which is what users experience as the wait.

### Kind

/kind bug

### Release Note

```release-note
Fixed an issue where rotating a Certificate's next private key while a CertificateRequest was in flight could mark the issuance as failed and delay it by a backoff, instead of waiting for the request to be rebuilt against the new key.
```


