### PR TITLE
Remove no-op verbosity gate on acmechallenges Error logs

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -309,12 +309,12 @@ func handleError(ctx context.Context, ch *cmacme.Challenge, err error) error {
 		// Errored, after which IsFinalState() makes the controller stop
 		// reconciling it (see issues #8696 and #8747).
 		if isTransientACMEError(err) {
-			logf.FromContext(ctx).V(logf.ErrorLevel).Error(err, "transient non-ACME API error, will retry")
+			logf.FromContext(ctx).Error(err, "transient non-ACME API error, will retry")
 			return err
 		}
 		ch.Status.State = cmacme.Errored
 		ch.Status.Reason = fmt.Sprintf("unexpected non-ACME API error: %v", err)
-		logf.FromContext(ctx).V(logf.ErrorLevel).Error(err, "unexpected non-ACME API error")
+		logf.FromContext(ctx).Error(err, "unexpected non-ACME API error")
 		return err
 	}
 


### PR DESCRIPTION
### Pull Request Motivation

Removes a no-op verbosity gate from the two error logs in the acmechallenges controller: [`sync.go#L312` and `#L317`](https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/controller/acmechallenges/sync.go#L311-L318) called `logf.FromContext(ctx).V(logf.ErrorLevel).Error(...)`.

The `V()` call has no effect: [`logr.Logger.Error` is always emitted, "regardless of verbosity level"](https://github.com/go-logr/logr/blob/v1.4.3/logr.go#L283-L294) (logr v1.4.3, the version in go.mod). It is doubly redundant because [`logf.ErrorLevel` is `0`](https://github.com/cert-manager/cert-manager/blob/56d902be23cd6449b8ea7925aeea728bb3bb1f39/pkg/logs/logs.go#L43) and `V(0)` returns the logger unchanged. So there is no behavior change here — the dead call just misled readers into thinking these error logs were verbosity-gated. (The `.V(logf.ErrorLevel).Info(...)` calls elsewhere in the codebase are left alone: there the `V(0)` meaningfully selects unconditional Info logging.)

**How we found it**: while investigating the nil-pointer logging placeholders (#6799, fixed by #9117 and #9120), we ran Kubernetes' [logcheck](https://github.com/kubernetes-sigs/logtools/tree/main/logcheck) linter over the repository. Its `verbosity-error` check flagged exactly these two lines.

**Why we are not adding logcheck to the standard lint checks right now**: the full run produced 25 findings and these two were the only actionable ones —

- 16 findings are `parameters`-check complaints that log keys must be *inlined* constant strings. They all trip on cert-manager's deliberate convention of naming shared log keys as constants (`logf.ResourceNameKey`, `logf.RelatedResourceKindKey`, … in `pkg/logs`), so for this codebase they are false positives; adopting the check would mean either widespread suppressions or abandoning that convention.
- 7 findings say a function should accept a context or a logger but not both — reasonable contextual-logging API advice, but a refactor discussion, not something to gate CI on.
- Unlike `loggercheck` (which golangci-lint ships and this repo already enables via makefile-modules), logcheck cannot be enabled through plain golangci-lint configuration — it needs a custom golangci-lint plugin build or a separate binary and make target, so it carries real integration cost.
- The check we actually want — flagging nil-unsafe `fmt.Stringer` pointers in log values — exists in neither tool yet; we have requested it upstream in both (kubernetes-sigs/logtools#34, timonwong/loggercheck#109). If the loggercheck one lands, this repo gets it automatically with the next golangci-lint bump.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```

*with claude fable-5*
