### PR TITLE
fix: reject non-CERTIFICATE PEM blocks with a clear error in decodeMultipleCerts

### DIFF
--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -87,6 +87,14 @@ func decodeMultipleCerts(certBytes []byte, decodeFn func([]byte) (*stdpem.Block,
 			return nil, err
 		}
 
+		// RFC 7468 §2 requires that the label be used to determine the type of
+		// content in a PEM block; reject anything that isn't a certificate
+		// rather than passing it to x509.ParseCertificate, which would fail
+		// with a misleading "malformed certificate" error.
+		if block.Type != "CERTIFICATE" {
+			return nil, errors.NewInvalidData("error decoding certificate PEM block: expected only \"CERTIFICATE\" blocks, found %q", block.Type)
+		}
+
 		// parse the tls certificate
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -87,12 +87,14 @@ func decodeMultipleCerts(certBytes []byte, decodeFn func([]byte) (*stdpem.Block,
 			return nil, err
 		}
 
-		// RFC 7468 §2 requires that the label be used to determine the type of
-		// content in a PEM block; reject anything that isn't a certificate
-		// rather than passing it to x509.ParseCertificate, which would fail
-		// with a misleading "malformed certificate" error.
-		if block.Type != "CERTIFICATE" {
-			return nil, errors.NewInvalidData("error decoding certificate PEM block: expected only \"CERTIFICATE\" blocks, found %q", block.Type)
+		// Reject anything that isn't labelled as a certificate rather than
+		// passing it to x509.ParseCertificate, which would fail with a
+		// misleading "malformed certificate" error. "X509 CERTIFICATE" and
+		// "X.509 CERTIFICATE" are historic labels (RFC 7468 §5.1) still
+		// produced by some older OpenSSL and Java toolchains, and are
+		// accepted alongside the standard "CERTIFICATE" label.
+		if block.Type != "CERTIFICATE" && block.Type != "X509 CERTIFICATE" && block.Type != "X.509 CERTIFICATE" {
+			return nil, errors.NewInvalidData("error decoding certificate PEM block: expected a \"CERTIFICATE\" block, found %q", block.Type)
 		}
 
 		// parse the tls certificate

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -144,9 +144,19 @@ func DecodeX509CertificateRequestBytes(csrBytes []byte) (*x509.CertificateReques
 		return nil, errors.NewInvalidData("error decoding certificate request PEM block: %s", err)
 	}
 
+	// Reject anything that isn't labelled as a certificate request rather
+	// than passing it to x509.ParseCertificateRequest, which would fail
+	// with a misleading error. "NEW CERTIFICATE REQUEST" is a historic
+	// label (RFC 7468 §7) still produced by some older OpenSSL
+	// toolchains, and is accepted alongside the standard "CERTIFICATE
+	// REQUEST" label.
+	if block.Type != "CERTIFICATE REQUEST" && block.Type != "NEW CERTIFICATE REQUEST" {
+		return nil, errors.NewInvalidData("error decoding certificate request PEM block: expected a \"CERTIFICATE REQUEST\" block, found %q", block.Type)
+	}
+
 	csr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewInvalidData("error parsing x509 certificate request: %s", err.Error())
 	}
 
 	return csr, nil

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -18,42 +18,13 @@ package pki
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
-	"math/big"
 	"strings"
 	"testing"
-	"time"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
-
-// generateSelfSignedCertBytesPEM generates a minimal self-signed certificate
-// and returns its PEM encoding, for use in tests that need valid CERTIFICATE
-// PEM blocks.
-func generateSelfSignedCertBytesPEM() ([]byte, error) {
-	key, err := rsa.GenerateKey(rand.Reader, MinRSAKeySize)
-	if err != nil {
-		return nil, err
-	}
-
-	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "test"},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(time.Hour),
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
-	if err != nil {
-		return nil, err
-	}
-
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}), nil
-}
 
 func generatePrivateKeyBytes(keyAlgo v1.PrivateKeyAlgorithm, keySize int) ([]byte, error) {
 	cert := buildCertificateWithKeyParams(keyAlgo, keySize)
@@ -74,26 +45,20 @@ func generatePKCS8PrivateKey(keyAlgo v1.PrivateKeyAlgorithm, keySize int) ([]byt
 }
 
 func TestDecodeX509CertificateSetBytes(t *testing.T) {
-	certBytes, err := generateSelfSignedCertBytesPEM()
-	if err != nil {
-		t.Fatalf("error generating cert bytes: %s", err)
-	}
+	certBytes := mustCreateBundle(t, nil, "test").pem
 
-	keyBytes, err := generatePrivateKeyBytes(v1.RSAKeyAlgorithm, MinRSAKeySize)
-	if err != nil {
-		t.Fatalf("error generating key bytes: %s", err)
-	}
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("dummy")})
 
 	// A bundle containing a valid certificate followed by a non-certificate
 	// PEM block, e.g. a combined cert+key file.
 	certAndKeyBytes := append(append([]byte{}, certBytes...), keyBytes...)
 
-	_, err = DecodeX509CertificateSetBytes(certAndKeyBytes)
+	_, err := DecodeX509CertificateSetBytes(certAndKeyBytes)
 	if err == nil {
 		t.Fatal("expected an error decoding a bundle containing a non-certificate PEM block, got none")
 	}
 
-	expectErrStr := `expected only "CERTIFICATE" blocks, found "RSA PRIVATE KEY"`
+	expectErrStr := `expected a "CERTIFICATE" block, found "RSA PRIVATE KEY"`
 	if !strings.Contains(err.Error(), expectErrStr) {
 		t.Errorf("expected err string to match: '%s', got: '%s'", expectErrStr, err.Error())
 	}

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -19,6 +19,8 @@ package pki
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"strings"
 	"testing"
@@ -69,6 +71,41 @@ func TestDecodeX509CertificateSetBytes(t *testing.T) {
 	}
 	if len(certs) != 1 {
 		t.Errorf("expected 1 certificate, got %d", len(certs))
+	}
+}
+
+func TestDecodeX509CertificateRequestBytes(t *testing.T) {
+	pk, err := GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrDER, err := EncodeCSR(&x509.CertificateRequest{Subject: pkix.Name{CommonName: "test"}}, pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	csr, err := DecodeX509CertificateRequestBytes(csrBytes)
+	if err != nil {
+		t.Fatalf("unexpected error decoding a valid CSR: %s", err)
+	}
+	if csr.Subject.CommonName != "test" {
+		t.Errorf("expected common name %q, got %q", "test", csr.Subject.CommonName)
+	}
+
+	// A PEM block that isn't labelled as a certificate request, e.g. a
+	// certificate mistakenly passed as spec.request.
+	nonCSRBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("dummy")})
+
+	_, err = DecodeX509CertificateRequestBytes(nonCSRBytes)
+	if err == nil {
+		t.Fatal("expected an error decoding a non-CSR PEM block, got none")
+	}
+
+	expectErrStr := `expected a "CERTIFICATE REQUEST" block, found "CERTIFICATE"`
+	if !strings.Contains(err.Error(), expectErrStr) {
+		t.Errorf("expected err string to match: '%s', got: '%s'", expectErrStr, err.Error())
 	}
 }
 

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -18,13 +18,42 @@ package pki
 
 import (
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 )
+
+// generateSelfSignedCertBytesPEM generates a minimal self-signed certificate
+// and returns its PEM encoding, for use in tests that need valid CERTIFICATE
+// PEM blocks.
+func generateSelfSignedCertBytesPEM() ([]byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, MinRSAKeySize)
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}), nil
+}
 
 func generatePrivateKeyBytes(keyAlgo v1.PrivateKeyAlgorithm, keySize int) ([]byte, error) {
 	cert := buildCertificateWithKeyParams(keyAlgo, keySize)
@@ -42,6 +71,40 @@ func generatePKCS8PrivateKey(keyAlgo v1.PrivateKeyAlgorithm, keySize int) ([]byt
 		return nil, err
 	}
 	return EncodePKCS8PrivateKey(privateKey)
+}
+
+func TestDecodeX509CertificateSetBytes(t *testing.T) {
+	certBytes, err := generateSelfSignedCertBytesPEM()
+	if err != nil {
+		t.Fatalf("error generating cert bytes: %s", err)
+	}
+
+	keyBytes, err := generatePrivateKeyBytes(v1.RSAKeyAlgorithm, MinRSAKeySize)
+	if err != nil {
+		t.Fatalf("error generating key bytes: %s", err)
+	}
+
+	// A bundle containing a valid certificate followed by a non-certificate
+	// PEM block, e.g. a combined cert+key file.
+	certAndKeyBytes := append(append([]byte{}, certBytes...), keyBytes...)
+
+	_, err = DecodeX509CertificateSetBytes(certAndKeyBytes)
+	if err == nil {
+		t.Fatal("expected an error decoding a bundle containing a non-certificate PEM block, got none")
+	}
+
+	expectErrStr := `expected only "CERTIFICATE" blocks, found "RSA PRIVATE KEY"`
+	if !strings.Contains(err.Error(), expectErrStr) {
+		t.Errorf("expected err string to match: '%s', got: '%s'", expectErrStr, err.Error())
+	}
+
+	certs, err := DecodeX509CertificateSetBytes(certBytes)
+	if err != nil {
+		t.Fatalf("unexpected error decoding a valid certificate: %s", err)
+	}
+	if len(certs) != 1 {
+		t.Errorf("expected 1 certificate, got %d", len(certs))
+	}
 }
 
 func TestDecodePrivateKeyBytes(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

`decodeMultipleCerts` in `pkg/util/pki/parse.go` passed every PEM block it found straight to `x509.ParseCertificate`, without checking `block.Type`. A bundle containing a valid certificate followed by any non-certificate PEM block (most commonly a combined certificate + key file, where a `PRIVATE KEY` block follows the certificates) was rejected with the misleading error `error parsing X.509 certificate: x509: malformed certificate`, even though every certificate in the input was valid. This affects `DecodeX509CertificateChainBytes`, `DecodeX509CertificateSetBytes` and `DecodeX509CertificateBytes`, and therefore every issuer and controller that parses user- or CA-supplied PEM through them.

`DecodeX509CertificateRequestBytes` had the same bug: no `block.Type` check, and the raw `x509.ParseCertificateRequest` error was returned unwrapped instead of being wrapped like every other decode function in the file.

Fixes https://github.com/cert-manager/cert-manager/issues/9153

### Approach

`decodeMultipleCerts` now checks `block.Type` before calling `x509.ParseCertificate`, and rejects any block that isn't labelled `CERTIFICATE` (or the historic `X509 CERTIFICATE` / `X.509 CERTIFICATE` labels from RFC 7468 §5.1, still emitted by some older OpenSSL and Java toolchains) with a clear error naming the actual block type found (e.g. `expected a "CERTIFICATE" block, found "PRIVATE KEY"`), rather than silently skipping it or passing it through to the parser.

Note this is a deliberate project choice, not an RFC requirement: RFC 7468 §2 says parsers "MAY disregard the label". It's also stricter than some of the ecosystem — client-go's `ParseCertsPEM` and the standard library's `x509.CertPool.AppendCertsFromPEM` both skip non-`CERTIFICATE` blocks rather than rejecting the whole input. Reject-everywhere (including in `DecodeX509CertificateSetBytes`, used for trust bundles) is deliberate here: this follows the issue reporter's own preferred option, since silently ignoring a private key that a user accidentally pasted into certificate input could hide a serious mistake. A skip-with-log approach for the trust-bundle case would match prior art better and remains an option for a follow-up if reviewers prefer it.

`DecodeX509CertificateRequestBytes` gets the equivalent fix: it now rejects blocks that aren't labelled `CERTIFICATE REQUEST` (or the historic `NEW CERTIFICATE REQUEST` label) with a clear error, and wraps the underlying parse error with `errors.NewInvalidData` for consistency with the rest of the file.

This does change behaviour for two kinds of previously-accepted input, both in the direction of a stricter, more accurate error rather than a silent success:
- A block whose label isn't `CERTIFICATE`/legacy equivalent (or `CERTIFICATE REQUEST`/legacy equivalent) but whose bytes happen to be valid X.509 DER previously parsed successfully because the label was never checked; it's now rejected with an error naming the mismatched label.
- Everything else that previously parsed successfully continues to parse successfully; the legacy certificate/CSR labels above are accepted specifically to preserve that.

Putting the label check in the shared `internal/pem` helper (so all `SafeDecode*` callers, e.g. `pkg/controller/acmeorders/sync.go`, get it once) is a larger change than this PR — happy to follow up separately if that's the preferred direction.

### Validation

Added `TestDecodeX509CertificateSetBytes` in `pkg/util/pki/parse_test.go`, which builds a bundle containing a valid self-signed certificate followed by a dummy `RSA PRIVATE KEY` PEM block (reproducing the combined cert+key scenario from the issue) and asserts the new, accurate error message; it also asserts that a certificate-only bundle still decodes successfully. Added `TestDecodeX509CertificateRequestBytes` covering the equivalent CSR case: a valid CSR decodes successfully, and a PEM block mislabelled as `CERTIFICATE` is rejected with the new error.

- `go test ./pkg/util/pki/...` passes.
- `go build ./pkg/util/pki/...` succeeds, `go vet ./pkg/util/pki/...` is clean, `gofmt -l` reports no issues on the changed files.
- This repo's PR CI runs via Prow and requires a maintainer to label the PR `ok-to-test` for an external contributor; I could not trigger or observe that CI here, so the above local commands are what I could verify directly.

### Kind

/kind bug

### Release Note

```release-note
Potentially breaking: fix a bug where a certificate bundle or CSR containing a valid certificate/request followed by a mislabelled PEM block (e.g. a private key in a combined cert+key file) was rejected with a misleading "malformed certificate" error; it now fails with an error naming the actual PEM block type found. Legacy but valid PEM labels (`X509 CERTIFICATE`, `X.509 CERTIFICATE`, `NEW CERTIFICATE REQUEST`) are still accepted. Note: a PEM block whose label doesn't match its expected type is now rejected even if its contents happen to be valid X.509 DER, which was previously accepted.
```

Fixes #9153

