### PR TITLE
fix(util): reject CSV input that cannot be read back unchanged, round-trip a single empty value

### DIFF
--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -406,12 +406,7 @@ func certificateDataAnnotationsForSecret(secret *corev1.Secret) (annotations map
 		}
 	}
 
-	certificateAnnotations, err := internalcertificates.AnnotationsForCertificate(certificate)
-	if err != nil {
-		return nil, err
-	}
-
-	return certificateAnnotations, nil
+	return internalcertificates.AnnotationsForCertificate(certificate), nil
 }
 
 func secretLabelsAndAnnotationsManagedFields(secret *corev1.Secret, fieldManager string) (labels, annotations sets.Set[string], err error) {

--- a/internal/controller/certificates/secrets.go
+++ b/internal/controller/certificates/secrets.go
@@ -19,6 +19,7 @@ package certificates
 import (
 	"bytes"
 	"crypto/x509"
+	"slices"
 
 	"github.com/cert-manager/cert-manager/internal/pem"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -30,17 +31,24 @@ import (
 // Certificate Secret's Annotations when issued. These annotations contain
 // information about the Certificate.
 // If the X.509 certificate is nil, an empty map will be returned.
-func AnnotationsForCertificate(certificate *x509.Certificate) (map[string]string, error) {
+//
+// The annotations are derived metadata, not the issued payload, so a value
+// that cannot be represented costs its own annotation and nothing else. That
+// is deliberate, because this function cannot afford to fail: it runs between
+// signing and the Secret Apply, where an error strands a certificate a CA has
+// already signed, and again in the post-issuance policy chain, where an error
+// short-circuits the checks that reconcile SecretTemplate metadata, keystores,
+// additional output formats and owner references.
+func AnnotationsForCertificate(certificate *x509.Certificate) map[string]string {
 	annotations := make(map[string]string)
 
 	if certificate == nil {
-		return annotations, nil
+		return annotations
 	}
 
 	// TODO: the reason that for some annotations we keep empty annotations and we don't for others is not clear.
 	// The keepEmpty parameter is only used here to maintain this unexplained previous behaviour.
 
-	var encodingErr error
 	addStringAnnotation := func(keepEmpty bool, key string, value string) {
 		if len(value) == 0 && !keepEmpty {
 			return
@@ -54,9 +62,26 @@ func AnnotationsForCertificate(certificate *x509.Certificate) (map[string]string
 
 		csvString, err := cmutil.JoinWithEscapeCSV(values)
 		if err != nil {
-			encodingErr = err
 			return
 		}
+
+		// ingress-shim parses these values back out with SplitWithEscapeCSV when
+		// an annotation is copied from a Secret onto an Ingress or Gateway, so an
+		// annotation is only worth publishing if it reads back as what went in. A
+		// value containing a CRLF does not: CSV parsing rewrites it as a line feed,
+		// and CRLF is legal in the UTF8String a CA signs. Drop that one annotation
+		// rather than publish a value the certificate does not say.
+		//
+		// The empty slice is exempt. It joins to "", which SplitWithEscapeCSV
+		// rejects by design, and it is what alt-names, ip-sans and uri-sans carry
+		// on nearly every Secret in existence.
+		if len(values) > 0 {
+			parsed, err := cmutil.SplitWithEscapeCSV(csvString)
+			if err != nil || !slices.Equal(parsed, values) {
+				return
+			}
+		}
+
 		annotations[key] = csvString
 	}
 
@@ -76,11 +101,7 @@ func AnnotationsForCertificate(certificate *x509.Certificate) (map[string]string
 	addCSVEncodedAnnotation(true, cmapi.IPSANAnnotationKey, utilpki.IPAddressesToString(certificate.IPAddresses))
 	addCSVEncodedAnnotation(true, cmapi.URISANAnnotationKey, utilpki.URLsToString(certificate.URIs))
 
-	if encodingErr != nil {
-		return nil, encodingErr
-	}
-
-	return annotations, nil
+	return annotations
 }
 
 // OutputFormatDER returns the byte slice of the private key in DER format. To

--- a/internal/controller/certificates/secrets_test.go
+++ b/internal/controller/certificates/secrets_test.go
@@ -118,6 +118,41 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 				"cert-manager.io/uri-sans":    "",
 			},
 		},
+		"a subject value containing a CRLF costs its own annotation and nothing else": {
+			certificate: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName:   "cert-manager",
+					Organization: []string{"Example\r\nOrganization"},
+					Locality:     []string{"City 1", "City 2"},
+				},
+				DNSNames: []string{"example.com"},
+			},
+			// The organizations annotation is dropped, because SplitWithEscapeCSV
+			// would hand ingress-shim back "Example\nOrganization". Every other
+			// annotation, and the issuance itself, is unaffected.
+			expAnnotations: map[string]string{
+				"cert-manager.io/common-name":        "cert-manager",
+				"cert-manager.io/subject-localities": "City 1,City 2",
+				"cert-manager.io/alt-names":          "example.com",
+				"cert-manager.io/ip-sans":            "",
+				"cert-manager.io/uri-sans":           "",
+			},
+		},
+		"a single empty subject value round-trips as an explicitly quoted empty field": {
+			certificate: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName:   "cert-manager",
+					Organization: []string{""},
+				},
+			},
+			expAnnotations: map[string]string{
+				"cert-manager.io/common-name":           "cert-manager",
+				"cert-manager.io/subject-organizations": `""`,
+				"cert-manager.io/alt-names":             "",
+				"cert-manager.io/ip-sans":               "",
+				"cert-manager.io/uri-sans":              "",
+			},
+		},
 		"if no certificate data, then expect no X.509 related annotations": {
 			certificate:    nil,
 			expAnnotations: map[string]string{},
@@ -126,9 +161,8 @@ func Test_AnnotationsForCertificateSecret(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotAnnotations, err := AnnotationsForCertificate(test.certificate)
+			gotAnnotations := AnnotationsForCertificate(test.certificate)
 			assert.Equal(t, test.expAnnotations, gotAnnotations)
-			assert.Equal(t, nil, err)
 		})
 	}
 }

--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -180,10 +180,7 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 		}
 	}
 
-	certificateDetailsAnnotations, err := certificates.AnnotationsForCertificate(certificate)
-	if err != nil {
-		return err
-	}
+	certificateDetailsAnnotations := certificates.AnnotationsForCertificate(certificate)
 	maps.Copy(secret.Annotations, certificateDetailsAnnotations)
 
 	// Add the certificate name and issuer details to the secret annotations.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,27 +103,22 @@ func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
 }
 
 // JoinWithEscapeCSV returns the given list as a single line of CSV that
-// is escaped with quotes if necessary
+// is escaped with quotes if necessary.
+//
+// A single empty value is written as `""` rather than as the bare empty line
+// encoding/csv would otherwise produce, so that SplitWithEscapeCSV can tell it
+// apart from "no values at all". No other input encodes to exactly `""` (a
+// literal quote character is written as `""""`), so the encoding stays
+// unambiguous to parse back.
+//
+// The empty slice is deliberately exempt from that round trip: it returns "",
+// which SplitWithEscapeCSV rejects with "no values found". Do not widen the
+// quoting rule to cover it. AnnotationsForCertificate writes alt-names,
+// ip-sans and uri-sans with keepEmpty=true, so that branch produces three
+// annotations on nearly every certificate Secret in existence, and changing
+// their value would rewrite every one of them on upgrade.
 func JoinWithEscapeCSV(in []string) (string, error) {
-	for _, v := range in {
-		if strings.Contains(v, "\r\n") {
-			// encoding/csv's reader silently normalises "\r\n" to "\n" inside a
-			// quoted field, so a value containing that sequence cannot round-trip
-			// through SplitWithEscapeCSV without being altered. Reject it here
-			// rather than writing a value that reads back different from what was
-			// given. A carriage return on its own does survive the round trip, so
-			// only the pair is rejected.
-			return "", fmt.Errorf("value %q contains a CRLF sequence, which cannot round-trip through CSV encoding", v)
-		}
-	}
-
 	if len(in) == 1 && in[0] == "" {
-		// encoding/csv writes a single empty field as an empty line, which
-		// SplitWithEscapeCSV cannot distinguish from "no values found" on
-		// read. Force explicit quoting for this one case so it round-trips.
-		// No other input produces exactly `""` as the entire output (a literal
-		// quote character would be encoded as `""""`), so this is unambiguous
-		// to parse back.
 		return `""`, nil
 	}
 
@@ -149,8 +144,23 @@ func JoinWithEscapeCSV(in []string) (string, error) {
 // in each field. For example, a user can specify:
 // "10 Downing Street, Westminster",Manchester
 // to produce []string{"10 Downing Street, Westminster", "Manchester"}, keeping the comma
-// in the first address. Empty lines or multiple CSV records are both rejected.
+// in the first address. Empty lines, multiple CSV records, and input that CSV
+// parsing cannot read back unchanged are all rejected.
 func SplitWithEscapeCSV(in string) ([]string, error) {
+	// encoding/csv's reader alters two inputs instead of failing on them: it
+	// normalizes a "\r\n" inside a quoted field to a bare "\n", and it drops a
+	// carriage return sitting at the very end of the input. Both hand the caller
+	// a value nobody wrote, which matters because this is the parser that reads
+	// user-authored Ingress and Gateway annotations. A carriage return anywhere
+	// else survives the parse unchanged and is left alone.
+	if strings.Contains(in, "\r\n") {
+		return nil, fmt.Errorf("refusing to use %q as input as it contains a CRLF sequence, which CSV parsing would rewrite as a line feed", in)
+	}
+
+	if strings.HasSuffix(in, "\r") {
+		return nil, fmt.Errorf("refusing to use %q as input as it ends in a carriage return, which CSV parsing would drop", in)
+	}
+
 	reader := csv.NewReader(strings.NewReader(in))
 
 	records, err := reader.ReadAll()

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -106,13 +106,14 @@ func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
 // is escaped with quotes if necessary
 func JoinWithEscapeCSV(in []string) (string, error) {
 	for _, v := range in {
-		if strings.ContainsRune(v, '\r') {
-			// encoding/csv's reader silently normalises "\r\n" to "\n" inside
-			// quoted fields, so a value containing a carriage return cannot
-			// round-trip through SplitWithEscapeCSV without being silently
-			// altered. Reject it here rather than writing a value that reads
-			// back different from what was given.
-			return "", fmt.Errorf("value %q contains a carriage return, which cannot round-trip through CSV encoding", v)
+		if strings.Contains(v, "\r\n") {
+			// encoding/csv's reader silently normalises "\r\n" to "\n" inside a
+			// quoted field, so a value containing that sequence cannot round-trip
+			// through SplitWithEscapeCSV without being altered. Reject it here
+			// rather than writing a value that reads back different from what was
+			// given. A carriage return on its own does survive the round trip, so
+			// only the pair is rejected.
+			return "", fmt.Errorf("value %q contains a CRLF sequence, which cannot round-trip through CSV encoding", v)
 		}
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -120,9 +120,10 @@ func JoinWithEscapeCSV(in []string) (string, error) {
 	if len(in) == 1 && in[0] == "" {
 		// encoding/csv writes a single empty field as an empty line, which
 		// SplitWithEscapeCSV cannot distinguish from "no values found" on
-		// read. Force explicit quoting for this one case so it round-trips;
-		// a bare, unquoted empty field is never produced by this function
-		// for any other input, so this is unambiguous to parse back.
+		// read. Force explicit quoting for this one case so it round-trips.
+		// No other input produces exactly `""` as the entire output (a literal
+		// quote character would be encoded as `""""`), so this is unambiguous
+		// to parse back.
 		return `""`, nil
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -105,6 +105,26 @@ func EqualKeyUsagesUnsorted(s1, s2 []cmapi.KeyUsage) bool {
 // JoinWithEscapeCSV returns the given list as a single line of CSV that
 // is escaped with quotes if necessary
 func JoinWithEscapeCSV(in []string) (string, error) {
+	for _, v := range in {
+		if strings.ContainsRune(v, '\r') {
+			// encoding/csv's reader silently normalises "\r\n" to "\n" inside
+			// quoted fields, so a value containing a carriage return cannot
+			// round-trip through SplitWithEscapeCSV without being silently
+			// altered. Reject it here rather than writing a value that reads
+			// back different from what was given.
+			return "", fmt.Errorf("value %q contains a carriage return, which cannot round-trip through CSV encoding", v)
+		}
+	}
+
+	if len(in) == 1 && in[0] == "" {
+		// encoding/csv writes a single empty field as an empty line, which
+		// SplitWithEscapeCSV cannot distinguish from "no values found" on
+		// read. Force explicit quoting for this one case so it round-trips;
+		// a bare, unquoted empty field is never produced by this function
+		// for any other input, so this is unambiguous to parse back.
+		return `""`, nil
+	}
+
 	b := new(bytes.Buffer)
 	writer := csv.NewWriter(b)
 	if err := writer.Write(in); err != nil {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -285,9 +285,34 @@ func TestJoinSplitWithEscapeCSVRoundTrip(t *testing.T) {
 	}
 }
 
-func TestJoinWithEscapeCSVRejectsCRLF(t *testing.T) {
-	_, err := JoinWithEscapeCSV([]string{"line1\r\nline2"})
-	if err == nil {
-		t.Fatal("JoinWithEscapeCSV with a value containing \\r\\n did not return an error, so it would silently corrupt on round trip")
+func TestSplitWithEscapeCSVRejectsInputItCannotReadBackUnchanged(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+	}{
+		{desc: "CRLF inside a quoted field, which the reader would rewrite as a line feed", in: "\"line1\r\nline2\""},
+		{desc: "a carriage return at the end of the input, which the reader would drop", in: "line1\r"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			out, err := SplitWithEscapeCSV(test.in)
+			if err == nil {
+				t.Fatalf("SplitWithEscapeCSV(%q) returned %+v and no error, so it silently altered its input", test.in, out)
+			}
+		})
+	}
+}
+
+func TestSplitWithEscapeCSVKeepsACarriageReturnItCanReadBack(t *testing.T) {
+	const in = "line1\rline2"
+
+	out, err := SplitWithEscapeCSV(in)
+	if err != nil {
+		t.Fatalf("SplitWithEscapeCSV(%q) returned unexpected error: %v", in, err)
+	}
+
+	if want := []string{in}; !slices.Equal(out, want) {
+		t.Errorf("SplitWithEscapeCSV(%q) = %+v, want %+v", in, out, want)
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -263,6 +263,7 @@ func TestJoinSplitWithEscapeCSVRoundTrip(t *testing.T) {
 		{desc: "multiple values", in: []string{"example.com", "other.example.com"}},
 		{desc: "value containing a comma", in: []string{"10 Downing Street, Westminster", "Manchester"}},
 		{desc: "single empty value", in: []string{""}},
+		{desc: "value containing a lone carriage return", in: []string{"line1\rline2"}},
 	}
 
 	for _, test := range tests {
@@ -284,9 +285,9 @@ func TestJoinSplitWithEscapeCSVRoundTrip(t *testing.T) {
 	}
 }
 
-func TestJoinWithEscapeCSVRejectsCarriageReturn(t *testing.T) {
+func TestJoinWithEscapeCSVRejectsCRLF(t *testing.T) {
 	_, err := JoinWithEscapeCSV([]string{"line1\r\nline2"})
 	if err == nil {
-		t.Fatal("JoinWithEscapeCSV with a value containing \\r did not return an error, so it would silently corrupt on round trip")
+		t.Fatal("JoinWithEscapeCSV with a value containing \\r\\n did not return an error, so it would silently corrupt on round trip")
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -253,3 +253,40 @@ func parseIPs(ipStrs []string) []net.IP {
 
 	return ips
 }
+
+func TestJoinSplitWithEscapeCSVRoundTrip(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   []string
+	}{
+		{desc: "single value", in: []string{"example.com"}},
+		{desc: "multiple values", in: []string{"example.com", "other.example.com"}},
+		{desc: "value containing a comma", in: []string{"10 Downing Street, Westminster", "Manchester"}},
+		{desc: "single empty value", in: []string{""}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			joined, err := JoinWithEscapeCSV(test.in)
+			if err != nil {
+				t.Fatalf("JoinWithEscapeCSV(%+v) returned unexpected error: %v", test.in, err)
+			}
+
+			out, err := SplitWithEscapeCSV(joined)
+			if err != nil {
+				t.Fatalf("SplitWithEscapeCSV(%q) (from JoinWithEscapeCSV(%+v)) returned unexpected error: %v", joined, test.in, err)
+			}
+
+			if !slices.Equal(out, test.in) {
+				t.Errorf("round trip of %+v produced %+v (via joined string %q)", test.in, out, joined)
+			}
+		})
+	}
+}
+
+func TestJoinWithEscapeCSVRejectsCarriageReturn(t *testing.T) {
+	_, err := JoinWithEscapeCSV([]string{"line1\r\nline2"})
+	if err == nil {
+		t.Fatal("JoinWithEscapeCSV with a value containing \\r did not return an error, so it would silently corrupt on round trip")
+	}
+}


### PR DESCRIPTION
Fixes #9147.

Reworked after @wallrj's review. The guard is unchanged in intent; it has moved to the layer where it cannot block issuance, and the rejection now sits on the parser rather than the writer.

## The bug

`JoinWithEscapeCSV`/`SplitWithEscapeCSV` are the round trip that stores certificate subject fields as Secret annotations and reads them back for ingress-shim. The round-trip property test on #9149 found two counterexamples:

1. `[""]` (a single empty value) joins to `""` — an empty line — which `SplitWithEscapeCSV` then rejects with `no values found after parsing ""`. `encoding/csv` writing one empty field is indistinguishable from zero records on read.
2. A value containing `"\r\n"` comes back as `"\n"`. `encoding/csv`'s reader normalizes line endings inside a quoted field, so the value changes instead of erroring.

## What changed since the previous revision

The previous revision rejected CRLF inside `JoinWithEscapeCSV`. As the review showed, that turned a previously-dead error path live at two call sites that cannot afford one:

- `AnnotationsForCertificate` runs between signing and the Secret Apply, so a CA-signed certificate carrying a CRLF in a subject field wedged: revision never bumps, Issuing condition never clears, `failedIssuanceAttempts` never increments.
- It runs again as the second link of the post-issuance policy chain, where an error short-circuits the checks that reconcile SecretTemplate metadata, keystores, additional output formats and owner references — and the consumer swallows the violation, so the Certificate stays `Ready=True`.

So the responsibilities are now split:

| Function | Behaviour |
|---|---|
| `JoinWithEscapeCSV` | Total again. Still encodes a single empty value as `""`; documents that the **empty slice is deliberately exempt** from the round trip, so nobody widens it later. |
| `SplitWithEscapeCSV` | Rejects input it cannot read back unchanged. It is the only production parser, and the one fed user-authored Ingress/Gateway annotations. |
| `AnnotationsForCertificate` | Drops the **single** offending annotation instead of discarding all twelve through a sticky error. Derived metadata, not payload. |

`AnnotationsForCertificate` no longer returns an error — there is nothing left for it to fail on, and making that structural is a stronger statement than a comment. It costs one branch each at its two call sites (`setValues`, `certificateDataAnnotationsForSecret`); it is an `internal/` function, so there is no downstream API surface. Happy to restore the `(map, error)` signature if you would rather keep the shape.

### What `SplitWithEscapeCSV` rejects, exactly

Measured against `encoding/csv` directly, only two inputs are read back as something else:

| Input | `encoding/csv` returns | Now |
|---|---|---|
| `"line1\r\nline2"` (quoted CRLF) | `line1\nline2` — rewritten | rejected |
| `line1\r` (trailing CR) | `line1` — dropped | rejected |
| `line1\rline2` (CR elsewhere) | `line1\rline2` — unchanged | accepted, unchanged |
| `"line1\rline2"` (quoted CR) | `line1\rline2` — unchanged | accepted, unchanged |

The title of the previous revision said "reject CR", which was wrong on both counts — a lone `\r` round-trips fine, and the rejection is no longer on the join side at all.

## Known consequence, stated rather than hidden

Encoding a single empty value as `""` changes a documented annotation value. For an existing Secret whose certificate has a single empty subject value, the mismatch check recomputes `""` against the stored empty string and rewrites it once. That converges, but it bumps `resourceVersion` and wakes watchers, so it is in the release note.

The same value has one awkward edge that this PR does not change: `cert-manager.io/alt-names: '""'` copied by hand from a Secret onto an Ingress is no longer treated as empty by [the `altNames != ""` guard in ingress-shim](https://github.com/cert-manager/cert-manager/blob/master/pkg/controller/certificate-shim/helper.go#L73), because that path splits on commas rather than through `SplitWithEscapeCSV`. Reaching it needs a certificate with exactly one, empty, DNS name and a manual copy of the annotation. Happy to add the guard here if you would rather close it in the same PR.

## Testing

New/changed:

- `TestSplitWithEscapeCSVRejectsInputItCannotReadBackUnchanged` — the two lossy shapes above.
- `TestSplitWithEscapeCSVKeepsACarriageReturnItCanReadBack` — pins the narrow rule, so widening the check back to every `\r` fails here.
- `Test_AnnotationsForCertificateSecret` — a subject value containing a CRLF costs its own annotation and nothing else; a single empty subject value stores `""`.
- `TestJoinWithEscapeCSVRejectsCRLF` is gone, since the join side no longer rejects.

`TestJoinSplitWithEscapeCSVRoundTrip` still overlaps the property test on #9149 as you noted; I have left it as the regression for the `[""]` case and am happy to drop it in favour of relaxing that test's `Assume` exclusions once both land.

Revert-checked: with the two guards removed, `TestSplitWithEscapeCSVRejectsInputItCannotReadBackUnchanged` fails on both cases and the CRLF annotation case reports the extra `cert-manager.io/subject-organizations: "\"Example\r\nOrganization\""`. With them in place:

```
go vet ./pkg/util/... ./internal/controller/certificates/... ./pkg/controller/certificates/... ./pkg/controller/certificate-shim/...   # clean
go test ./pkg/util/... ./internal/controller/certificates/... ./pkg/controller/certificates/... ./pkg/controller/certificate-shim/... # all ok
```

## Release Notes

```release-note
`SplitWithEscapeCSV` now rejects input that CSV parsing cannot read back unchanged — a CRLF inside a quoted field, or a trailing carriage return — instead of silently altering the value. A certificate subject value that cannot be encoded no longer fails issuance: only the affected Secret annotation is omitted. A certificate with a single empty subject value now stores that annotation as `""` instead of an empty string, so any existing Secret with one is rewritten once on upgrade.
```
