### PR TITLE
fix: Record Warning events for silent per-Certificate failures

### DIFF
--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -41,6 +41,11 @@ import (
 // DefaultPassword is the string "changeit", a commonly-used password for keystore files.
 const DefaultKeystorePassword = "changeit"
 
+const (
+	reasonKeystorePasswordSecretNotFound = "KeystorePasswordSecretNotFound"
+	reasonSecretDataFailed               = "SecretDataFailed"
+)
+
 var (
 	certificateGvk = cmapi.SchemeGroupVersion.WithKind("Certificate")
 )
@@ -101,6 +106,11 @@ func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate,
 	log = logf.WithResource(log, secret)
 
 	if err := s.setValues(crt, secret, data); err != nil {
+		// setValues is the single choke point for every failure to build the
+		// Secret contents. These are typically a misconfiguration of the
+		// Certificate that repeats on every reconcile, so record them rather
+		// than leaving them visible only in the controller logs.
+		s.recorder.Eventf(crt, corev1.EventTypeWarning, reasonSecretDataFailed, "Failed to build Secret data: %s", err.Error())
 		return err
 	}
 
@@ -260,7 +270,7 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 			pwSecret, err := s.secretLister.Secrets(crt.Namespace).Get(ref.Name)
 
 			if apierrors.IsNotFound(err) {
-				s.recorder.Eventf(crt, corev1.EventTypeWarning, "KeystorePasswordSecretNotFound", "PKCS12 keystore password Secret %q not found", ref.Name)
+				s.recorder.Eventf(crt, corev1.EventTypeWarning, reasonKeystorePasswordSecretNotFound, "PKCS12 keystore password Secret %q not found", ref.Name)
 			}
 
 			if err != nil {
@@ -315,7 +325,7 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 			pwSecret, err := s.secretLister.Secrets(crt.Namespace).Get(ref.Name)
 
 			if apierrors.IsNotFound(err) {
-				s.recorder.Eventf(crt, corev1.EventTypeWarning, "KeystorePasswordSecretNotFound", "JKS keystore password Secret %q not found", ref.Name)
+				s.recorder.Eventf(crt, corev1.EventTypeWarning, reasonKeystorePasswordSecretNotFound, "JKS keystore password Secret %q not found", ref.Name)
 			}
 
 			if err != nil {

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -30,7 +30,6 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/tools/record"
 	fakeclock "k8s.io/utils/clock/testing"
 
 	"github.com/cert-manager/cert-manager/internal/pem"
@@ -98,6 +97,22 @@ func Test_SecretsManager(t *testing.T) {
 		gen.SetCertificateKeystore(&cmapi.CertificateKeystores{PKCS12: &cmapi.PKCS12Keystore{Create: true, Password: &keystorePassword}}),
 	)
 
+	// PKCS#12 passwords are encoded as UCS-2, so a password containing a rune
+	// outside the Basic Multilingual Plane can never be encoded. The webhook
+	// only checks that the password is non-empty, so such a Certificate is
+	// accepted and then fails on every reconcile.
+	nonBMPKeystorePassword := "password🔐"
+	baseCertWithNonBMPPKCS12Password := gen.CertificateFrom(baseCertBundle.Certificate,
+		gen.SetCertificateKeystore(&cmapi.CertificateKeystores{PKCS12: &cmapi.PKCS12Keystore{Create: true, Password: &nonBMPKeystorePassword}}),
+	)
+
+	baseCertWithJKSPasswordSecretRef := gen.CertificateFrom(baseCertBundle.Certificate,
+		gen.SetCertificateKeystore(&cmapi.CertificateKeystores{JKS: &cmapi.JKSKeystore{
+			Create:            true,
+			PasswordSecretRef: cmmeta.SecretKeySelector{LocalObjectReference: cmmeta.LocalObjectReference{Name: "jks-password"}},
+		}}),
+	)
+
 	block, _, _ := pem.SafeDecodePrivateKey(baseCertBundle.PrivateKeyBytes)
 	tlsDerContent := block.Bytes
 
@@ -110,6 +125,10 @@ func Test_SecretsManager(t *testing.T) {
 		applyFn    func(t *testing.T) testcoreclients.ApplyFn
 
 		expectedErr bool
+
+		// expectedEvents are the events expected to be recorded against the
+		// Certificate, in order.
+		expectedEvents []string
 	}{
 		"if secret does not exists and unable to decode certificate, then error": {
 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
@@ -126,6 +145,9 @@ func Test_SecretsManager(t *testing.T) {
 				}
 			},
 			expectedErr: true,
+			expectedEvents: []string{
+				"Warning SecretDataFailed Failed to build Secret data: error decoding certificate PEM block: no valid certificates found",
+			},
 		},
 
 		"if secret does not exist, create new Secret, with owner disabled": {
@@ -801,6 +823,53 @@ func Test_SecretsManager(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+
+		"if the PKCS12 keystore password cannot be encoded, record a Warning event": {
+			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
+			certificate:        baseCertWithNonBMPPKCS12Password,
+			existingSecret:     nil,
+			secretData: SecretData{
+				Certificate: baseCertBundle.CertBytes, PrivateKey: baseCertBundle.PrivateKeyBytes,
+				CertificateName: "test", IssuerName: "ca-issuer", IssuerKind: "Issuer", IssuerGroup: "foo.io",
+			},
+			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
+				return func(context.Context, *applycorev1.SecretApplyConfiguration, metav1.ApplyOptions) (*corev1.Secret, error) {
+					t.Error("unexpected apply call")
+					return nil, nil
+				}
+			},
+			expectedErr: true,
+			expectedEvents: []string{
+				"Warning SecretDataFailed Failed to build Secret data: failed to add keystores to Secret: error encoding PKCS12 bundle: pkcs12: string contains characters that cannot be encoded in UCS-2",
+			},
+		},
+
+		"if the JKS keystore password Secret has no data for the referenced key, record a Warning event": {
+			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
+			certificate:        baseCertWithJKSPasswordSecretRef,
+			// The fake Secret lister returns this Secret for every name, so it
+			// stands in both for the target Secret and for the password Secret.
+			// passwordSecretRef.key is unset and never defaulted, so the lookup
+			// is for the empty key, which this Secret has no data for.
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: gen.DefaultTestNamespace, Name: "output"},
+				Data:       map[string][]byte{"not-the-password-key": []byte("foo")},
+			},
+			secretData: SecretData{
+				Certificate: baseCertBundle.CertBytes, PrivateKey: baseCertBundle.PrivateKeyBytes,
+				CertificateName: "test", IssuerName: "ca-issuer", IssuerKind: "Issuer", IssuerGroup: "foo.io",
+			},
+			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
+				return func(context.Context, *applycorev1.SecretApplyConfiguration, metav1.ApplyOptions) (*corev1.Secret, error) {
+					t.Error("unexpected apply call")
+					return nil, nil
+				}
+			},
+			expectedErr: true,
+			expectedEvents: []string{
+				`Warning SecretDataFailed Failed to build Secret data: failed to add keystores to Secret: JKS keystore password Secret contains no data for key ""`,
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -815,9 +884,10 @@ func Test_SecretsManager(t *testing.T) {
 			}
 			secretLister := testcorelisters.NewFakeSecretLister(mod)
 
+			recorder := new(testpkg.FakeRecorder)
 			testManager := NewSecretsManager(
 				secretClient, secretLister,
-				record.NewFakeRecorder(10),
+				recorder,
 				testpkg.FieldManager,
 				test.certificateOptions.EnableOwnerRef,
 			)
@@ -829,6 +899,8 @@ func Test_SecretsManager(t *testing.T) {
 			if err == nil && test.expectedErr {
 				t.Errorf("expected to get an error but did not get one")
 			}
+
+			assert.Equal(t, test.expectedEvents, recorder.Events)
 		})
 	}
 }

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -52,7 +52,8 @@ import (
 )
 
 const (
-	ControllerName = "certificates-issuing"
+	ControllerName                   = "certificates-issuing"
+	reasonTemporaryCertificateFailed = "TemporaryCertificateFailed"
 )
 
 type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, error)
@@ -400,6 +401,9 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	// return early - we will sync again since the target Secret has been
 	// updated.
 	if issued, err := c.ensureTemporaryCertificate(ctx, crt, pk); err != nil || issued {
+		if err != nil {
+			c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonTemporaryCertificateFailed, "Failed to issue temporary certificate: %s", err.Error())
+		}
 		return err
 	}
 

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -19,6 +19,7 @@ package issuing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -60,6 +61,10 @@ func TestIssuingController(t *testing.T) {
 
 		certificate             *cmapi.Certificate
 		expSecretUpdateDataCall *internal.SecretData
+
+		// localTemporarySigner, if set, overrides the signer that the runner
+		// otherwise wires up to return a valid temporary certificate.
+		localTemporarySigner localTemporarySignerFn
 
 		expectedErr bool
 	}
@@ -824,6 +829,44 @@ func TestIssuingController(t *testing.T) {
 			expectedErr: false,
 		},
 
+		// Issuing a temporary certificate can fail on a Certificate that the
+		// webhook accepts, e.g. an unsupported spec.privateKey.encoding, and
+		// then fails identically on every reconcile.
+		"if certificate is in Issuing state with temp annotation and the temporary certificate cannot be issued, record a Warning event": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert,
+						gen.AddCertificateAnnotations(map[string]string{
+							cmapi.IssueTemporaryCertificateAnnotation: "true",
+						}),
+					),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestPending,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedEvents: []string{
+					"Warning TemporaryCertificateFailed Failed to issue temporary certificate: this is a signing error",
+				},
+			},
+			localTemporarySigner: func(_ *cmapi.Certificate, _ []byte) ([]byte, error) {
+				return nil, errors.New("this is a signing error")
+			},
+			expectedErr: true,
+		},
+
 		"if certificate is in Issuing state with temp annotation, one CertificateRequest Pending, a target Secret but with no data, issue temporary certificate to that Secret": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{
@@ -1575,6 +1618,9 @@ func TestIssuingController(t *testing.T) {
 			_, _, err := w.Register(test.builder.Context)
 			require.NoError(t, err)
 			w.controller.localTemporarySigner = testLocalTemporarySignerFn(exampleBundle.LocalTemporaryCertificateBytes)
+			if test.localTemporarySigner != nil {
+				w.controller.localTemporarySigner = test.localTemporarySigner
+			}
 
 			var secretsUpdateDataCalled bool
 			w.controller.secretsUpdateData = func(_ context.Context, _ *cmapi.Certificate, secretData internal.SecretData) error {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -21,7 +21,9 @@ import (
 	"crypto"
 	"encoding/pem"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -51,9 +53,10 @@ import (
 )
 
 const (
-	ControllerName      = "certificates-request-manager"
-	reasonRequestFailed = "RequestFailed"
-	reasonRequested     = "Requested"
+	ControllerName        = "certificates-request-manager"
+	reasonRequestFailed   = "RequestFailed"
+	reasonRequested       = "Requested"
+	reasonRequestConflict = "RequestConflict"
 )
 
 var (
@@ -227,7 +230,16 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		// TODO: we should handle this case better, but for now do nothing to
 		//  avoid getting into loops where we keep creating multiple requests
 		//  and deleting them again.
-		log.V(logf.ErrorLevel).Info("Multiple matching CertificateRequest resources exist, delete one of them. This is likely an error and should be reported on the issue tracker!")
+		// Issuance cannot make progress until a human deletes all but one of
+		// these CertificateRequests, and no error is returned here, so this is
+		// recorded on the Certificate as well as logged.
+		names := make([]string, len(requests))
+		for i, req := range requests {
+			names[i] = req.Name
+		}
+		slices.Sort(names)
+		log.V(logf.ErrorLevel).Info("Multiple matching CertificateRequest resources exist, delete all but one of them to allow issuance to continue", "requests", names)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestConflict, "Multiple matching CertificateRequest resources exist (%s), delete all but one of them to allow issuance to continue", strings.Join(names, ", "))
 		return nil
 	}
 
@@ -453,7 +465,8 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 	}
 
 	if err := c.waitForCertificateRequestToExist(ctx, cr.Namespace, cr.Name); err != nil {
-		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried. %w", err)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed waiting for CertificateRequest %q to be observed: %s - will retry", cr.Name, err.Error())
+		return fmt.Errorf("failed whilst waiting for CertificateRequest %q to be observed. Request will be retried. %w", cr.Name, err)
 	}
 	return nil
 }

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -17,7 +17,6 @@ limitations under the License.
 package requestmanager
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"encoding/pem"
@@ -180,6 +179,11 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	pk, err := pki.DecodePrivateKeyBytes(nextPrivateKeySecret.Data[corev1.TLSPrivateKeyKey])
 	if err != nil {
 		log.Error(err, "Failed to decode next private key secret data, waiting for keymanager before processing certificate")
+		return nil
+	}
+	pkViolations := pki.PrivateKeyMatchesSpec(pk, crt.Spec)
+	if len(pkViolations) > 0 {
+		logf.WithResource(log, nextPrivateKeySecret).Info("stored next private key does not match requirements on Certificate resource, waiting for keymanager controller", "violations", pkViolations)
 		return nil
 	}
 
@@ -384,11 +388,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		return err
 	}
 
-	csrPEM := bytes.NewBuffer([]byte{})
-	err = pem.Encode(csrPEM, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
-	if err != nil {
-		return err
-	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
 	annotations := controllerpkg.BuildAnnotationsToCopy(crt.Annotations, c.copiedAnnotationPrefixes)
 	annotations[cmapi.CertificateRequestRevisionAnnotationKey] = strconv.Itoa(nextRevision)
@@ -409,7 +409,7 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		Spec: cmapi.CertificateRequestSpec{
 			Duration:  crt.Spec.Duration,
 			IssuerRef: crt.Spec.IssuerRef,
-			Request:   csrPEM.Bytes(),
+			Request:   csrPEM,
 			IsCA:      crt.Spec.IsCA,
 			Usages:    crt.Spec.Usages,
 		},
@@ -425,6 +425,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		// use a cryptographic hash function to hash the full certificate name to 64 characters.
 		// Finally, for Certificates with a name longer than 233 characters, we build the CertificateRequest
 		// name as follows: <first-168-chars-of-certificate-name>-<64-char-hash>-<19-char-nextRevision>
+		//
+		// ComputeSecureUniqueDeterministicNameFromData only errors if the maximum
+		// length is below the 64 character hash, and the hash write it does
+		// internally never fails, so 233 cannot error here.
 		crName, err := apiutil.ComputeSecureUniqueDeterministicNameFromData(crt.Name, 233)
 		if err != nil {
 			return err

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -54,6 +54,18 @@ func mustGenerateRSA(t *testing.T) []byte {
 	return d
 }
 
+func mustGenerateECDSA(t *testing.T) []byte {
+	pk, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := pki.EncodePKCS8PrivateKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
 func relaxedCertificateRequestMatcher(l coretesting.Action, r coretesting.Action) error {
 	objL := l.(coretesting.CreateAction).GetObject().(*cmapi.CertificateRequest).DeepCopy()
 	objR := r.(coretesting.CreateAction).GetObject().(*cmapi.CertificateRequest).DeepCopy()
@@ -746,6 +758,26 @@ func TestProcessItem(t *testing.T) {
 			expectedEvents: []string{
 				`Warning RequestFailed Failed to generate CSR: invalid CIDR address: 10.0.0.0 - will not retry`,
 			},
+		},
+		// The keymanager regenerates a next private key that does not match the
+		// spec, so this controller must not act on it: no CertificateRequest is
+		// created, no event is recorded and no error is returned. Without the
+		// guard, the CSR would be built and pki.EncodeCSR would fail on every
+		// reconcile.
+		"do nothing if the next private key does not match spec.privateKey.algorithm, waiting for the keymanager": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists-with-mismatched-key"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateECDSA(t)},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle3.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists-with-mismatched-key"),
+				func(crt *cmapi.Certificate) {
+					crt.Spec.PrivateKey = &cmapi.CertificatePrivateKey{Algorithm: cmapi.RSAKeyAlgorithm}
+				},
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+			),
 		},
 	}
 	for name, test := range tests {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package requestmanager
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -642,7 +643,10 @@ func TestProcessItem(t *testing.T) {
 				),
 			},
 		},
-		"should do nothing if multiple owned and up to date CertificateRequests for the current revision exist": {
+		// This state is terminal: nothing is deleted, no error is returned and so
+		// the item is forgotten, and every re-sync takes the same branch. A human
+		// has to delete the surplus CertificateRequests, hence the Warning event.
+		"should record a Warning event if multiple owned and up to date CertificateRequests for the current revision exist": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
@@ -669,6 +673,9 @@ func TestProcessItem(t *testing.T) {
 						cmapi.CertificateRequestRevisionAnnotationKey:   "6",
 					}),
 				),
+			},
+			expectedEvents: []string{
+				`Warning RequestConflict Multiple matching CertificateRequest resources exist (random-value-1, random-value-2), delete all but one of them to allow issuance to continue`,
 			},
 		},
 		"should recreate the CertificateRequest if the current 'next' CertificateRequest failed during previous issuance cycle": {
@@ -843,5 +850,77 @@ func TestProcessItem(t *testing.T) {
 				builder.T.Error(err)
 			}
 		})
+	}
+}
+
+// If the CertificateRequest we just created never turns up in our own lister,
+// createNewCertificateRequest returns an error so the item is retried. If the
+// lister is still stale on that retry, it can create a second
+// CertificateRequest for the same revision, which ProcessItem refuses to
+// resolve. The timeout is worth surfacing on the Certificate for that reason.
+func TestCreateNewCertificateRequestWaitTimeout(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.StableCertificateRequestName, false)
+
+	bundle := mustCreateCryptoBundle(t, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: "test"},
+		Spec:       cmapi.CertificateSpec{CommonName: "test-wait-timeout"},
+	})
+	pk, err := pki.DecodePrivateKeyBytes(bundle.privateKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	builder := &testpkg.Builder{
+		T:               t,
+		StringGenerator: func(i int) string { return "notrandom" },
+		ExpectedEvents: []string{
+			`Normal Requested Created new CertificateRequest resource "test-notrandom"`,
+			`Warning RequestFailed Failed waiting for CertificateRequest "test-notrandom" to be observed: context deadline exceeded - will retry`,
+		},
+		ExpectedActions: []testpkg.Action{
+			testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+				gen.CertificateRequestFrom(bundle.certificateRequest,
+					// The create action records the object as submitted, i.e.
+					// before the apiserver expands generateName.
+					gen.SetCertificateRequestName(""),
+					func(cr *cmapi.CertificateRequest) { cr.GenerateName = "test-" },
+					gen.SetCertificateRequestAnnotations(map[string]string{
+						cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+						cmapi.CertificateRequestRevisionAnnotationKey:   "1",
+					}),
+				)), relaxedCertificateRequestMatcher),
+		},
+	}
+	builder.Init()
+
+	w := &controllerWrapper{}
+	if _, _, err := w.Register(builder.Context); err != nil {
+		t.Fatal(err)
+	}
+	// The informers are deliberately never started, so the CertificateRequest
+	// lister never observes the CertificateRequest created below - exactly what
+	// a lagging informer looks like to the controller.
+	defer builder.Stop()
+
+	// Cut the 5s poll short rather than making the test wait for it; the poll
+	// honours the parent context.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	// gen.CertificateFrom applies the API defaults, so that the created
+	// CertificateRequest matches the defaulted fixture below.
+	err = w.controller.createNewCertificateRequest(ctx, gen.CertificateFrom(bundle.certificate), pk, 1, "exists")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+	if !strings.Contains(err.Error(), `failed whilst waiting for CertificateRequest "test-notrandom" to be observed`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := builder.AllEventsCalled(); err != nil {
+		t.Error(err)
+	}
+	if err := builder.AllActionsExecuted(); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9182

Note that the scope is a bit wider than reported. The original one mentioned `pki.EncodeCSR` and `pem.Encode`, I swept `pkg/controller/certificates/` for the same defect and fixed what turned up. For easy review they are in separate commits.

1. `requestmanager`: the two paths #9182 names are fixed structurally rather than evented. Adds the `PrivateKeyMatchesSpec` guard the issuing controller already has, so we wait for the keymanager instead of rebuilding a CSR that cannot be signed; `pem.Encode` becomes `pem.EncodeToMemory`, which has no error return. The remaining unreachable branch keeps its comment and records no event.
2. `issuing`: one event at the `setValues` choke point rather than per-site ones in `setKeystores`, which also covers empty literal passwords, non-NotFound password Secret errors, `additionalOutputFormats` and an undecodable issued cert — all previously silent. The temporary certificate event sits at the call site so it covers `EncodePrivateKey` too.
3. `requestmanager`: the `waitForCertificateRequestToExist` timeout, and `RequestConflict` on the `len(requests) > 1` branch. That one is silent *and* terminal, it returns nil, so nothing requeues and issuance stops until a human deletes the extra CertificateRequests.

I used AI to scan outside `pkg/controller/certificates/`, it turns out that the category is already covered: `issuers/sync.go` events every `Setup` error, the `certificaterequests` issuers go through `util.Reporter`, ACME uses `Status.Reason`, `cainjector` has no recorder.

### Kind

/kind bug

### Release Note

```release-note
Record Secret data failures, temporary certificate signing failures, and conflicting CertificateRequests as Warning events on the `Certificate` instead of only logging them. The certificates-request-manager controller now waits for the keymanager when the next private key does not match the Certificate spec, instead of repeatedly building a CSR that cannot be signed.

```
