### PR TITLE
Route53: resume waiting for a pending record change instead of submitting a duplicate

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -76,6 +76,11 @@ type Solver struct {
 	secretLister            internalinformers.SecretLister
 	dnsProviderConstructors dnsProviderConstructors
 	webhookSolvers          map[string]webhook.Solver
+	// route53PendingChanges is shared by all the Route 53 DNS providers
+	// constructed by this Solver, so that a retried Present or CleanUp
+	// resumes waiting for a previously submitted record change instead of
+	// submitting a duplicate.
+	route53PendingChanges *route53.PendingChangesCache
 }
 
 // Present performs the work to configure DNS to resolve a DNS01 challenge.
@@ -407,7 +412,8 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			route53.Ambient(canUseAmbientCredentials),
 			route53.Nameservers(nameservers),
 			route53.UserAgent(s.RESTConfig.UserAgent),
-			route53.Resolver(s.DNSResolver))
+			route53.Resolver(s.DNSResolver),
+			route53.PendingChanges(s.route53PendingChanges))
 
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %w", err)
@@ -580,7 +586,8 @@ func NewSolver(ctx *controller.Context) (*Solver, error) {
 			acmedns.NewDNSProviderFromOptions,
 			digitalocean.NewDNSProviderFromOptions,
 		},
-		webhookSolvers: initialized,
+		webhookSolvers:        initialized,
+		route53PendingChanges: route53.NewPendingChangesCache(),
 	}, nil
 }
 

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -509,6 +509,7 @@ func TestRoute53TrimCreds(t *testing.T) {
 				Ambient:         new(false),
 				UserAgent:       f.Solver.RESTConfig.UserAgent,
 				Resolver:        s.DNSResolver,
+				PendingChanges:  s.route53PendingChanges,
 			}},
 		},
 	}
@@ -581,6 +582,7 @@ func TestRoute53SecretAccessKey(t *testing.T) {
 				UserAgent:       s.RESTConfig.UserAgent,
 				Ambient:         new(false),
 				Resolver:        s.DNSResolver,
+				PendingChanges:  s.route53PendingChanges,
 			}},
 		},
 	}
@@ -630,11 +632,12 @@ func TestRoute53AmbientCreds(t *testing.T) {
 					return &fakeDNSProviderCall{
 						name: "route53",
 						args: []any{route53.DNSProviderOptions{
-							Region:      "us-west-2",
-							Nameservers: f.Solver.DNS01Nameservers,
-							UserAgent:   f.Solver.RESTConfig.UserAgent,
-							Ambient:     new(true),
-							Resolver:    f.Solver.DNSResolver,
+							Region:         "us-west-2",
+							Nameservers:    f.Solver.DNS01Nameservers,
+							UserAgent:      f.Solver.RESTConfig.UserAgent,
+							Ambient:        new(true),
+							Resolver:       f.Solver.DNSResolver,
+							PendingChanges: f.Solver.route53PendingChanges,
 						}},
 					}
 				},
@@ -677,11 +680,12 @@ func TestRoute53AmbientCreds(t *testing.T) {
 					return &fakeDNSProviderCall{
 						name: "route53",
 						args: []any{route53.DNSProviderOptions{
-							Region:      "us-west-2",
-							Nameservers: util.RecursiveNameservers,
-							UserAgent:   f.Solver.RESTConfig.UserAgent,
-							Ambient:     new(false),
-							Resolver:    f.Solver.DNSResolver,
+							Region:         "us-west-2",
+							Nameservers:    util.RecursiveNameservers,
+							UserAgent:      f.Solver.RESTConfig.UserAgent,
+							Ambient:        new(false),
+							Resolver:       f.Solver.DNSResolver,
+							PendingChanges: f.Solver.route53PendingChanges,
 						}},
 					}
 				},
@@ -738,11 +742,12 @@ func TestSolverForChallengeNameservers(t *testing.T) {
 				return fakeDNSProviderCall{
 					name: "route53",
 					args: []any{route53.DNSProviderOptions{
-						Region:      "us-west-2",
-						Nameservers: perSolverNameservers,
-						Ambient:     new(false),
-						UserAgent:   f.Solver.RESTConfig.UserAgent,
-						Resolver:    f.Solver.DNSResolver,
+						Region:         "us-west-2",
+						Nameservers:    perSolverNameservers,
+						Ambient:        new(false),
+						UserAgent:      f.Solver.RESTConfig.UserAgent,
+						Resolver:       f.Solver.DNSResolver,
+						PendingChanges: f.Solver.route53PendingChanges,
 					}},
 				}
 			},
@@ -804,11 +809,12 @@ func TestSolverForChallengeNameservers(t *testing.T) {
 				return fakeDNSProviderCall{
 					name: "route53",
 					args: []any{route53.DNSProviderOptions{
-						Region:      "us-west-2",
-						Nameservers: util.RecursiveNameservers,
-						Ambient:     new(false),
-						UserAgent:   f.Solver.RESTConfig.UserAgent,
-						Resolver:    f.Solver.DNSResolver,
+						Region:         "us-west-2",
+						Nameservers:    util.RecursiveNameservers,
+						Ambient:        new(false),
+						UserAgent:      f.Solver.RESTConfig.UserAgent,
+						Resolver:       f.Solver.DNSResolver,
+						PendingChanges: f.Solver.route53PendingChanges,
 					}},
 				}
 			},
@@ -966,12 +972,13 @@ func TestRoute53AssumeRole(t *testing.T) {
 					return &fakeDNSProviderCall{
 						name: "route53",
 						args: []any{route53.DNSProviderOptions{
-							Region:      "us-west-2",
-							Role:        "my-role",
-							Nameservers: f.Solver.DNS01Nameservers,
-							UserAgent:   f.Solver.RESTConfig.UserAgent,
-							Ambient:     new(true),
-							Resolver:    f.Solver.DNSResolver,
+							Region:         "us-west-2",
+							Role:           "my-role",
+							Nameservers:    f.Solver.DNS01Nameservers,
+							UserAgent:      f.Solver.RESTConfig.UserAgent,
+							Ambient:        new(true),
+							Resolver:       f.Solver.DNSResolver,
+							PendingChanges: f.Solver.route53PendingChanges,
 						}},
 					}
 				},
@@ -1016,12 +1023,13 @@ func TestRoute53AssumeRole(t *testing.T) {
 						name: "route53",
 						args: []any{
 							route53.DNSProviderOptions{
-								Region:      "us-west-2",
-								Role:        "my-other-role",
-								Nameservers: f.Solver.DNS01Nameservers,
-								UserAgent:   f.Solver.RESTConfig.UserAgent,
-								Ambient:     new(false),
-								Resolver:    f.Solver.DNSResolver,
+								Region:         "us-west-2",
+								Role:           "my-other-role",
+								Nameservers:    f.Solver.DNS01Nameservers,
+								UserAgent:      f.Solver.RESTConfig.UserAgent,
+								Ambient:        new(false),
+								Resolver:       f.Solver.DNSResolver,
+								PendingChanges: f.Solver.route53PendingChanges,
 							},
 						},
 					}

--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -79,6 +79,28 @@ var GetChangeResponse = `<?xml version="1.0" encoding="UTF-8"?>
    </ChangeInfo>
 </GetChangeResponse>`
 
+var GetChangePendingResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Id>123456</Id>
+      <Status>PENDING</Status>
+      <SubmittedAt>2016-02-10T01:36:41.958Z</SubmittedAt>
+   </ChangeInfo>
+</GetChangeResponse>`
+
+// An example of the error returned by the GetChange API when the requested
+// change does not exist:
+// - https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html#API_GetChange_Errors
+var GetChangeNoSuchChange404Response = `<?xml version="1.0"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>NoSuchChange</Code>
+    <Message>Could not find change: 123456</Message>
+  </Error>
+  <RequestId>SOMEREQUESTID</RequestId>
+</ErrorResponse>`
+
 var ChangeResourceRecordSets403Response = `<?xml version="1.0"?>
 <ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
   <Error>

--- a/pkg/issuer/acme/dns/route53/options.go
+++ b/pkg/issuer/acme/dns/route53/options.go
@@ -47,6 +47,12 @@ type DNSProviderOptions struct {
 	UserAgent string
 	// Resolver performs DNS lookups during challenge verification.
 	Resolver util.Resolver
+	// PendingChanges is a cache of the IDs of record changes which have been
+	// submitted but have not yet reached the INSYNC status. Supply a shared
+	// instance so that a retried Present or CleanUp resumes waiting for the
+	// original change instead of submitting a duplicate. When nil, a new
+	// cache private to this DNSProvider is used.
+	PendingChanges *PendingChangesCache
 }
 
 // DNSProviderOption is a functional option for configuring a DNSProvider.
@@ -137,4 +143,18 @@ func (r WithResolver) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
 // Resolver returns a WithResolver option that sets the Resolver field on DNSProviderOptions.
 func Resolver(r util.Resolver) WithResolver {
 	return WithResolver{Resolver: r}
+}
+
+// WithPendingChanges sets the PendingChanges cache on DNSProviderOptions.
+type WithPendingChanges struct{ *PendingChangesCache }
+
+// ApplyToDNSProviderOptions sets the PendingChanges field.
+func (p WithPendingChanges) ApplyToDNSProviderOptions(o *DNSProviderOptions) {
+	o.PendingChanges = p.PendingChangesCache
+}
+
+// PendingChanges returns a WithPendingChanges option that sets the
+// PendingChanges cache on DNSProviderOptions.
+func PendingChanges(c *PendingChangesCache) WithPendingChanges {
+	return WithPendingChanges{PendingChangesCache: c}
 }

--- a/pkg/issuer/acme/dns/route53/pendingchanges.go
+++ b/pkg/issuer/acme/dns/route53/pendingchanges.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route53
+
+import (
+	"sync"
+
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// PendingChangesCache remembers the ID of a Route 53 record change which has
+// been submitted but has not yet reached the INSYNC status, so that a retried
+// Present or CleanUp resumes polling GetChange for the original change instead
+// of submitting a duplicate ChangeResourceRecordSets request. Supply a single
+// shared instance to every DNSProvider in the process, because a new
+// DNSProvider is constructed for every challenge reconcile.
+// See https://github.com/cert-manager/cert-manager/issues/9066
+type PendingChangesCache struct {
+	mu      sync.Mutex
+	changes map[pendingChangeKey]pendingChange
+}
+
+type pendingChangeKey struct {
+	fqdn  string
+	value string
+}
+
+type pendingChange struct {
+	action   route53types.ChangeAction
+	changeID string
+}
+
+// NewPendingChangesCache returns an empty PendingChangesCache.
+func NewPendingChangesCache() *PendingChangesCache {
+	return &PendingChangesCache{
+		changes: map[pendingChangeKey]pendingChange{},
+	}
+}
+
+// get returns the ID of a pending change for the given action, fqdn and value.
+// A pending change for the same record but a different action (e.g. an upsert
+// pending when a delete is requested) is superseded, not resumed.
+func (c *PendingChangesCache) get(action route53types.ChangeAction, fqdn, value string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	change, ok := c.changes[pendingChangeKey{fqdn: fqdn, value: value}]
+	if !ok || change.action != action {
+		return "", false
+	}
+	return change.changeID, true
+}
+
+func (c *PendingChangesCache) put(action route53types.ChangeAction, fqdn, value, changeID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.changes[pendingChangeKey{fqdn: fqdn, value: value}] = pendingChange{action: action, changeID: changeID}
+}
+
+func (c *PendingChangesCache) delete(fqdn, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.changes, pendingChangeKey{fqdn: fqdn, value: value})
+}

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -29,6 +29,9 @@ import (
 
 const (
 	route53TTL = 10
+
+	changePollTimeout  = 120 * time.Second
+	changePollInterval = 4 * time.Second
 )
 
 // DNSProvider implements the util.ChallengeProvider interface
@@ -38,6 +41,14 @@ type DNSProvider struct {
 	hostedZoneID     string
 	userAgent        string
 	resolver         util.Resolver
+	pendingChanges   *PendingChangesCache
+
+	// pollTimeout and pollInterval control how long a single Present or
+	// CleanUp call waits for a submitted record change to reach the INSYNC
+	// status. They exist so that tests can wait for less than the default
+	// changePollTimeout.
+	pollTimeout  time.Duration
+	pollInterval time.Duration
 }
 
 func NewDNSProviderFromOptions(ctx context.Context, options ...DNSProviderOption) (*DNSProvider, error) {
@@ -72,12 +83,20 @@ func NewDNSProviderFromOptions(ctx context.Context, options ...DNSProviderOption
 
 	client := route53.NewFromConfig(cfg)
 
+	pendingChanges := opt.PendingChanges
+	if pendingChanges == nil {
+		pendingChanges = NewPendingChangesCache()
+	}
+
 	return &DNSProvider{
 		client:           client,
 		hostedZoneID:     opt.HostedZoneID,
 		dns01Nameservers: opt.Nameservers,
 		userAgent:        opt.UserAgent,
 		resolver:         opt.Resolver,
+		pendingChanges:   pendingChanges,
+		pollTimeout:      changePollTimeout,
+		pollInterval:     changePollInterval,
 	}, nil
 }
 
@@ -121,53 +140,75 @@ func (r *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) e
 
 func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.ChangeAction, fqdn, value string, ttl int) error {
 	log := logf.FromContext(ctx)
-	hostedZoneID, err := r.getHostedZoneID(ctx, fqdn)
-	if err != nil {
-		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %w", err)
-	}
 
-	recordSet := newTXTRecordSet(fqdn, value, ttl)
-	reqParams := &route53.ChangeResourceRecordSetsInput{
-		HostedZoneId: aws.String(hostedZoneID),
-		ChangeBatch: &route53types.ChangeBatch{
-			Comment: aws.String("Managed by cert-manager"),
-			Changes: []route53types.Change{
-				{
-					Action:            action,
-					ResourceRecordSet: recordSet,
+	changeID, resuming := r.pendingChanges.get(action, fqdn, value)
+	if resuming {
+		log.V(logf.DebugLevel).Info(
+			"Found a previously submitted Route 53 record change which has not yet propagated. "+
+				"Resuming the wait for it to reach the INSYNC status instead of submitting a new change.",
+			"changeID", changeID,
+		)
+	} else {
+		// Forget any pending change for the same record with a different
+		// action; the change submitted below supersedes it.
+		r.pendingChanges.delete(fqdn, value)
+
+		hostedZoneID, err := r.getHostedZoneID(ctx, fqdn)
+		if err != nil {
+			return fmt.Errorf("failed to determine Route 53 hosted zone ID: %w", err)
+		}
+
+		recordSet := newTXTRecordSet(fqdn, value, ttl)
+		reqParams := &route53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(hostedZoneID),
+			ChangeBatch: &route53types.ChangeBatch{
+				Comment: aws.String("Managed by cert-manager"),
+				Changes: []route53types.Change{
+					{
+						Action:            action,
+						ResourceRecordSet: recordSet,
+					},
 				},
 			},
-		},
-	}
-
-	resp, err := r.client.ChangeResourceRecordSets(ctx, reqParams)
-	if err != nil {
-		// If we try to delete something and get a 'InvalidChangeBatch' that
-		// means it's already deleted, no need to consider it an error.
-		var apiErr *route53types.InvalidChangeBatch
-		if errors.As(err, &apiErr) && action == route53types.ChangeActionDelete {
-			log.V(logf.DebugLevel).Info(
-				"Got InvalidChangeBatch error when attempting to delete the TXT record. "+
-					"Ignoring the error and assuming that the TXT record has already been deleted.",
-				"error", err,
-			)
-			return nil
 		}
-		return fmt.Errorf("failed to change Route 53 record set: %w", err)
 
+		resp, err := r.client.ChangeResourceRecordSets(ctx, reqParams)
+		if err != nil {
+			// If we try to delete something and get a 'InvalidChangeBatch' that
+			// means it's already deleted, no need to consider it an error.
+			var apiErr *route53types.InvalidChangeBatch
+			if errors.As(err, &apiErr) && action == route53types.ChangeActionDelete {
+				log.V(logf.DebugLevel).Info(
+					"Got InvalidChangeBatch error when attempting to delete the TXT record. "+
+						"Ignoring the error and assuming that the TXT record has already been deleted.",
+					"error", err,
+				)
+				return nil
+			}
+			return fmt.Errorf("failed to change Route 53 record set: %w", err)
+
+		}
+
+		changeID = *resp.ChangeInfo.Id
+		r.pendingChanges.put(action, fqdn, value, changeID)
 	}
 
-	statusID := resp.ChangeInfo.Id
-
-	return util.WaitFor(120*time.Second, 4*time.Second, func() (bool, error) {
+	return util.WaitFor(r.pollTimeout, r.pollInterval, func() (bool, error) {
 		reqParams := &route53.GetChangeInput{
-			Id: statusID,
+			Id: aws.String(changeID),
 		}
 		resp, err := r.client.GetChange(ctx, reqParams)
 		if err != nil {
+			// The remembered change no longer exists, so forget it and let
+			// the next attempt submit a new change.
+			var apiErr *route53types.NoSuchChange
+			if errors.As(err, &apiErr) {
+				r.pendingChanges.delete(fqdn, value)
+			}
 			return false, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
 		if resp.ChangeInfo.Status == route53types.ChangeStatusInsync {
+			r.pendingChanges.delete(fqdn, value)
 			return true, nil
 		}
 		return false, nil

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -204,8 +204,7 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		if err != nil {
 			// The remembered change no longer exists, so forget it, stop
 			// waiting, and let the next attempt submit a new change.
-			var apiErr *route53types.NoSuchChange
-			if errors.As(err, &apiErr) {
+			if _, ok := errors.AsType[*route53types.NoSuchChange](err); ok {
 				r.pendingChanges.delete(fqdn, value)
 				vanishedErr = fmt.Errorf("failed to query Route 53 change status: %w", err)
 				return true, nil

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -193,17 +193,22 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		r.pendingChanges.put(action, fqdn, value, changeID)
 	}
 
-	return util.WaitFor(r.pollTimeout, r.pollInterval, func() (bool, error) {
+	// util.WaitFor has no way to stop early with an error, so a fatal poll
+	// result is smuggled out through vanishedErr.
+	var vanishedErr error
+	waitErr := util.WaitFor(r.pollTimeout, r.pollInterval, func() (bool, error) {
 		reqParams := &route53.GetChangeInput{
 			Id: aws.String(changeID),
 		}
 		resp, err := r.client.GetChange(ctx, reqParams)
 		if err != nil {
-			// The remembered change no longer exists, so forget it and let
-			// the next attempt submit a new change.
+			// The remembered change no longer exists, so forget it, stop
+			// waiting, and let the next attempt submit a new change.
 			var apiErr *route53types.NoSuchChange
 			if errors.As(err, &apiErr) {
 				r.pendingChanges.delete(fqdn, value)
+				vanishedErr = fmt.Errorf("failed to query Route 53 change status: %w", err)
+				return true, nil
 			}
 			return false, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
@@ -213,6 +218,10 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		}
 		return false, nil
 	})
+	if vanishedErr != nil {
+		return vanishedErr
+	}
+	return waitErr
 }
 
 func (r *DNSProvider) getHostedZoneID(ctx context.Context, fqdn string) (string, error) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -14,7 +14,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -50,7 +53,15 @@ func makeRoute53Provider(ts *httptest.Server) (*DNSProvider, error) {
 	cfg.BaseEndpoint = aws.String(ts.URL)
 
 	client := route53.NewFromConfig(cfg)
-	return &DNSProvider{client: client, dns01Nameservers: util.RecursiveNameservers, resolver: util.NewCachingResolver()}, nil
+	return &DNSProvider{
+		client:           client,
+		dns01Nameservers: util.RecursiveNameservers,
+		resolver:         util.NewCachingResolver(),
+		pendingChanges:   NewPendingChangesCache(),
+		// Fail fast in tests if a change unexpectedly stays PENDING.
+		pollTimeout:  3 * time.Second,
+		pollInterval: 10 * time.Millisecond,
+	}, nil
 }
 
 func TestAmbientCredentialsFromEnv(t *testing.T) {
@@ -292,6 +303,135 @@ func TestRoute53Present(t *testing.T) {
 	err = provider.Present(ctx, "bar.example.com", "bar.example.com.", keyAuth)
 	require.Error(t, err, "Expected Present to return an error")
 	assert.Equal(t, `failed to change Route 53 record set: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 403, RequestID: SOMEREQUESTID, api error AccessDenied: User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU`, err.Error())
+}
+
+// pendingChangeServer is a stateful mock of the Route 53 API for exercising
+// the PendingChangesCache: it counts ChangeResourceRecordSets requests and
+// allows the GetChange response to be switched between test steps.
+type pendingChangeServer struct {
+	*httptest.Server
+	mu          sync.Mutex
+	changeCalls int
+	getChange   MockResponse
+}
+
+func newPendingChangeServer(t *testing.T) *pendingChangeServer {
+	s := &pendingChangeServer{
+		getChange: MockResponse{StatusCode: 200, Body: GetChangePendingResponse},
+	}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("X-Amzn-Requestid", "SOMEREQUESTID")
+		switch {
+		case r.URL.Path == "/2013-04-01/hostedzonesbyname":
+			_, _ = w.Write([]byte(ListHostedZonesByNameResponse))
+		case strings.HasSuffix(r.URL.Path, "/rrset"):
+			s.changeCalls++
+			_, _ = w.Write([]byte(ChangeResourceRecordSetsResponse))
+		case strings.HasPrefix(r.URL.Path, "/2013-04-01/change/"):
+			w.WriteHeader(s.getChange.StatusCode)
+			_, _ = w.Write([]byte(s.getChange.Body))
+		default:
+			require.FailNow(t, "Requested path not found: "+r.URL.Path)
+		}
+	}))
+	t.Cleanup(s.Server.Close)
+	return s
+}
+
+func (s *pendingChangeServer) setGetChange(resp MockResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getChange = resp
+}
+
+func (s *pendingChangeServer) changeCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.changeCalls
+}
+
+// TestRoute53PresentResumesPendingChange demonstrates that when Present times
+// out waiting for a submitted record change to reach the INSYNC status, a
+// retried Present polls GetChange for the original change instead of
+// submitting a duplicate ChangeResourceRecordSets request.
+// See https://github.com/cert-manager/cert-manager/issues/9066
+func TestRoute53PresentResumesPendingChange(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ts := newPendingChangeServer(t)
+
+	provider, err := makeRoute53Provider(ts.Server)
+	require.NoError(t, err)
+	provider.pollTimeout = 100 * time.Millisecond
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "Time limit exceeded", "Expected Present to time out while the change is PENDING")
+	assert.Equal(t, 1, ts.changeCallCount())
+
+	ts.setGetChange(MockResponse{StatusCode: 200, Body: GetChangeResponse})
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.NoError(t, err, "Expected the retried Present to succeed once the change is INSYNC")
+	assert.Equal(t, 1, ts.changeCallCount(), "Expected the retried Present to resume the original change, not submit a new one")
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, ts.changeCallCount(), "Expected a new change to be submitted once the original reached INSYNC")
+}
+
+// TestRoute53CleanupSupersedesPendingPresent demonstrates that a pending
+// change is only resumed by a retry of the same action: a CleanUp after a
+// timed-out Present submits its own change rather than resuming the upsert,
+// and vice versa.
+func TestRoute53CleanupSupersedesPendingPresent(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ts := newPendingChangeServer(t)
+
+	provider, err := makeRoute53Provider(ts.Server)
+	require.NoError(t, err)
+	provider.pollTimeout = 100 * time.Millisecond
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "Time limit exceeded")
+	assert.Equal(t, 1, ts.changeCallCount())
+
+	err = provider.CleanUp(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "Time limit exceeded")
+	assert.Equal(t, 2, ts.changeCallCount(), "Expected CleanUp to submit a delete, not resume the pending upsert")
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "Time limit exceeded")
+	assert.Equal(t, 3, ts.changeCallCount(), "Expected Present to submit an upsert, not resume the pending delete")
+}
+
+// TestRoute53PresentForgetsVanishedChange demonstrates that when the
+// remembered change no longer exists (GetChange returns NoSuchChange), it is
+// forgotten so that the next attempt submits a new change.
+func TestRoute53PresentForgetsVanishedChange(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ts := newPendingChangeServer(t)
+
+	provider, err := makeRoute53Provider(ts.Server)
+	require.NoError(t, err)
+	provider.pollTimeout = 100 * time.Millisecond
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "Time limit exceeded")
+	assert.Equal(t, 1, ts.changeCallCount())
+
+	ts.setGetChange(MockResponse{StatusCode: 404, Body: GetChangeNoSuchChange404Response})
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.ErrorContains(t, err, "NoSuchChange", "Expected the retried Present to fail while polling the vanished change")
+	assert.Equal(t, 1, ts.changeCallCount())
+
+	ts.setGetChange(MockResponse{StatusCode: 200, Body: GetChangeResponse})
+
+	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, ts.changeCallCount(), "Expected a new change to be submitted after the original vanished")
 }
 
 func TestRoute53Cleanup(t *testing.T) {

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -356,7 +356,10 @@ func (s *pendingChangeServer) changeCallCount() int {
 // TestRoute53PresentResumesPendingChange demonstrates that when Present times
 // out waiting for a submitted record change to reach the INSYNC status, a
 // retried Present polls GetChange for the original change instead of
-// submitting a duplicate ChangeResourceRecordSets request.
+// submitting a duplicate ChangeResourceRecordSets request. The retry uses a
+// new DNSProvider sharing the same PendingChangesCache, because in production
+// a new provider is constructed for every challenge reconcile and only the
+// cache is shared between them.
 // See https://github.com/cert-manager/cert-manager/issues/9066
 func TestRoute53PresentResumesPendingChange(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
@@ -372,11 +375,15 @@ func TestRoute53PresentResumesPendingChange(t *testing.T) {
 
 	ts.setGetChange(MockResponse{StatusCode: 200, Body: GetChangeResponse})
 
-	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	retryProvider, err := makeRoute53Provider(ts.Server)
+	require.NoError(t, err)
+	retryProvider.pendingChanges = provider.pendingChanges
+
+	err = retryProvider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
 	assert.NoError(t, err, "Expected the retried Present to succeed once the change is INSYNC")
 	assert.Equal(t, 1, ts.changeCallCount(), "Expected the retried Present to resume the original change, not submit a new one")
 
-	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
+	err = retryProvider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, ts.changeCallCount(), "Expected a new change to be submitted once the original reached INSYNC")
 }
@@ -425,6 +432,7 @@ func TestRoute53PresentForgetsVanishedChange(t *testing.T) {
 
 	err = provider.Present(ctx, "example.com", "_acme-challenge.example.com.", "123456d==")
 	assert.ErrorContains(t, err, "NoSuchChange", "Expected the retried Present to fail while polling the vanished change")
+	assert.NotContains(t, err.Error(), "Time limit exceeded", "Expected Present to stop polling as soon as the change was reported missing")
 	assert.Equal(t, 1, ts.changeCallCount())
 
 	ts.setGetChange(MockResponse{StatusCode: 200, Body: GetChangeResponse})

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -102,6 +102,7 @@ func buildFakeSolver(b *test.Builder, dnsProviders dnsProviderConstructors) *Sol
 		Context:                 b.Context,
 		secretLister:            b.Context.KubeSharedInformerFactory.Secrets().Lister(),
 		dnsProviderConstructors: dnsProviders,
+		route53PendingChanges:   route53.NewPendingChangesCache(),
 	}
 	b.Start()
 	return s


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9066

When a Route 53 `ChangeResourceRecordSets` request does not reach the `INSYNC` status within 120 seconds, `Present` returns an error and the challenge controller retries it, submitting a fresh (idempotent but wasted) change on every retry. AWS documents that propagation can take up to ~30 minutes, so when Route 53 is under heavy traffic the retries compound the very rate limiting the user is already suffering from.

In #9066, an AWS engineer confirmed that the `INSYNC` gate must stay (querying the authoritative nameservers is not a substitute, because each is the front end of an anycast fleet), and recommended polling `GetChange` for the *same* change instead of re-submitting.

This PR makes `Present` and `CleanUp` resumable:

* A `PendingChangesCache`, owned by the DNS `Solver` and injected into every Route 53 provider it constructs (a new provider is constructed for every challenge reconcile, so the cache cannot live on the provider), remembers the change ID of a submitted-but-not-yet-`INSYNC` change, keyed by FQDN and record value.
* A retried `Present` or `CleanUp` resumes polling `GetChange` for the remembered change instead of submitting a duplicate. The cumulative wait across the controller's existing retries now covers the propagation worst case, without blocking a controller worker for longer than before.
* A pending change is forgotten when it reaches `INSYNC`, when `GetChange` reports `NoSuchChange`, or when it is superseded by a change for the same record with a different action (so a `CleanUp` after a timed-out `Present` never resumes the upsert, and vice versa).

The cache is in-memory, so a controller restart costs at most one extra idempotent change per in-flight challenge.

An alternative considered was persisting the change ID in the Challenge status and moving the wait to the Check phase, but that would need API and webhook-solver interface changes; this fix is contained in the Route 53 provider and its wiring.

### Kind

/kind bug

### Release Note

```release-note
The Route53 DNS01 solver now remembers the record changes it has submitted: if a change does not propagate before the Present timeout, the retry resumes waiting for the original change instead of submitting a duplicate, reducing Route 53 API traffic and rate limiting.
```

*with claude fable-5*
