### PR TITLE
Add design: client-side rate limiting and API Priority and Fairness

### DIFF
--- a/design/20260816.client-side-rate-limiting.md
+++ b/design/20260816.client-side-rate-limiting.md
@@ -1,0 +1,345 @@
+# Client-side rate limiting and API Priority and Fairness
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Supported Versions](#supported-versions)
+- [Production Readiness](#production-readiness)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [ ] design doc discussed and approved
+- [ ] Test plan agreed upon and tests implemented
+- [ ] Feature gate status agreed upon (whether new functionality is placed behind a feature gate or not)
+- [ ] Graduation criteria in place if required
+- [ ] User-facing documentation has been PR-ed against the release branch in [cert-manager/website][]
+
+[cert-manager/website]: https://github.com/cert-manager/website
+
+## Summary
+
+All cert-manager components will rely on [API Priority and Fairness][apf] (AP&F)
+by default, when the API server has it enabled, and will fall back to safe
+client-side rate limits when it does not. Platform administrators who
+deliberately want to cap cert-manager's request rate will be able to set hard
+client-side limits on every component, and those limits will be honored — but
+the clients used for leader election and for event recording will never share
+the rate limiter with the reconcilers, so a hard limit cannot cause missed
+leader election lease renewals or lost reconcile throughput due to event
+storms.
+
+[apf]: https://kubernetes.io/docs/concepts/cluster-administration/flow-control/
+
+## Motivation
+
+The Kubernetes API server has protected itself with AP&F since Kubernetes 1.20
+(GA in 1.29). AP&F limits *concurrency* (in-flight requests), queues the
+excess fairly across clients, and rejects with HTTP 429 only when queues
+overflow. On such clusters, `client-go`'s client-side token-bucket rate
+limiter protects nothing and only slows clients down; SIG API Machinery
+recommends disabling it, and [controller-runtime has done so unconditionally
+since v0.21][cr-3119]. [Flux][flux-269] and [Config Sync][config-sync] disable
+it when they detect AP&F.
+
+cert-manager followed in v1.21.0 ([#8757][], fixing [#6890][]): the controller
+probes the API server for the AP&F response header at startup and, when found,
+disables client-side rate limiting. That shipped with a bug ([#9158][]):
+explicitly configured `kubernetesAPIQPS`/`kubernetesAPIBurst` are also
+ignored, so an administrator can no longer cap the request rate at all.
+[#9159][] proposes fixing the bug by reverting #8757 entirely, which would
+reintroduce the throughput regression for every AP&F-enabled cluster (in
+practice, all of them) and contradict both the ecosystem direction and
+cert-manager's own cainjector, which has run without client-side rate limiting
+since cert-manager v1.19.0 via [controller-runtime's
+`GetConfigOrDie`][cr-getconfig].
+
+Two pre-existing defects make hard limits more dangerous than they should be:
+
+- The single token bucket is shared, via the `RateLimiter` pointer copied by
+  `rest.CopyConfig`, with the client that renews the leader election lease.
+  Under sustained throttling, lease renewal competes with ~30 reconcilers for
+  tokens and can miss `RenewDeadline`, crash-looping the controller.
+- The event broadcaster records events through the same rate-limited client,
+  so a burst of events consumes the reconcile budget and vice versa. (The
+  kubelet separates these budgets with `--event-qps`/`--event-burst` for the
+  same reason.)
+
+[cr-3119]: https://github.com/kubernetes-sigs/controller-runtime/pull/3119
+[cr-getconfig]: https://github.com/kubernetes-sigs/controller-runtime/blob/v0.24.1/pkg/client/config/config.go#L101-L105
+[flux-269]: https://github.com/fluxcd/pkg/issues/269
+[config-sync]: https://github.com/GoogleContainerTools/kpt-config-sync/blob/2f68032d50c9/pkg/client/restconfig/restconfig.go#L121-L140
+[#6890]: https://github.com/cert-manager/cert-manager/issues/6890
+[#8757]: https://github.com/cert-manager/cert-manager/pull/8757
+[#9158]: https://github.com/cert-manager/cert-manager/issues/9158
+[#9159]: https://github.com/cert-manager/cert-manager/pull/9159
+
+### Goals
+
+- All components (controller, webhook, cainjector) use AP&F by default when
+  the API server has it enabled: no client-side rate limiting, no
+  configuration required.
+- When AP&F is not enabled (or cannot be detected), components fall back to
+  conservative client-side rate limits which do not compromise leader
+  election.
+- Explicitly configured `kubernetesAPIQPS`/`kubernetesAPIBurst` are always
+  honored, including on AP&F-enabled clusters (fixes [#9158][]).
+- Hard limits cannot break leader election or starve reconcilers via event
+  recording: those clients get their own budgets.
+- No breaking changes for existing configurations; the behavior changes that
+  are inherent to the bug fix are clearly called out in release notes.
+- Administrators can observe client-side throttling through metrics, not just
+  log messages.
+
+### Non-Goals
+
+- Changing sibling projects (istio-csr, trust-manager, csi-driver,
+  approver-policy). They are controller-runtime based and already default to
+  no client-side rate limiting; the config API proposed here should be
+  copyable to them later.
+- Rate limiting for startupapicheck (a one-shot job) or the ACME HTTP-01
+  solver (which does not talk to the Kubernetes API).
+- Shipping FlowSchema/PriorityLevelConfiguration resources in the Helm chart
+  to give cert-manager a dedicated AP&F priority level. Possible future work.
+- Rate limiting of requests to external services (ACME servers, DNS APIs,
+  Venafi, Vault); those have their own mechanisms.
+
+## Proposal
+
+1. Make `kubernetesAPIQPS` and `kubernetesAPIBurst` **optional** (pointer)
+   fields in the component configuration APIs, and stop writing the defaults
+   (20/50) into them during defaulting. This makes "the administrator set a
+   value" distinguishable from "the value was defaulted" — the root cause of
+   [#9158][] — without changing any configuration file semantics:
+
+   | Configuration | AP&F enabled | AP&F disabled / probe failed |
+   |---|---|---|
+   | unset (Auto) | no client-side rate limiting | 20 QPS / 50 burst |
+   | explicit values | honored | honored |
+   | explicit `-1` | no client-side rate limiting | no client-side rate limiting |
+
+   The "unset" row reproduces the released v1.21 behavior exactly, so
+   upgrades are invisible for everyone who has not set these options.
+
+2. Keep the AP&F startup probe (`HEAD /livez/ping`, checking for the
+   `X-Kubernetes-Pf-Flowschema-Uid` response header, 5 second timeout), but
+   only consult it when the options are unset. Probe failure logs a warning
+   and falls back to 20/50.
+
+3. Give the **leader election client its own rate limiter budget**,
+   unconditionally. The leader election `rest.Config` gets a private, generous
+   token bucket (or none), never the shared reconciler bucket. Lease renewal
+   is a handful of requests per period; exempting it does not meaningfully
+   weaken a deliberate cap.
+
+4. Give the **event recording sink its own budget** as well, so that event
+   storms and reconcile traffic cannot starve each other. `client-go`'s event
+   correlator already deduplicates and caps event spam.
+
+5. Add the same optional `kubernetesAPIQPS`/`kubernetesAPIBurst` fields to
+   `WebhookConfiguration` and `CAInjectorConfiguration` (purely additive; they
+   have no such options today) and route all three components through one
+   shared resolution helper, so the table above holds everywhere.
+
+6. Tighten validation: accept exactly `-1` or values ≥ 1 (and burst ≥ QPS);
+   reject `0` (which client-go silently treats as 5 QPS) and fractional
+   negatives such as `-0.5` (which today silently disable rate limiting).
+
+7. Ensure `client-go`'s rate limiter latency metric
+   (`rest_client_rate_limiter_duration_seconds`) is registered and exposed by
+   every component, and log a startup warning when a configured QPS is
+   suspiciously low (for example, below 5).
+
+### User Stories
+
+#### Story 1: Large-scale deployment, defaults untouched
+
+An administrator runs cert-manager with tens of thousands of Certificates on
+a current Kubernetes cluster. They configure nothing. cert-manager detects
+AP&F and re-syncs at whatever concurrency the API server can fairly grant;
+mass re-syncs complete in minutes rather than hours.
+
+#### Story 2: Metered control plane
+
+An administrator runs cert-manager against a managed control plane which
+bills per API request. They set `kubernetesAPIQPS: 20` and
+`kubernetesAPIBurst: 50` on all three components. The caps are honored even
+though AP&F is enabled. Leader election and event recording are unaffected,
+so the controller does not crash-loop under load.
+
+#### Story 3: AP&F disabled
+
+An administrator has disabled AP&F
+(`kube-apiserver --enable-priority-and-fairness=false`). cert-manager's probe
+finds no AP&F header and applies the conservative 20/50 defaults, protecting
+the unshielded API server, while leader election remains exempt.
+
+### Notes/Constraints/Caveats
+
+- The probe detects "AP&F enabled on the API server instance that answered",
+  not "supported". Behind a load balancer fronting mixed API server
+  configurations the result may vary per connection; this is unchanged from
+  v1.21 and acceptable because mixed configurations are transient.
+- The probe result is a snapshot at component startup. AP&F cannot be toggled
+  without restarting the API server, and cert-manager components restart
+  cheaply, so no re-probing is proposed.
+- The versioned configuration API change (scalar → pointer fields in
+  `v1alpha1` Go structs) is source-compatible for YAML/JSON users but
+  source-*incompatible* for Go programs importing
+  `pkg/apis/config/*/v1alpha1`. These packages exist primarily for
+  cert-manager's own binaries; the break will be release-noted.
+- CLI flag equivalents must distinguish set from unset via
+  `pflag.FlagSet.Changed`, not by comparing against the default value.
+
+### Risks and Mitigations
+
+- **Removing all client-side limits could overwhelm marginal API servers.**
+  Mitigation: this has been the shipped default for the whole v1.21 line and
+  for cainjector since v1.19.0, with no reports of API server overload; AP&F
+  queues and sheds excess load by design.
+- **Validation tightening rejects previously accepted nonsense values**
+  (`0`, `-0.5`). Anyone relying on them was getting behavior they almost
+  certainly did not intend (5 QPS and unlimited, respectively). Called out
+  in the release notes with the exact replacement values.
+- **Exempting leader election weakens a deliberate cap.** The exemption is a
+  few requests per `RetryPeriod`; an administrator capping cert-manager at
+  20 QPS for billing reasons will not notice single-digit extra requests, and
+  the alternative is a controller that can crash-loop by design.
+
+## Design Details
+
+- `internal/apis/config/{controller,webhook,cainjector}/v1alpha1`:
+  `KubernetesAPIQPS *float32`, `KubernetesAPIBurst *int32`; defaulting no
+  longer populates them. The internal (hub) types keep resolved scalar fields;
+  resolution happens in one new helper, e.g.
+  `internal/controller/clientset.RateLimitsFor(cfg, probeResult)`, returning
+  the effective QPS/burst (or "unlimited") per the table above.
+- `pkg/controller/context.go` `NewContextFactory`:
+  - resolve rate limits via the helper;
+  - construct the shared reconciler `RateLimiter` only when a limit applies;
+  - build the leader election config by `rest.CopyConfig` **followed by**
+    replacing `RateLimiter` with a private limiter (today the pointer copy is
+    what leaks the shared bucket);
+  - construct the event broadcaster sink from a config with its own limiter.
+- cainjector currently takes its config from controller-runtime's
+  `GetConfigOrDie` (unconditional `-1`). It moves to the shared helper: unset
+  still means unlimited on AP&F clusters; on non-AP&F clusters cainjector
+  gains the 20/50 fallback it never had. This is a behavior change only for
+  the rare AP&F-disabled cluster, and makes all components consistent.
+- Validation per component:
+  `(qps == -1 && burst == -1) || (qps >= 1 && burst >= qps)`; both must be
+  set together (setting only one is an error, replacing today's silent
+  client-go defaults).
+- Helm chart: document the options in the three components' `config` blocks
+  in `values.yaml`; no new chart values needed.
+
+### Test Plan
+
+- Unit tests for the resolution helper: full matrix of
+  {unset, explicit, -1} × {AP&F detected, not detected, probe error}.
+- Unit tests for validation (rejecting 0, fractional negatives, half-set
+  pairs).
+- Existing `pkg/controller/context_test.go` probe tests extended: explicit
+  values honored despite the AP&F header; leader election client's limiter is
+  not the reconciler limiter (compare pointers).
+- Integration test: with a hard 1 QPS limit and induced reconcile load,
+  leader election lease renewal still succeeds.
+- E2E (make e2e against kind with
+  `--enable-priority-and-fairness=false`): components start, log the
+  fallback, and apply 20/50.
+
+### Graduation Criteria
+
+No feature gate. The unset behavior is identical to released v1.21 behavior;
+the changed behaviors are bug fixes (explicit values honored, leader election
+exempted). A feature gate would force users to opt in to a bug fix.
+
+### Upgrade / Downgrade Strategy
+
+- Upgrade with options unset: no observable change.
+- Upgrade with options explicitly set (currently ignored under AP&F): the
+  values take effect — this is the fix for [#9158][] and gets an
+  `action required` release note telling administrators to remove the options
+  if they had set them expecting them to be ignored.
+- Downgrade to v1.21: explicit values are ignored again under AP&F; `-1`
+  in config is accepted by v1.21 validation (`>= -1`), so configs written for
+  this design remain loadable.
+
+### Supported Versions
+
+All Kubernetes versions supported by cert-manager (≥ 1.33 as of v1.21) have
+AP&F GA. The fallback path exists only for clusters where an administrator
+has explicitly disabled AP&F.
+
+## Production Readiness
+
+### How can this feature be enabled / disabled for an existing cert-manager installation?
+
+There is no toggle. Administrators control behavior through
+`kubernetesAPIQPS`/`kubernetesAPIBurst`: unset (Auto), explicit caps, or `-1`
+(unlimited). Setting explicit values reproduces pre-v1.21 behavior exactly.
+
+### Does this feature depend on any specific services running in the cluster?
+
+No. The AP&F probe is a single `HEAD /livez/ping` request to the API server
+at startup, per component, with a 5 second timeout and a safe fallback.
+
+### Will enabling / using this feature result in new API calls?
+
+One `HEAD` request per component start (webhook and cainjector gain the probe
+the controller already performs). Removing client-side limits does not
+increase the number of requests cert-manager makes, only the rate at which
+queued work drains; AP&F governs the server-side impact.
+
+### Will enabling / using this feature result in increasing size or count of existing API objects?
+
+No.
+
+### Will enabling / using this feature result in significant increase of resource usage?
+
+No. Faster re-syncs shift the same work earlier; memory and CPU envelopes are
+unchanged.
+
+## Drawbacks
+
+- Three configuration APIs change instead of one, and the pointer fields make
+  the Go API slightly less convenient for cert-manager's own code.
+- Keeping the probe keeps its failure modes (startup network dependency,
+  load balancer skew) for the benefit of the rare AP&F-disabled cluster.
+  The simpler controller-runtime approach was rejected below, but reasonable
+  people may weigh this differently.
+
+## Alternatives
+
+- **Revert #8757 entirely ([#9159][]).** Fixes the explicit-config bug but
+  reinstates the throughput regression for effectively every cluster,
+  contradicts SIG API Machinery guidance and the ecosystem
+  (controller-runtime, Flux, Config Sync), and leaves cainjector and the
+  controller with opposite defaults.
+- **Drop the probe and default to unlimited unconditionally**
+  (controller-runtime's approach). Simpler, and consistent with what
+  cainjector does today. Rejected because cert-manager explicitly supports
+  operators who run hardened or unusual control planes; a probe with a safe
+  fallback costs one HEAD request.
+- **A mode enum** (`rateLimiting: Auto | Unlimited | Limited` plus QPS/burst).
+  More self-describing than pointer-fields-plus-`-1`, but a larger API surface
+  and a second way to express what unset/`-1` already express. Can be layered
+  on later if users find the sentinel confusing.
+- **Ship a dedicated FlowSchema for cert-manager** so administrators can cap
+  cert-manager server-side via AP&F itself. Attractive, but AP&F caps
+  concurrency rather than request rate, so it does not serve the metered
+  control plane use-case; and managed control planes often do not let
+  customers configure AP&F. Possible future addition, orthogonal to this fix.


### PR DESCRIPTION
Design for fixing #9158 without reverting #8757, as discussed in [this comment](https://github.com/cert-manager/cert-manager/issues/9158#issuecomment-5307336614).

In brief:

- `kubernetesAPIQPS`/`kubernetesAPIBurst` become optional fields and defaulting stops writing 20/50 into them, so explicitly configured values can be distinguished from defaults and are always honoured — including on AP&F-enabled clusters. Unset means Auto: no client-side rate limiting when AP&F is detected, 20/50 otherwise, which is exactly what v1.21 ships today, so upgrades are invisible unless the options are set.
- The leader election client and the event recording sink get their own rate limiter budgets in every mode, so a hard cap cannot cause missed lease renewals or let event storms starve reconcilers.
- The same optional fields are added to `WebhookConfiguration` and `CAInjectorConfiguration` so all components behave consistently.
- Validation is tightened to `-1` or values ≥ 1 with burst ≥ QPS.

Intended to guide a rework of #9159 rather than replace @yeonhwanp's effort.

Refs #9158, #8757, #6890.

*with claude fable-5*
