### PR TITLE
fix(pki): reject an otherName value that is not explicitly tagged

### DIFF
--- a/pkg/util/pki/sans.go
+++ b/pkg/util/pki/sans.go
@@ -39,7 +39,11 @@ var (
 */
 type OtherName struct {
 	TypeID asn1.ObjectIdentifier
-	Value  asn1.RawValue `asn1:"tag:0,explicit"`
+	// Value must already carry the explicit [0] wrapper, holding exactly one
+	// well-formed element. The struct tag does not add it: encoding/asn1 honors
+	// `tag:0,explicit` when reading a RawValue but writes a RawValue out
+	// verbatim, so MarshalSANs emits whatever it is given here.
+	Value asn1.RawValue `asn1:"tag:0,explicit"`
 }
 
 // Based on RFC 5280, section 4.2.1.6
@@ -198,34 +202,70 @@ func forEachSAN(extension []byte, callback func(v asn1.RawValue) error) error {
 	return nil
 }
 
-// checkOtherNameValue reports whether an OtherName value carries the explicit
-// [0] tag that RFC 5280 section 4.2.1.6 requires of it:
+// checkSANsRoundTrip returns an error unless the SubjectAlternativeName
+// contents in value parse back as the same GeneralNames they were built from.
 //
-//	value [0] EXPLICIT ANY DEFINED BY type-id
+// Several GeneralName choices are supplied by the caller as an asn1.RawValue,
+// and encoding/asn1 writes a RawValue out verbatim - makeField returns early for
+// rawValueType - so both the `tag:N` given to MarshalWithParams and the
+// `asn1:"tag:0,explicit"` on OtherName.Value are honored when reading and
+// ignored when writing. A value supplied without the tag its choice is defined
+// with in RFC 5280 section 4.2.1.6 is therefore emitted as-is, and nothing
+// reports a problem:
 //
-// The field is an asn1.RawValue, and encoding/asn1 writes a RawValue out
-// verbatim: the `tag:0,explicit` on the field is honoured when reading but not
-// when writing. A value handed to MarshalSANs without that wrapper is therefore
-// emitted without it, producing a SubjectAlternativeName extension that
-// UnmarshalSANs - and any parser following RFC 5280 - refuses to read.
-func checkOtherNameValue(value asn1.RawValue) error {
-	raw := value
+//   - an otherName missing its explicit [0] wrapper produces an extension that
+//     UnmarshalSANs, in this same package, cannot read at all;
+//   - an x400Address missing its [3] tag, whose own tag happens to be one of the
+//     universal tags 0-8, is read back as a different GeneralName choice
+//     entirely, because UnmarshalSANs dispatches on that tag.
+//
+// Checking the finished bytes against the parser keeps the two in agreement by
+// construction, for every choice at once and for any choice added later, rather
+// than one hand-rolled check per loop that can drift from the parser it mirrors
+// - which is the class of bug being fixed here.
+func checkSANsRoundTrip(value []byte, gns GeneralNames) error {
+	const cause = "a GeneralName value supplied without the tag RFC 5280 section 4.2.1.6 defines it with will do this"
 
-	// A RawValue carrying FullBytes is written out as those bytes, so they are
-	// what has to be checked.
-	if len(value.FullBytes) > 0 {
-		rest, err := asn1.Unmarshal(value.FullBytes, &raw)
-		if err != nil {
-			return fmt.Errorf("x509: otherName value is not valid DER: %w", err)
-		}
-		if len(rest) != 0 {
-			return errors.New("x509: trailing data after otherName value")
+	parsed, err := UnmarshalSANs(value)
+	if err != nil {
+		return fmt.Errorf("x509: the SubjectAlternativeName contents cannot be parsed back; %s: %w", cause, err)
+	}
+
+	for _, choice := range []struct {
+		name     string
+		encoded  int
+		readBack int
+	}{
+		{"otherName", len(gns.OtherNames), len(parsed.OtherNames)},
+		{"rfc822Name", len(gns.RFC822Names), len(parsed.RFC822Names)},
+		{"dNSName", len(gns.DNSNames), len(parsed.DNSNames)},
+		{"x400Address", len(gns.X400Addresses), len(parsed.X400Addresses)},
+		{"directoryName", len(gns.DirectoryNames), len(parsed.DirectoryNames)},
+		{"ediPartyName", len(gns.EDIPartyNames), len(parsed.EDIPartyNames)},
+		{"uniformResourceIdentifier", len(gns.UniformResourceIdentifiers), len(parsed.UniformResourceIdentifiers)},
+		{"iPAddress", len(gns.IPAddresses), len(parsed.IPAddresses)},
+		{"registeredID", len(gns.RegisteredIDs), len(parsed.RegisteredIDs)},
+	} {
+		if choice.encoded != choice.readBack {
+			return fmt.Errorf("x509: encoded %d %s(s) but %d parsed back; %s",
+				choice.encoded, choice.name, choice.readBack, cause)
 		}
 	}
 
-	// [0] EXPLICIT is a constructed, context-specific tag 0.
-	if raw.Class != asn1.ClassContextSpecific || raw.Tag != 0 || !raw.IsCompound {
-		return errors.New("x509: otherName value must be wrapped in an explicit [0] tag, as required by RFC 5280 section 4.2.1.6")
+	// value is [0] EXPLICIT ANY, so exactly one well-formed element belongs
+	// inside the wrapper. encoding/asn1 does not descend into a RawValue under an
+	// explicit tag, so the round-trip above is satisfied by a wrapper holding
+	// arbitrary bytes - which matchOtherNames, reading this same field, then
+	// fails on.
+	for i, otherName := range parsed.OtherNames {
+		var inner asn1.RawValue
+		rest, err := asn1.Unmarshal(otherName.Value.Bytes, &inner)
+		if err != nil {
+			return fmt.Errorf("x509: otherName %d: the explicitly tagged value is not valid DER: %w", i, err)
+		}
+		if len(rest) != 0 {
+			return fmt.Errorf("x509: otherName %d: trailing data after the explicitly tagged value", i)
+		}
 	}
 
 	return nil
@@ -236,6 +276,9 @@ func checkOtherNameValue(value asn1.RawValue) error {
 // SubjectAlternativeName extension.
 func MarshalSANs(gns GeneralNames, hasSubject bool) (pkix.Extension, error) {
 	var rawValues []asn1.RawValue
+	// tag is ignored when val is an asn1.RawValue: encoding/asn1 writes a
+	// RawValue out verbatim, so such a value has to carry its own tag already.
+	// checkSANsRoundTrip, below, is what enforces that.
 	addMarshalable := func(tag int, val any) error {
 		fullBytes, err := asn1.MarshalWithParams(val, fmt.Sprint("tag:", tag))
 		if err != nil {
@@ -279,9 +322,6 @@ func MarshalSANs(gns GeneralNames, hasSubject bool) (pkix.Extension, error) {
 
 	// Add support for the remaining SAN types.
 	for _, val := range gns.OtherNames {
-		if err := checkOtherNameValue(val.Value); err != nil {
-			return pkix.Extension{}, err
-		}
 		if err := addMarshalable(nameTypeOtherName, val); err != nil {
 			return pkix.Extension{}, err
 		}
@@ -309,6 +349,10 @@ func MarshalSANs(gns GeneralNames, hasSubject bool) (pkix.Extension, error) {
 
 	byteValue, err := asn1.Marshal(rawValues)
 	if err != nil {
+		return pkix.Extension{}, err
+	}
+
+	if err := checkSANsRoundTrip(byteValue, gns); err != nil {
 		return pkix.Extension{}, err
 	}
 

--- a/pkg/util/pki/sans.go
+++ b/pkg/util/pki/sans.go
@@ -198,6 +198,39 @@ func forEachSAN(extension []byte, callback func(v asn1.RawValue) error) error {
 	return nil
 }
 
+// checkOtherNameValue reports whether an OtherName value carries the explicit
+// [0] tag that RFC 5280 section 4.2.1.6 requires of it:
+//
+//	value [0] EXPLICIT ANY DEFINED BY type-id
+//
+// The field is an asn1.RawValue, and encoding/asn1 writes a RawValue out
+// verbatim: the `tag:0,explicit` on the field is honoured when reading but not
+// when writing. A value handed to MarshalSANs without that wrapper is therefore
+// emitted without it, producing a SubjectAlternativeName extension that
+// UnmarshalSANs - and any parser following RFC 5280 - refuses to read.
+func checkOtherNameValue(value asn1.RawValue) error {
+	raw := value
+
+	// A RawValue carrying FullBytes is written out as those bytes, so they are
+	// what has to be checked.
+	if len(value.FullBytes) > 0 {
+		rest, err := asn1.Unmarshal(value.FullBytes, &raw)
+		if err != nil {
+			return fmt.Errorf("x509: otherName value is not valid DER: %w", err)
+		}
+		if len(rest) != 0 {
+			return errors.New("x509: trailing data after otherName value")
+		}
+	}
+
+	// [0] EXPLICIT is a constructed, context-specific tag 0.
+	if raw.Class != asn1.ClassContextSpecific || raw.Tag != 0 || !raw.IsCompound {
+		return errors.New("x509: otherName value must be wrapped in an explicit [0] tag, as required by RFC 5280 section 4.2.1.6")
+	}
+
+	return nil
+}
+
 // adapted from https://cs.opensource.google/go/go/+/master:src/crypto/x509/x509.go;l=1059-1103;drc=e2d9574b14b3db044331da0c6fadeb62315c644a
 // MarshalSANs marshals a list of addresses into the contents of an X.509
 // SubjectAlternativeName extension.
@@ -246,6 +279,9 @@ func MarshalSANs(gns GeneralNames, hasSubject bool) (pkix.Extension, error) {
 
 	// Add support for the remaining SAN types.
 	for _, val := range gns.OtherNames {
+		if err := checkOtherNameValue(val.Value); err != nil {
+			return pkix.Extension{}, err
+		}
 		if err := addMarshalable(nameTypeOtherName, val); err != nil {
 			return pkix.Extension{}, err
 		}

--- a/pkg/util/pki/sans_test.go
+++ b/pkg/util/pki/sans_test.go
@@ -101,12 +101,19 @@ func generateOtherName(t *testing.T, val UniversalValue) asn1.RawValue {
 // An OtherName value that is not wrapped in the explicit [0] tag RFC 5280
 // requires used to marshal without complaint, into an extension that
 // UnmarshalSANs could not read back.
-func TestMarshalSANsRejectsUnwrappedOtherNameValue(t *testing.T) {
+func TestMarshalSANsRejectsValuesItCannotReadBack(t *testing.T) {
 	oid := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 20, 2, 3}
 
 	inner, err := MarshalUniversalValue(UniversalValue{UTF8String: "upn@example.com"})
 	if err != nil {
 		t.Fatalf("MarshalUniversalValue returned an error: %v", err)
+	}
+	wrapped := func(b []byte) asn1.RawValue {
+		return asn1.RawValue{Tag: 0, Class: asn1.ClassContextSpecific, IsCompound: true, Bytes: b}
+	}
+	oidValue, err := asn1.Marshal(asn1.ObjectIdentifier{1, 2, 3, 4})
+	if err != nil {
+		t.Fatalf("asn1.Marshal returned an error: %v", err)
 	}
 
 	tests := map[string]struct {
@@ -114,15 +121,15 @@ func TestMarshalSANsRejectsUnwrappedOtherNameValue(t *testing.T) {
 		expErr bool
 	}{
 		"wrapped in an explicit [0] tag, as csr.go builds it": {
-			value: asn1.RawValue{
-				Tag:        0,
-				Class:      asn1.ClassContextSpecific,
-				IsCompound: true,
-				Bytes:      inner,
-			},
+			value: wrapped(inner),
 		},
 		"wrapped, carrying FullBytes as well": {
 			value: generateOtherName(t, UniversalValue{UTF8String: "upn@example.com"}),
+		},
+		// value is ANY DEFINED BY type-id, so the inner element is not required
+		// to be a UTF8String.
+		"wrapped around a value that is not a UTF8String": {
+			value: wrapped(oidValue),
 		},
 		"unwrapped, the inner value given through FullBytes": {
 			value:  asn1.RawValue{FullBytes: inner},
@@ -138,6 +145,27 @@ func TestMarshalSANsRejectsUnwrappedOtherNameValue(t *testing.T) {
 		},
 		"no value at all": {
 			value:  asn1.RawValue{},
+			expErr: true,
+		},
+		// The wrapper is the right shape but holds nothing. UnmarshalSANs fails
+		// on the result with "explicit tag has no child".
+		"an empty wrapper": {
+			value:  wrapped(nil),
+			expErr: true,
+		},
+		"an empty wrapper given through FullBytes": {
+			value:  asn1.RawValue{FullBytes: []byte{0xa0, 0x00}},
+			expErr: true,
+		},
+		// A correct wrapper is not enough on its own: encoding/asn1 does not
+		// descend into a RawValue under an explicit tag, so these survive both
+		// marshalling and UnmarshalSANs, and fail later in matchOtherNames.
+		"a wrapper holding bytes that are not an element": {
+			value:  wrapped([]byte{0xff}),
+			expErr: true,
+		},
+		"a wrapper holding two elements": {
+			value:  wrapped(append(append([]byte{}, inner...), inner...)),
 			expErr: true,
 		},
 	}
@@ -158,8 +186,73 @@ func TestMarshalSANsRejectsUnwrappedOtherNameValue(t *testing.T) {
 			}
 
 			// Whatever MarshalSANs accepts, UnmarshalSANs must be able to read.
-			if _, err := UnmarshalSANs(extension.Value); err != nil {
-				t.Fatalf("UnmarshalSANs could not read back a marshalled extension: %v", err)
+			parsed, err := UnmarshalSANs(extension.Value)
+			if err != nil {
+				t.Fatalf("UnmarshalSANs could not read back a marshaled extension: %v", err)
+			}
+
+			// ...and so must the otherName path that matchOtherNames uses.
+			var innerValue asn1.RawValue
+			if _, err := asn1.Unmarshal(parsed.OtherNames[0].Value.Bytes, &innerValue); err != nil {
+				t.Fatalf("the value inside the wrapper could not be read back: %v", err)
+			}
+		})
+	}
+}
+
+// x400Address is [3] ORAddress, and the tag parameter is equally inert for the
+// asn1.RawValue that carries it. An unwrapped value whose own tag is one of the
+// universal tags 0-8 is not merely unreadable: UnmarshalSANs dispatches on that
+// tag, so it comes back as a different GeneralName choice entirely.
+func TestMarshalSANsRejectsUntaggedX400Address(t *testing.T) {
+	// [3] is implicit, so the ORAddress SEQUENCE tag is replaced by the [3] tag
+	// rather than nested inside it. Note this cannot be built with
+	// asn1.MarshalWithParams(..., "tag:3") - for a RawValue that parameter is
+	// exactly the one that does nothing.
+	tagged := asn1.RawValue{Tag: nameTypeX400Address, Class: asn1.ClassContextSpecific, IsCompound: true}
+	// universal tag 2 is INTEGER, and nameTypeDNSName is 2
+	misleading, err := asn1.Marshal(42)
+	if err != nil {
+		t.Fatalf("asn1.Marshal returned an error: %v", err)
+	}
+
+	tests := map[string]struct {
+		value  asn1.RawValue
+		expErr bool
+	}{
+		"carrying its [3] tag, as UnmarshalSANs returns it": {
+			value: tagged,
+		},
+		"the same value given through FullBytes": {
+			value: asn1.RawValue{FullBytes: []byte{0xa3, 0x00}},
+		},
+		"untagged, and read back as a dNSName instead": {
+			value:  asn1.RawValue{FullBytes: misleading},
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gns := GeneralNames{X400Addresses: []asn1.RawValue{test.value}}
+
+			extension, err := MarshalSANs(gns, true)
+			if test.expErr {
+				if err == nil {
+					t.Fatalf("expected MarshalSANs to reject the value, but it returned %v", extension)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MarshalSANs returned an error: %v", err)
+			}
+
+			parsed, err := UnmarshalSANs(extension.Value)
+			if err != nil {
+				t.Fatalf("UnmarshalSANs could not read back a marshaled extension: %v", err)
+			}
+			if len(parsed.X400Addresses) != 1 {
+				t.Fatalf("expected the value to come back as an x400Address, got %+v", parsed)
 			}
 		})
 	}

--- a/pkg/util/pki/sans_test.go
+++ b/pkg/util/pki/sans_test.go
@@ -98,6 +98,73 @@ func generateOtherName(t *testing.T, val UniversalValue) asn1.RawValue {
 	return rv
 }
 
+// An OtherName value that is not wrapped in the explicit [0] tag RFC 5280
+// requires used to marshal without complaint, into an extension that
+// UnmarshalSANs could not read back.
+func TestMarshalSANsRejectsUnwrappedOtherNameValue(t *testing.T) {
+	oid := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 20, 2, 3}
+
+	inner, err := MarshalUniversalValue(UniversalValue{UTF8String: "upn@example.com"})
+	if err != nil {
+		t.Fatalf("MarshalUniversalValue returned an error: %v", err)
+	}
+
+	tests := map[string]struct {
+		value  asn1.RawValue
+		expErr bool
+	}{
+		"wrapped in an explicit [0] tag, as csr.go builds it": {
+			value: asn1.RawValue{
+				Tag:        0,
+				Class:      asn1.ClassContextSpecific,
+				IsCompound: true,
+				Bytes:      inner,
+			},
+		},
+		"wrapped, carrying FullBytes as well": {
+			value: generateOtherName(t, UniversalValue{UTF8String: "upn@example.com"}),
+		},
+		"unwrapped, the inner value given through FullBytes": {
+			value:  asn1.RawValue{FullBytes: inner},
+			expErr: true,
+		},
+		"unwrapped, the inner value given through Tag and Bytes": {
+			value: asn1.RawValue{
+				Tag:   asn1.TagUTF8String,
+				Class: asn1.ClassUniversal,
+				Bytes: []byte("upn@example.com"),
+			},
+			expErr: true,
+		},
+		"no value at all": {
+			value:  asn1.RawValue{},
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gns := GeneralNames{OtherNames: []OtherName{{TypeID: oid, Value: test.value}}}
+
+			extension, err := MarshalSANs(gns, true)
+			if test.expErr {
+				if err == nil {
+					t.Fatalf("expected MarshalSANs to reject the value, but it returned %v", extension)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MarshalSANs returned an error: %v", err)
+			}
+
+			// Whatever MarshalSANs accepts, UnmarshalSANs must be able to read.
+			if _, err := UnmarshalSANs(extension.Value); err != nil {
+				t.Fatalf("UnmarshalSANs could not read back a marshalled extension: %v", err)
+			}
+		})
+	}
+}
+
 func TestMarshalAndUnmarshalSANs(t *testing.T) {
 	type testCase struct {
 		hasSubject   bool


### PR DESCRIPTION
### Pull Request Motivation

From the open follow-ups in #9155:

> `MarshalSANs` accepts unwrapped otherName values and emits an extension that `UnmarshalSANs` then rejects ([sans.go#L204](https://github.com/cert-manager/cert-manager/blob/cd21f71bdf49ff3f8c90af6b3adf176b1461028f/pkg/util/pki/sans.go#L204))

RFC 5280 section 4.2.1.6 defines the value of an `OtherName` as

```
value [0] EXPLICIT ANY DEFINED BY type-id
```

and `OtherName.Value` carries the matching `asn1:"tag:0,explicit"` struct tag. `encoding/asn1` honors that tag when **reading** a `RawValue`, but writes a `RawValue` out **verbatim** (`makeField` returns early for `rawValueType`) — the tag is inert on the marshalling side. A value handed to `MarshalSANs` without the wrapper was therefore emitted without it, and nothing anywhere reported a problem.

The same is true of the `tag:N` parameter `addMarshalable` passes to `asn1.MarshalWithParams`, which is why this is a class of bug rather than one instance.

### The change

Rather than hand-roll a check per loop, **check the finished extension against the parser**: `MarshalSANs` now parses its own output back with `UnmarshalSANs` and requires every `GeneralName` choice to return in the same number it went in as. The marshaller and the parser agree by construction, for every choice at once and for any choice added later, instead of a mirror of the parser that can drift from it — which is the bug being fixed.

Reworked from the first version of this PR after @wallrj's review, which found two ways past the hand-rolled check and pointed out that `x400Address` carries the same hazard one loop down. Three cases the previous version emitted are now rejected:

| input | what used to happen |
|---|---|
| an empty wrapper (`A0 00`, either shape) | passed the shape check; `UnmarshalSANs` then failed with `explicit tag has no child` |
| an `x400Address` with no `[3]` tag whose own tag is a universal tag 0–8 | **read back as a different `GeneralName` choice** — an `INTEGER` comes back as a `dNSName`, since `UnmarshalSANs` dispatches on `v.Tag` |
| a correct wrapper holding bytes that are not one well-formed element | survived marshal *and* `UnmarshalSANs`, then failed in cert-manager's own `matchOtherNames` |

**One correction to the review, and the reason the change is not purely the round-trip.** The suggestion was that parse-back would reject both otherName cases for free. It rejects the empty wrapper, but not the third row: `encoding/asn1` does not descend into a `RawValue` under an explicit tag ([asn1.go#L789-L792](https://github.com/golang/go/blob/go1.25.5/src/encoding/asn1/asn1.go#L789-L792) — *"The inner element should not be parsed for RawValues"*), so `A0 01 FF` parses back happily. I checked this with a probe before relying on it:

```
case                         parse-back only    parse-back + inner
control wrapped+valid        accept             accept
control FullBytes wrapped    accept             accept
unwrapped FullBytes          REJECT             REJECT
empty wrapper                REJECT             REJECT
garbage inside wrapper       accept             REJECT
two elements inside wrapper  accept             REJECT
```

So the value inside the wrapper is parsed explicitly as well — reading it from `parsed.Value.Bytes`, the same place `matchOtherNames` reads it from, which is also what keeps a value supplied through `FullBytes` from being falsely rejected. `value` is `ANY DEFINED BY type-id`, so this requires one well-formed element and nothing more; a non-`UTF8String` inner value is still accepted, and there is a test for that.

Also addressed from the review: the doc comment now says "returns an error" rather than "reports whether", US spelling throughout, a comment on `addMarshalable` recording that its `tag` parameter does nothing for an `asn1.RawValue`, and the contract documented on the exported `OtherName.Value` field itself so the next out-of-tree caller does not hit the same surprise.

Everything in tree already supplies the tags — `CreateCertificateRequest` builds `asn1.RawValue{Tag: 0, Class: asn1.ClassContextSpecific, IsCompound: true, Bytes: value}` explicitly, and the `generateOtherName` test helper does the same — so this asserts what the callers were already doing and moves the failure to the point where the mistake is made. `MarshalSANs` has exactly one non-test caller, `csr.go:251`.

### Tests

`TestMarshalSANsRejectsValuesItCannotReadBack` covers 4 accepted shapes and 7 rejected ones; `TestMarshalSANsRejectsUntaggedX400Address` covers the mirrored `[3]` case, including the silent reclassification. For every accepted shape it asserts both that `UnmarshalSANs` can read the result *and* that the value inside the wrapper parses — the two properties that were broken.

- **Revert-checked**: with the `checkSANsRoundTrip` call removed and the tests kept, exactly the 8 rejection cases fail and every accepted shape still passes.
- `./pkg/util/...`, `./internal/apis/certmanager/...`, `./pkg/controller/certificates/...` and `./pkg/apis/...` are **all green** — that is the full set of packages that reach `MarshalSANs`.
- `go vet` and `gofmt` clean.

<!-- Based on an older master because my token cannot push the workflow files current master carries; the compare API confirms the PR touches exactly these 2 files. Happy to rebase whenever it's useful. -->

### Kind

/kind bug

### Release Note

```release-note
`MarshalSANs` now verifies that the SubjectAlternativeName extension it produces can be parsed back, and returns an error instead of emitting one that cannot. This rejects `otherName` and `x400Address` values supplied without the context-specific tag RFC 5280 requires, which previously produced an unreadable extension or, for `x400Address`, one that parsed back as a different name type.
```

**AI disclosure:** this change, and my replies on it, were prepared with the assistance of Claude Code. I review the change, the verification and each reply before it is posted, and I stand behind them as my own.
