### PR TITLE
Return an error when the CNAME lookup fails during a DNS01 challenge

### DIFF
--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -38,6 +38,7 @@ func DNS01LookupFQDN(ctx context.Context, domain string, followCNAME bool, names
 	}
 	if target == "" {
 		// No CNAME record on the challenge name, so there is nothing to follow.
+		logf.FromContext(ctx).V(logf.DebugLevel).Info("No CNAME found", "fqdn", fqdn)
 		return fqdn, nil
 	}
 
@@ -111,11 +112,17 @@ func lookupCNAMETarget(ctx context.Context, fqdn string, nameservers []string) (
 	if err != nil {
 		return "", err
 	}
-	// Any rcode other than NOERROR (NXDOMAIN, SERVFAIL, ...) means there is no
-	// CNAME to use. followCNAMEs treats these the same way, returning the name
-	// unchanged.
-	if r.Rcode != dns.RcodeSuccess {
+	// NXDOMAIN means the name does not exist, so there is no CNAME to use. Any
+	// other non-NOERROR rcode (SERVFAIL, REFUSED, ...) means it is unknown
+	// whether a CNAME exists, which must not be silently treated as "no CNAME":
+	// the challenge record would then be created under the wrong name.
+	// See: https://github.com/cert-manager/cert-manager/issues/8095
+	switch r.Rcode {
+	case dns.RcodeSuccess:
+	case dns.RcodeNameError:
 		return "", nil
+	default:
+		return "", errUnexpectedRcode(fqdn, nameservers, r.Rcode)
 	}
 
 	for _, rr := range r.Answer {

--- a/pkg/issuer/acme/dns/util/dns_test.go
+++ b/pkg/issuer/acme/dns/util/dns_test.go
@@ -391,6 +391,47 @@ func TestDNS01LookupFQDN_WildcardCNAME(t *testing.T) {
 			},
 		},
 		{
+			// A resolver that answers but cannot resolve the challenge name
+			// leaves it unknown whether a CNAME exists, so the lookup must fail
+			// rather than silently use the original name.
+			// See: https://github.com/cert-manager/cert-manager/issues/8095
+			name:    "SERVFAIL for the challenge name should be returned as an error",
+			domain:  "example.com",
+			follow:  true,
+			wantErr: true,
+			mockDNS: []interaction{
+				{"CNAME _acme-challenge.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure},
+				}},
+			},
+		},
+		{
+			// Like the transport-failure case above, a SERVFAIL on the wildcard
+			// probe must not break a delegation that used to work.
+			name:     "SERVFAIL for the wildcard probe should fall back to following the CNAME",
+			domain:   "monitoring.example.com",
+			follow:   true,
+			wantFQDN: "_acme-challenge.dns-validation.example.net.",
+			mockDNS: []interaction{
+				{"CNAME _acme-challenge.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{
+						&dns.CNAME{
+							Hdr:    dns.RR_Header{Name: "_acme-challenge.monitoring.example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+							Target: "_acme-challenge.dns-validation.example.net.",
+						},
+					},
+				}},
+				{"CNAME *.monitoring.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure},
+				}},
+				{"CNAME _acme-challenge.dns-validation.example.net.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+					Answer: []dns.RR{},
+				}},
+			},
+		},
+		{
 			// Failing to look up the challenge name is not a new failure mode:
 			// followCNAMEs would have made the same query and failed too.
 			name:      "challenge name lookup failure should be returned",

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -94,6 +94,12 @@ func getNameservers(path string, defaults []string) []string {
 	return systemNameservers
 }
 
+// errUnexpectedRcode is returned when a CNAME query gets a response code that
+// leaves it unknown whether a CNAME record exists, e.g. SERVFAIL or REFUSED.
+func errUnexpectedRcode(fqdn string, nameservers []string, rcode int) error {
+	return fmt.Errorf("could not determine whether there is a CNAME record for %q: DNS query to nameservers %v returned response code %s", fqdn, nameservers, dns.RcodeToString[rcode])
+}
+
 // Follows the CNAME records and returns the last non-CNAME fully qualified domain name
 // that it finds. Returns an error when a loop is found in the CNAME chain. The
 // argument fqdnChain is used by the function itself to keep track of which fqdns it
@@ -109,7 +115,7 @@ func followCNAMEs(ctx context.Context, fqdn string, nameservers []string, fqdnCh
 		// NXDOMAIN: the name does not exist, so there is no CNAME to follow.
 		return fqdn, nil
 	default:
-		return "", fmt.Errorf("could not determine whether there is a CNAME record for %q: DNS query to nameservers %v returned response code %s", fqdn, nameservers, dns.RcodeToString[r.Rcode])
+		return "", errUnexpectedRcode(fqdn, nameservers, r.Rcode)
 	}
 	for _, rr := range r.Answer {
 		cn, ok := rr.(*dns.CNAME)

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -103,8 +103,13 @@ func followCNAMEs(ctx context.Context, fqdn string, nameservers []string, fqdnCh
 	if err != nil {
 		return "", err
 	}
-	if r.Rcode != dns.RcodeSuccess {
-		return fqdn, err
+	switch r.Rcode {
+	case dns.RcodeSuccess:
+	case dns.RcodeNameError:
+		// NXDOMAIN: the name does not exist, so there is no CNAME to follow.
+		return fqdn, nil
+	default:
+		return "", fmt.Errorf("could not determine whether there is a CNAME record for %q: DNS query to nameservers %v returned response code %s", fqdn, nameservers, dns.RcodeToString[r.Rcode])
 	}
 	for _, rr := range r.Answer {
 		cn, ok := rr.(*dns.CNAME)
@@ -120,6 +125,9 @@ func followCNAMEs(ctx context.Context, fqdn string, nameservers []string, fqdnCh
 			return "", fmt.Errorf("Found recursive CNAME record to %q when looking up %q", cn.Target, fqdn)
 		}
 		return followCNAMEs(ctx, cn.Target, nameservers, append(fqdnChain, fqdn)...)
+	}
+	if len(fqdnChain) == 0 {
+		logf.FromContext(ctx).V(logf.DebugLevel).Info("No CNAME found", "fqdn", fqdn)
 	}
 	return fqdn, nil
 }

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -249,6 +249,43 @@ func Test_followCNAMEs(t *testing.T) {
 			},
 		},
 		{
+			name: "Return fqdn unchanged on NXDOMAIN",
+			args: args{
+				fqdn: "missing.example.com.",
+			},
+			want:    "missing.example.com.",
+			wantErr: false,
+			mock: []interaction{
+				{"CNAME missing.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
+				}},
+			},
+		},
+		{
+			name: "Error on SERVFAIL",
+			args: args{
+				fqdn: "broken.example.com.",
+			},
+			wantErr: true,
+			mock: []interaction{
+				{"CNAME broken.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure},
+				}},
+			},
+		},
+		{
+			name: "Error on REFUSED",
+			args: args{
+				fqdn: "refused.example.com.",
+			},
+			wantErr: true,
+			mock: []interaction{
+				{"CNAME refused.example.com.", &dns.Msg{
+					MsgHdr: dns.MsgHdr{Rcode: dns.RcodeRefused},
+				}},
+			},
+		},
+		{
 			name: "Error on recursive CNAME",
 			args: args{
 				fqdn: "recursive.example.com.",


### PR DESCRIPTION
### Pull Request Motivation

Fixes #8095

When `cnameStrategy: Follow` is configured and the CNAME query receives a SERVFAIL, REFUSED, or other unexpected response code, `followCNAMEs` silently returned the original, unresolved record name. Solvers then tried to create the challenge record under the wrong name in the delegated zone, producing confusing provider-side errors such as Route53's `InvalidChangeBatch: [RRSet with DNS name _acme-challenge.test.example.com. is not permitted in zone letsencrypt.example.com.]` — with no hint that CNAME resolution had failed upstream. See [my diagnosis on the issue](https://github.com/cert-manager/cert-manager/issues/8095#issuecomment-4927649978) for the full analysis.

This PR:

- treats any response code other than NOERROR and NXDOMAIN as a retryable error, so a flaky or misconfigured resolver surfaces on the Challenge instead of failing silently (as [requested by @telmich](https://github.com/cert-manager/cert-manager/issues/8095#issuecomment-4928307326));
- keeps the fallback for NXDOMAIN and NOERROR-without-CNAME, because a missing CNAME is the normal case for `cnameStrategy: Follow` on domains solved directly;
- logs that fallback at debug level, as [suggested by @ThatsMrTalbot](https://github.com/cert-manager/cert-manager/issues/8095#issuecomment-4945280351), so it can be diagnosed with `--v=6` — previously nothing was logged unless a CNAME was actually found.

### Relation to #5716 / #5751 / #8639

Same code path (`cnameStrategy: Follow`), opposite symptom: #8639 stopped cert-manager following a CNAME the user never intended (synthesized from a wildcard record), while this PR stops it *silently not following* a CNAME the user did intend when the lookup fails. #8639 moved first-hop resolution into `lookupCNAMETarget`, which carried the same silent rcode fallback, so the second commit here applies the same handling there; the wildcard probe keeps its documented tolerance of failures.

### Kind

/kind bug

### Release Note

```release-note
ACME DNS01: when `cnameStrategy: Follow` is set and the CNAME lookup fails (e.g. SERVFAIL from the configured recursive nameservers), the challenge now fails with a clear, retryable error instead of silently attempting to create the record under the original, unresolved name.
```

*with claude fable-5*

