### PR TITLE
fix: Reject invalid CIDRs in Certificate `nameConstraints` at admission time

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -213,17 +213,7 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	}
 
 	if crt.NameConstraints != nil {
-		if !utilfeature.DefaultFeatureGate.Enabled(feature.NameConstraints) {
-			el = append(el, field.Forbidden(fldPath.Child("nameConstraints"), "feature gate NameConstraints must be enabled"))
-		} else {
-			if !crt.IsCA {
-				el = append(el, field.Invalid(fldPath.Child("nameConstraints"), crt.NameConstraints, "isCa should be true when nameConstraints is set"))
-			}
-
-			if crt.NameConstraints.Permitted == nil && crt.NameConstraints.Excluded == nil {
-				el = append(el, field.Invalid(fldPath.Child("nameConstraints"), crt.NameConstraints, "either permitted or excluded must be set"))
-			}
-		}
+		el = append(el, validateNameConstraints(crt, fldPath)...)
 	}
 
 	el = append(el, validateAdditionalOutputFormats(crt, fldPath)...)
@@ -400,6 +390,42 @@ func ValidateDuration(crt *internalcmapi.CertificateSpec, fldPath *field.Path) f
 		}
 	}
 
+	return el
+}
+
+func validateNameConstraints(crt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+	nameConstraintsPath := fldPath.Child("nameConstraints")
+	if !utilfeature.DefaultFeatureGate.Enabled(feature.NameConstraints) {
+		return field.ErrorList{field.Forbidden(nameConstraintsPath, "feature gate NameConstraints must be enabled")}
+	}
+
+	el := field.ErrorList{}
+
+	if !crt.IsCA {
+		el = append(el, field.Invalid(nameConstraintsPath, crt.NameConstraints, "isCA should be true when nameConstraints is set"))
+	}
+
+	if crt.NameConstraints.Permitted == nil && crt.NameConstraints.Excluded == nil {
+		el = append(el, field.Invalid(nameConstraintsPath, crt.NameConstraints, "either permitted or excluded must be set"))
+	}
+
+	el = append(el, validateNameConstraintItem(crt.NameConstraints.Permitted, nameConstraintsPath.Child("permitted"))...)
+	el = append(el, validateNameConstraintItem(crt.NameConstraints.Excluded, nameConstraintsPath.Child("excluded"))...)
+
+	return el
+}
+
+func validateNameConstraintItem(item *internalcmapi.NameConstraintItem, fldPath *field.Path) field.ErrorList {
+	if item == nil {
+		return nil
+	}
+
+	el := field.ErrorList{}
+	for i, cidr := range item.IPRanges {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			el = append(el, field.Invalid(fldPath.Child("ipRanges").Index(i), cidr, "invalid CIDR address"))
+		}
+	}
 	return el
 }
 

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -748,6 +748,10 @@ func TestValidateCertificate(t *testing.T) {
 					NameConstraints: &internalcmapi.NameConstraints{
 						Permitted: &internalcmapi.NameConstraintItem{
 							DNSDomains: []string{"example.com"},
+							// The invalid CIDR must not be reported: the feature
+							// gate check short-circuits all other nameConstraints
+							// validation.
+							IPRanges: []string{"10.0.0.0"},
 						},
 					},
 					IssuerRef: validIssuerRef,
@@ -758,6 +762,54 @@ func TestValidateCertificate(t *testing.T) {
 				field.Forbidden(
 					fldPath.Child("nameConstraints"), "feature gate NameConstraints must be enabled"),
 			},
+		},
+		"valid with name constraints ipRanges": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IsCA:       true,
+					NameConstraints: &internalcmapi.NameConstraints{
+						Permitted: &internalcmapi.NameConstraintItem{
+							IPRanges: []string{"10.0.0.0/8", "192.168.0.0/16", "2001:db8::/32"},
+						},
+						Excluded: &internalcmapi.NameConstraintItem{
+							IPRanges: []string{"172.16.0.0/12", "fd00::/8"},
+						},
+					},
+					IssuerRef: validIssuerRef,
+				},
+			},
+			a:                             someAdmissionRequest,
+			nameConstraintsFeatureEnabled: true,
+		},
+		"invalid with name constraints ipRanges": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IsCA:       true,
+					NameConstraints: &internalcmapi.NameConstraints{
+						Permitted: &internalcmapi.NameConstraintItem{
+							IPRanges: []string{"10.0.0.0", "10.0.0.0/8", "not-a-cidr"},
+						},
+						Excluded: &internalcmapi.NameConstraintItem{
+							IPRanges: []string{"2001:db8::/32", "192.168.0.1"},
+						},
+					},
+					IssuerRef: validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Invalid(
+					fldPath.Child("nameConstraints", "permitted", "ipRanges").Index(0), "10.0.0.0", "invalid CIDR address"),
+				field.Invalid(
+					fldPath.Child("nameConstraints", "permitted", "ipRanges").Index(2), "not-a-cidr", "invalid CIDR address"),
+				field.Invalid(
+					fldPath.Child("nameConstraints", "excluded", "ipRanges").Index(1), "192.168.0.1", "invalid CIDR address"),
+			},
+			nameConstraintsFeatureEnabled: true,
 		},
 		"signature algorithm SHA+RSA allowed for empty key (RSA)": {
 			cfg: &internalcmapi.Certificate{


### PR DESCRIPTION
### Pull Request Motivation

A `Certificate` with an invalid CIDR such as `10.0.0.0` (no prefix length) in `spec.nameConstraints.permitted.ipRanges` or `spec.nameConstraints.excluded.ipRanges` was accepted by the validating webhook, and then failed on every CSR-generation attempt with `invalid CIDR address: 10.0.0.0`. Because the failure is derived entirely from the spec, retrying could never succeed, the Certificate was permanently un-issuable.

Fixes #9181

### E2E Verification

<details>
<summary>Rejection with exact message (permitted.ipRanges)</summary>

```
$ kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: s1-permitted-bad
  namespace: nc-cidr-after
spec:
  isCA: true
  commonName: s1-permitted-bad
  secretName: s1-permitted-bad-tls
  issuerRef:
    name: selfsigned
    kind: Issuer
    group: cert-manager.io
  nameConstraints:
    permitted:
      ipRanges:
        - "10.0.0.0"
EOF
Error from server (Forbidden): error when creating "s1-permitted-bad.yaml": admission webhook "webhook.cert-manager.io" denied the request: spec.nameConstraints.permitted.ipRanges[0]: Invalid value: "10.0.0.0": invalid CIDR address

$ kubectl get certificate -n nc-cidr-after
No resources found in nc-cidr-after namespace.
```

</details>

<details>
<summary>Rejection via excluded.ipRanges</summary>

```
$ kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: s2-excluded-bad
  namespace: nc-cidr-after
spec:
  isCA: true
  commonName: s2-excluded-bad
  secretName: s2-excluded-bad-tls
  issuerRef:
    name: selfsigned
    kind: Issuer
    group: cert-manager.io
  nameConstraints:
    excluded:
      ipRanges:
        - "10.0.0.0"
EOF
Error from server (Forbidden): error when creating "s2-excluded-bad.yaml": admission webhook "webhook.cert-manager.io" denied the request: spec.nameConstraints.excluded.ipRanges[0]: Invalid value: "10.0.0.0": invalid CIDR address
```

</details>

<details>
<summary> A valid Certificate cannot be edited into an invalid one</summary>

This is the desirable direction of the UPDATE coverage. It prevents a Ready Certificate from being broken.

```
$ kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: s7-update-block
  namespace: nc-cidr-after
spec:
  isCA: true
  commonName: s7-update-block
  secretName: s7-update-block-tls
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: selfsigned
    kind: Issuer
    group: cert-manager.io
  nameConstraints:
    permitted:
      ipRanges:
        - "10.0.0.0/8"
EOF
certificate.cert-manager.io/s7-update-block created

$ kubectl wait --for=condition=Ready --timeout=120s certificate/s7-update-block -n nc-cidr-after
certificate.cert-manager.io/s7-update-block condition met

$ kubectl patch certificate s7-update-block -n nc-cidr-after --type=merge -p '{"spec":{"nameConstraints":{"permitted":{"ipRanges":["10.0.0.0"]}}}}'
Error from server (Forbidden): admission webhook "webhook.cert-manager.io" denied the request: spec.nameConstraints.permitted.ipRanges[0]: Invalid value: "10.0.0.0": invalid CIDR address
```

</details>

### Kind

/kind bug

### Release Note

```release-note
The webhook now rejects Certificates whose `spec.nameConstraints.permitted.ipRanges` or `spec.nameConstraints.excluded.ipRanges` contain an invalid CIDR, rather than accepting a spec that can never be issued.
```
