### PR TITLE
Lower Cloudflare DNS01 challenge record TTL from 120 to 60 seconds

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -176,7 +176,7 @@ func (c *DNSProvider) Present(ctx context.Context, domain, fqdn, value string) e
 			Type:    "TXT",
 			Name:    util.UnFqdn(fqdn),
 			Content: value,
-			TTL:     120,
+			TTL:     60,
 		}
 
 		body, err := json.Marshal(rec)


### PR DESCRIPTION
Fixes #6662.

The issue asked for a configurable TTL on Cloudflare DNS01 challenge records, and #9047 (thanks @AkashKumar7902) implemented that as a new v1 API field. But the issue author [confirmed](https://github.com/cert-manager/cert-manager/pull/9047#issuecomment-5261629345) that the real requirement is simply a *lower* TTL — "basically the lower the ttl is, the better" — with configurability only a nice-to-have.

60 seconds is the lowest TTL Cloudflare accepts on all plans — ["you can choose a TTL between 30 seconds (Enterprise) or 60 seconds (non-Enterprise) and 1 day"](https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/) — so this one-line change gives every user the fastest cache expiry without adding permanent API surface. It also matches the TTL our other providers use: [clouddns](https://github.com/cert-manager/cert-manager/blob/578dc721040cc3de35df9fb1dd12d950ef7eff4f/pkg/issuer/acme/dns/clouddns/clouddns.go#L171), [azuredns](https://github.com/cert-manager/cert-manager/blob/578dc721040cc3de35df9fb1dd12d950ef7eff4f/pkg/issuer/acme/dns/azuredns/azuredns.go#L311) and [digitalocean](https://github.com/cert-manager/cert-manager/blob/578dc721040cc3de35df9fb1dd12d950ef7eff4f/pkg/issuer/acme/dns/digitalocean/digitalocean.go#L134) all use 60.

If a concrete need for per-issuer TTL configurability turns up later, it should be a provider-generic field on the `dns01` solver rather than Cloudflare-only.

/kind cleanup

```release-note
The TTL of Cloudflare DNS01 challenge records is lowered from 120 seconds to 60 seconds — the minimum Cloudflare allows — so that stale challenge records expire from caching resolvers sooner.
```

*with claude fable-5*
