### PR TITLE
Fix orphaned Certificates when Ingress is deleted

### DIFF
--- a/pkg/controller/certificate-shim/ingresses/controller.go
+++ b/pkg/controller/certificate-shim/ingresses/controller.go
@@ -22,12 +22,15 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	clientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	shimhelper "github.com/cert-manager/cert-manager/pkg/controller/certificate-shim"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -39,6 +42,8 @@ const (
 
 type controller struct {
 	ingressLister networkingv1listers.IngressLister
+	certLister    cmlisters.CertificateLister
+	cmClient      clientset.Interface
 	sync          shimhelper.SyncFn
 }
 
@@ -50,7 +55,8 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 	c.sync = shimhelper.SyncFnFor(ctx.Recorder, log, ctx.CMClient, cmShared.Certmanager().V1().Certificates().Lister(), ctx.IngressShimOptions, ctx.FieldManager)
-
+	c.certLister = cmShared.Certmanager().V1().Certificates().Lister()
+	c.cmClient = ctx.CMClient
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
 		controllerpkg.DefaultItemBasedRateLimiter(),
 		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
@@ -93,17 +99,63 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.TypedRateLi
 
 func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	namespace, name := key.Namespace, key.Name
+	log := logf.FromContext(ctx, ControllerName)
 
 	ingress, err := c.ingressLister.Ingresses(namespace).Get(name)
-	if err != nil && !k8sErrors.IsNotFound(err) {
+	if k8sErrors.IsNotFound(err) {
+		// The Ingress no longer exists. Clean up any orphaned Certificates that
+		// were created by this Ingress to prevent cert-manager from continually
+		// attempting to renew certificates for non-existent Ingresses.
+		log.V(logf.DebugLevel).Info("ingress no longer exists, cleaning up orphaned certificates", "ingress", key)
+
+		return c.cleanupOrphanedCertificates(ctx, namespace, name)
+	}
+	if err != nil {
 		return err
 	}
-	if ingress == nil || ingress.DeletionTimestamp != nil {
-		// If the Ingress object was/ is being deleted, we don't want to start creating Certificates.
+	if ingress.DeletionTimestamp != nil {
+		// If the Ingress object is being deleted, we don't want to start creating Certificates.
 		return nil
 	}
 
 	return c.sync(ctx, ingress)
+}
+
+// cleanupOrphanedCertificates deletes Certificates that have an ownerReference
+// to an Ingress that no longer exists. This is necessary when Kubernetes
+// garbage collection fail to clean up dependents in certain cases, such as when the ownerReference uses a deprecated API version (e.g., networking.k8s.io/v1beta1).
+func (c *controller) cleanupOrphanedCertificates(ctx context.Context, namespace, ingressName string) error {
+	log := logf.FromContext(ctx, ControllerName)
+
+	// List all Certificates in the namespace
+	certs, err := c.certLister.Certificates(namespace).List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list certificates: %w", err)
+	}
+
+	// Find and delete Certificates owned by the deleted Ingress
+	for _, cert := range certs {
+		owner := metav1.GetControllerOf(cert)
+		if owner == nil {
+			continue
+		}
+
+		// Check if this Certificate is owned by the deleted Ingress
+		if owner.Kind == "Ingress" && owner.Name == ingressName {
+			err := c.cmClient.CertmanagerV1().Certificates(namespace).Delete(ctx, cert.Name, metav1.DeleteOptions{})
+			if err != nil && !k8sErrors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete orphaned certificate %s/%s: %w", namespace, cert.Name, err)
+			}
+			if err == nil {
+				log.V(logf.InfoLevel).Info("deleted orphaned certificate",
+					"certificate", cert.Name,
+					"namespace", namespace,
+					"ingress", ingressName)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Whenever a Certificate gets updated, added or deleted, we want to reconcile

--- a/pkg/controller/certificate-shim/ingresses/controller_test.go
+++ b/pkg/controller/certificate-shim/ingresses/controller_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -184,6 +186,196 @@ func Test_controller_Register(t *testing.T) {
 				assert.Equal(t, []types.NamespacedName{test.expectRequeueKey}, gotKeys)
 			} else {
 				assert.Nil(t, gotKeys)
+			}
+		})
+	}
+}
+
+func Test_controller_ProcessItem_CleansUpOrphanedCertificates(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingCMObjects []runtime.Object
+		ingressKey        types.NamespacedName
+		expectDeleted     []string
+		expectNotDeleted  []string
+	}{
+		{
+			name: "deletes certificate when owning ingress does not exist",
+			existingCMObjects: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "orphaned-cert",
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&networkingv1.Ingress{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: "test-ns",
+										Name:      "deleted-ingress",
+										UID:       "test-uid-123",
+									},
+								},
+								ingressGVK,
+							),
+						},
+					},
+				},
+			},
+			ingressKey: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "deleted-ingress",
+			},
+			expectDeleted:    []string{"orphaned-cert"},
+			expectNotDeleted: []string{},
+		},
+		{
+			name: "deletes multiple orphaned certificates for the same ingress",
+			existingCMObjects: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "orphaned-cert-1",
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&networkingv1.Ingress{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: "test-ns",
+										Name:      "deleted-ingress",
+										UID:       "test-uid-123",
+									},
+								},
+								ingressGVK,
+							),
+						},
+					},
+				},
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "orphaned-cert-2",
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&networkingv1.Ingress{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: "test-ns",
+										Name:      "deleted-ingress",
+										UID:       "test-uid-456",
+									},
+								},
+								ingressGVK,
+							),
+						},
+					},
+				},
+			},
+			ingressKey: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "deleted-ingress",
+			},
+			expectDeleted:    []string{"orphaned-cert-1", "orphaned-cert-2"},
+			expectNotDeleted: []string{},
+		},
+		{
+			name: "does not delete certificates owned by different ingress",
+			existingCMObjects: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "orphaned-cert",
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&networkingv1.Ingress{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: "test-ns",
+										Name:      "deleted-ingress",
+										UID:       "test-uid-123",
+									},
+								},
+								ingressGVK,
+							),
+						},
+					},
+				},
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "other-cert",
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&networkingv1.Ingress{
+									ObjectMeta: metav1.ObjectMeta{
+										Namespace: "test-ns",
+										Name:      "other-ingress",
+										UID:       "test-uid-456",
+									},
+								},
+								ingressGVK,
+							),
+						},
+					},
+				},
+			},
+			ingressKey: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "deleted-ingress",
+			},
+			expectDeleted:    []string{"orphaned-cert"},
+			expectNotDeleted: []string{"other-cert"},
+		},
+		{
+			name: "does not delete certificates without owner references",
+			existingCMObjects: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "standalone-cert",
+					},
+				},
+			},
+			ingressKey: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "deleted-ingress",
+			},
+			expectDeleted:    []string{},
+			expectNotDeleted: []string{"standalone-cert"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := &testpkg.Builder{T: t, CertManagerObjects: test.existingCMObjects}
+			b.Init()
+
+			c := &controller{
+				ingressLister: b.Context.KubeSharedInformerFactory.Ingresses().Lister(),
+				certLister:    b.Context.SharedInformerFactory.Certmanager().V1().Certificates().Lister(),
+				cmClient:      b.CMClient,
+			}
+
+			b.Start()
+			defer b.Stop()
+
+			// Wait for informers to sync
+			b.Sync()
+
+			// Give the informer cache time to populate
+			time.Sleep(100 * time.Millisecond)
+
+			// Call ProcessItem for the non-existent Ingress
+			err := c.ProcessItem(context.Background(), test.ingressKey)
+			require.NoError(t, err)
+
+			// Verify deleted certificates
+			for _, certName := range test.expectDeleted {
+				_, err := b.CMClient.CertmanagerV1().Certificates(test.ingressKey.Namespace).Get(context.Background(), certName, metav1.GetOptions{})
+				assert.True(t, apierrors.IsNotFound(err),
+					"expected certificate %s to be deleted, got error: %v", certName, err)
+			}
+
+			// Verify not deleted certificates
+			for _, certName := range test.expectNotDeleted {
+				_, err := b.CMClient.CertmanagerV1().Certificates(test.ingressKey.Namespace).Get(context.Background(), certName, metav1.GetOptions{})
+				assert.NoError(t, err, "expected certificate %s to NOT be deleted", certName)
 			}
 		})
 	}


### PR DESCRIPTION
This fixes issue #7486 where Certificates remained orphaned after their owning Ingress was deleted.

The ingress-shim controller now proactively detects and removes orphaned Certificates when their owning Ingress no longer exists.

Changes:
- Add cleanupOrphanedCertificates in ingress-shim controller ProcessItem
- Detect and delete Certificates when owning Ingress is not found
- Add unit tests for orphaned Certificate cleanup

Fixes #7486

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
Fixes issue #7486 where Certificates remained orphaned after their owning
Ingress was deleted.

This fix proactively cleans up orphaned Certificates when the
ingress-shim controller detects the owning Ingress no longer exists.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Ingress-shim now cleans up orphaned Certificates when their owning
Ingress no longer exists.
```
