### PR TITLE
Honor configured Kubernetes API rate limits

### DIFF
--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -20,20 +20,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"path"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	flowcontrolapi "k8s.io/api/flowcontrol/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -44,7 +39,6 @@ import (
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
@@ -293,38 +287,22 @@ func NewContextFactory(ctx context.Context, opts ContextOptions) (*ContextFactor
 	}
 	restConfig = util.RestConfigWithUserAgent(restConfig)
 	log := logf.FromContext(ctx)
-
-	const apfProbeTimeout = 5 * time.Second
-	apfProbeCtx, cancel := context.WithTimeout(ctx, apfProbeTimeout)
-	defer cancel()
-
-	apfEnabled, err := isAPFEnabled(apfProbeCtx, restConfig)
-	if err != nil {
-		log.Error(err, "Failed to determine whether API Priority and Fairness is enabled, falling back to client-side rate limiting")
-		apfEnabled = false
-	}
-
-	if apfEnabled {
-		restConfig.QPS = -1
-		restConfig.Burst = -1
-	} else {
-		restConfig.QPS = opts.KubernetesAPIQPS
-		restConfig.Burst = opts.KubernetesAPIBurst
-		// Construct a single RateLimiter used across all built Context's clients.
-		// Adapted from
-		// https://github.com/kubernetes/client-go/blob/v0.23.3/kubernetes/clientset.go#L431-L435
-		if restConfig.RateLimiter == nil && restConfig.QPS >= 0 {
-			if restConfig.QPS == 0 {
-				restConfig.QPS = rest.DefaultQPS // 5
-			}
-			if restConfig.Burst == 0 {
-				restConfig.Burst = rest.DefaultBurst // 10
-			}
-			if restConfig.Burst <= 0 {
-				return nil, errors.New("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
-			}
-			restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(restConfig.QPS, restConfig.Burst)
+	restConfig.QPS = opts.KubernetesAPIQPS
+	restConfig.Burst = opts.KubernetesAPIBurst
+	// Construct a single RateLimiter used across all built Context's clients.
+	// Adapted from
+	// https://github.com/kubernetes/client-go/blob/v0.23.3/kubernetes/clientset.go#L431-L435
+	if restConfig.RateLimiter == nil && restConfig.QPS >= 0 {
+		if restConfig.QPS == 0 {
+			restConfig.QPS = rest.DefaultQPS // 5
 		}
+		if restConfig.Burst == 0 {
+			restConfig.Burst = rest.DefaultBurst // 10
+		}
+		if restConfig.Burst <= 0 {
+			return nil, errors.New("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+		}
+		restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(restConfig.QPS, restConfig.Burst)
 	}
 
 	clients, err := buildClients(restConfig, opts)
@@ -495,66 +473,4 @@ func buildClients(restConfig *rest.Config, opts ContextOptions) (contextClients,
 	}
 
 	return contextClients{kubeClient, cmClient, gwClient, metadataOnlyClient, gatewayAvailable}, nil
-}
-
-// serverUrl returns the base URL for the cluster based on the supplied config.
-// Host and Version are required. GroupVersion is ignored.
-// Based on `serverURL` from kubernetes-sigs/cli-utils
-func serverURL(config *rest.Config) (*url.URL, error) {
-	// TODO: move the default to secure when the apiserver supports TLS by default
-	// config.Insecure is taken to mean "I want HTTPS but don't bother checking the certs against a CA."
-	hasCA := len(config.CAFile) != 0 || len(config.CAData) != 0
-	hasCert := len(config.CertFile) != 0 || len(config.CertData) != 0
-	defaultTLS := hasCA || hasCert || config.Insecure
-	host := config.Host
-	if host == "" {
-		host = "localhost"
-	}
-
-	hostURL, _, err := rest.DefaultServerURL(host, config.APIPath, schema.GroupVersion{}, defaultTLS)
-	return hostURL, err
-}
-
-// Based on `IsEnabled` from kubernetes-sigs/cli-utils
-func isAPFEnabled(ctx context.Context, config *rest.Config) (bool, error) {
-	tcfg, err := config.TransportConfig()
-	if err != nil {
-		return false, fmt.Errorf("building transport config: %w", err)
-	}
-	rt, err := transport.New(tcfg)
-	if err != nil {
-		return false, fmt.Errorf("building round tripper: %w", err)
-	}
-
-	u, err := serverURL(config)
-	if err != nil {
-		return false, fmt.Errorf("parsing API server host URL: %w", err)
-	}
-
-	u.Path = path.Join(u.Path, "livez/ping")
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
-	if err != nil {
-		return false, fmt.Errorf("building request: %w", err)
-	}
-
-	if config.UserAgent != "" {
-		req.Header.Set("User-Agent", config.UserAgent)
-	}
-
-	resp, err := rt.RoundTrip(req)
-	if err != nil {
-		return false, fmt.Errorf("making %s request: %w", u.Path, err)
-	}
-
-	if resp.Body != nil {
-		resp.Body.Close()
-	}
-
-	// If the flowcontrol header is present, AP&F is enabled.
-	if value := resp.Header.Get(flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID); value != "" {
-		return true, nil
-	}
-
-	return false, nil
 }

--- a/pkg/controller/context_test.go
+++ b/pkg/controller/context_test.go
@@ -17,97 +17,80 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	flowcontrolapi "k8s.io/api/flowcontrol/v1"
-	"k8s.io/client-go/rest"
 )
 
 func Test_NewContextFactory(t *testing.T) {
-	ctxFactory, err := NewContextFactory(t.Context(), ContextOptions{
-		APIServerHost:      "localhost:8443",
-		KubernetesAPIQPS:   10,
-		KubernetesAPIBurst: 10,
-	})
-	assert.NoError(t, err)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set(flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID, "unused-uuid")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
 
-	// Ensure a single RateLimiter is preserved across Contexts.
-	ctx1, err := ctxFactory.Build("test-1")
-	assert.NoError(t, err)
-	ctx2, err := ctxFactory.Build("test-2")
-	assert.NoError(t, err)
-
-	assert.NotNil(t, ctx1.RESTConfig.RateLimiter)
-	assert.Same(t, ctx1.RESTConfig.RateLimiter, ctx2.RESTConfig.RateLimiter)
-}
-
-func Test_isAPFEnabled(t *testing.T) {
-	testCases := []struct {
-		name            string
-		responseHeaders map[string]string
-		statusCode      int
-		expectedEnabled bool
+	testCases := map[string]struct {
+		qps                 float32
+		burst               int
+		expectedQPS         float32
+		expectedBurst       int
+		expectedRateLimiter bool
 	}{
-		{
-			name: "APF header present indicates enabled",
-			responseHeaders: map[string]string{
-				flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID: "unused-uuid",
-			},
-			statusCode:      http.StatusOK,
-			expectedEnabled: true,
+		"configured QPS and burst": {
+			qps:                 10,
+			burst:               20,
+			expectedQPS:         10,
+			expectedBurst:       20,
+			expectedRateLimiter: true,
 		},
-		{
-			name:            "no APF header indicates disabled",
-			statusCode:      http.StatusOK,
-			expectedEnabled: false,
+		"client-go defaults": {
+			qps:                 0,
+			burst:               0,
+			expectedQPS:         5,
+			expectedBurst:       10,
+			expectedRateLimiter: true,
 		},
-		{
-			name: "APF header present with non-200 status still indicates enabled",
-			responseHeaders: map[string]string{
-				flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID: "unused-uuid",
-			},
-			statusCode:      http.StatusInternalServerError,
-			expectedEnabled: true,
-		},
-		{
-			name:            "no APF header with non-200 status indicates disabled",
-			statusCode:      http.StatusNotFound,
-			expectedEnabled: false,
+		"disabled rate limiting": {
+			qps:                 -1,
+			burst:               -1,
+			expectedQPS:         -1,
+			expectedBurst:       -1,
+			expectedRateLimiter: false,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-			defer cancel()
-
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				assert.Equal(t, "/livez/ping", req.URL.Path)
-				assert.Equal(t, http.MethodHead, req.Method)
-				for k, v := range tc.responseHeaders {
-					w.Header().Set(k, v)
-				}
-				w.WriteHeader(tc.statusCode)
-			}))
-			defer server.Close()
-
-			enabled, err := isAPFEnabled(ctx, &rest.Config{Host: server.URL})
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctxFactory, err := NewContextFactory(t.Context(), ContextOptions{
+				APIServerHost:      server.URL,
+				KubernetesAPIQPS:   tc.qps,
+				KubernetesAPIBurst: tc.burst,
+			})
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedEnabled, enabled)
+
+			// Ensure a single RateLimiter is preserved across Contexts.
+			ctx1, err := ctxFactory.Build("test-1")
+			assert.NoError(t, err)
+			ctx2, err := ctxFactory.Build("test-2")
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expectedQPS, ctx1.RESTConfig.QPS)
+			assert.Equal(t, tc.expectedBurst, ctx1.RESTConfig.Burst)
+			if tc.expectedRateLimiter {
+				assert.NotNil(t, ctx1.RESTConfig.RateLimiter)
+				assert.Same(t, ctx1.RESTConfig.RateLimiter, ctx2.RESTConfig.RateLimiter)
+			} else {
+				assert.Nil(t, ctx1.RESTConfig.RateLimiter)
+				assert.Nil(t, ctx2.RESTConfig.RateLimiter)
+			}
 		})
 	}
-}
 
-func Test_isAPFEnabled_invalidHost(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
-	enabled, err := isAPFEnabled(ctx, &rest.Config{Host: "://invalid"})
-	assert.Error(t, err)
-	assert.False(t, enabled)
+	assert.Zero(t, requests.Load())
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9158.

#8757 automatically disabled client-side Kubernetes API rate limiting when API Priority and Fairness (APF) was detected. APF limits concurrent work through seats, queues, and rejection, but does not impose a requests-per-second ceiling. The automatic override also ignored `kubernetesAPIQPS` and `kubernetesAPIBurst` values selected by operators.

This change removes the APF-specific override and startup probe, and always constructs the shared client-side rate limiter from the existing configuration. Existing behavior for positive values, zero values that select client-go defaults, and QPS `-1` as an explicit opt-out is preserved.

### Kind

/kind bug

### Release Note

```release-note
The controller now honors configured Kubernetes API QPS and burst limits when API Priority and Fairness is enabled. Set `kubernetesAPIQPS` to `-1` to disable client-side rate limiting.
```