### PR TITLE
fix(issuing): surface stalled CertificateRequest with failureTime but no Ready condition

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -350,7 +350,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 			// Ready condition reason is Failed), so surface it loudly rather
 			// than waiting silently forever.
 			message := fmt.Sprintf("CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", req.Name)
-			log.V(logf.InfoLevel).Info(message)
+			log.V(logf.ErrorLevel).Info(message)
 			c.recorder.Event(crt, corev1.EventTypeWarning, reasonStalled, message)
 			return nil
 		}

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -54,6 +54,7 @@ import (
 const (
 	ControllerName                   = "certificates-issuing"
 	reasonTemporaryCertificateFailed = "TemporaryCertificateFailed"
+	reasonStalled                    = "Stalled"
 )
 
 type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, error)
@@ -342,12 +343,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 			// The CertificateRequest has a failureTime but no Ready condition.
 			// This is not reachable via the in-tree issuers, which always set
 			// both in the same update, but can happen with an external issuer
-			// or a partially applied status. Neither this controller nor the
-			// requestmanager controller can make progress from this state, so
-			// surface it loudly rather than waiting silently forever.
-			message := "CertificateRequest has a failureTime set but no Ready condition; issuance is stalled"
+			// writing failureTime and the Ready condition in separate updates,
+			// or with a partially applied status. Neither this controller nor
+			// the requestmanager controller can make progress from this state
+			// (the requestmanager only cleans up a CertificateRequest whose
+			// Ready condition reason is Failed), so surface it loudly rather
+			// than waiting silently forever.
+			message := fmt.Sprintf("CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", req.Name)
 			log.V(logf.InfoLevel).Info(message)
-			c.recorder.Event(crt, corev1.EventTypeWarning, "Stalled", message)
+			c.recorder.Event(crt, corev1.EventTypeWarning, reasonStalled, message)
 			return nil
 		}
 		log.V(logf.DebugLevel).Info("CertificateRequest does not have Ready condition, waiting...")

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -338,6 +338,18 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	if crReadyCond == nil {
+		if req.Status.FailureTime != nil {
+			// The CertificateRequest has a failureTime but no Ready condition.
+			// This is not reachable via the in-tree issuers, which always set
+			// both in the same update, but can happen with an external issuer
+			// or a partially applied status. Neither this controller nor the
+			// requestmanager controller can make progress from this state, so
+			// surface it loudly rather than waiting silently forever.
+			message := "CertificateRequest has a failureTime set but no Ready condition; issuance is stalled"
+			log.V(logf.InfoLevel).Info(message)
+			c.recorder.Event(crt, corev1.EventTypeWarning, "Stalled", message)
+			return nil
+		}
 		log.V(logf.DebugLevel).Info("CertificateRequest does not have Ready condition, waiting...")
 		return nil
 	}

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -514,7 +514,7 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
-		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, do nothing": {
+		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, emit a Stalled event": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{
@@ -539,7 +539,9 @@ func TestIssuingController(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{},
-				ExpectedEvents:  []string{},
+				ExpectedEvents: []string{
+					"Warning Stalled CertificateRequest has a failureTime set but no Ready condition; issuance is stalled",
+				},
 			},
 			expectedErr: false,
 		},

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -525,7 +525,10 @@ func TestIssuingController(t *testing.T) {
 						gen.AddCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
 						}),
-						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Hour * -1)}),
+						// After the Issuing transition, so this is the "stalled
+						// during the current attempt" case, not the earlier
+						// "failed during a previous issuance" case handled above.
+						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Second)}),
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
@@ -540,8 +543,36 @@ func TestIssuingController(t *testing.T) {
 				},
 				ExpectedActions: []testpkg.Action{},
 				ExpectedEvents: []string{
-					"Warning Stalled CertificateRequest has a failureTime set but no Ready condition; issuance is stalled",
+					fmt.Sprintf("Warning Stalled CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", exampleBundle.CertificateRequest.Name),
 				},
+			},
+			expectedErr: false,
+		},
+		"if certificate is in Issuing state, one CertificateRequest with no failure time and no Ready condition, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequest,
+						// Explicit, so the case keeps covering the missing condition.
+						func(cr *cmapi.CertificateRequest) { cr.Status.Conditions = nil },
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
 			},
 			expectedErr: false,
 		},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

A CertificateRequest that carries `status.failureTime` but no Ready condition leaves its Certificate stuck at `Issuing=True` with nothing to move it along: the issuing controller's wait branch for a nil Ready condition returns silently at debug level, and the requestmanager controller only deletes a request whose Ready condition reason is `Failed`, so a nil condition is never cleaned up. The in-tree issuers can't reach this state (they set `failureTime` and the Ready condition together), but an external issuer or a partially applied status can, and until now the operator had no signal beyond one debug-level log line.

This PR narrows the existing nil-Ready-condition branch in the issuing controller: when `status.failureTime` is also set (the specific stalled case), it now logs at Info level and emits a Warning `Stalled` Event on the Certificate, so the state is visible via `kubectl describe certificate` and default-verbosity logs. The common "still waiting for the issuer" case (no `failureTime` set) is unchanged and stays at debug level, so this doesn't add noise to normal in-progress issuance. This is an observability-only change; control flow (`return nil`) is unchanged in both branches.

Validated with `go test -count=1 ./pkg/controller/certificates/issuing/...`, which includes an updated unit test reproducing the exact state from the issue (a CertificateRequest with `failureTime` set and empty `conditions`). I confirmed the updated assertion fails without the code change and passes with it. Also ran `go vet`, `gofmt -l`, and `golangci-lint run` on the changed package (0 issues). No live-cluster/e2e run was performed since this change doesn't alter reconciliation behaviour.

Report: https://github.com/cert-manager/cert-manager/issues/9126

### Kind

/kind bug

### Release Note

```release-note
`cert-manager` now emits a Warning `Stalled` Event and an Info-level log on a Certificate when its current CertificateRequest has a `failureTime` set but no `Ready` condition, a state that previously stalled issuance silently.
```

Fixes #9126