### PR TITLE
fix: search 9 years in cron Next for leap-day schedules

### DIFF
--- a/internal/cron/spec.go
+++ b/internal/cron/spec.go
@@ -59,6 +59,10 @@ var (
 const (
 	// Set the top bit if a star was included in the expression.
 	starBit = 1 << 63
+
+	// nextSearchLimitYears is how far Next will search for a matching time.
+	// Must cover the 8-year gap between leap days around a non-leap century year.
+	nextSearchLimitYears = 9
 )
 
 // Next returns the next time this schedule is activated, greater than the given
@@ -94,8 +98,10 @@ func (s *SpecSchedule) Next(t time.Time) time.Time {
 	// This flag indicates whether a field has been incremented.
 	added := false
 
-	// If no time is found within five years, return zero.
-	yearLimit := t.Year() + 5
+	// If no time is found within this horizon, return zero.
+	// Ordinary schedules resolve in well under five years, but Feb 29 can be
+	// eight years apart around a non-leap century year (2096-03-01 → 2104-02-29).
+	yearLimit := t.Year() + nextSearchLimitYears
 
 WRAP:
 	if t.Year() > yearLimit {

--- a/internal/cron/spec_test.go
+++ b/internal/cron/spec_test.go
@@ -1,9 +1,17 @@
-// +skip_license_check
-
 /*
-This file contains portions of code directly taken from the 'robfig/cron' project.
-A copy of the license for this code can be found in the file named LICENSE in
-this directory.
+Copyright The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package cron

--- a/internal/cron/spec_test.go
+++ b/internal/cron/spec_test.go
@@ -1,0 +1,54 @@
+// +skip_license_check
+
+/*
+This file contains portions of code directly taken from the 'robfig/cron' project.
+A copy of the license for this code can be found in the file named LICENSE in
+this directory.
+*/
+
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextLeapDayAcrossNonLeapCentury(t *testing.T) {
+	sched, err := ParseStandard("0 0 29 2 *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2100 is not a leap year, so the gap from 2096-02-29 to 2104-02-29 is 8 years.
+	// A 5-year search horizon returns the zero time here.
+	got := sched.Next(time.Date(2096, time.March, 1, 0, 0, 0, 0, time.UTC))
+	want := time.Date(2104, time.February, 29, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("Next() = %v, want %v", got, want)
+	}
+}
+
+func TestNextLeapDayCommonFourYearGap(t *testing.T) {
+	sched, err := ParseStandard("0 0 29 2 *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := sched.Next(time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC))
+	want := time.Date(2028, time.February, 29, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("Next() = %v, want %v", got, want)
+	}
+}
+
+func TestNextImpossibleDateStillZero(t *testing.T) {
+	sched, err := ParseStandard("0 0 31 2 *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := sched.Next(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC))
+	if !got.IsZero() {
+		t.Fatalf("Next() = %v, want zero time", got)
+	}
+}

--- a/internal/cron/spec_test.go
+++ b/internal/cron/spec_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2026 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Pull Request Motivation

`internal/cron` `Next()` stopped searching after five years. Leap-day schedules such as `0 0 29 2 *` can have an eight-year gap around a non-leap century year (`2096-03-01` → `2104-02-29`), so `Next` returned the zero time and renewal windows treated that as a `WindowError`.

Fixes #9148

### Kind

/kind bug

### Release Note

```release-note
Fix certificate renewal windows using February 29 cron schedules across non-leap century years.
```

### Verification

`go test ./internal/cron/ -count=1` — includes a regression for 2096-03-01 → 2104-02-29, the common 4-year leap-day case, and an impossible date that still returns zero.

### AI

Assisted by Grok (xAI) for locating the horizon, adding tests, and drafting this description. I reviewed the change.