### PR TITLE
Make ACME HTTP01 and DNS01 solver waits respect context cancellation

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -209,7 +209,11 @@ func (c *DNSProvider) Present(ctx context.Context, domain, fqdn, value string) e
 
 	// wait for change to be acknowledged
 	for chg.Status == "pending" {
-		time.Sleep(time.Second)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 
 		chg, err = c.client.Changes.Get(c.project, zone, chg.Id).Context(ctx).Do()
 		if err != nil {

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -138,7 +138,11 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 
 	ttl := 60
 	log.V(logf.DebugLevel).Info("waiting DNS record TTL to allow the DNS01 record to propagate for domain", "ttl", ttl, "fqdn", fqdn)
-	time.Sleep(time.Second * time.Duration(ttl))
+	select {
+	case <-time.After(time.Second * time.Duration(ttl)):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	log.V(logf.DebugLevel).Info("ACME DNS01 validation record propagated", "fqdn", fqdn)
 
 	return nil

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -159,7 +159,7 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 
 	statusID := resp.ChangeInfo.Id
 
-	return util.WaitFor(120*time.Second, 4*time.Second, func() (bool, error) {
+	return util.WaitFor(ctx, 120*time.Second, 4*time.Second, func() (bool, error) {
 		reqParams := &route53.GetChangeInput{
 			Id: statusID,
 		}

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -323,14 +323,17 @@ func UnFqdn(name string) string {
 	return strings.TrimSuffix(name, ".")
 }
 
-// WaitFor polls the given function 'f', once every 'interval', up to 'timeout'.
-func WaitFor(timeout, interval time.Duration, f func() (bool, error)) error {
+// WaitFor polls the given function 'f', once every 'interval', up to 'timeout'
+// or until the context is cancelled.
+func WaitFor(ctx context.Context, timeout, interval time.Duration, f func() (bool, error)) error {
 	var lastErr string
-	timeup := time.After(timeout)
+	timeoutCh := time.After(timeout)
 	for {
 		select {
-		case <-timeup:
+		case <-timeoutCh:
 			return fmt.Errorf("Time limit exceeded. Last error: %s", lastErr)
+		case <-ctx.Done():
+			return ctx.Err()
 		default:
 		}
 
@@ -342,6 +345,10 @@ func WaitFor(timeout, interval time.Duration, f func() (bool, error)) error {
 			lastErr = err.Error()
 		}
 
-		time.Sleep(interval)
+		select {
+		case <-time.After(interval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -12,17 +12,37 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWaitForStopsWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	start := time.Now()
+	err := WaitFor(ctx, time.Minute, 2*time.Second, func() (bool, error) {
+		cancel()
+		return false, nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Errorf("WaitFor did not stop promptly after cancellation: %s", elapsed)
+	}
+}
 
 func TestFindZoneByFqdn(t *testing.T) {
 	tests := []struct {

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -176,8 +176,12 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 		log.V(logf.DebugLevel).Info("reachability test passed, re-checking in 2s time")
 
 		if i != s.requiredPasses-1 {
-			// sleep for 2s between checks
-			time.Sleep(time.Second * 2)
+			// sleep for 2s between checks, but respect context cancellation
+			select {
+			case <-time.After(time.Second * 2):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"k8s.io/client-go/rest"
@@ -95,6 +97,32 @@ func TestCheck(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestCheckStopsSleepingWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	calls := 0
+	s := Solver{
+		Context: &controller.Context{RESTConfig: new(rest.Config)},
+		testReachability: countReachabilityTestCalls(&calls, func(context.Context, *url.URL, string, []string, string) error {
+			cancel()
+			return nil
+		}),
+		requiredPasses: 2,
+	}
+
+	start := time.Now()
+	err := s.Check(ctx, nil, &cmacme.Challenge{})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 reachability call, got %d", calls)
+	}
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Errorf("Check slept through the cancelled context for %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Make HTTP01 and DNS01 solver self-check waits respect context cancellation, so cert-manager can stop in-flight propagation checks promptly during shutdown.

## Changes

- Replace the HTTP01 self-check delay with a context-aware wait.
- Make the DNS01 TTL wait and Cloud DNS change polling context-aware.
- Make the DNS polling helper context-aware and update its Route 53 caller.
- Add regression coverage for HTTP01 and DNS wait cancellation.

## Impact

The controller passes its worker context through to solver checks. When cert-manager begins shutting down, in-flight HTTP01 and DNS01 waits now stop promptly instead of sleeping through their current delay. Normal successful-path behavior and retry intervals are unchanged.

## Testing

- Focused tests pass for HTTP01, DNS, DNS utility, Cloud DNS, and Route 53 packages.
- `git diff --check` passes.

### Kind

/kind bug

### Release Note

```release-note
HTTP01 and DNS01 self-check waits now stop promptly when cert-manager begins shutting down, instead of sleeping through their current delay.
```