### PR TITLE
fix: schedule checks for non-ARI certificates at expiry time (#7895)

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -258,6 +258,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 			klog.SafePtr(crt.Status.RenewalTime))
 		return c.updateOrApplyStatus(ctx, crt)
 	}
+
+	// Schedule next check to ensure expired certificates are detected
+	// For ACME with ARI, this is handled in useARIForRenewal
+	// For non-ARI certificates, schedule check at certificate expiry time
+	now := c.clock.Now()
+	if crt.Status.NotAfter != nil && (crt.Status.ACME == nil || crt.Status.ACME.ARI == nil) {
+		c.scheduledWorkQueue.Add(key, crt.Status.NotAfter.Time.Sub(now))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes issue #7895: Certificate Ready condition shows True for expired certificates

## Root Cause

Readiness controller only scheduled next checks for ACME certificates with ARI (Automatic Renewal Info). Non-ACME and ACME-without-ARI certificates were never re-checked after initial validation.

## Scenario (The Bug)

1. Certificate is issued with valid expiry date
2. Readiness check runs → Ready=True ✓ (correct)
3. **No next check scheduled** (missing for non-ARI certs) ← THE BUG
4. Time passes, certificate expires  
5. Readiness condition is never re-evaluated
6. User sees **Ready=True even though cert is EXPIRED** ✗ (wrong!)

## Solution

Schedule a check at the certificate's NotAfter (expiry) time for certificates without ARI scheduling:
- Non-ACME certificates now get checked at expiry
- ACME without ARI now gets checked at expiry
- ACME with ARI continues using ARI scheduling (unchanged)
- Expired certificates are detected within seconds of expiry

## Changes

- Added scheduling logic in  to queue checks at NotAfter time for non-ARI certificates
- Logic: Check if certificate has NotAfter time and no ARI, then schedule at that time
- Preserves existing ARI behavior - only adds checks where they were missing

## Testing

Existing test "Certificate is not Ready when it has expired" verifies that the policy chain correctly evaluates expiry. This fix ensures the readiness controller will continually re-check certificates so expired status is detected.

Manual verification steps:
1. Create cert with non-ACME issuer (e.g., Vault)
2. Let certificate expire
3. Verify Ready condition updates to False within 60 seconds
4. Verify no panic or errors in controller logs