### PR TITLE
Fix issues reported by golangci-lint v2.13.0

### DIFF
--- a/internal/apis/certmanager/validation/issuer_test.go
+++ b/internal/apis/certmanager/validation/issuer_test.go
@@ -674,8 +674,9 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				Server:     "valid-server",
 				PrivateKey: validSecretKeyRef,
 				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
-					KeyID:        "test",
-					Key:          validSecretKeyRef,
+					KeyID: "test",
+					Key:   validSecretKeyRef,
+					//nolint:staticcheck // SA1019 setting the deprecated eab.KeyAlgorithm field is intentional: this test asserts the deprecation warning.
 					KeyAlgorithm: cmacme.HS384,
 				},
 				Solvers: []cmacme.ACMEChallengeSolver{

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -622,13 +622,11 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 	}{
 		"if there are no cert-manager annotations and the certificate data is nil, should return false": {
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:labels": {
 								"f:controller.cert-manager.io/fao": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -636,8 +634,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 		},
 		"if optional cert-manager annotations are present with no certificate data, should return false": {
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:labels": {
 								"f:controller.cert-manager.io/fao": {}
 							},
@@ -649,8 +646,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 								"f:cert-manager.io/issuer-kind": {},
 								"f:cert-manager.io/issuer-group": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -658,8 +654,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 		},
 		"if cert-manager annotations are present with certificate data, should return false": {
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:labels": {
 								"f:controller.cert-manager.io/fao": {}
 							},
@@ -675,8 +670,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 								"f:cert-manager.io/ip-sans": {},
 								"f:cert-manager.io/uri-sans": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			secretData:   map[string][]byte{corev1.TLSCertKey: baseCertBundle.CertBytes},
 			expReason:    "",
@@ -685,8 +679,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 		},
 		"if required and optional cert-manager annotations are present with certificate data but certificate data is nil, should return true": {
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:labels": {
 								"f:controller.cert-manager.io/fao": {}
 							},
@@ -700,8 +693,7 @@ func Test_SecretManagedLabelsAndAnnotationsManagedFieldsMismatch(t *testing.T) {
 								"f:cert-manager.io/uri-sans": {},
 								"f:cert-manager.io/ip-sans": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretManagedMetadataMismatch,
 			expMessage:   "Secret has these extra Annotations: [cert-manager.io/ip-sans cert-manager.io/uri-sans]",
@@ -863,16 +855,14 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 		"if template is nil, managed fields is not nil but not managed by cert-manager, should return false": {
 			tmpl: nil,
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:bar": {}
 							},
 							"f:labels": {
 								"f:123": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -898,16 +888,14 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 		"if template is nil but managed fields is not nil, should return true": {
 			tmpl: nil,
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo": {}
 							},
 							"f:labels": {
 								"f:abc": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret has these extra Labels: [abc]",
@@ -919,8 +907,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo3": {}
@@ -929,8 +916,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret is missing these Template Annotations: [foo2 foo4]",
@@ -942,8 +928,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456", "ghi": "789"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -952,8 +937,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:erg": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret is missing these Template Labels: [def ghi]",
@@ -965,8 +949,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -975,8 +958,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -988,8 +970,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {},
@@ -1000,8 +981,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret has these extra Annotations: [foo3 foo4]",
@@ -1013,8 +993,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -1025,8 +1004,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:ghi": {},
 								"f:jkl": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret has these extra Labels: [ghi jkl]",
@@ -1038,8 +1016,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -1048,8 +1025,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret is missing these Template Annotations: [foo3]",
@@ -1061,8 +1037,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456", "ghi": "789"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{{
-				Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -1071,8 +1046,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    SecretTemplateMismatch,
 			expMessage:   "Secret is missing these Template Labels: [ghi]",
@@ -1084,15 +1058,12 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Labels:      map[string]string{"abc": "123", "def": "456", "ghi": "789"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:labels": {
 								"f:ghi": {}
 							}
-						}}`),
-				}},
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+						}}`)},
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo3": {}
@@ -1101,11 +1072,9 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-				}},
+						}}`)},
 				{Manager: fieldManager,
-					FieldsV1: &metav1.FieldsV1{
-						Raw: []byte(`{"f:metadata": {
+					FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {}
@@ -1114,8 +1083,7 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 								"f:abc": {},
 								"f:def": {}
 							}
-						}}`),
-					}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -1126,16 +1094,14 @@ func Test_SecretSecretTemplateManagedFieldsMismatch(t *testing.T) {
 				Annotations: map[string]string{"foo1": "bar1", "foo2": "bar2"},
 			},
 			secretManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-					Raw: []byte(`{"f:metadata": {
+				{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:foo1": {},
 								"f:foo2": {},
 								"f:cert-manager.io/foo1": {},
 								"f:cert-manager.io/foo2": {}
 							}
-						}}`),
-				}},
+						}}`)},
 			},
 			expReason:    "",
 			expMessage:   "",
@@ -1492,13 +1458,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1515,13 +1479,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1538,14 +1500,12 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1562,13 +1522,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1585,13 +1543,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1608,14 +1564,12 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1634,13 +1588,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1659,13 +1611,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1685,14 +1635,12 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1711,13 +1659,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1736,13 +1682,11 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1762,14 +1706,12 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1789,20 +1731,16 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {}
-							}}`),
-							}},
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							}}`)},
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1822,22 +1760,18 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
-							}}`),
-							}},
-							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							}}`)},
+							{Manager: "not-cert-manager", FieldsV1: metav1.NewFieldsV1(`
 							{"f:data": {
 								".": {},
 								"f:key.der": {},
 								"f:tls-combined.pem": {}
-							}}`),
-							}},
+							}}`)},
 						},
 					},
 				},
@@ -1889,13 +1823,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},
@@ -1911,13 +1843,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 								{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"uid-123\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},
@@ -1933,13 +1863,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 								{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"uid-123\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},
@@ -1966,13 +1894,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 								{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},
@@ -1988,13 +1914,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 								{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"uid-123\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},
@@ -2010,13 +1934,11 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 				Secret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						ManagedFields: []metav1.ManagedFieldsEntry{
-							{Manager: "not-cert-manager-test", FieldsV1: &metav1.FieldsV1{
-								Raw: []byte(`
+							{Manager: "not-cert-manager-test", FieldsV1: metav1.NewFieldsV1(`
 								{"f:metadata": {
 								"f:ownerReferences": {
 								"k:{\"uid\":\"uid-123\"}": {}
-							}}}`),
-							}},
+							}}}`)},
 						},
 					},
 				},

--- a/pkg/acme/client/http_test.go
+++ b/pkg/acme/client/http_test.go
@@ -192,8 +192,7 @@ func TestInstrumentedRoundTripper_CapsOversizedResponseBody(t *testing.T) {
 	// number of bytes delivered to the caller stays bounded by the limit
 	// regardless of how much the server tried to send, keeping memory bounded.
 	n, err := io.Copy(io.Discard, resp.Body)
-	var maxBytesErr *http.MaxBytesError
-	if !errors.As(err, &maxBytesErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); !ok {
 		t.Fatalf("expected a *http.MaxBytesError reading an oversized body, got %T: %v", err, err)
 	}
 	if n > maxACMEResponseBodyBytes {

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -246,45 +246,33 @@ func stabilizeSolverErrorMessage(err error) string {
 		return ""
 	}
 	fullMessage := err.Error()
-	{
-		var target *awshttp.ResponseError
-		if errors.As(err, &target) {
-			fullMessage = strings.ReplaceAll(
-				fullMessage,
-				target.Error(),
-				"<redacted AWS SDK error: http.ResponseError: see events and logs for details>",
-			)
-		}
+	if target, ok := errors.AsType[*awshttp.ResponseError](err); ok {
+		fullMessage = strings.ReplaceAll(
+			fullMessage,
+			target.Error(),
+			"<redacted AWS SDK error: http.ResponseError: see events and logs for details>",
+		)
 	}
-	{
-		var target *azidentity.AuthenticationFailedError
-		if errors.As(err, &target) {
-			fullMessage = strings.ReplaceAll(
-				fullMessage,
-				target.Error(),
-				"<redacted Azure SDK error: azidentity.AuthenticationFailedError: see events and logs for details>",
-			)
-		}
+	if target, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
+		fullMessage = strings.ReplaceAll(
+			fullMessage,
+			target.Error(),
+			"<redacted Azure SDK error: azidentity.AuthenticationFailedError: see events and logs for details>",
+		)
 	}
-	{
-		var target *azcore.ResponseError
-		if errors.As(err, &target) {
-			fullMessage = strings.ReplaceAll(
-				fullMessage,
-				target.Error(),
-				"<redacted Azure SDK error: azcore.ResponseError: see events and logs for details>",
-			)
-		}
+	if target, ok := errors.AsType[*azcore.ResponseError](err); ok {
+		fullMessage = strings.ReplaceAll(
+			fullMessage,
+			target.Error(),
+			"<redacted Azure SDK error: azcore.ResponseError: see events and logs for details>",
+		)
 	}
-	{
-		var target *godo.ErrorResponse
-		if errors.As(err, &target) {
-			fullMessage = strings.ReplaceAll(
-				fullMessage,
-				target.Error(),
-				"<redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
-			)
-		}
+	if target, ok := errors.AsType[*godo.ErrorResponse](err); ok {
+		fullMessage = strings.ReplaceAll(
+			fullMessage,
+			target.Error(),
+			"<redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
+		)
 	}
 	return fullMessage
 }

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -266,8 +266,7 @@ func isRetryableError(err error) bool {
 			return false
 		}
 	}
-	var acmeErr *acmeapi.Error
-	if errors.As(err, &acmeErr) {
+	if acmeErr, ok := errors.AsType[*acmeapi.Error](err); ok {
 		if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 			return false
 		}
@@ -850,8 +849,7 @@ func isARIReplacesRejection(err error) bool {
 	if errors.Is(err, acmeapi.ErrCADoesNotSupportARI) {
 		return true
 	}
-	var ae *acmeapi.Error
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*acmeapi.Error](err); ok {
 		if ae.ProblemType == "urn:ietf:params:acme:error:alreadyReplaced" {
 			return true
 		}

--- a/pkg/controller/certificates/issuing/secret_manager_test.go
+++ b/pkg/controller/certificates/issuing/secret_manager_test.go
@@ -199,8 +199,7 @@ func Test_ensureSecretData(t *testing.T) {
 					Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
-						FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`{"f:metadata": {
+						FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:cert-manager.io/common-name": {},
 								"f:cert-manager.io/alt-names": {},
@@ -215,7 +214,6 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:another-label": {}
 							}
 						}}`),
-						},
 					}},
 				},
 				Data: map[string][]byte{
@@ -242,8 +240,7 @@ func Test_ensureSecretData(t *testing.T) {
 					Annotations: map[string]string{"foo": "bar"}, Labels: map[string]string{"abc": "123"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: "not-cert-manager",
-						FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`{"f:metadata": {
+						FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:cert-manager.io/common-name": {},
 								"f:cert-manager.io/alt-names": {},
@@ -255,8 +252,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:controller.cert-manager.io/fao": {},
 								"f:abc": {}
 							}
-						}}`),
-						}},
+						}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -285,8 +281,7 @@ func Test_ensureSecretData(t *testing.T) {
 					Labels:      map[string]string{"abc": "123", cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
-						FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`{"f:metadata": {
+						FieldsV1: metav1.NewFieldsV1(`{"f:metadata": {
 							"f:annotations": {
 								"f:cert-manager.io/common-name": {},
 								"f:cert-manager.io/alt-names": {},
@@ -298,8 +293,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:controller.cert-manager.io/fao": {},
 								"f:abc": {}
 							}
-						}}`),
-						}},
+						}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -457,8 +451,7 @@ func Test_ensureSecretData(t *testing.T) {
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
-						FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						FieldsV1: metav1.NewFieldsV1(`
 							{
 								"f:metadata": {
 									"f:labels": {
@@ -479,7 +472,6 @@ func Test_ensureSecretData(t *testing.T) {
 									"f:key.der": {}
 								}
 							}`),
-						},
 					}},
 				},
 				Data: map[string][]byte{
@@ -504,8 +496,7 @@ func Test_ensureSecretData(t *testing.T) {
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{{
 						Manager: fieldManager,
-						FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						FieldsV1: metav1.NewFieldsV1(`
 							{
 								"f:metadata": {
 									"f:labels": {
@@ -526,7 +517,6 @@ func Test_ensureSecretData(t *testing.T) {
 									"f:key.der": {}
 								}
 							}`),
-						},
 					}},
 				},
 				Data: map[string][]byte{
@@ -549,8 +539,7 @@ func Test_ensureSecretData(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-secret",
 					Labels: map[string]string{cmapi.PartOfCertManagerControllerLabelKey: "true"},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -564,8 +553,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{"tls.crt": cert, "tls.key": pk, "key.der": pkDER},
@@ -585,8 +573,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -600,8 +587,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{"tls.crt": cert, "tls.key": pk, "key.der": pkDER},
@@ -633,8 +619,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-234"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -648,8 +633,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -692,8 +676,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -707,8 +690,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -750,8 +732,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -765,8 +746,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -807,8 +787,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -822,8 +801,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -866,8 +844,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -881,8 +858,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -924,8 +900,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -939,8 +914,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -982,8 +956,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -997,8 +970,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -1039,8 +1011,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -1054,8 +1025,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{
@@ -1098,8 +1068,7 @@ func Test_ensureSecretData(t *testing.T) {
 						{APIVersion: "cert-manager.io/v1", Kind: "Certificate", Name: "test-name", UID: types.UID("uid-123"), Controller: new(true), BlockOwnerDeletion: new(true)},
 					},
 					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
-							Raw: []byte(`
+						{Manager: fieldManager, FieldsV1: metav1.NewFieldsV1(`
 							{"f:metadata": {
 								"f:labels": {
 									"f:controller.cert-manager.io/fao": {}
@@ -1113,8 +1082,7 @@ func Test_ensureSecretData(t *testing.T) {
 								"f:ownerReferences": {
 									"k:{\"uid\":\"uid-123\"}": {}
 								}
-							}}`),
-						}},
+							}}`)},
 					},
 				},
 				Data: map[string][]byte{

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -372,9 +372,6 @@ func httpClientForVcert(options *httpClientForVcertOptions) *http.Client {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			// Note: This DualStack setting is copied from vcert but
-			// deviates from the http.DefaultTransport in Go's stdlib.
-			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -642,9 +642,8 @@ func TestAuthFailedError_ErrorAndUnwrap(t *testing.T) {
 		t.Error("errors.Is should find underlying error through Unwrap chain")
 	}
 
-	var authErr AuthFailedError
 	wrapped := fmt.Errorf("client.VerifyCredentials: %w", err)
-	if !errors.As(wrapped, &authErr) {
+	if _, ok := errors.AsType[AuthFailedError](wrapped); !ok {
 		t.Error("errors.As should find AuthFailedError through wrapping chain")
 	}
 }

--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -33,8 +33,7 @@ import (
 func (v *Venafi) Setup(ctx context.Context, issuer cmapi.GenericIssuer) (err error) {
 	defer func() {
 		if err != nil {
-			var authErr venaficlient.AuthFailedError
-			if errors.As(err, &authErr) {
+			if authErr, ok := errors.AsType[venaficlient.AuthFailedError](err); ok {
 				msg := fmt.Sprintf("OAuth token request failed: %v", authErr.Err)
 				apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), cmapi.IssuerConditionReady, cmmeta.ConditionFalse, "AuthFailed", msg)
 				err = errors.New(msg)

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -44,7 +44,7 @@ func RestConfigWithUserAgent(restConfig *rest.Config, component ...string) *rest
 // Taken from
 // https://github.com/kubernetes/kubernetes/blob/9a75e7b0fd1b567f774a3373be640e19b33e7ef1/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go#L252
 func PrefixFromUserAgent(u string) string {
-	m := strings.Split(u, "/")[0]
+	m, _, _ := strings.Cut(u, "/")
 	buf := bytes.NewBuffer(nil)
 	for _, r := range m {
 		// Ignore non-printable characters

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -169,7 +169,7 @@ func TestMetricsController(t *testing.T) {
 			return err
 		}
 
-		trimmedOutput := strings.SplitN(string(output), "# HELP go_gc_duration_seconds", 2)[0]
+		trimmedOutput, _, _ := strings.Cut(string(output), "# HELP go_gc_duration_seconds")
 		if strings.TrimSpace(trimmedOutput) != strings.TrimSpace(expectedOutput) {
 			return fmt.Errorf("got unexpected metrics output\nexp:\n%s\ngot:\n%s\n",
 				expectedOutput, output)

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -216,7 +216,8 @@ func SetIssuerACMEEABWithKeyAlgorithm(keyID, secretName string, keyAlgorithm cma
 			spec.ACME = &cmacme.ACMEIssuer{}
 		}
 		spec.ACME.ExternalAccountBinding = &cmacme.ACMEExternalAccountBinding{
-			KeyID:        keyID,
+			KeyID: keyID,
+			//nolint:staticcheck // SA1019 setting the deprecated eab.KeyAlgorithm field is intentional: this modifier exists so tests can exercise the legacy field.
 			KeyAlgorithm: keyAlgorithm,
 			Key: cmmeta.SecretKeySelector{
 				Key: "key",


### PR DESCRIPTION
Fixes the lint failures blocking #9174, which vendors golangci-lint v2.13.0 and Go 1.27.0. The newer `modernize` and `staticcheck` analysers report issues in existing code, failing `pull-cert-manager-master-make-verify` on that PR. These fixes lint clean under both v2.12.2 (current master) and v2.13.0, so landing this first lets the Renovate PR rebase and merge cleanly.

- Rewrite `errors.As` calls to `errors.AsType` (modernize `errorsastype`).
- Replace `strings.Split`/`SplitN` with `strings.Cut` where only the prefix is used (modernize `stringscut`).
- Replace all `metav1.FieldsV1{Raw: ...}` literals with [`metav1.NewFieldsV1`](https://github.com/kubernetes/apimachinery/blob/v0.36.3/pkg/apis/meta/v1/fieldsv1_byte.go#L94), as direct access to `Raw` is deprecated in apimachinery v0.36 (staticcheck SA1019). CI reported only three of these because of golangci-lint's default [`max-same-issues: 3`](https://golangci-lint.run/docs/configuration/file/#issues-configuration) cap; all 55 are converted here.
- Drop the deprecated `DualStack` dialer field in the Venafi client; Fast Fallback has been the default [since Go 1.12](https://pkg.go.dev/net#Dialer).
- Add `nolint:staticcheck` to the two test sites which intentionally set the deprecated ACME EAB `keyAlgorithm` field.

Verified by running `make verify-golangci-lint` with the Go 1.27.0 / golangci-lint v2.13.0 tool versions from #9174 overlaid on this branch: 0 issues. All affected package tests pass.

```release-note
NONE
```

*with claude fable-5*