### PR TITLE
Record a Warning event when CSR generation fails

### DIFF
--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -376,6 +376,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	)
 	if err != nil {
 		log.Error(err, "Failed to generate CSR - will not retry")
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to generate CSR: %s", err.Error())
 		return nil
 	}
 	csrDER, err := pki.EncodeCSR(x509CSR, pk)

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -376,7 +376,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	)
 	if err != nil {
 		log.Error(err, "Failed to generate CSR - will not retry")
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to generate CSR: %s", err.Error())
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to generate CSR: %s - will not retry", err.Error())
 		return nil
 	}
 	csrDER, err := pki.EncodeCSR(x509CSR, pk)

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -719,6 +719,34 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
+		"record a Warning event if CSR generation fails, e.g. due to a malformed NameConstraints IP range": {
+			featuresFlags: map[featuregate.Feature]bool{
+				feature.NameConstraints: true,
+			},
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists-for-nameconstraints-test"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle3.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists-for-nameconstraints-test"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateIsCA(true),
+				func(crt *cmapi.Certificate) {
+					crt.Spec.NameConstraints = &cmapi.NameConstraints{
+						Critical: true,
+						Permitted: &cmapi.NameConstraintItem{
+							// Missing the required "/prefix" - not a valid CIDR.
+							IPRanges: []string{"10.0.0.0"},
+						},
+					}
+				},
+			),
+			expectedEvents: []string{
+				`Warning RequestFailed Failed to generate CSR: invalid CIDR address: 10.0.0.0`,
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -744,7 +744,7 @@ func TestProcessItem(t *testing.T) {
 				},
 			),
 			expectedEvents: []string{
-				`Warning RequestFailed Failed to generate CSR: invalid CIDR address: 10.0.0.0`,
+				`Warning RequestFailed Failed to generate CSR: invalid CIDR address: 10.0.0.0 - will not retry`,
 			},
 		},
 	}


### PR DESCRIPTION
### Pull Request Motivation
 Fixes #9139

This is to fix the issue #[9139](https://github.com/cert-manager/cert-manager/issues/9139).

`createNewCertificateRequest` (`pkg/controller/certificates/requestmanager/requestmanager_controller.go`)
already records a Warning event via the `reasonRequestFailed` reason when creating the `CertificateRequest`
object fails, but when the earlier `pki.GenerateCSR` call fails, the error is only logged
(`"Failed to generate CSR - will not retry"`) and the function returns `nil` — silently swallowed. Since
nothing else clears the `Certificate`'s `Issuing` condition without a `CertificateRequest` being created, this
leaves the `Certificate` stuck at `Ready=False` indefinitely with zero user-visible signal beyond a controller
log line.

This PR adds the same `c.recorder.Eventf(...)` call already used for the sibling failure path a few lines
below, so both failure modes in this function are now surfaced consistently. It's a one-line functional
change plus a regression test (added to the existing table-driven `TestProcessItem` suite) that reproduces
the swallow via a malformed `nameConstraints` IP range — confirmed the added test fails without the fix and
passes with it.

Reproduced live on a `kind` cluster running cert-manager v1.21.1 before filing (details in the linked issue),
then verified the fix itself end-to-end: built this branch into a real controller image, swapped it into the
same live cluster in place of the stock image, and confirmed `kubectl describe certificate` now shows
`Warning RequestFailed Failed to generate CSR: ...` on the same Certificate that previously showed no events
at all.

#### Before Fix
There is no recoreded warning event from `kubectl describe certificate`

```
Status:
  Conditions:
    Last Transition Time:        2026-08-14T04:30:36Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      True
    Type:                        Issuing
    Last Transition Time:        2026-08-14T04:30:36Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      False
    Type:                        Ready
  Next Private Key Secret Name:  repro-root-ca-cjd6w
Events:                          <none>  <--------------------------------- NOTHING HERE
```

#### After Fix

Note generated warning event from `kubectl describe certificate`

```
Status:
  Conditions:
    Last Transition Time:        2026-08-14T04:30:36Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      True
    Type:                        Issuing
    Last Transition Time:        2026-08-14T04:30:36Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      False
    Type:                        Ready
  Next Private Key Secret Name:  repro-root-ca-cjd6w
Events:
  Type     Reason         Age   From                                       Message
  ----     ------         ----  ----                                       -------
  Warning  RequestFailed  17m   cert-manager-certificates-request-manager  Failed to generate CSR: invalid CIDR address: 10.0.0.0

```


### Kind

/kind bug

### Release Note

```release-note
cert-manager now records a Warning event on a `Certificate` when CSR generation fails during (re-)issuance, instead of only logging the failure.
```
