### PR TITLE
Use server-side apply to trigger issuance in flaky private key rotation tests

### DIFF
--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -139,16 +139,19 @@ func TestGeneratesNewPrivateKeyIfMarkedInvalidRequest(t *testing.T) {
 	t.Logf("Issuance acknowledged as failed as expected")
 	t.Logf("Triggering new issuance")
 
-	crt, err = cmCl.CertmanagerV1().Certificates(crt.Namespace).Get(t.Context(), crt.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get certificate: %v", err)
-	}
-
-	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "ManualTrigger", "triggered by test case manually")
-	crt, err = cmCl.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(t.Context(), crt, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatalf("failed to update certificate: %v", err)
-	}
+	// Trigger a new issuance using a server-side apply patch, which cannot
+	// conflict with the concurrent status updates made by the controllers
+	// under test. The Conditions field is a list map keyed by Type, so this
+	// only takes ownership of the Issuing condition.
+	applyCertificateStatus(t, cmCl, "test-trigger", namespace, crt.Name, cmapi.CertificateStatus{
+		Conditions: []cmapi.CertificateCondition{{
+			Type:               cmapi.CertificateConditionIssuing,
+			Status:             cmmeta.ConditionTrue,
+			Reason:             "ManualTrigger",
+			Message:            "triggered by test case manually",
+			ObservedGeneration: crt.Generation,
+		}},
+	})
 
 	var secondReq cmapi.CertificateRequest
 	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {
@@ -286,16 +289,19 @@ func TestGeneratesNewPrivateKeyPerRequest(t *testing.T) {
 	t.Logf("Issuance acknowledged as failed as expected")
 	t.Logf("Triggering new issuance")
 
-	crt, err = cmCl.CertmanagerV1().Certificates(crt.Namespace).Get(t.Context(), crt.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get certificate: %v", err)
-	}
-
-	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "ManualTrigger", "triggered by test case manually")
-	crt, err = cmCl.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(t.Context(), crt, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatalf("failed to update certificate: %v", err)
-	}
+	// Trigger a new issuance using a server-side apply patch, which cannot
+	// conflict with the concurrent status updates made by the controllers
+	// under test. The Conditions field is a list map keyed by Type, so this
+	// only takes ownership of the Issuing condition.
+	applyCertificateStatus(t, cmCl, "test-trigger", namespace, crt.Name, cmapi.CertificateStatus{
+		Conditions: []cmapi.CertificateCondition{{
+			Type:               cmapi.CertificateConditionIssuing,
+			Status:             cmmeta.ConditionTrue,
+			Reason:             "ManualTrigger",
+			Message:            "triggered by test case manually",
+			ObservedGeneration: crt.Generation,
+		}},
+	})
 
 	var secondReq cmapi.CertificateRequest
 	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond*500, time.Second*10, true, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
### Pull Request Motivation

`TestGeneratesNewPrivateKeyPerRequest` failed in `pull-cert-manager-release-1.21-make-test` on #9151 ([build log](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/9151/pull-cert-manager-release-1.21-make-test/2088507624868810752)):

```
generates_new_private_key_per_request_test.go:297: failed to update certificate: Operation cannot be fulfilled on certificates.cert-manager.io "testcrt": the object has been modified; please apply your changes to the latest version and try again
```

The test triggers a re-issuance with an unguarded read-modify-write: `Get` the Certificate, set the `Issuing` condition, `UpdateStatus`. But the test also runs six certificate controllers, which all write to the same Certificate's status with plain `UpdateStatus` while the `ServerSideApply` feature gate is off (e.g. [trigger](https://github.com/cert-manager/cert-manager/blob/cd21f71bdf49ff3f8c90af6b3adf176b1461028f/pkg/controller/certificates/trigger/trigger_controller.go#L264), [issuing](https://github.com/cert-manager/cert-manager/blob/cd21f71bdf49ff3f8c90af6b3adf176b1461028f/pkg/controller/certificates/issuing/issuing_controller.go#L528)). A controller write committing between the test's `Get` and `UpdateStatus` makes the test's update fail with the optimistic-locking conflict above.

I could not make the test itself lose this race locally (120 clean runs, including 20 pinned to 2 CPUs alongside 4 busy-loop processes, and 10 with an artificial 2-second gap between the `Get` and the `UpdateStatus`), but the same interleaving shows up in passing runs with the conflict landing on the controller side instead — a controller re-queue logged in the window between the test triggering issuance and the new request appearing:

```
    generates_new_private_key_per_request_test.go:287: Triggering new issuance
I0815 11:56:20.559420 ... "re-queuing item due to optimistic locking on resource" ... error="Operation cannot be fulfilled on certificates.cert-manager.io \"testcrt\": the object has been modified; ..."
```

Which party gets the 409 is a coin flip; on a loaded CI node the test sometimes loses.

### The fix

Replace the read-modify-write with a server-side apply patch of only the `Issuing` condition, under a dedicated field manager, reusing the `applyCertificateStatus` helper from `status_scalar_apply_test.go`. Server-side apply carries no `resourceVersion` precondition, so it cannot hit an optimistic-locking conflict. And because `status.conditions` is a list map keyed by `Type` — the property `Test_ConditionsListType` exists to prove — the patch takes ownership of the `Issuing` condition only, without disturbing the conditions managed by the controllers.

`TestGeneratesNewPrivateKeyIfMarkedInvalidRequest` has the identical pattern and gets the identical fix. The `CertificateRequest` `UpdateStatus` calls in this file are left alone: none of the controllers running in these tests writes CertificateRequest status, so they have nothing to conflict with.

There are ~14 more unguarded `UpdateStatus` read-modify-writes across `test/integration` which could adopt the same idiom; most exercise a single controller so are far less exposed. I can follow up if there's appetite.

Verified with 20 runs of `TestGeneratesNewPrivateKeyPerRequest` pinned to 2 CPUs alongside 4 CPU-hog processes, plus a normal run of both modified tests: all pass.

### Kind

/kind flake

### Release Note

```release-note
NONE
```

*with claude fable-5*
