### PR TITLE
Fix nil pointer panic placeholders in readiness controller debug log

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
@@ -249,24 +250,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		crt.Status.RenewalTime = nil
 	}
 	if !apiequality.Semantic.DeepEqual(oldCrt.Status, crt.Status) {
+		// klog.SafePtr prevents a nil *metav1.Time from reaching the logger's
+		// Stringer call, which would panic in the promoted time.Time.String
+		// method and render the field as "<panic: ...>".
 		log.V(logf.DebugLevel).Info("updating status fields", "notAfter",
-			formatTime(crt.Status.NotAfter), "notBefore", formatTime(crt.Status.NotBefore), "renewalTime",
-			formatTime(crt.Status.RenewalTime))
+			klog.SafePtr(crt.Status.NotAfter), "notBefore", klog.SafePtr(crt.Status.NotBefore), "renewalTime",
+			klog.SafePtr(crt.Status.RenewalTime))
 		return c.updateOrApplyStatus(ctx, crt)
 	}
 	return nil
-}
-
-// formatTime renders a possibly-nil time for logging. A nil *metav1.Time must
-// not be passed to the logger directly: its String method is promoted from the
-// embedded time.Time with a value receiver, so calling it through a nil
-// pointer panics, which the logger recovers from by rendering the field as
-// "<panic: runtime error: invalid memory address or nil pointer dereference>".
-func formatTime(t *metav1.Time) string {
-	if t == nil {
-		return "<nil>"
-	}
-	return t.String()
 }
 
 func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) time.Time {

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -250,11 +250,23 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 	if !apiequality.Semantic.DeepEqual(oldCrt.Status, crt.Status) {
 		log.V(logf.DebugLevel).Info("updating status fields", "notAfter",
-			crt.Status.NotAfter, "notBefore", crt.Status.NotBefore, "renewalTime",
-			crt.Status.RenewalTime)
+			formatTime(crt.Status.NotAfter), "notBefore", formatTime(crt.Status.NotBefore), "renewalTime",
+			formatTime(crt.Status.RenewalTime))
 		return c.updateOrApplyStatus(ctx, crt)
 	}
 	return nil
+}
+
+// formatTime renders a possibly-nil time for logging. A nil *metav1.Time must
+// not be passed to the logger directly: its String method is promoted from the
+// embedded time.Time with a value receiver, so calling it through a nil
+// pointer panics, which the logger recovers from by rendering the field as
+// "<panic: runtime error: invalid memory address or nil pointer dereference>".
+func formatTime(t *metav1.Time) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.String()
 }
 
 func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) time.Time {

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -574,16 +574,6 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 	}
 }
 
-func TestFormatTime(t *testing.T) {
-	if got, want := formatTime(nil), "<nil>"; got != want {
-		t.Errorf("formatTime(nil) = %q, want %q", got, want)
-	}
-	tm := metav1.NewTime(time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC))
-	if got, want := formatTime(&tm), "2026-08-10 12:00:00 +0000 UTC"; got != want {
-		t.Errorf("formatTime(&tm) = %q, want %q", got, want)
-	}
-}
-
 func TestReadinessForARI(t *testing.T) {
 	now := time.Now().UTC()
 	metaNow := metav1.NewTime(now)

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -574,6 +574,16 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 	}
 }
 
+func TestFormatTime(t *testing.T) {
+	if got, want := formatTime(nil), "<nil>"; got != want {
+		t.Errorf("formatTime(nil) = %q, want %q", got, want)
+	}
+	tm := metav1.NewTime(time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC))
+	if got, want := formatTime(&tm), "2026-08-10 12:00:00 +0000 UTC"; got != want {
+		t.Errorf("formatTime(&tm) = %q, want %q", got, want)
+	}
+}
+
 func TestReadinessForARI(t *testing.T) {
 	now := time.Now().UTC()
 	metaNow := metav1.NewTime(now)


### PR DESCRIPTION
### Pull Request Motivation

Fixes #6799.

Several users reported log lines like this and understandably read them as a cert-manager crash:

```
I1016 09:37:11.439826  1 readiness_controller.go:191] "updating status fields" logger="cert-manager.controller" key="REDACTED/tls-certificate" notAfter="<panic: runtime error: invalid memory address or nil pointer dereference>" notBefore="<panic: runtime error: invalid memory address or nil pointer dereference>" renewalTime="<panic: runtime error: invalid memory address or nil pointer dereference>"
```

No crash actually occurs. The readiness controller passes `crt.Status.NotAfter`, `NotBefore` and `RenewalTime` (all `*metav1.Time`) straight to the structured logger. `metav1.Time` embeds `time.Time`, whose [`String` method has a value receiver](https://cs.opensource.google/go/go/+/go1.24.0:src/time/format.go;l=517), so calling it through a nil pointer dereferences nil. klog recovers from the panic in [`StringerToString`](https://github.com/kubernetes/klog/blob/v2.140.0/internal/serialize/keyvalues.go#L224-L234) and renders the placeholder instead.

The fields are nil (and the log line fires) whenever the status changes while the certificate has no decodable secret — for example a new Certificate whose Ready condition flips before issuance, which is why the reporters on #6799 saw it while debugging unrelated stuck-issuance problems.

This PR wraps the three nullable timestamps in [`klog.SafePtr`](https://github.com/kubernetes/klog/blob/v2.140.0/safeptr.go#L29-L34), the helper klog added for exactly this Stringer-on-nil-pointer case (kubernetes/klog#393). kubernetes/kubernetes uses the same pattern for nullable `metav1.Time` fields, e.g. [`FilterActivePods` logging `pod.DeletionTimestamp` at v1.30.0](https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/controller/controller_utils.go#L954). Nil fields now render as `notAfter=null`. This is the only call site in the codebase that logs a `*metav1.Time`.

Reproduction (klog v2.140.0, apimachinery v0.36.3, the versions in go.mod):

```go
var notAfter *metav1.Time
klog.V(3).InfoS("before", "notAfter", notAfter)
klog.V(3).InfoS("after", "notAfter", klog.SafePtr(notAfter))
// I0810 ... "before" notAfter="<panic: runtime error: invalid memory address or nil pointer dereference>"
// I0810 ... "after" notAfter=null
```

### Kind

/kind bug

### Release Note

```release-note
Fixed misleading `<panic: runtime error: invalid memory address or nil pointer dereference>` placeholders in the certificate readiness controller's debug log message "updating status fields", seen when a Certificate's notAfter, notBefore or renewalTime status fields were empty. The panic was caught and recovered by the logging library; cert-manager did not crash.
```

*with claude fable-5*
