### PR TITLE
Fix nil pointer panic placeholder in cainjector secret mismatch log

### DIFF
--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -133,9 +134,13 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	// usually set the ownerReference of the Secret.
 	owner := owningCertForSecret(&secret)
 	if owner == nil || *owner != certName {
+		// klog.SafePtr prevents the nil owner (annotation missing) from
+		// reaching the logger's Stringer call, which would panic in the
+		// promoted value-receiver String method and render the field as
+		// "<panic: ...>".
 		log.V(logf.WarnLevel).Info(
 			"refusing to target secret: cert-manager.io/certificate-name annotation does not match",
-			"annotationValue", owner,
+			"annotationValue", klog.SafePtr(owner),
 			"expected", certName,
 		)
 		return nil, nil


### PR DESCRIPTION
### Pull Request Motivation

Another instance of the bug class fixed in #9117 (issue #6799): a nil pointer logged through logr panics in the promoted value-receiver `String` method, and klog recovers by rendering the field as `<panic: runtime error: invalid memory address or nil pointer dereference>`, which users mistake for a cert-manager crash.

**How we found it**: after fixing #9117 we prototyped a golangci-lint rule (gocritic's ruleguard checker) — preserved at [wallrj/cert-manager@8e8382f](https://github.com/wallrj/cert-manager/commit/8e8382fddc27ef0cd7f947808b4cc9797ac03bfb), including a demonstration file and the generator script — that flags pointer values passed to `logr.Logger.Info/Error/WithValues` when the pointed-to type implements `fmt.Stringer`. Run over the whole repository it produced three findings: two are constructed immediately before logging and can never be nil, but this one can:

- [`owningCertForSecret` returns nil](https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/controller/cainjector/reconciler.go#L172-L181) when the Secret has no `cert-manager.io/certificate-name` annotation, and
- [the warning log in exactly the `owner == nil` branch](https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/controller/cainjector/sources.go#L134-L142) passes that nil `*types.NamespacedName` to the logger as `annotationValue`.

So any cainjector user pointing `cert-manager.io/inject-ca-from` at a Certificate whose Secret was not created by that Certificate gets the panic placeholder in the very log line that is supposed to explain the problem. The fix wraps the value in [`klog.SafePtr`](https://github.com/kubernetes/klog/blob/v2.140.0/safeptr.go#L29-L34), as in #9117; nil now renders as `annotationValue=null`.

We decided not to ship the lint rule itself: expressing "any key/value position" in ruleguard required one rule per (method, argument position) to work around matcher limitations, which is too fragile to maintain. We are instead proposing the check upstream to the linters (links to follow in a comment).

### Kind

/kind bug

### Release Note

```release-note
Fixed a cainjector warning log message that rendered `<panic: runtime error: invalid memory address or nil pointer dereference>` instead of the annotation value when the target Secret lacks the `cert-manager.io/certificate-name` annotation. The panic was caught and recovered by the logging library; cainjector did not crash.
```

*with claude fable-5*
