### PR TITLE
fix(vault): keep Vault response bodies out of Issuer status

### DIFF
--- a/internal/vault/errors.go
+++ b/internal/vault/errors.go
@@ -56,6 +56,15 @@ func SafeErrorMessage(err error) string {
 	// RawError is set when the body could not be decoded as a Vault error
 	// response, in which case Errors holds the raw body verbatim. That body was
 	// not written by Vault, so it is not safe to reflect.
+	//
+	// This check is best-effort rather than a guarantee. RawError is false
+	// whenever the body parsed as Vault's error envelope, which is not the same
+	// as the body having been written by Vault: any endpoint that responds with
+	// {"errors": ["..."]} decodes cleanly, and its strings are still reflected
+	// here. Unlike ACME, whose problem documents carry a
+	// urn:ietf:params:acme:error prefix we can key on, a Vault error response
+	// has no marker that a hostile endpoint could not also produce. The
+	// truncation below is what bounds that residual case.
 	if respErr.RawError {
 		return fmt.Sprintf(messageTemplateNonVaultErrorResponse, respErr.StatusCode)
 	}
@@ -66,5 +75,54 @@ func SafeErrorMessage(err error) string {
 // LoggableErrorMessage renders err for the cert-manager logs, where the full
 // response details are useful for debugging.
 func LoggableErrorMessage(err error) string {
+	// Recover the unsanitised error if this one left the package through
+	// sanitizeError, so that the logs keep the detail that was withheld from the
+	// API server.
+	if sanitized, ok := errors.AsType[*sanitizedError](err); ok {
+		err = sanitized.err
+	}
+
 	return cmerrors.TruncateMessage(err.Error(), maxVaultErrorLogLength)
+}
+
+// sanitizedError renders as a message that is safe to persist to the API server
+// while keeping the original error reachable, both for the logs via
+// LoggableErrorMessage and for callers matching on it with errors.Is and
+// errors.As.
+type sanitizedError struct {
+	safe string
+	err  error
+}
+
+func (e *sanitizedError) Error() string { return e.safe }
+
+func (e *sanitizedError) Unwrap() error { return e.err }
+
+// sanitizeError prepares err to leave this package. Every caller of New, Sign
+// and IsVaultInitializedAndUnsealed copies the error it gets back into a
+// Kubernetes Event and into the status of an Issuer, a CertificateRequest or a
+// CertificateSigningRequest, all of which are persisted to the API server and
+// readable by anyone who can read the resource. Sanitising here rather than at
+// each of those sinks means a new caller cannot reintroduce the disclosure by
+// forgetting to call SafeErrorMessage.
+func sanitizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Only an error carrying a response can hold content chosen by whatever
+	// spec.vault.server points at. Leaving every other error untouched keeps it
+	// matchable by the callers that type-assert on it without going through
+	// errors.As, notably cmerrors.IsInvalidData.
+	if _, ok := errors.AsType[*vault.ResponseError](err); !ok {
+		return err
+	}
+
+	safe := SafeErrorMessage(err)
+	if safe == err.Error() {
+		// Nothing was withheld, so there is no reason to obscure the chain.
+		return err
+	}
+
+	return &sanitizedError{safe: safe, err: err}
 }

--- a/internal/vault/errors.go
+++ b/internal/vault/errors.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"errors"
+	"fmt"
+
+	vault "github.com/hashicorp/vault/api"
+
+	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
+)
+
+const (
+	messageTemplateNonVaultErrorResponse = "the Vault server returned an HTTP %d response which is not a Vault error response; the response body has been omitted and can be found in the cert-manager logs"
+
+	// maxVaultErrorMessageLength bounds how much of an error is copied into an
+	// Issuer status condition or a Kubernetes Event.
+	maxVaultErrorMessageLength = 1024
+
+	// maxVaultErrorLogLength bounds how much of an error is written to the logs.
+	// Logs are not persisted to the API server so this can be more generous than
+	// maxVaultErrorMessageLength, but an unbounded response body must not be
+	// able to flood the log either.
+	maxVaultErrorLogLength = 8192
+)
+
+// SafeErrorMessage renders err for inclusion in an Issuer status condition and
+// in the Kubernetes Events raised alongside it. Both are persisted to the API
+// server and are readable by anyone who can read the Issuer, so they must not
+// carry content chosen by whatever spec.vault.server points at.
+func SafeErrorMessage(err error) string {
+	// Use errors.AsType rather than a bare type assertion so that a response
+	// error which has been wrapped on its way up cannot bypass this check.
+	respErr, ok := errors.AsType[*vault.ResponseError](err)
+	if !ok {
+		// Not a response from the server: this was raised locally or by the
+		// Kubernetes API and carries no remote content.
+		return cmerrors.TruncateMessage(err.Error(), maxVaultErrorMessageLength)
+	}
+
+	// RawError is set when the body could not be decoded as a Vault error
+	// response, in which case Errors holds the raw body verbatim. That body was
+	// not written by Vault, so it is not safe to reflect.
+	if respErr.RawError {
+		return fmt.Sprintf(messageTemplateNonVaultErrorResponse, respErr.StatusCode)
+	}
+
+	return cmerrors.TruncateMessage(err.Error(), maxVaultErrorMessageLength)
+}
+
+// LoggableErrorMessage renders err for the cert-manager logs, where the full
+// response details are useful for debugging.
+func LoggableErrorMessage(err error) string {
+	return cmerrors.TruncateMessage(err.Error(), maxVaultErrorLogLength)
+}

--- a/internal/vault/errors_test.go
+++ b/internal/vault/errors_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+
+	cmerrors "github.com/cert-manager/cert-manager/pkg/util/errors"
+)
+
+// sentinel is a string which must never be copied into an Issuer status
+// condition. It stands in for whatever an endpoint which is not Vault happens
+// to reflect back at us.
+const sentinel = "SENSITIVE-RESPONSE-BODY"
+
+func TestSafeErrorMessage(t *testing.T) {
+	tests := map[string]struct {
+		err error
+
+		// want asserts on the whole message, wantContains on a substring.
+		want         string
+		wantContains string
+	}{
+		"a local error is reflected verbatim": {
+			err:  errors.New("error initializing Vault client: parse \" https://vault.example.com\": first path segment in URL cannot contain colon"),
+			want: "error initializing Vault client: parse \" https://vault.example.com\": first path segment in URL cannot contain colon",
+		},
+		"a raw response body is omitted": {
+			err: &vault.ResponseError{
+				StatusCode: 500,
+				RawError:   true,
+				Errors:     []string{sentinel},
+			},
+			want: fmt.Sprintf(messageTemplateNonVaultErrorResponse, 500),
+		},
+		"a raw response body is omitted when the error has been wrapped": {
+			err: fmt.Errorf("error calling Vault server: %w", &vault.ResponseError{
+				StatusCode: 302,
+				RawError:   true,
+				Errors:     []string{sentinel},
+			}),
+			want: fmt.Sprintf(messageTemplateNonVaultErrorResponse, 302),
+		},
+		"a Vault error response is reflected": {
+			err: &vault.ResponseError{
+				StatusCode: 403,
+				Errors:     []string{"permission denied"},
+			},
+			wantContains: "permission denied",
+		},
+		"a wrapped Vault error response keeps the context it was wrapped with": {
+			err: fmt.Errorf("error logging in to Vault server: %w", &vault.ResponseError{
+				StatusCode: 400,
+				Errors:     []string{"invalid role ID"},
+			}),
+			wantContains: "error logging in to Vault server: ",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := SafeErrorMessage(test.err)
+
+			if strings.Contains(got, sentinel) {
+				t.Errorf("SafeErrorMessage() = %q, which leaks the response body", got)
+			}
+			if len(got) > maxVaultErrorMessageLength {
+				t.Errorf("message is %d bytes, want at most %d", len(got), maxVaultErrorMessageLength)
+			}
+
+			switch {
+			case test.want != "":
+				if got != test.want {
+					t.Errorf("SafeErrorMessage() = %q, want %q", got, test.want)
+				}
+			case test.wantContains != "":
+				if !strings.Contains(got, test.wantContains) {
+					t.Errorf("SafeErrorMessage() = %q, want it to contain %q", got, test.wantContains)
+				}
+			}
+		})
+	}
+}
+
+func TestSafeErrorMessageBoundsLength(t *testing.T) {
+	// Even a genuine Vault server must not be able to fill the Issuer status,
+	// which is persisted to the API server.
+	err := &vault.ResponseError{
+		StatusCode: 403,
+		Errors:     []string{strings.Repeat("a", 4*maxVaultErrorMessageLength)},
+	}
+
+	got := SafeErrorMessage(err)
+	if !strings.HasSuffix(got, cmerrors.TruncationMarker) {
+		t.Errorf("SafeErrorMessage() = %q, want it to be marked as truncated", got)
+	}
+	if len(got) > maxVaultErrorMessageLength {
+		t.Errorf("message is %d bytes, want at most %d", len(got), maxVaultErrorMessageLength)
+	}
+}
+
+func TestLoggableErrorMessageBoundsLength(t *testing.T) {
+	// The logs are allowed to carry the response body, but an unbounded body
+	// must not be able to flood them.
+	err := &vault.ResponseError{
+		StatusCode: 500,
+		RawError:   true,
+		Errors:     []string{strings.Repeat("a", 4*maxVaultErrorLogLength)},
+	}
+
+	got := LoggableErrorMessage(err)
+	if !strings.HasSuffix(got, cmerrors.TruncationMarker) {
+		t.Errorf("LoggableErrorMessage() = %q, want it to be marked as truncated", got)
+	}
+	if len(got) > maxVaultErrorLogLength {
+		t.Errorf("message is %d bytes, want at most %d", len(got), maxVaultErrorLogLength)
+	}
+}

--- a/internal/vault/errors_test.go
+++ b/internal/vault/errors_test.go
@@ -118,6 +118,101 @@ func TestSafeErrorMessageBoundsLength(t *testing.T) {
 	}
 }
 
+func TestSanitizeError(t *testing.T) {
+	rawResponse := &vault.ResponseError{
+		StatusCode: 500,
+		RawError:   true,
+		Errors:     []string{sentinel},
+	}
+
+	tests := map[string]struct {
+		err error
+
+		// wantUnchanged asserts that the same error is handed straight back,
+		// which matters for the callers that match on it without errors.As.
+		wantUnchanged bool
+		wantMessage   string
+	}{
+		"a nil error stays nil": {
+			err:           nil,
+			wantUnchanged: true,
+		},
+		"a local error is left alone": {
+			err:           errors.New("error initializing Vault client: unable to load credentials"),
+			wantUnchanged: true,
+		},
+		"an invalid data error is left alone so that IsInvalidData still matches": {
+			err:           cmerrors.NewInvalidData("no data for %q in secret", "key1"),
+			wantUnchanged: true,
+		},
+		"a Vault error response short enough to reflect is left alone": {
+			err: &vault.ResponseError{
+				StatusCode: 403,
+				Errors:     []string{"permission denied"},
+			},
+			wantUnchanged: true,
+		},
+		"a raw response body is replaced": {
+			err:         rawResponse,
+			wantMessage: fmt.Sprintf(messageTemplateNonVaultErrorResponse, 500),
+		},
+		"a raw response body is replaced when the error has been wrapped": {
+			err:         fmt.Errorf("failed to sign certificate by vault: %w", rawResponse),
+			wantMessage: fmt.Sprintf(messageTemplateNonVaultErrorResponse, 500),
+		},
+		"an oversized Vault error response is truncated": {
+			err: &vault.ResponseError{
+				StatusCode: 403,
+				Errors:     []string{strings.Repeat("a", 4*maxVaultErrorMessageLength)},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := sanitizeError(test.err)
+
+			if test.wantUnchanged {
+				if got != test.err {
+					t.Fatalf("sanitizeError() = %v, want the error to be handed back unchanged", got)
+				}
+
+				return
+			}
+
+			if strings.Contains(got.Error(), sentinel) {
+				t.Errorf("sanitizeError() = %q, which leaks the response body", got)
+			}
+			if len(got.Error()) > maxVaultErrorMessageLength {
+				t.Errorf("message is %d bytes, want at most %d", len(got.Error()), maxVaultErrorMessageLength)
+			}
+			if test.wantMessage != "" && got.Error() != test.wantMessage {
+				t.Errorf("sanitizeError() = %q, want %q", got, test.wantMessage)
+			}
+
+			// The original has to stay reachable, both for the logs and for the
+			// callers that match on what the server returned.
+			if !strings.Contains(LoggableErrorMessage(got), test.err.Error()) {
+				t.Errorf("LoggableErrorMessage() = %q, want it to keep the original error", LoggableErrorMessage(got))
+			}
+			if _, ok := errors.AsType[*vault.ResponseError](got); !ok {
+				t.Error("sanitizeError() returned an error that errors.As can no longer unwrap to a *vault.ResponseError")
+			}
+		})
+	}
+}
+
+func TestSanitizeErrorKeepsInvalidDataMatchable(t *testing.T) {
+	// cmerrors.IsInvalidData type-asserts rather than using errors.As, so an
+	// invalid data error must never be wrapped on its way out of this package.
+	// The signing controller relies on this to decide not to retry.
+	err := sanitizeError(cmerrors.NewInvalidData("no data for %q in secret", "key1"))
+
+	if !cmerrors.IsInvalidData(err) {
+		t.Errorf("IsInvalidData() = false for %v, want true", err)
+	}
+}
+
 func TestLoggableErrorMessageBoundsLength(t *testing.T) {
 	// The logs are allowed to carry the response body, but an unbounded body
 	// must not be able to flood them.

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -116,6 +116,15 @@ type Vault struct {
 // Returned errors may be network failures and should be considered for
 // retrying.
 func New(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (Interface, error) {
+	v, err := newVault(ctx, namespace, createTokenFn, secretsLister, issuer, canUseAmbientCredentials)
+	if err != nil {
+		return nil, sanitizeError(err)
+	}
+
+	return v, nil
+}
+
+func newVault(ctx context.Context, namespace string, createTokenFn func(ns string) CreateToken, secretsLister internalinformers.SecretLister, issuer v1.GenericIssuer, canUseAmbientCredentials bool) (*Vault, error) {
 	v := &Vault{
 		createToken:              createTokenFn(namespace),
 		secretsLister:            secretsLister,
@@ -160,6 +169,12 @@ func New(ctx context.Context, namespace string, createTokenFn func(ns string) Cr
 
 // Sign will connect to a Vault instance to sign a certificate signing request.
 func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []byte, err error) {
+	cert, ca, err = v.sign(csrPEM, duration)
+
+	return cert, ca, sanitizeError(err)
+}
+
+func (v *Vault) sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []byte, err error) {
 	csr, err := pki.DecodeX509CertificateRequestBytes(csrPEM)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode CSR for signing: %s", err)
@@ -190,7 +205,9 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to sign certificate by vault: %s", err)
+		// Wrap rather than stringify so that the response error survives for
+		// sanitizeError to recognise on the way out.
+		return nil, nil, fmt.Errorf("failed to sign certificate by vault: %w", err)
 	}
 
 	vaultResult := certutil.Secret{}
@@ -919,6 +936,10 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 }
 
 func (v *Vault) IsVaultInitializedAndUnsealed() error {
+	return sanitizeError(v.isVaultInitializedAndUnsealed())
+}
+
+func (v *Vault) isVaultInitializedAndUnsealed() error {
 	healthURL := path.Join("/v1", "sys", "health")
 	healthRequest := v.clientSys.NewRequest("GET", healthURL)
 	healthResp, err := v.clientSys.RawRequest(healthRequest)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -478,7 +478,7 @@ func (v *Vault) requestTokenWithAppRoleRef(client Client, appRole *v1.VaultAppRo
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return "", fmt.Errorf("error logging in to Vault server: %s", err.Error())
+		return "", fmt.Errorf("error logging in to Vault server: %w", err)
 	}
 
 	vaultResult := vault.Secret{}
@@ -557,7 +557,7 @@ func (v *Vault) requestTokenWithClientCertificate(client Client, clientCertifica
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
+		return "", fmt.Errorf("error calling Vault server: %w", err)
 	}
 
 	vaultResult := vault.Secret{}
@@ -660,7 +660,7 @@ func (v *Vault) requestTokenWithKubernetesAuth(ctx context.Context, client Clien
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
+		return "", fmt.Errorf("error calling Vault server: %w", err)
 	}
 
 	vaultResult := vault.Secret{}
@@ -761,7 +761,7 @@ func (v *Vault) requestTokenWithAWSAuth(ctx context.Context, client Client, awsA
 	loginPath := path.Join(mountPath, "login")
 	secret, err := client.Write(loginPath, loginData)
 	if err != nil {
-		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
+		return "", fmt.Errorf("error calling Vault server: %w", err)
 	}
 
 	// Guard against empty secret

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1941,3 +1941,125 @@ func TestSignIntegration(t *testing.T) {
 	require.NotEmpty(t, certPEM)
 	require.NotEmpty(t, caPEM)
 }
+
+// TestExportedFunctionsDoNotLeakResponseBodies pins the invariant that the
+// exported surface of this package never returns an error carrying a response
+// body chosen by whatever spec.vault.server points at. Callers render these
+// errors into Issuer, CertificateRequest and CertificateSigningRequest
+// conditions and into the Kubernetes Events raised alongside them, all of which
+// are persisted to the API server, so the sanitising has to happen here rather
+// than at each of those sinks.
+func TestExportedFunctionsDoNotLeakResponseBodies(t *testing.T) {
+	const (
+		vaultToken = "token1"
+		vaultPath  = "my_pki_mount/sign/my-role-name"
+	)
+
+	privatekey := generateRSAPrivateKey(t)
+	csrPEM := generateCSR(t, privatekey)
+
+	// An endpoint which is not Vault, reflecting content of its own choosing.
+	// The body is not a Vault error response, so the Vault client hands it back
+	// verbatim.
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusInternalServerError)
+		_, err := fmt.Fprintf(response, "<html><body>%s</body></html>", sentinel)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	secretsLister := listers.FakeSecretListerFrom(listers.NewFakeSecretLister(),
+		listers.SetFakeSecretNamespaceListerGet(
+			&corev1.Secret{
+				Data: map[string][]byte{
+					"key1": []byte(vaultToken),
+				},
+			}, nil),
+	)
+
+	secretRef := cmmeta.SecretKeySelector{
+		LocalObjectReference: cmmeta.LocalObjectReference{Name: "secret1"},
+		Key:                  "key1",
+	}
+
+	newIssuer := func(auth cmapiv1.VaultAuth) *cmapiv1.Issuer {
+		return &cmapiv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer1",
+				Namespace: "k8s-ns1",
+			},
+			Spec: cmapiv1.IssuerSpec{
+				IssuerConfig: cmapiv1.IssuerConfig{
+					Vault: &cmapiv1.VaultIssuer{
+						Server: server.URL,
+						Path:   vaultPath,
+						Auth:   auth,
+					},
+				},
+			},
+		}
+	}
+
+	newVaultForIssuer := func(t *testing.T, auth cmapiv1.VaultAuth) (Interface, error) {
+		t.Helper()
+
+		return New(t.Context(), "k8s-ns1", func(ns string) CreateToken { return nil },
+			secretsLister, newIssuer(auth), false)
+	}
+
+	// Token auth reads the token from a Secret without talking to the server, so
+	// it is what gets us a client for the calls whose own request must be the
+	// one that fails.
+	tokenAuth := cmapiv1.VaultAuth{TokenSecretRef: &secretRef}
+
+	newClient := func(t *testing.T) Interface {
+		t.Helper()
+
+		v, err := newVaultForIssuer(t, tokenAuth)
+		require.NoError(t, err)
+
+		return v
+	}
+
+	tests := map[string]func(t *testing.T) error{
+		"New": func(t *testing.T) error {
+			// AppRole auth logs in to the server, which makes New itself the
+			// call that sees the response.
+			_, err := newVaultForIssuer(t, cmapiv1.VaultAuth{
+				AppRole: &cmapiv1.VaultAppRole{
+					RoleId:    "role1",
+					SecretRef: secretRef,
+				},
+			})
+
+			return err
+		},
+		"Sign": func(t *testing.T) error {
+			_, _, err := newClient(t).Sign(csrPEM, time.Hour)
+
+			return err
+		},
+		"IsVaultInitializedAndUnsealed": func(t *testing.T) error {
+			return newClient(t).IsVaultInitializedAndUnsealed()
+		},
+	}
+
+	for name, call := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := call(t)
+			require.Error(t, err)
+
+			// Error is what the callers render into a condition and an Event,
+			// whether or not they remember to ask for a safe message.
+			assert.NotContains(t, err.Error(), sentinel,
+				"the error returned to the caller leaks the response body")
+			assert.LessOrEqual(t, len(err.Error()), maxVaultErrorMessageLength,
+				"the error returned to the caller is not bounded")
+
+			// The detail withheld from the API server is still available to
+			// whoever can read the controller logs.
+			assert.Contains(t, LoggableErrorMessage(err), sentinel,
+				"the response body should remain recoverable for the logs")
+		})
+	}
+}

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -84,10 +84,6 @@ const (
 	// Issuer status condition or a Kubernetes Event. Both are persisted to the
 	// API server, so their size has to be bounded even for well behaved ACME servers.
 	maxACMEErrorMessageLength = 1024
-
-	// truncationMarker is appended to messages shortened by truncateMessage so
-	// that readers can tell the message is incomplete.
-	truncationMarker = "... (truncated)"
 )
 
 // Setup will verify an existing ACME registration, or create one if not
@@ -478,7 +474,7 @@ func safeErrorMessage(err error) string {
 	if !ok {
 		// Not a response from the ACME server: this was raised locally or by the
 		// Kubernetes API and carries no remote content.
-		return truncateMessage(err.Error(), maxACMEErrorMessageLength)
+		return cmerrors.TruncateMessage(err.Error(), maxACMEErrorMessageLength)
 	}
 
 	// ProblemType is only populated when the response body was successfully
@@ -490,7 +486,7 @@ func safeErrorMessage(err error) string {
 		return fmt.Sprintf(messageTemplateNonACMEErrorResponse, acmeErr.StatusCode)
 	}
 
-	return truncateMessage(acmeErr.Error(), maxACMEErrorMessageLength)
+	return cmerrors.TruncateMessage(acmeErr.Error(), maxACMEErrorMessageLength)
 }
 
 // isACMEProblemType reports whether problemType names an ACME error type, in
@@ -500,26 +496,6 @@ func isACMEProblemType(problemType string) bool {
 
 	return strings.HasPrefix(problemType, acmeErrorURNPrefix) ||
 		strings.HasPrefix(problemType, legacyACMEErrorURNPrefix)
-}
-
-// truncateMessage bounds s to maxLen bytes in total, including the marker which
-// is appended so that readers can tell the message is incomplete.
-func truncateMessage(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-
-	// Cutting on a byte boundary can split a multi-byte rune in half. Replacing
-	// invalid sequences keeps the result valid UTF-8, which the API server
-	// requires of the strings it stores.
-	if maxLen <= len(truncationMarker) {
-		return strings.ToValidUTF8(s[:maxLen], "")
-	}
-
-	truncated := strings.ToValidUTF8(s[:maxLen-len(truncationMarker)], "")
-
-	// Trim trailing whitespace so that the marker reads cleanly.
-	return strings.TrimRight(truncated, " \t\r\n") + truncationMarker
 }
 
 func ensureEmailUpToDate(ctx context.Context, cl client.Interface, acc *acmeapi.Account, specEmail string) (*acmeapi.Account, string, error) {

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -886,7 +886,7 @@ func TestSafeErrorMessageBoundsLength(t *testing.T) {
 	if !strings.HasSuffix(got, errors.TruncationMarker) {
 		t.Errorf("safeErrorMessage() = %q, want it to be marked as truncated", got)
 	}
-	if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
+	if len(got) > maxACMEErrorMessageLength {
 		t.Errorf("message is %d bytes, want at most %d", len(got), maxACMEErrorMessageLength)
 	}
 }

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -884,80 +883,11 @@ func TestSafeErrorMessageBoundsLength(t *testing.T) {
 	}
 
 	got := safeErrorMessage(err)
-	if !strings.HasSuffix(got, truncationMarker) {
+	if !strings.HasSuffix(got, errors.TruncationMarker) {
 		t.Errorf("safeErrorMessage() = %q, want it to be marked as truncated", got)
 	}
 	if len(got) > maxACMEErrorMessageLength+len("... (truncated)") {
 		t.Errorf("message is %d bytes, want at most %d", len(got), maxACMEErrorMessageLength)
-	}
-}
-
-func TestTruncateMessage(t *testing.T) {
-	tests := map[string]struct {
-		in     string
-		maxLen int
-		want   string
-	}{
-		// maxLen is a bound on the whole result, so a limit of 20 leaves 5 bytes
-		// for the message once the 15 byte marker has been accounted for.
-		"a message within the limit is returned unchanged": {
-			in:     "short",
-			maxLen: 20,
-			want:   "short",
-		},
-		"a message at the limit is returned unchanged": {
-			in:     "exactly20bytes!!!!!!",
-			maxLen: 20,
-			want:   "exactly20bytes!!!!!!",
-		},
-		"a longer message is truncated": {
-			in:     "abcdefghijklmnopqrstuvwxyz",
-			maxLen: 20,
-			want:   "abcde" + truncationMarker,
-		},
-		"trailing whitespace is trimmed before the marker is added": {
-			in:     "abc  defghijklmnopqrstuvwxyz",
-			maxLen: 20,
-			want:   "abc" + truncationMarker,
-		},
-		"a multi-byte rune is not split in half": {
-			// Each £ is two bytes, so the 5 byte budget falls in the middle of
-			// the third one.
-			in:     strings.Repeat("£", 12),
-			maxLen: 20,
-			want:   "££" + truncationMarker,
-		},
-		"an invalid byte sequence is dropped": {
-			in:     "ab\xffcdefghijklmnopqrstuvwxyz",
-			maxLen: 20,
-			want:   "abcd" + truncationMarker,
-		},
-		"a limit too small for the marker drops the marker": {
-			in:     "abcdefghij",
-			maxLen: 4,
-			want:   "abcd",
-		},
-		"a limit too small for the marker still respects rune boundaries": {
-			in:     strings.Repeat("£", 4),
-			maxLen: 3,
-			want:   "£",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := truncateMessage(test.in, test.maxLen)
-			if got != test.want {
-				t.Errorf("truncateMessage() = %q, want %q", got, test.want)
-			}
-			if !utf8.ValidString(got) {
-				t.Errorf("truncateMessage() = %q, which is not valid UTF-8", got)
-			}
-			// maxLen bounds the result in full, marker included.
-			if len(got) > test.maxLen {
-				t.Errorf("truncateMessage() returned %d bytes, want at most %d", len(got), test.maxLen)
-			}
-		})
 	}
 }
 

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -151,16 +151,17 @@ func (v *Vault) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 		msg := vaultinternal.SafeErrorMessage(err)
 		logVaultError(ctx, issuer, messageVaultClientInitFailed, msg, err)
 		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultClientInitFailed, msg))
-		// Return the sanitised message rather than the error itself: the Issuer
-		// controllers copy the returned error into a Kubernetes Event.
-		return fmt.Errorf("%s", msg)
+		// The Issuer controllers copy the returned error into a Kubernetes
+		// Event, but internal/vault has already taken any response body out of
+		// it, so it can be returned whole and callers keep the chain.
+		return err
 	}
 
 	if err := client.IsVaultInitializedAndUnsealed(); err != nil {
 		msg := vaultinternal.SafeErrorMessage(err)
 		logVaultError(ctx, issuer, messageVaultInitializedAndUnsealedFailed, msg, err)
 		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultInitializedAndUnsealedFailed, msg))
-		return fmt.Errorf("%s", msg)
+		return err
 	}
 
 	logf.FromContext(ctx).V(logf.DebugLevel).Info(messageVaultVerified, "issuer", klog.KObj(issuer))

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -148,18 +148,35 @@ func (v *Vault) Setup(ctx context.Context, issuer v1.GenericIssuer) error {
 
 	client, err := vaultinternal.New(ctx, v.ResourceNamespace(issuer), v.createTokenFn, v.secretsLister, issuer, v.CanUseAmbientCredentials(issuer))
 	if err != nil {
-		logf.FromContext(ctx).V(logf.WarnLevel).Info(messageVaultClientInitFailed, "err", err, "issuer", klog.KObj(issuer))
-		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultClientInitFailed, err.Error()))
-		return err
+		msg := vaultinternal.SafeErrorMessage(err)
+		logVaultError(ctx, issuer, messageVaultClientInitFailed, msg, err)
+		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultClientInitFailed, msg))
+		// Return the sanitised message rather than the error itself: the Issuer
+		// controllers copy the returned error into a Kubernetes Event.
+		return fmt.Errorf("%s", msg)
 	}
 
 	if err := client.IsVaultInitializedAndUnsealed(); err != nil {
-		logf.FromContext(ctx).V(logf.WarnLevel).Info(messageVaultInitializedAndUnsealedFailed, "err", err, "issuer", klog.KObj(issuer))
-		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultInitializedAndUnsealedFailed, err.Error()))
-		return err
+		msg := vaultinternal.SafeErrorMessage(err)
+		logVaultError(ctx, issuer, messageVaultInitializedAndUnsealedFailed, msg, err)
+		apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, fmt.Sprintf("%s: %s", messageVaultInitializedAndUnsealedFailed, msg))
+		return fmt.Errorf("%s", msg)
 	}
 
 	logf.FromContext(ctx).V(logf.DebugLevel).Info(messageVaultVerified, "issuer", klog.KObj(issuer))
 	apiutil.SetIssuerCondition(issuer, issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionTrue, successVaultVerified, messageVaultVerified)
 	return nil
+}
+
+// logVaultError reports a failed interaction with the Vault server. The warning
+// carries the same sanitised message as the status condition, because operators
+// who are not allowed to read the cert-manager logs still see it via kubectl
+// logs of the controller. The unsanitised error, which may contain a response
+// body chosen by whatever spec.vault.server points at, is only written at debug
+// level and is truncated so that it cannot flood the log.
+func logVaultError(ctx context.Context, issuer v1.GenericIssuer, message, safeMessage string, err error) {
+	log := logf.FromContext(ctx)
+
+	log.V(logf.WarnLevel).Info(message, "err", safeMessage, "issuer", klog.KObj(issuer))
+	log.V(logf.DebugLevel).Info(message, "err", vaultinternal.LoggableErrorMessage(err), "issuer", klog.KObj(issuer))
 }

--- a/pkg/issuer/vault/setup_test.go
+++ b/pkg/issuer/vault/setup_test.go
@@ -490,3 +490,113 @@ func TestVault_Setup(t *testing.T) {
 		})
 	}
 }
+
+// TestVault_SetupDoesNotLeakResponseBody checks that a non-2xx response which
+// is not a Vault error response never reaches the Issuer status. spec.vault.server
+// is not restricted, so the endpoint being dialled is not necessarily Vault, and
+// the Ready condition is readable by anyone who can read the Issuer.
+func TestVault_SetupDoesNotLeakResponseBody(t *testing.T) {
+	// A body which is not valid JSON, so that the Vault client cannot decode it
+	// as an error response and hands it back to us verbatim.
+	const sentinelBody = "SENSITIVE-RESPONSE-BODY"
+
+	// 403 rather than a 5xx so that the Vault client does not retry, which would
+	// make this test needlessly slow.
+	notVaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		if _, err := w.Write([]byte(sentinelBody)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer notVaultServer.Close()
+
+	tests := []struct {
+		name        string
+		givenAuth   v1.VaultAuth
+		expectCond  string
+		expectedErr string
+	}{
+		{
+			// The AppRole login happens while the client is being built, so this
+			// fails before IsVaultInitializedAndUnsealed is reached.
+			name: "the client initialization path",
+			givenAuth: v1.VaultAuth{
+				AppRole: &v1.VaultAppRole{
+					RoleId: "role-id",
+					SecretRef: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{Name: "cert-manager"},
+						Key:                  "token",
+					},
+				},
+			},
+			expectCond:  "Ready False: VaultError: Failed to initialize Vault client: the Vault server returned an HTTP 403 response which is not a Vault error response; the response body has been omitted and can be found in the cert-manager logs",
+			expectedErr: "the Vault server returned an HTTP 403 response which is not a Vault error response; the response body has been omitted and can be found in the cert-manager logs",
+		},
+		{
+			// Token auth needs no login request, so the client is built and the
+			// health check is the first thing to talk to the server.
+			name: "the health check path",
+			givenAuth: v1.VaultAuth{
+				TokenSecretRef: &cmmeta.SecretKeySelector{
+					LocalObjectReference: cmmeta.LocalObjectReference{Name: "cert-manager"},
+					Key:                  "token",
+				},
+			},
+			expectCond:  "Ready False: VaultError: Failed to verify Vault is initialized and unsealed: the Vault server returned an HTTP 403 response which is not a Vault error response; the response body has been omitted and can be found in the cert-manager logs",
+			expectedErr: "the Vault server returned an HTTP 403 response which is not a Vault error response; the response body has been omitted and can be found in the cert-manager logs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			givenIssuer := &v1.Issuer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-issuer",
+					Namespace: "test-namespace",
+				},
+				Spec: v1.IssuerSpec{
+					IssuerConfig: v1.IssuerConfig{
+						Vault: &v1.VaultIssuer{
+							Path:   "pki_int",
+							Server: notVaultServer.URL,
+							Auth:   tt.givenAuth,
+						},
+					},
+				},
+			}
+
+			v := &Vault{
+				Context: &controller.Context{CMClient: cmfake.NewClientset(givenIssuer)},
+				createTokenFn: func(ns string) vaultinternal.CreateToken {
+					return func(ctx context.Context, saName string, req *authv1.TokenRequest, opts metav1.CreateOptions) (*authv1.TokenRequest, error) {
+						return &authv1.TokenRequest{Status: authv1.TokenRequestStatus{Token: "token"}}, nil
+					}
+				},
+				secretsLister: &testlisters.FakeSecretLister{
+					SecretsFn: func(namespace string) corelisters.SecretNamespaceLister {
+						return &testlisters.FakeSecretNamespaceLister{
+							GetFn: func(name string) (*corev1.Secret, error) {
+								return &corev1.Secret{
+									ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+									Data:       map[string][]byte{"token": []byte("root")},
+								}, nil
+							},
+						}
+					},
+				},
+			}
+
+			err := v.Setup(t.Context(), givenIssuer)
+
+			// The Issuer controllers copy the returned error into a Kubernetes
+			// Event, so it has to be sanitised too.
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.expectedErr)
+
+			require.Len(t, givenIssuer.Status.Conditions, 1)
+			assert.Equal(t, tt.expectCond, fmt.Sprintf("%s %s: %s: %s", givenIssuer.Status.Conditions[0].Type, givenIssuer.Status.Conditions[0].Status, givenIssuer.Status.Conditions[0].Reason, givenIssuer.Status.Conditions[0].Message))
+
+			assert.NotContains(t, givenIssuer.Status.Conditions[0].Message, sentinelBody)
+			assert.NotContains(t, err.Error(), sentinelBody)
+		})
+	}
+}

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -16,7 +16,14 @@ limitations under the License.
 
 package errors
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// TruncationMarker is appended to messages shortened by TruncateMessage so that
+// readers can tell the message is incomplete.
+const TruncationMarker = "... (truncated)"
 
 type invalidDataError struct{ error }
 
@@ -29,4 +36,24 @@ func IsInvalidData(err error) bool {
 		return false
 	}
 	return true
+}
+
+// TruncateMessage bounds s to maxLen bytes in total, including the marker which
+// is appended so that readers can tell the message is incomplete.
+func TruncateMessage(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+
+	// Cutting on a byte boundary can split a multi-byte rune in half. Replacing
+	// invalid sequences keeps the result valid UTF-8, which the API server
+	// requires of the strings it stores.
+	if maxLen <= len(TruncationMarker) {
+		return strings.ToValidUTF8(s[:maxLen], "")
+	}
+
+	truncated := strings.ToValidUTF8(s[:maxLen-len(TruncationMarker)], "")
+
+	// Trim trailing whitespace so that the marker reads cleanly.
+	return strings.TrimRight(truncated, " \t\r\n") + TruncationMarker
 }

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -41,6 +41,12 @@ func IsInvalidData(err error) bool {
 // TruncateMessage bounds s to maxLen bytes in total, including the marker which
 // is appended so that readers can tell the message is incomplete.
 func TruncateMessage(s string, maxLen int) string {
+	// Nothing fits within a non-positive bound. Guarding here also keeps a
+	// negative bound from panicking on the slices below.
+	if maxLen <= 0 {
+		return ""
+	}
+
 	if len(s) <= maxLen {
 		return s
 	}

--- a/pkg/util/errors/errors_test.go
+++ b/pkg/util/errors/errors_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateMessage(t *testing.T) {
+	tests := map[string]struct {
+		in     string
+		maxLen int
+		want   string
+	}{
+		// maxLen is a bound on the whole result, so a limit of 20 leaves 5 bytes
+		// for the message once the 15 byte marker has been accounted for.
+		"a message within the limit is returned unchanged": {
+			in:     "short",
+			maxLen: 20,
+			want:   "short",
+		},
+		"a message at the limit is returned unchanged": {
+			in:     "exactly20bytes!!!!!!",
+			maxLen: 20,
+			want:   "exactly20bytes!!!!!!",
+		},
+		"a longer message is truncated": {
+			in:     "abcdefghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abcde" + TruncationMarker,
+		},
+		"trailing whitespace is trimmed before the marker is added": {
+			in:     "abc  defghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abc" + TruncationMarker,
+		},
+		"a multi-byte rune is not split in half": {
+			// Each £ is two bytes, so the 5 byte budget falls in the middle of
+			// the third one.
+			in:     strings.Repeat("£", 12),
+			maxLen: 20,
+			want:   "££" + TruncationMarker,
+		},
+		"an invalid byte sequence is dropped": {
+			in:     "ab\xffcdefghijklmnopqrstuvwxyz",
+			maxLen: 20,
+			want:   "abcd" + TruncationMarker,
+		},
+		"a limit too small for the marker drops the marker": {
+			in:     "abcdefghij",
+			maxLen: 4,
+			want:   "abcd",
+		},
+		"a limit too small for the marker still respects rune boundaries": {
+			in:     strings.Repeat("£", 4),
+			maxLen: 3,
+			want:   "£",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TruncateMessage(test.in, test.maxLen)
+			if got != test.want {
+				t.Errorf("TruncateMessage() = %q, want %q", got, test.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("TruncateMessage() = %q, which is not valid UTF-8", got)
+			}
+			// maxLen bounds the result in full, marker included.
+			if len(got) > test.maxLen {
+				t.Errorf("TruncateMessage() returned %d bytes, want at most %d", len(got), test.maxLen)
+			}
+		})
+	}
+}

--- a/pkg/util/errors/errors_test.go
+++ b/pkg/util/errors/errors_test.go
@@ -72,6 +72,23 @@ func TestTruncateMessage(t *testing.T) {
 			maxLen: 3,
 			want:   "£",
 		},
+		"a zero limit keeps nothing": {
+			in:     "abcdefghij",
+			maxLen: 0,
+			want:   "",
+		},
+		// No caller passes a negative bound today, but this is a shared helper
+		// and slicing by one would panic.
+		"a negative limit keeps nothing": {
+			in:     "abcdefghij",
+			maxLen: -1,
+			want:   "",
+		},
+		"a negative limit keeps nothing when there is nothing to keep": {
+			in:     "",
+			maxLen: -1,
+			want:   "",
+		},
 	}
 
 	for name, test := range tests {
@@ -84,8 +101,8 @@ func TestTruncateMessage(t *testing.T) {
 				t.Errorf("TruncateMessage() = %q, which is not valid UTF-8", got)
 			}
 			// maxLen bounds the result in full, marker included.
-			if len(got) > test.maxLen {
-				t.Errorf("TruncateMessage() returned %d bytes, want at most %d", len(got), test.maxLen)
+			if want := max(test.maxLen, 0); len(got) > want {
+				t.Errorf("TruncateMessage() returned %d bytes, want at most %d", len(got), want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

## Problem

spec.vault.server is an unrestricted URL, so the endpoint the Vault issuer dials during `Setup()` is not necessarily Vault — it can be any address reachable from the controller. When that endpoint returned a non-2xx response whose body could not be decoded as a Vault error document, `hashicorp/vault/api` set `ResponseError.RawError` and handed the body back verbatim, and `Setup()` copied it straight into `Issuer.status.conditions[Ready].message`:

  - Response reflection: the raw body is persisted to the API server and readable by anyone who can `kubectl get issuer -o yaml`, turning the Issuer into a way to read back responses from arbitrary internal endpoints (the SSRF primitive itself is tracked in #8756).
  - Two affected paths: client initialisation via `vaultinternal.New(...)`, and the health check via `IsVaultInitializedAndUnsealed()`.
  - Escalation via Events: pkg/controller/issuers/sync.go copies the error returned by` Setup()` into a Warning Event, so sanitising only the condition message would leave the same content exposed one layer up.
  - Unbounded size: even a genuine Vault error was copied in full, so a large response could bloat the persisted status.

## Solution

Adds `vaultinternal.SafeErrorMessage`, which uses `errors.AsType[*vault.ResponseError]` so a wrapped error cannot bypass the check, then branches on `RawError` — set precisely when the body was not a Vault error document. Those responses now report the status code only; genuine Vault errors are still reflected but truncated to 1 KiB. The full error is logged at debug level, truncated to 8 KiB so an unbounded body cannot flood the log. The sanitised message is used for the returned error as well as the condition.

Four Vault login helpers flattened errors with %s and `err.Error()`, destroying the `*vault.ResponseError` type before it could be inspected; they now wrap with %w, with no change to the rendered text. The UTF-8-safe truncation added for the equivalent ACME fix (#9202) moves from` pkg/issuer/acme` to `pkg/util/errors`so both issuers share one implementation. Legitimate Vault servers behave unchanged.

## Test plan

  - [ ] `TestVault_SetupDoesNotLeakResponseBody` — an `httptest.Server` returning 403 with a non-JSON sentinel body, covering both the client-init path (AppRole) and the health-check path (token auth); asserts the sentinel appears in neither the condition message nor the returned error.
  - [ ] Verified the test is load-bearing by mutation: neutering the `RawError` branch, and reverting the AppRole site to %s — each reproduces the leak and fails the test.
  - [ ] `TestSafeErrorMessage` — local errors, raw bodies (bare and wrapped), and genuine Vault errors; every case asserts the sentinel is absent and the 1 KiB bound holds.
  - [ ] `TestSafeErrorMessageBoundsLength` / `TestLoggableErrorMessageBoundsLength` — an oversized Vault error is marked truncated and stays within bounds.
  - [ ] `TestTruncateMessage` moved to `pkg/util/errors` unchanged; existing `TestVault_Setup` cases pass without modification.
  - [ ] `go build ./..., go vet`, and gofmt clean; tests green across internal/vault, pkg/util/errors, pkg/issuer/..., and pkg/controller/{issuers,clusterissuers,certificaterequests}/....

## Release Note

```release-note
Fixed an issue where the body of a non-Vault HTTP response from `spec.vault.server` could be copied into the Vault Issuer's Ready condition and its Kubernetes Events. Such responses now report only the HTTP status code, and Vault's own error messages are truncated before being persisted.```