### PR TITLE
shim: validate annotation values in translateAnnotations

### DIFF
--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -186,7 +186,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 	}
 
 	if duration, found := ingLikeAnnotations[cmapi.DurationAnnotationKey]; found {
-		d, err := time.ParseDuration(duration)
+		duration, err := time.ParseDuration(duration)
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/mail"
 	"reflect"
 	"strconv"
 	"strings"
@@ -67,6 +69,9 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 	}
 
 	if commonName, found := ingLikeAnnotations[cmapi.CommonNameAnnotationKey]; found {
+		if len(commonName) > 64 {
+			return fmt.Errorf("%w %q: common name may not be more than 64 bytes", errInvalidIngressAnnotation, cmapi.CommonNameAnnotationKey)
+		}
 		crt.Spec.CommonName = commonName
 	}
 
@@ -77,11 +82,22 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 
 	if ipSANs, found := ingLikeAnnotations[cmapi.IPSANAnnotationKey]; found && ipSANs != "" {
 		ipAddresses := strings.Split(ipSANs, ",")
+		for _, ipStr := range ipAddresses {
+			if net.ParseIP(strings.TrimSpace(ipStr)) == nil {
+				return fmt.Errorf("%w %q: %q is not a valid IP address", errInvalidIngressAnnotation, cmapi.IPSANAnnotationKey, ipStr)
+			}
+		}
 		crt.Spec.IPAddresses = append(crt.Spec.IPAddresses, ipAddresses...)
 	}
 
 	if emailAddresses, found := ingLikeAnnotations[cmapi.EmailsAnnotationKey]; found {
-		crt.Spec.EmailAddresses = strings.Split(emailAddresses, ",")
+		emails := strings.Split(emailAddresses, ",")
+		for _, email := range emails {
+			if _, err := mail.ParseAddress(strings.TrimSpace(email)); err != nil {
+				return fmt.Errorf("%w %q: %q is not a valid email address", errInvalidIngressAnnotation, cmapi.EmailsAnnotationKey, email)
+			}
+		}
+		crt.Spec.EmailAddresses = emails
 	}
 
 	subject := &cmapi.X509Subject{}
@@ -158,17 +174,23 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 	}
 
 	if duration, found := ingLikeAnnotations[cmapi.DurationAnnotationKey]; found {
-		duration, err := time.ParseDuration(duration)
+		d, err := time.ParseDuration(duration)
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}
-		crt.Spec.Duration = &metav1.Duration{Duration: duration}
+		if d < time.Hour {
+			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, time.Hour)
+		}
+		crt.Spec.Duration = &metav1.Duration{Duration: d}
 	}
 
 	if renewBefore, found := ingLikeAnnotations[cmapi.RenewBeforeAnnotationKey]; found {
 		duration, err := time.ParseDuration(renewBefore)
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, err)
+		}
+		if duration < 5*time.Minute {
+			return fmt.Errorf("%w %q: renewBefore must be greater than %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, 5*time.Minute)
 		}
 		crt.Spec.RenewBefore = &metav1.Duration{Duration: duration}
 	}

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -82,22 +82,28 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 
 	if ipSANs, found := ingLikeAnnotations[cmapi.IPSANAnnotationKey]; found && ipSANs != "" {
 		ipAddresses := strings.Split(ipSANs, ",")
+		trimmedIPs := make([]string, 0, len(ipAddresses))
 		for _, ipStr := range ipAddresses {
-			if net.ParseIP(strings.TrimSpace(ipStr)) == nil {
+			ipStr = strings.TrimSpace(ipStr)
+			if net.ParseIP(ipStr) == nil {
 				return fmt.Errorf("%w %q: %q is not a valid IP address", errInvalidIngressAnnotation, cmapi.IPSANAnnotationKey, ipStr)
 			}
+			trimmedIPs = append(trimmedIPs, ipStr)
 		}
-		crt.Spec.IPAddresses = append(crt.Spec.IPAddresses, ipAddresses...)
+		crt.Spec.IPAddresses = append(crt.Spec.IPAddresses, trimmedIPs...)
 	}
 
 	if emailAddresses, found := ingLikeAnnotations[cmapi.EmailsAnnotationKey]; found {
 		emails := strings.Split(emailAddresses, ",")
+		trimmedEmails := make([]string, 0, len(emails))
 		for _, email := range emails {
-			if _, err := mail.ParseAddress(strings.TrimSpace(email)); err != nil {
+			email = strings.TrimSpace(email)
+			if _, err := mail.ParseAddress(email); err != nil {
 				return fmt.Errorf("%w %q: %q is not a valid email address", errInvalidIngressAnnotation, cmapi.EmailsAnnotationKey, email)
 			}
+			trimmedEmails = append(trimmedEmails, email)
 		}
-		crt.Spec.EmailAddresses = emails
+		crt.Spec.EmailAddresses = trimmedEmails
 	}
 
 	subject := &cmapi.X509Subject{}
@@ -178,7 +184,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}
-		if d < time.Hour {
+		if d <= time.Hour {
 			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, time.Hour)
 		}
 		crt.Spec.Duration = &metav1.Duration{Duration: d}
@@ -189,7 +195,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, err)
 		}
-		if duration < 5*time.Minute {
+		if duration <= 5*time.Minute {
 			return fmt.Errorf("%w %q: renewBefore must be greater than %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, 5*time.Minute)
 		}
 		crt.Spec.RenewBefore = &metav1.Duration{Duration: duration}

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -190,10 +190,10 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}
-		if d < cmapi.MinimumCertificateDuration {
+		if duration < cmapi.MinimumCertificateDuration {
 			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, cmapi.MinimumCertificateDuration)
 		}
-		crt.Spec.Duration = &metav1.Duration{Duration: d}
+		crt.Spec.Duration = &metav1.Duration{Duration: duration}
 	}
 
 	if renewBefore, found := ingLikeAnnotations[cmapi.RenewBeforeAnnotationKey]; found {

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -191,7 +191,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}
 		if duration < cmapi.MinimumCertificateDuration {
-			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, cmapi.MinimumCertificateDuration)
+			return fmt.Errorf("%w %q: duration must be greater than or equal to %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, cmapi.MinimumCertificateDuration)
 		}
 		crt.Spec.Duration = &metav1.Duration{Duration: duration}
 	}

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -202,7 +202,7 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, err)
 		}
 		if duration < cmapi.MinimumRenewBefore {
-			return fmt.Errorf("%w %q: renewBefore must be greater than %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, cmapi.MinimumRenewBefore)
+			return fmt.Errorf("%w %q: renewBefore must be greater than or equal to %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, cmapi.MinimumRenewBefore)
 		}
 		crt.Spec.RenewBefore = &metav1.Duration{Duration: duration}
 	}

--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -93,13 +93,19 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		crt.Spec.IPAddresses = append(crt.Spec.IPAddresses, trimmedIPs...)
 	}
 
-	if emailAddresses, found := ingLikeAnnotations[cmapi.EmailsAnnotationKey]; found {
+	if emailAddresses, found := ingLikeAnnotations[cmapi.EmailsAnnotationKey]; found && emailAddresses != "" {
 		emails := strings.Split(emailAddresses, ",")
 		trimmedEmails := make([]string, 0, len(emails))
 		for _, email := range emails {
 			email = strings.TrimSpace(email)
-			if _, err := mail.ParseAddress(email); err != nil {
+			e, err := mail.ParseAddress(email)
+			if err != nil {
 				return fmt.Errorf("%w %q: %q is not a valid email address", errInvalidIngressAnnotation, cmapi.EmailsAnnotationKey, email)
+			}
+			// Mirror the cert-manager webhook: reject display-name forms
+			// (e.g. "Name <a@b.com>") so the stored value is exactly the address.
+			if e.Address != email {
+				return fmt.Errorf("%w %q: %q must only contain the email address itself", errInvalidIngressAnnotation, cmapi.EmailsAnnotationKey, email)
 			}
 			trimmedEmails = append(trimmedEmails, email)
 		}
@@ -184,8 +190,8 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
 		}
-		if d <= time.Hour {
-			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, time.Hour)
+		if d < cmapi.MinimumCertificateDuration {
+			return fmt.Errorf("%w %q: duration must be greater than %s", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, cmapi.MinimumCertificateDuration)
 		}
 		crt.Spec.Duration = &metav1.Duration{Duration: d}
 	}
@@ -195,8 +201,8 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 		if err != nil {
 			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, err)
 		}
-		if duration <= 5*time.Minute {
-			return fmt.Errorf("%w %q: renewBefore must be greater than %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, 5*time.Minute)
+		if duration < cmapi.MinimumRenewBefore {
+			return fmt.Errorf("%w %q: renewBefore must be greater than %s", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, cmapi.MinimumRenewBefore)
 		}
 		crt.Spec.RenewBefore = &metav1.Duration{Duration: duration}
 	}

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -365,6 +365,14 @@ func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
 			annotations:   map[string]string{cmapi.CommonNameAnnotationKey: strings.Repeat("a", 65)},
 			expectedError: errInvalidIngressAnnotation,
 		},
+		"duration exactly one hour rejected": {
+			annotations:   map[string]string{cmapi.DurationAnnotationKey: "1h"},
+			expectedError: errInvalidIngressAnnotation,
+		},
+		"renew-before exactly five minutes rejected": {
+			annotations:   map[string]string{cmapi.RenewBeforeAnnotationKey: "5m"},
+			expectedError: errInvalidIngressAnnotation,
+		},
 	}
 
 	for name, tc := range tests {
@@ -373,5 +381,23 @@ func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
 			err := translateAnnotations(crt, tc.annotations)
 			assertErrorIs(t, err, tc.expectedError)
 		})
+	}
+}
+
+// Test_translateAnnotations_validAnnotationValuesWithWhitespace ensures that,
+// when a valid annotation value contains surrounding whitespace, the shim
+// trims it before storing so the resulting Certificate passes admission
+// validation (regression for cert-manager/cert-manager#9145).
+func Test_translateAnnotations_validAnnotationValuesWithWhitespace(t *testing.T) {
+	crt := gen.Certificate("example-cert")
+	annotations := map[string]string{
+		cmapi.IPSANAnnotationKey:    "1.2.3.4, 5.6.7.8",
+		cmapi.EmailsAnnotationKey:   "test@example.com, admin@example.com",
+		cmapi.DurationAnnotationKey: "2160h",
+	}
+	err := translateAnnotations(crt, annotations)
+	if assert.NoError(t, err) {
+		assert.Equal(t, []string{"1.2.3.4", "5.6.7.8"}, crt.Spec.IPAddresses)
+		assert.Equal(t, []string{"test@example.com", "admin@example.com"}, crt.Spec.EmailAddresses)
 	}
 }

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -18,6 +18,7 @@ package shimhelper
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -330,5 +331,47 @@ func Test_translateAnnotations(t *testing.T) {
 func assertErrorIs(t *testing.T, err, target error) {
 	if assert.Error(t, err) {
 		assert.Truef(t, errors.Is(err, target), "unexpected error type. err: %v, target: %v", err, target)
+	}
+}
+
+// Test_translateAnnotations_invalidAnnotationValues is a regression test for
+// cert-manager/cert-manager#9145: translateAnnotations copied several annotation
+// values into the Certificate spec without validating them, so admission
+// validation rejected the resulting Certificate and the Ingress author got no
+// certificate and only an opaque controller error. The shim must reject these
+// at sync time with errInvalidIngressAnnotation, naming the offending annotation.
+func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
+	tests := map[string]struct {
+		annotations   map[string]string
+		expectedError error
+	}{
+		"ip-sans not an IP": {
+			annotations:   map[string]string{cmapi.IPSANAnnotationKey: "2160h"},
+			expectedError: errInvalidIngressAnnotation,
+		},
+		"email-sans not an email": {
+			annotations:   map[string]string{cmapi.EmailsAnnotationKey: "2160h"},
+			expectedError: errInvalidIngressAnnotation,
+		},
+		"duration too small": {
+			annotations:   map[string]string{cmapi.DurationAnnotationKey: "-5s"},
+			expectedError: errInvalidIngressAnnotation,
+		},
+		"renew-before too small": {
+			annotations:   map[string]string{cmapi.RenewBeforeAnnotationKey: "-5s"},
+			expectedError: errInvalidIngressAnnotation,
+		},
+		"common-name too long": {
+			annotations:   map[string]string{cmapi.CommonNameAnnotationKey: strings.Repeat("a", 65)},
+			expectedError: errInvalidIngressAnnotation,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			crt := gen.Certificate("example-cert")
+			err := translateAnnotations(crt, tc.annotations)
+			assertErrorIs(t, err, tc.expectedError)
+		})
 	}
 }

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -353,6 +353,10 @@ func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
 			annotations:   map[string]string{cmapi.EmailsAnnotationKey: "2160h"},
 			expectedError: errInvalidIngressAnnotation,
 		},
+		"email-sans display-name form rejected": {
+			annotations:   map[string]string{cmapi.EmailsAnnotationKey: "Name <test@example.com>"},
+			expectedError: errInvalidIngressAnnotation,
+		},
 		"duration too small": {
 			annotations:   map[string]string{cmapi.DurationAnnotationKey: "-5s"},
 			expectedError: errInvalidIngressAnnotation,
@@ -363,14 +367,6 @@ func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
 		},
 		"common-name too long": {
 			annotations:   map[string]string{cmapi.CommonNameAnnotationKey: strings.Repeat("a", 65)},
-			expectedError: errInvalidIngressAnnotation,
-		},
-		"duration exactly one hour rejected": {
-			annotations:   map[string]string{cmapi.DurationAnnotationKey: "1h"},
-			expectedError: errInvalidIngressAnnotation,
-		},
-		"renew-before exactly five minutes rejected": {
-			annotations:   map[string]string{cmapi.RenewBeforeAnnotationKey: "5m"},
 			expectedError: errInvalidIngressAnnotation,
 		},
 	}
@@ -391,9 +387,10 @@ func Test_translateAnnotations_invalidAnnotationValues(t *testing.T) {
 func Test_translateAnnotations_validAnnotationValuesWithWhitespace(t *testing.T) {
 	crt := gen.Certificate("example-cert")
 	annotations := map[string]string{
-		cmapi.IPSANAnnotationKey:    "1.2.3.4, 5.6.7.8",
-		cmapi.EmailsAnnotationKey:   "test@example.com, admin@example.com",
-		cmapi.DurationAnnotationKey: "2160h",
+		cmapi.IPSANAnnotationKey:       "1.2.3.4, 5.6.7.8",
+		cmapi.EmailsAnnotationKey:      "test@example.com, admin@example.com",
+		cmapi.DurationAnnotationKey:    "2160h",
+		cmapi.RenewBeforeAnnotationKey: "5m",
 	}
 	err := translateAnnotations(crt, annotations)
 	if assert.NoError(t, err) {


### PR DESCRIPTION
### Pull Request Motivation

Fixes cert-manager/cert-manager#9145.

`translateAnnotations` in the ingress/certificate-shim copied several annotation values into the Certificate spec without validating them. Admission validation then rejected the resulting Certificate, so the Ingress author got no certificate and only an opaque controller error.

This change validates the five problematic annotation values at sync time and returns `errInvalidIngressAnnotation` (as already done for the escaped-CSV subject annotations), so the failure is reported on the Ingress with a message naming the offending annotation:

- `cert-manager.io/ip-sans`: each entry must parse as an IP (whitespace-trimmed before storing)
- `cert-manager.io/email-sans`: each entry must parse as an email (whitespace-trimmed before storing)
- `cert-manager.io/duration`: must be greater than or equal to 1h (rejects < 1h)
- `cert-manager.io/renew-before`: must be greater than or equal to 5m (rejects < 5m)
- `cert-manager.io/common-name`: must be <= 64 bytes

### Kind

/kind bug

### Release Note

```release-note
NONE
```