### PR TITLE
fix(issuing): do not panic on a failed request with no Ready condition

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -300,7 +300,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	// failed CertificateRequest from the previous issuance for the same
 	// revision. Leave it to the certificate-requests controller to delete the
 	// CertificateRequest and create a new one.
-	if req.Status.FailureTime != nil &&
+	if req.Status.FailureTime != nil && crReadyCond != nil &&
 		req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) && crReadyCond.Reason == cmapi.CertificateRequestReasonFailed {
 		log.V(logf.InfoLevel).Info("Found a failed CertificateRequest from previous issuance, waiting for it to be deleted...")
 		return nil

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -509,6 +509,35 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequest,
+						// Explicit, so the case keeps covering the missing condition.
+						func(cr *cmapi.CertificateRequest) { cr.Status.Conditions = nil },
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Hour * -1)}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
+			},
+			expectedErr: false,
+		},
 		"if certificate is in Issuing state, one CertificateRequest, and is ready, but the CertificateRequest contains a violation, do nothing": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9119

Spotted by @wallrj while reviewing #9116, and split out as he suggested since it is reachable on its own.

`ProcessItem` reads `crReadyCond.Reason` in the guard that skips a CertificateRequest which failed during a previous issuance:

https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/controller/certificates/issuing/issuing_controller.go#L286-L290

but `crReadyCond` is only checked for nil further down, after the `Denied` and `InvalidRequest` branches:

https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/controller/certificates/issuing/issuing_controller.go#L322-L325

A CertificateRequest that carries `status.failureTime` and has no Ready condition therefore dereferences a nil pointer, and since this runs in the controller's process it takes the whole thing down rather than failing the one Certificate.

I added the nil check to the guard instead of hoisting the existing one, because hoisting changes behaviour. `CertificateRequestIsDenied` does not depend on the Ready condition, so a request denied before an issuer set Ready currently fails issuance; moving the nil check above that branch would make it wait instead. Adding the check where the dereference happens leaves every other path exactly as it was.

### Kind

/kind bug

### Testing

`TestIssuingController` gains a case with `failureTime` set and no Ready condition. On master it does not fail an assertion, it panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestIssuingController/if_certificate_is_in_Issuing_state,_one_CertificateRequest_with_a_failure_time_but_no_Ready_condition,_do_nothing
```

### Release Note

```release-note
Fixed a panic in the certificates-issuing controller when a CertificateRequest has a failure time set but no Ready condition.
```

### Documentation updates

NONE
