### PR TITLE
fix(acme): keep ACME server response bodies out of Issuer status

### DIFF
--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -66,6 +67,17 @@ const (
 	messageTemplateFailedToParseURL        = "Failed to parse existing ACME server URI %q: %v"
 	messageTemplateFailedToParseAccountURL = "Failed to parse existing ACME account URI %q: %v"
 	messageTemplateFailedToGetEABKey       = "failed to get External Account Binding key from secret: %v"
+	messageTemplateNonACMEErrorResponse    = "the ACME server returned an HTTP %d response which is not an RFC 8555 problem document; the response body has been omitted and can be found in the cert-manager logs"
+
+	// acmeErrorURNPrefix is the URN namespace that RFC 8555 section 6.7 reserves
+	// for ACME error types. A problem document which does not identify itself
+	// using this namespace did not come from an ACME endpoint.
+	acmeErrorURNPrefix = "urn:ietf:params:acme:error:"
+
+	// maxACMEErrorMessageLength bounds how much of an error is copied into an
+	// Issuer status condition or a Kubernetes Event. Both are persisted to the
+	// API server, so their size has to be bounded even for well behaved ACME servers.
+	maxACMEErrorMessageLength = 1024
 )
 
 // Setup will verify an existing ACME registration, or create one if not
@@ -331,7 +343,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		// TODO: this error could be from an account registration or an attempt
 		// to retrieve an existing account - perhaps we should log different
 		// messages in those two scenarios.
-		msg := messageAccountRegistrationFailed + err.Error()
+		msg := messageAccountRegistrationFailed + safeErrorMessage(err)
 		log.Error(err, "failed to register an ACME account")
 
 		acmeErr, ok := err.(*acmeapi.Error)
@@ -376,7 +388,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 	specEmail := issuer.GetSpec().ACME.Email
 	account, registeredEmail, err := ensureEmailUpToDate(ctx, cl, account, specEmail)
 	if err != nil {
-		msg := messageAccountUpdateFailed + err.Error()
+		msg := messageAccountUpdateFailed + safeErrorMessage(err)
 		log.Error(err, "failed to update ACME account")
 		a.recorder.Event(issuer, corev1.EventTypeWarning, errorAccountUpdateFailed, msg)
 
@@ -439,6 +451,52 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		reason:  successAccountRegistered,
 		message: messageAccountRegistered,
 	}
+}
+
+// safeErrorMessage renders err for inclusion in an Issuer status condition and
+// in the Kubernetes Events raised alongside it. Both are persisted to the API
+// server and are readable by anyone who can read the Issuer, so they must not
+// carry content chosen by the ACME server.
+func safeErrorMessage(err error) string {
+	acmeErr, ok := err.(*acmeapi.Error)
+	if !ok {
+		// Not a response from the ACME server: this was raised locally or by the
+		// Kubernetes API and carries no remote content.
+		return truncateMessage(err.Error(), maxACMEErrorMessageLength)
+	}
+
+	// ProblemType is only populated when the response body was successfully
+	// unmarshalled as a problem document, and RFC 8555 section 6.7 requires ACME
+	// errors to use the urn:ietf:params:acme:error: namespace. Anything else is
+	// either a raw body the client could not parse or a problem document from
+	// some other service, and in both cases it is not safe to reflect.
+	if !strings.HasPrefix(strings.ToLower(acmeErr.ProblemType), acmeErrorURNPrefix) {
+		return fmt.Sprintf(messageTemplateNonACMEErrorResponse, acmeErr.StatusCode)
+	}
+
+	return truncateMessage(acmeErr.Error(), maxACMEErrorMessageLength)
+}
+
+// truncateMessage bounds s to maxLen bytes, appending a marker so that readers
+// can tell the message is incomplete.
+func truncateMessage(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+
+	truncated := s[:maxLen]
+	// Cutting on a byte boundary can split a multi-byte rune in half. Drop any
+	// trailing partial rune so that the result is always valid UTF-8, which the
+	// API server requires of the strings it stores.
+	for len(truncated) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(truncated); r != utf8.RuneError || size > 1 {
+			break
+		}
+		truncated = truncated[:len(truncated)-1]
+	}
+
+	// trim spaces to make output readable if it ends with whitespace
+	return strings.TrimSpace(truncated) + "... (truncated)"
 }
 
 func ensureEmailUpToDate(ctx context.Context, cl client.Interface, acc *acmeapi.Account, specEmail string) (*acmeapi.Account, string, error) {

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -22,10 +22,10 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
-	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +38,7 @@ import (
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
-	"github.com/cert-manager/cert-manager/pkg/util/errors"
+	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	acmeapi "github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
@@ -74,10 +74,20 @@ const (
 	// using this namespace did not come from an ACME endpoint.
 	acmeErrorURNPrefix = "urn:ietf:params:acme:error:"
 
+	// legacyACMEErrorURNPrefix is the namespace used by the pre-RFC 8555 drafts.
+	// Some CAs still emit it, and isBadNonce in third_party/forked/acme already
+	// tolerates such variations, so errors using it are treated as genuine ACME
+	// errors too.
+	legacyACMEErrorURNPrefix = "urn:acme:error:"
+
 	// maxACMEErrorMessageLength bounds how much of an error is copied into an
 	// Issuer status condition or a Kubernetes Event. Both are persisted to the
 	// API server, so their size has to be bounded even for well behaved ACME servers.
 	maxACMEErrorMessageLength = 1024
+
+	// truncationMarker is appended to messages shortened by truncateMessage so
+	// that readers can tell the message is incomplete.
+	truncationMarker = "... (truncated)"
 )
 
 // Setup will verify an existing ACME registration, or create one if not
@@ -163,7 +173,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 			reason:  errorAccountVerificationFailed,
 			message: wrapErr.Error(),
 		}
-	case errors.IsInvalidData(err):
+	case cmerrors.IsInvalidData(err):
 		msg := fmt.Sprintf("%s%v", messageInvalidPrivateKey, err)
 		return setupResult{
 			err: nil,
@@ -305,7 +315,7 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		eabKey, err := a.getEABKey(ctx, ns, eabObj.Key)
 		switch {
 		// Do not re-try if we fail to get the MAC key as it does not exist at the reference.
-		case apierrors.IsNotFound(err), errors.IsInvalidData(err):
+		case apierrors.IsNotFound(err), cmerrors.IsInvalidData(err):
 			log.Error(err, "failed to verify ACME account")
 			msg := messageAccountRegistrationFailed + err.Error()
 			a.recorder.Event(issuer, corev1.EventTypeWarning,
@@ -374,8 +384,10 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		}
 
 		// Otherwise if we receive anything other than a 400, we will retry.
+		// Return the sanitised message rather than the ACME error itself: the
+		// Issuer controllers copy the returned error into a Kubernetes Event.
 		return setupResult{
-			err: err,
+			err: fmt.Errorf("%s", msg),
 
 			status:  cmmeta.ConditionFalse,
 			reason:  errorAccountRegistrationFailed,
@@ -420,8 +432,10 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 		}
 
 		// Otherwise if we receive anything other than a 400, we will retry.
+		// Return the sanitised message rather than the ACME error itself: the
+		// Issuer controllers copy the returned error into a Kubernetes Event.
 		return setupResult{
-			err: err,
+			err: fmt.Errorf("%s", msg),
 
 			status:  cmmeta.ConditionFalse,
 			reason:  errorAccountUpdateFailed,
@@ -458,7 +472,9 @@ func (a *Acme) setup(ctx context.Context, issuer v1.GenericIssuer) setupResult {
 // server and are readable by anyone who can read the Issuer, so they must not
 // carry content chosen by the ACME server.
 func safeErrorMessage(err error) string {
-	acmeErr, ok := err.(*acmeapi.Error)
+	// Use errors.AsType rather than a bare type assertion so that an ACME error
+	// which has been wrapped on its way up cannot bypass this check.
+	acmeErr, ok := errors.AsType[*acmeapi.Error](err)
 	if !ok {
 		// Not a response from the ACME server: this was raised locally or by the
 		// Kubernetes API and carries no remote content.
@@ -466,37 +482,44 @@ func safeErrorMessage(err error) string {
 	}
 
 	// ProblemType is only populated when the response body was successfully
-	// unmarshalled as a problem document, and RFC 8555 section 6.7 requires ACME
-	// errors to use the urn:ietf:params:acme:error: namespace. Anything else is
-	// either a raw body the client could not parse or a problem document from
-	// some other service, and in both cases it is not safe to reflect.
-	if !strings.HasPrefix(strings.ToLower(acmeErr.ProblemType), acmeErrorURNPrefix) {
+	// unmarshalled as a problem document, and an ACME error identifies itself
+	// using one of the ACME error URN namespaces. Anything else is either a raw
+	// body the client could not parse or a problem document from some other
+	// service, and in both cases it is not safe to reflect.
+	if !isACMEProblemType(acmeErr.ProblemType) {
 		return fmt.Sprintf(messageTemplateNonACMEErrorResponse, acmeErr.StatusCode)
 	}
 
 	return truncateMessage(acmeErr.Error(), maxACMEErrorMessageLength)
 }
 
-// truncateMessage bounds s to maxLen bytes, appending a marker so that readers
-// can tell the message is incomplete.
+// isACMEProblemType reports whether problemType names an ACME error type, in
+// either the namespace reserved by RFC 8555 section 6.7 or the pre-RFC one.
+func isACMEProblemType(problemType string) bool {
+	problemType = strings.ToLower(problemType)
+
+	return strings.HasPrefix(problemType, acmeErrorURNPrefix) ||
+		strings.HasPrefix(problemType, legacyACMEErrorURNPrefix)
+}
+
+// truncateMessage bounds s to maxLen bytes in total, including the marker which
+// is appended so that readers can tell the message is incomplete.
 func truncateMessage(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
 
-	truncated := s[:maxLen]
-	// Cutting on a byte boundary can split a multi-byte rune in half. Drop any
-	// trailing partial rune so that the result is always valid UTF-8, which the
-	// API server requires of the strings it stores.
-	for len(truncated) > 0 {
-		if r, size := utf8.DecodeLastRuneInString(truncated); r != utf8.RuneError || size > 1 {
-			break
-		}
-		truncated = truncated[:len(truncated)-1]
+	// Cutting on a byte boundary can split a multi-byte rune in half. Replacing
+	// invalid sequences keeps the result valid UTF-8, which the API server
+	// requires of the strings it stores.
+	if maxLen <= len(truncationMarker) {
+		return strings.ToValidUTF8(s[:maxLen], "")
 	}
 
-	// trim spaces to make output readable if it ends with whitespace
-	return strings.TrimSpace(truncated) + "... (truncated)"
+	truncated := strings.ToValidUTF8(s[:maxLen-len(truncationMarker)], "")
+
+	// Trim trailing whitespace so that the marker reads cleanly.
+	return strings.TrimRight(truncated, " \t\r\n") + truncationMarker
 }
 
 func ensureEmailUpToDate(ctx context.Context, cl client.Interface, acc *acmeapi.Account, specEmail string) (*acmeapi.Account, string, error) {
@@ -575,7 +598,7 @@ func (a *Acme) getEABKey(ctx context.Context, ns string, eab cmmeta.SecretKeySel
 
 	encodedKeyData, ok := sec.Data[eab.Key]
 	if !ok {
-		return nil, errors.NewInvalidData("failed to find external account binding key data in Secret %q at index %q", eab.Name, eab.Key)
+		return nil, cmerrors.NewInvalidData("failed to find external account binding key data in Secret %q at index %q", eab.Name, eab.Key)
 	}
 
 	// decode the base64 encoded secret key data.
@@ -584,7 +607,7 @@ func (a *Acme) getEABKey(ctx context.Context, ns string, eab cmmeta.SecretKeySel
 	// base64 encoding.
 	keyData := make([]byte, base64.RawURLEncoding.DecodedLen(len(encodedKeyData)))
 	if _, err := base64.RawURLEncoding.Decode(keyData, encodedKeyData); err != nil {
-		return nil, errors.NewInvalidData("failed to decode external account binding key data: %v", err)
+		return nil, cmerrors.NewInvalidData("failed to decode external account binding key data: %v", err)
 	}
 
 	return keyData, nil

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -107,6 +107,14 @@ func TestAcme_Setup(t *testing.T) {
 			StatusCode: 403,
 			Detail:     fmt.Sprintf("{\"AccessKeyId\":%q,\"Token\":\"internal-only\"}", reflectedBodySecret),
 		}
+		// reflectedBody5xxACMEErr is the same, but with a status code which
+		// makes setup retry. That path returns the error to the Issuer
+		// controllers, which copy it into an Event of their own.
+		reflectedBody5xxACMEErr = &acmeapi.Error{
+			StatusCode: 502,
+			Detail:     fmt.Sprintf("{\"AccessKeyId\":%q,\"Token\":\"internal-only\"}", reflectedBodySecret),
+		}
+		reflectedBody5xxMessage = fmt.Sprintf(messageTemplateNonACMEErrorResponse, 502)
 		//TODO: we should probably mock calls to net/url instead of doing this.
 		invalidURLErr = parseURLErr(invalidURL)
 
@@ -388,6 +396,19 @@ func TestAcme_Setup(t *testing.T) {
 					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403))),
 			},
 		},
+		"Attempt to register ACME account returns a retryable response which is not a problem document": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                reflectedBody5xxACMEErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(readyFalseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+reflectedBody5xxMessage)),
+			},
+			wantsErr: true,
+		},
 		"ACME account already exists, attempting to retrieve it fails with unknown error": {
 			issuer:                     gen.IssuerFrom(baseIssuer),
 			kfsKey:                     rsaPrivKey,
@@ -580,6 +601,25 @@ func TestAcme_Setup(t *testing.T) {
 			expectedEvents: []string{
 				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403)))},
 		},
+		"Attempt to update ACME account returns a retryable response which is not a problem document": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEEmail(someEmail)),
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			registerErr:                acmeapi.ErrAccountAlreadyExists,
+			getRegAcc:                  &acmeapi.Account{Contact: []string{"some@test.com"}},
+			expectedRegisteredAcc:      &acmeapi.Account{Contact: []string{someEmailURL}},
+			updateRegError:             reflectedBody5xxACMEErr,
+			wantsErr:                   true,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(readyTrueCondition,
+					gen.SetIssuerConditionStatus(cmmeta.ConditionFalse),
+					gen.SetIssuerConditionReason(errorAccountUpdateFailed),
+					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, reflectedBody5xxMessage))),
+			},
+			expectedEvents: []string{
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, reflectedBody5xxMessage))},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -653,6 +693,13 @@ func TestAcme_Setup(t *testing.T) {
 			gotErr := a.Setup(t.Context(), test.issuer)
 			if gotErr == nil && test.wantsErr {
 				t.Errorf("Expected error %v, got %v", test.wantsErr, gotErr)
+			}
+
+			// The Issuer controllers copy the error returned here into a
+			// Kubernetes Event, so it must not carry content chosen by the
+			// ACME server either.
+			if gotErr != nil && strings.Contains(gotErr.Error(), reflectedBodySecret) {
+				t.Errorf("Returned error leaks ACME server controlled content: %v", gotErr)
 			}
 
 			// Verify that a client was removed from cache if expected.
@@ -762,6 +809,21 @@ func TestSafeErrorMessage(t *testing.T) {
 			},
 			wantContains: "unsupported key type",
 		},
+		"a problem document in the pre-RFC 8555 namespace is reported in full": {
+			err: &acmeapi.Error{
+				StatusCode:  400,
+				ProblemType: "urn:acme:error:badNonce",
+				Detail:      "JWS has an invalid anti-replay nonce",
+			},
+			want: "400 urn:acme:error:badNonce: JWS has an invalid anti-replay nonce",
+		},
+		"a wrapped ACME error is still sanitised": {
+			err: fmt.Errorf("registering account: %w", &acmeapi.Error{
+				StatusCode: 403,
+				Detail:     secret,
+			}),
+			want: fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403),
+		},
 		"a reflected response body is omitted": {
 			err: &acmeapi.Error{
 				StatusCode: 403,
@@ -794,7 +856,7 @@ func TestSafeErrorMessage(t *testing.T) {
 			if strings.Contains(got, secret) {
 				t.Errorf("message leaks server controlled content: %q", got)
 			}
-			if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
+			if len(got) > maxACMEErrorMessageLength {
 				t.Errorf("message is %d bytes, want at most %d", len(got), maxACMEErrorMessageLength)
 			}
 
@@ -822,7 +884,7 @@ func TestSafeErrorMessageBoundsLength(t *testing.T) {
 	}
 
 	got := safeErrorMessage(err)
-	if !strings.HasSuffix(got, "... (truncated)") {
+	if !strings.HasSuffix(got, truncationMarker) {
 		t.Errorf("safeErrorMessage() = %q, want it to be marked as truncated", got)
 	}
 	if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
@@ -836,32 +898,49 @@ func TestTruncateMessage(t *testing.T) {
 		maxLen int
 		want   string
 	}{
+		// maxLen is a bound on the whole result, so a limit of 20 leaves 5 bytes
+		// for the message once the 15 byte marker has been accounted for.
 		"a message within the limit is returned unchanged": {
 			in:     "short",
-			maxLen: 10,
+			maxLen: 20,
 			want:   "short",
 		},
 		"a message at the limit is returned unchanged": {
-			in:     "exactly10!",
-			maxLen: 10,
-			want:   "exactly10!",
+			in:     "exactly20bytes!!!!!!",
+			maxLen: 20,
+			want:   "exactly20bytes!!!!!!",
 		},
 		"a longer message is truncated": {
-			in:     "abcdefghijklmnop",
-			maxLen: 10,
-			want:   "abcdefghij... (truncated)",
+			in:     "abcdefghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abcde" + truncationMarker,
 		},
 		"trailing whitespace is trimmed before the marker is added": {
-			in:     "abcdefgh  ijklmnop",
-			maxLen: 10,
-			want:   "abcdefgh... (truncated)",
+			in:     "abc  defghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abc" + truncationMarker,
 		},
 		"a multi-byte rune is not split in half": {
-			// Each £ is two bytes, so a limit of 5 falls in the middle of the
-			// third one.
+			// Each £ is two bytes, so the 5 byte budget falls in the middle of
+			// the third one.
+			in:     strings.Repeat("£", 12),
+			maxLen: 20,
+			want:   "££" + truncationMarker,
+		},
+		"an invalid byte sequence is dropped": {
+			in:     "ab\xffcdefghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abcd" + truncationMarker,
+		},
+		"a limit too small for the marker drops the marker": {
+			in:     "abcdefghij",
+			maxLen: 4,
+			want:   "abcd",
+		},
+		"a limit too small for the marker still respects rune boundaries": {
 			in:     strings.Repeat("£", 4),
-			maxLen: 5,
-			want:   "££... (truncated)",
+			maxLen: 3,
+			want:   "£",
 		},
 	}
 
@@ -873,6 +952,10 @@ func TestTruncateMessage(t *testing.T) {
 			}
 			if !utf8.ValidString(got) {
 				t.Errorf("truncateMessage() = %q, which is not valid UTF-8", got)
+			}
+			// maxLen bounds the result in full, marker included.
+			if len(got) > test.maxLen {
+				t.Errorf("truncateMessage() returned %d bytes, want at most %d", len(got), test.maxLen)
 			}
 		})
 	}

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -24,8 +24,10 @@ import (
 	"net/url"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +83,30 @@ func TestAcme_Setup(t *testing.T) {
 		invalidURL     = "%"
 		acmeErr450     = &acmeapi.Error{StatusCode: 450}
 		acmeErr500     = &acmeapi.Error{StatusCode: 500}
+
+		// acmeErr450 and acmeErr500 carry no ProblemType, so they are not
+		// recognised as RFC 8555 problem documents and are reported by status
+		// code alone.
+		acmeErr450Message = fmt.Sprintf(messageTemplateNonACMEErrorResponse, 450)
+		acmeErr500Message = fmt.Sprintf(messageTemplateNonACMEErrorResponse, 500)
+
+		// conformantACMEErr is what a real ACME server returns. Its detail is
+		// useful to the operator and is safe to surface on the Issuer.
+		conformantACMEErr = &acmeapi.Error{
+			StatusCode:  400,
+			ProblemType: "urn:ietf:params:acme:error:invalidEmail",
+			Detail:      "contact email has an invalid domain: empty label",
+		}
+
+		// reflectedBodyACMEErr models a response from an endpoint which is not an
+		// ACME server. The ACME client cannot parse the body as a problem
+		// document, so it copies it verbatim into Detail; it must not reach the
+		// Issuer status or the Events raised alongside it.
+		reflectedBodySecret  = "AKIAIOSFODNN7EXAMPLE"
+		reflectedBodyACMEErr = &acmeapi.Error{
+			StatusCode: 403,
+			Detail:     fmt.Sprintf("{\"AccessKeyId\":%q,\"Token\":\"internal-only\"}", reflectedBodySecret),
+		}
 		//TODO: we should probably mock calls to net/url instead of doing this.
 		invalidURLErr = parseURLErr(invalidURL)
 
@@ -322,7 +348,7 @@ func TestAcme_Setup(t *testing.T) {
 			expectedConditions: []cmapi.IssuerCondition{
 				*gen.IssuerConditionFrom(readyFalseCondition,
 					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
-					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr450.Error())),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr450Message)),
 			},
 		},
 		"Attempt to register ACME account returns an ACME error outside of range [400,500)": {
@@ -334,9 +360,33 @@ func TestAcme_Setup(t *testing.T) {
 			expectedConditions: []cmapi.IssuerCondition{
 				*gen.IssuerConditionFrom(readyFalseCondition,
 					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
-					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr500.Error())),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr500Message)),
 			},
 			wantsErr: true,
+		},
+		"Attempt to register ACME account returns a conformant ACME error": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                conformantACMEErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(readyFalseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+conformantACMEErr.Error())),
+			},
+		},
+		"Attempt to register ACME account returns a response which is not a problem document": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                reflectedBodyACMEErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(readyFalseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403))),
+			},
 		},
 		"ACME account already exists, attempting to retrieve it fails with unknown error": {
 			issuer:                     gen.IssuerFrom(baseIssuer),
@@ -476,10 +526,10 @@ func TestAcme_Setup(t *testing.T) {
 				*gen.IssuerConditionFrom(readyTrueCondition,
 					gen.SetIssuerConditionStatus(cmmeta.ConditionFalse),
 					gen.SetIssuerConditionReason(errorAccountUpdateFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr450.Error()))),
+					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr450Message))),
 			},
 			expectedEvents: []string{
-				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr450.Error()))},
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr450Message))},
 		},
 		"ACME account with legacy EAB key algorithm set, spec email different from registered email and registered failed with retryable ACME Error": {
 			issuer: gen.IssuerFrom(baseIssuer,
@@ -507,10 +557,28 @@ func TestAcme_Setup(t *testing.T) {
 				*gen.IssuerConditionFrom(readyTrueCondition,
 					gen.SetIssuerConditionStatus(cmmeta.ConditionFalse),
 					gen.SetIssuerConditionReason(errorAccountUpdateFailed),
-					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr500.Error()))),
+					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr500Message))),
 			},
 			expectedEvents: []string{
-				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr500.Error()))},
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, acmeErr500Message))},
+		},
+		"Attempt to update ACME account returns a response which is not a problem document": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEEmail(someEmail)),
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			registerErr:                acmeapi.ErrAccountAlreadyExists,
+			getRegAcc:                  &acmeapi.Account{Contact: []string{"some@test.com"}},
+			expectedRegisteredAcc:      &acmeapi.Account{Contact: []string{someEmailURL}},
+			updateRegError:             reflectedBodyACMEErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(readyTrueCondition,
+					gen.SetIssuerConditionStatus(cmmeta.ConditionFalse),
+					gen.SetIssuerConditionReason(errorAccountUpdateFailed),
+					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%s", messageAccountUpdateFailed, fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403)))),
+			},
+			expectedEvents: []string{
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountUpdateFailed, fmt.Sprintf("%s%s", messageAccountUpdateFailed, fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403)))},
 		},
 	}
 	for name, test := range tests {
@@ -660,6 +728,154 @@ func mustGenerateRSAKey(t *testing.T) crypto.Signer {
 		t.Fatal(err)
 	}
 	return key
+}
+
+func TestSafeErrorMessage(t *testing.T) {
+	// secret stands in for content which the ACME server is able to reflect back
+	// to us but which the reader of an Issuer must not be able to see.
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+
+	tests := map[string]struct {
+		err error
+		// want is the exact message expected, and is only checked when set.
+		want string
+		// wantContains is checked when want is empty.
+		wantContains string
+	}{
+		"a locally raised error is reported unchanged": {
+			err:  fmt.Errorf("failed to build ACME client"),
+			want: "failed to build ACME client",
+		},
+		"a conformant problem document is reported in full": {
+			err: &acmeapi.Error{
+				StatusCode:  400,
+				ProblemType: "urn:ietf:params:acme:error:rateLimited",
+				Detail:      "too many registrations for this IP",
+			},
+			want: "400 urn:ietf:params:acme:error:rateLimited: too many registrations for this IP",
+		},
+		"a conformant problem document is recognised regardless of casing": {
+			err: &acmeapi.Error{
+				StatusCode:  400,
+				ProblemType: "URN:IETF:PARAMS:ACME:ERROR:badCSR",
+				Detail:      "unsupported key type",
+			},
+			wantContains: "unsupported key type",
+		},
+		"a reflected response body is omitted": {
+			err: &acmeapi.Error{
+				StatusCode: 403,
+				Detail:     fmt.Sprintf("<html><body>%s</body></html>", secret),
+			},
+			want: fmt.Sprintf(messageTemplateNonACMEErrorResponse, 403),
+		},
+		"a problem document from a service which is not an ACME server is omitted": {
+			err: &acmeapi.Error{
+				StatusCode:  500,
+				ProblemType: "https://internal.example.com/errors/database",
+				Detail:      fmt.Sprintf("connection string: %s", secret),
+			},
+			want: fmt.Sprintf(messageTemplateNonACMEErrorResponse, 500),
+		},
+		"a URN outside the ACME error namespace is omitted": {
+			err: &acmeapi.Error{
+				StatusCode:  500,
+				ProblemType: "urn:ietf:params:acme:notanerror:" + secret,
+				Detail:      secret,
+			},
+			want: fmt.Sprintf(messageTemplateNonACMEErrorResponse, 500),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := safeErrorMessage(test.err)
+
+			if strings.Contains(got, secret) {
+				t.Errorf("message leaks server controlled content: %q", got)
+			}
+			if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
+				t.Errorf("message is %d bytes, want at most %d", len(got), maxACMEErrorMessageLength)
+			}
+
+			switch {
+			case test.want != "":
+				if got != test.want {
+					t.Errorf("safeErrorMessage() = %q, want %q", got, test.want)
+				}
+			case test.wantContains != "":
+				if !strings.Contains(got, test.wantContains) {
+					t.Errorf("safeErrorMessage() = %q, want it to contain %q", got, test.wantContains)
+				}
+			}
+		})
+	}
+}
+
+func TestSafeErrorMessageBoundsLength(t *testing.T) {
+	// Even a conformant ACME server must not be able to fill the Issuer status,
+	// which is persisted to the API server.
+	err := &acmeapi.Error{
+		StatusCode:  400,
+		ProblemType: "urn:ietf:params:acme:error:malformed",
+		Detail:      strings.Repeat("a", 4*maxACMEErrorMessageLength),
+	}
+
+	got := safeErrorMessage(err)
+	if !strings.HasSuffix(got, "... (truncated)") {
+		t.Errorf("safeErrorMessage() = %q, want it to be marked as truncated", got)
+	}
+	if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
+		t.Errorf("message is %d bytes, want at most %d", len(got), maxACMEErrorMessageLength)
+	}
+}
+
+func TestTruncateMessage(t *testing.T) {
+	tests := map[string]struct {
+		in     string
+		maxLen int
+		want   string
+	}{
+		"a message within the limit is returned unchanged": {
+			in:     "short",
+			maxLen: 10,
+			want:   "short",
+		},
+		"a message at the limit is returned unchanged": {
+			in:     "exactly10!",
+			maxLen: 10,
+			want:   "exactly10!",
+		},
+		"a longer message is truncated": {
+			in:     "abcdefghijklmnop",
+			maxLen: 10,
+			want:   "abcdefghij... (truncated)",
+		},
+		"trailing whitespace is trimmed before the marker is added": {
+			in:     "abcdefgh  ijklmnop",
+			maxLen: 10,
+			want:   "abcdefgh... (truncated)",
+		},
+		"a multi-byte rune is not split in half": {
+			// Each £ is two bytes, so a limit of 5 falls in the middle of the
+			// third one.
+			in:     strings.Repeat("£", 4),
+			maxLen: 5,
+			want:   "££... (truncated)",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := truncateMessage(test.in, test.maxLen)
+			if got != test.want {
+				t.Errorf("truncateMessage() = %q, want %q", got, test.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateMessage() = %q, which is not valid UTF-8", got)
+			}
+		})
+	}
 }
 
 func TestValidateDNSSolvers(t *testing.T) {


### PR DESCRIPTION
# Description

## Problem

The ACME issuer's `Setup` path registers or updates an account against `spec.acme.server`, and on failure copies the returned error into places that are persisted to the API server: the Issuer's `Ready` condition message, a Warning Event raised on the update path, and — via the error returned to the Issuer and ClusterIssuer controllers — a second `ErrInitIssuer` Warning Event.

`spec.acme.server` is user-controlled and may point at any URL the controller can reach. When a request fails, the ACME client's `responseError()` copies the response body verbatim into `Error.Detail` whenever that body doesn't parse as a problem document. Reflecting that error into the Issuer status turns it into an oracle for HTTP endpoints the reader cannot otherwise reach:

- **Information disclosure**: the body of an internal endpoint (cloud
      metadata, an admin API, anything on the pod network) lands in `Issuer.status.conditions[Ready].message`, readable by anyone with `get issuer` and persisted to etcd.
- **Unbounded status growth**: even a well-behaved server's error was copied at whatever length it arrived.

## Solution

Sanitise at the boundary, in cert-manager-owned code. `safeErrorMessage()` surfaces an ACME error in full only when it identifies itself as an ACME problem document, matched case-insensitively against the `urn:ietf:params:acme:error:` namespace reserved by RFC 8555 §6.7 and the pre-RFC `urn:acme:error:` namespace that some CAs still emit. Anything else — a raw body the client couldn't parse, or an RFC 7807 document from some other service — is reported by status code alone. This fails closed: the degradation is a less specific condition message.

The sanitised message is also what `setup()` returns on the retryable (5xx) paths, rather than the `*acmeapi.Error` itself, so the leak doesn't reappear one layer up in the Event the sync controllers raise. Neither caller inspects the error's type, so retry behaviour is unchanged.

Genuine ACME errors keep their detail, so rate-limit and `invalidEmail` explanations still reach operators unchanged. Messages are bounded at 1024 bytes in total, marker included, with `strings.ToValidUTF8` guaranteeing the result is valid UTF-8 even when the cut falls mid-rune. The unabridged error continues to be written to the controller log via the existing `log.Error` calls, keeping full detail available to privileged readers.

Locally-raised and Kubernetes API errors (private key generation, EAB Secret lookups) carry no remote content and are unchanged.

##  Test plan

- [ ] `TestSafeErrorMessage` — eight cases: locally-raised errors pass through; conformant problem documents in both the RFC 8555 and pre-RFC namespaces keep their detail; casing variants are recognised; a reflected HTML body, a non-ACME RFC 7807 document, a URN outside the error namespace, and a wrapped ACME error are all reduced to status code. Every case asserts the planted secret is absent and the length is bounded.
- [ ] `TestSafeErrorMessageBoundsLength` — a conformant server cannot fill the status with an oversized `Detail`.
- [ ] `TestTruncateMessage` — eight cases, including a multi-byte rune split at the byte limit, an invalid byte mid-string, and limits smaller than the truncation marker; all results asserted valid UTF-8 and within the bound.
- [ ] Five new `TestAcme_Setup` cases cover every sink end to end: the condition, the update-path Warning Event, and the error returned on the 5xx retry paths for both register and update. The shared runner now asserts that the error returned from `Setup` never carries server-controlled content.
- [ ] Four existing expectations updated: `acmeErr450`/`acmeErr500` carry no `ProblemType`, so they now correctly render as non-conformant.
- [ ] Mutation-checked three ways — reverting the two call sites to `err.Error()` fails 8 subtests; reverting the 5xx branches to `err: err` fails 2; reverting `errors.AsType` to a bare type assertion fails 1, leaking `"registering account: 403 : AKIAIOSFODNN7EXAMPLE"`.
- [ ] `go test ./pkg/issuer/acme/... ./pkg/controller/issuers/..../pkg/controller/clusterissuers/...`, `go build ./...`, `go vet`, and `gofmt` all clean.

## Release note

  ```release-note
ACME Issuer response bodies are no longer reflected into Issuer status conditions or Kubernetes Events. Only ACME problem documents are surfaced (bounded in length); other responses are reported by HTTP status code alone, with the full error available in the controller logs.```