### PR TITLE
fix: encode directoryName SANs with explicit tagging

### DIFF
--- a/pkg/util/pki/sans.go
+++ b/pkg/util/pki/sans.go
@@ -131,7 +131,9 @@ func UnmarshalSANs(value []byte) (GeneralNames, error) {
 			gns.X400Addresses = append(gns.X400Addresses, v)
 		case nameTypeDirectoryName:
 			var rdn pkix.RDNSequence
-			if _, err := asn1.UnmarshalWithParams(v.FullBytes, &rdn, fmt.Sprintf("tag:%d", nameTypeDirectoryName)); err != nil {
+			// directoryName is [4] Name, and Name is a CHOICE, so RFC 5280
+			// section 4.2.1.6 (per X.680) requires the tag to be explicit.
+			if _, err := asn1.UnmarshalWithParams(v.FullBytes, &rdn, fmt.Sprintf("explicit,tag:%d", nameTypeDirectoryName)); err != nil {
 				return err
 			}
 			gns.DirectoryNames = append(gns.DirectoryNames, rdn)
@@ -256,9 +258,13 @@ func MarshalSANs(gns GeneralNames, hasSubject bool) (pkix.Extension, error) {
 		}
 	}
 	for _, val := range gns.DirectoryNames {
-		if err := addMarshalable(nameTypeDirectoryName, val); err != nil {
+		// directoryName is [4] Name, and Name is a CHOICE, so RFC 5280
+		// section 4.2.1.6 (per X.680) requires the tag to be explicit.
+		fullBytes, err := asn1.MarshalWithParams(val, fmt.Sprintf("explicit,tag:%d", nameTypeDirectoryName))
+		if err != nil {
 			return pkix.Extension{}, err
 		}
+		rawValues = append(rawValues, asn1.RawValue{FullBytes: fullBytes})
 	}
 	for _, val := range gns.EDIPartyNames {
 		if err := addMarshalable(nameTypeEDIPartyName, val); err != nil {

--- a/pkg/util/pki/sans_test.go
+++ b/pkg/util/pki/sans_test.go
@@ -239,3 +239,44 @@ wWy44hfcegrvch51oNMscwQ5NCJRGYI6q3T9yexVug==
 		}
 	}
 }
+
+func TestMarshalAndUnmarshalDirectoryNameSANs(t *testing.T) {
+	rdn := pkix.Name{
+		CommonName:   "dir.example.org",
+		Organization: []string{"ExampleOrg"},
+	}.ToRDNSequence()
+
+	// directoryName is [4] Name and Name is a CHOICE, so RFC 5280 section
+	// 4.2.1.6 (per X.680) requires the [4] tag to be explicit. Build a
+	// conformant SAN extension value directly with encoding/asn1 (an oracle
+	// independent of MarshalSANs) so the assertions below pin the wire format,
+	// not just self-consistency of the round trip.
+	dirNameElem, err := asn1.MarshalWithParams(rdn, "explicit,tag:4")
+	if err != nil {
+		t.Fatalf("marshalling oracle directoryName element: %v", err)
+	}
+	conformantValue, err := asn1.Marshal([]asn1.RawValue{{FullBytes: dirNameElem}})
+	if err != nil {
+		t.Fatalf("marshalling oracle SAN sequence: %v", err)
+	}
+
+	// Marshal side: MarshalSANs must emit the explicit form byte for byte.
+	ext, err := MarshalSANs(GeneralNames{DirectoryNames: []pkix.RDNSequence{rdn}}, true)
+	if err != nil {
+		t.Fatalf("MarshalSANs returned an error: %v", err)
+	}
+	if !reflect.DeepEqual(ext.Value, conformantValue) {
+		t.Errorf("MarshalSANs directoryName is not RFC 5280 conformant:\n got: % x\nwant: % x", ext.Value, conformantValue)
+	}
+
+	// Parse side: UnmarshalSANs must accept a conformant, explicitly tagged
+	// directoryName SAN (before the fix it failed with "sequence tag mismatch").
+	gns, err := UnmarshalSANs(conformantValue)
+	if err != nil {
+		t.Fatalf("UnmarshalSANs failed on a conformant directoryName SAN: %v", err)
+	}
+	want := GeneralNames{DirectoryNames: []pkix.RDNSequence{rdn}}
+	if !reflect.DeepEqual(gns, want) {
+		t.Errorf("UnmarshalSANs round trip mismatch:\n got: %v\nwant: %v", gns, want)
+	}
+}


### PR DESCRIPTION
`UnmarshalSANs` and `MarshalSANs` in `pkg/util/pki` tag the `directoryName` SAN implicitly (`tag:4`). But `directoryName` is `[4] Name` and `Name` is a `CHOICE`, so the `[4]` tag has to be explicit (RFC 5280 section 4.2.1.6; per X.680 a tag on an untagged `CHOICE` is explicit even in an IMPLICIT TAGS module). That is the form OpenSSL and crypto/x509 produce.

Two consequences:

- `UnmarshalSANs` cannot parse a conforming `directoryName` SAN. approver-policy calls `UnmarshalSANs` and fails closed on a decode error, so a CertificateRequest carrying a valid `directoryName` SAN is denied with "subjectAltName (SAN) extension could not be decoded".
- `MarshalSANs` emits a `directoryName` whose contents start with the RDNSequence `SET` instead of the wrapping `SEQUENCE`, so the DER is not what a conforming parser expects.

What changed:
- `sans.go`: use `explicit,tag:4` for `directoryName` in both `UnmarshalSANs` and `MarshalSANs`.
- `sans_test.go`: add `TestMarshalAndUnmarshalDirectoryNameSANs`. It builds a conforming SAN with `encoding/asn1` directly (independent of `MarshalSANs`) and checks both directions against it.

Reproduce before the change: take an OpenSSL-generated certificate with a `dirName` SAN (`CN=dir.example.org, O=ExampleOrg`). `UnmarshalSANs` on its SAN extension returns `asn1: structure error: sequence tag mismatch`, and `MarshalSANs` of the same RDNSequence yields an element `a4 2f 31 ...` (the `[4]` wrapping a `SET` directly) instead of `a4 31 30 2f 31 ...` (the `[4]` wrapping a `SEQUENCE`). The new test covers both and fails before this change, passes after.

Checked:
- `go test ./pkg/util/pki/`
- `go vet ./pkg/util/pki/`

```release-note
Fixed a bug where ASN Unmarshal with SAN extension was not getting explicitly tagged for `directoryName`
```