### PR TITLE
Deflake TestDynamicSource_FailingSign

### DIFF
--- a/pkg/server/tls/dynamic_source_test.go
+++ b/pkg/server/tls/dynamic_source_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tls
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -213,15 +214,13 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 					// Rotate the root
 					mockAuth.notifyCh <- struct{}{}
 
-					// Sleep for a short time to allow the DynamicSource to generate a new certificate
-					time.Sleep(50 * time.Millisecond)
-
-					// Call the GetCertificate method, should return a NEW certificate
-					cert2, err := source.GetCertificate(&tls.ClientHelloInfo{})
-					assert.NoError(t, err)
-					assert.NotNil(t, cert2)
-
-					assert.NotEqual(t, cert.Certificate[0], cert2.Certificate[0])
+					// Wait for the DynamicSource to generate a new certificate; how
+					// long that takes varies with the load on the test machine.
+					previous := cert
+					assert.Eventually(t, func() bool {
+						cert, err = source.GetCertificate(&tls.ClientHelloInfo{})
+						return err == nil && cert != nil && !bytes.Equal(cert.Certificate[0], previous.Certificate[0])
+					}, 10*time.Second, 10*time.Millisecond)
 				}
 			},
 		},
@@ -252,20 +251,14 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 				assert.NotNil(t, cert)
 
 				for range 5 {
-					// Sleep for a short time to allow the DynamicSource to generate a new certificate
-					// The certificate should get renewed after 100ms, we wait for 200ms to allow for
-					// possible delays of max 100ms (based on experiments, we noticed that issuance of
-					// a cert takes about 30ms, so 100ms should be a large enough margin).
-					time.Sleep(200 * time.Millisecond)
-
-					// Call the GetCertificate method, should return a NEW certificate
-					newCert, err := source.GetCertificate(&tls.ClientHelloInfo{})
-					assert.NoError(t, err)
-					assert.NotNil(t, newCert)
-
-					assert.NotEqual(t, cert.Certificate[0], newCert.Certificate[0])
-
-					cert = newCert
+					// Wait for the DynamicSource to renew the certificate, which
+					// should happen 100ms after its NotBefore time; how long the
+					// renewal takes varies with the load on the test machine.
+					previous := cert
+					assert.Eventually(t, func() bool {
+						cert, err = source.GetCertificate(&tls.ClientHelloInfo{})
+						return err == nil && cert != nil && !bytes.Equal(cert.Certificate[0], previous.Certificate[0])
+					}, 10*time.Second, 10*time.Millisecond)
 				}
 			},
 		},
@@ -292,17 +285,19 @@ func TestDynamicSource_FailingSign(t *testing.T) {
 			group.Go(func() error {
 				return source.Start(gctx)
 			})
-			t.Cleanup(func() {
-				err := group.Wait()
-				if tc.expStartErr == "" {
-					assert.NoError(t, err)
-				} else {
-					assert.Error(t, err)
-					assert.Contains(t, err.Error(), tc.expStartErr)
-				}
-			})
-
 			tc.testFn(t, source, mockAuth)
+
+			if tc.expStartErr == "" {
+				// Start returns nil only after t.Context is cancelled, which
+				// happens just before Cleanup-registered functions are called.
+				t.Cleanup(func() {
+					assert.NoError(t, group.Wait())
+				})
+			} else {
+				// Wait while t.Context is still alive: Start must return this
+				// error on its own, not as a side effect of test shutdown.
+				assert.ErrorContains(t, group.Wait(), tc.expStartErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes three races that make `TestDynamicSource_FailingSign` flaky. It failed twice in a row on the CI for #9196, each time in a different way, once with a panic that took down the other parallel subtests:

- [failure 1](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/9196/pull-cert-manager-master-make-test/2091967901857746944): `rotate_root` asserted a new serving certificate 50ms after signalling a root rotation, but regeneration took longer on a loaded machine.
- [failure 2](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/9196/pull-cert-manager-master-make-test/2092121294513377280): `certificate_authority_stopped_unexpectedly` panicked in its cleanup. The test waited for `Start` in `t.Cleanup`, but [`t.Context` is cancelled just before cleanup functions run](https://pkg.go.dev/testing#T.Context), so `Start`'s authority goroutine could observe the cancelled context and [treat the stop as a clean shutdown](https://github.com/cert-manager/cert-manager/blob/c2192471af0f75d1d199470ff10d1e4283a5d24c/pkg/server/tls/dynamic_source.go#L99-L104), returning nil instead of the expected error. `assert.Error` then failed and the next line called `err.Error()` on the nil error — hence the panic. This window was opened when #7783 replaced the explicit cancel-after-Wait handling with `t.Context()`.
- A third case, `expire_leaf`, has the same fixed-sleep problem as `rotate_root` and fails reliably under load (`go test -race -count=10`).

The fix:

- Poll with `assert.Eventually` instead of fixed sleeps in `rotate_root` and `expire_leaf`.
- For the cases that expect an error from `Start`, wait at the end of the test body — while the test context is still alive — rather than in `t.Cleanup`, and use `assert.ErrorContains` so an unexpected nil error fails cleanly instead of panicking.

Verified with `go test -race -run TestDynamicSource_FailingSign -count=10 ./pkg/server/tls/` (fails on master under this load, passes with this change) and `go test -race -count=3 ./pkg/server/tls/...`.

The fixed sleeps date back to #6784, which added these tests; #6914 already widened the `expire_leaf` sleep from 100ms to 200ms after CI failures. No behaviour of `DynamicSource` itself is changed.

/kind cleanup

```release-note
NONE
```

*with claude fable-5*

