### PR TITLE
Clarify licensing for copied cron code

### DIFF
--- a/internal/cron/LICENSE
+++ b/internal/cron/LICENSE
@@ -1,3 +1,12 @@
+Much of the code in this package contains code directly copied from the 'robfig/cron' project
+on GitHub (https://github.com/robfig/cron) under the license available at:
+
+https://github.com/robfig/cron/blob/v3.0.1/LICENSE
+
+The full license is copied below:
+
+---
+
 Copyright (C) 2012 Rob Figueiredo
 All Rights Reserved.
 
@@ -19,3 +28,7 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Any code which is not copied from the cron project remains licensed under the license in the root of the repo.

--- a/internal/cron/parser_test.go
+++ b/internal/cron/parser_test.go
@@ -1,10 +1,21 @@
-// +skip_license_check
-
 /*
-This file contains portions of code directly taken from the 'robfig/cron' project.
-A copy of the license for this code can be found in the file named LICENSE in
-this directory.
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
+// This file originally mistakenly included the claim that it was copied from the robfig/cron project
+// but it is entirely original work added by the cert-manager project
 
 package cron
 


### PR DESCRIPTION
### Pull Request Motivation

Reviewing #9170 made me re-review the license for this folder and I think there was a minor heading mistake already present.

This isn't really important but it's probably worth clarifying a little more!

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
