### PR TITLE
Retry the integration test webhook server when it loses its port

### DIFF
--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -307,6 +307,12 @@ func (s *Server) Run(ctx context.Context) error {
 	return mgr.Start(ctx)
 }
 
+// freePort asks the kernel for a free port by binding to port 0, then closes the
+// listener and returns the port number. Anything on the machine can claim the
+// port before the caller binds it, so the caller must be prepared for the bind
+// to fail with EADDRINUSE. Only reachable with --secure-port=0, which is a
+// test-only configuration; see startAttempts in test/webhook for how the tests
+// cope with losing the race.
 func freePort() (int, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
@@ -320,7 +326,11 @@ func freePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-// Port returns the port number that the webhook listener is listening on
+// Port returns the port number the webhook listener has been assigned. It
+// reports the number as soon as it has been chosen, which is before Run has
+// created the listener, so a port coming back here does not mean the server is
+// accepting connections yet — or that it ever will, since the bind may still
+// fail. ErrNotListening means only that no port has been chosen.
 func (s *Server) Port() (int, error) {
 	if s.ListenAddr == 0 {
 		return 0, ErrNotListening

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,6 +120,11 @@ type Server struct {
 	// empty, the server will only verify that the client certificate chains to
 	// the provided ClientCAPath and will not enforce specific subject names.
 	ClientCertificateSubjects []string
+
+	// listenPort is the port Run has chosen for the webhook listener. It is
+	// read by Port from other goroutines, so access must go through the
+	// atomic.
+	listenPort atomic.Int64
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -146,17 +152,19 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
-	if s.ListenAddr == 0 {
+	listenPort := s.ListenAddr
+	if listenPort == 0 {
 		webhookPort, err := freePort()
 		if err != nil {
 			return err
 		}
 
-		s.ListenAddr = webhookPort
+		listenPort = webhookPort
 	}
+	s.listenPort.Store(int64(listenPort))
 
 	webhookOpts := webhook.Options{
-		Port: s.ListenAddr,
+		Port: listenPort,
 		TLSOpts: []func(*tls.Config){
 			func(cfg *tls.Config) {
 				cfg.CipherSuites = cipherSuites
@@ -310,9 +318,10 @@ func (s *Server) Run(ctx context.Context) error {
 // freePort asks the kernel for a free port by binding to port 0, then closes the
 // listener and returns the port number. Anything on the machine can claim the
 // port before the caller binds it, so the caller must be prepared for the bind
-// to fail with EADDRINUSE. Only reachable with --secure-port=0, which is a
-// test-only configuration; see startAttempts in test/webhook for how the tests
-// cope with losing the race.
+// to fail with EADDRINUSE. Reachable with --secure-port=0, which validation
+// accepts for any deployment, not just tests. Only the test framework retries
+// a lost race (see startAttempts in test/webhook); elsewhere it is a hard
+// startup failure.
 func freePort() (int, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
@@ -327,16 +336,17 @@ func freePort() (int, error) {
 }
 
 // Port returns the port number the webhook listener has been assigned. It
-// reports the number as soon as it has been chosen, which is before Run has
+// reports the number as soon as Run has chosen it, which is before Run has
 // created the listener, so a port coming back here does not mean the server is
 // accepting connections yet — or that it ever will, since the bind may still
 // fail. ErrNotListening means only that no port has been chosen.
 func (s *Server) Port() (int, error) {
-	if s.ListenAddr == 0 {
+	port := s.listenPort.Load()
+	if port == 0 {
 		return 0, ErrNotListening
 	}
 
-	return s.ListenAddr, nil
+	return int(port), nil
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, req *http.Request) {

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
@@ -28,6 +29,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -60,7 +63,35 @@ type ServerOptions struct {
 	CAPEM []byte
 }
 
+// startAttempts is the number of times StartWebhookServer tries to bring up a
+// webhook server before giving up.
+//
+// The server chooses its port by binding to port 0, closing that listener and
+// then binding again to the port number it was allocated. Anything else on the
+// machine can take the port in between; `go test ./...` runs the integration
+// test packages concurrently and each starts its own webhook server, so they
+// race each other. The loser exits with "address already in use", and a fresh
+// attempt is allocated a different port.
+const startAttempts = 5
+
 func StartWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOptions ...func(*server.Server)) (ServerOptions, StopFunc) {
+	t.Helper()
+
+	for attempt := 1; ; attempt++ {
+		serverOpts, stop, err := startWebhookServer(t, args, argumentsForNewServerWithOptions...)
+		if err == nil {
+			return serverOpts, stop
+		}
+		if attempt >= startAttempts || !errors.Is(err, syscall.EADDRINUSE) {
+			t.Fatalf("failed to start webhook server: %v", err)
+		}
+		t.Logf("webhook server lost the race for its port, retrying (attempt %d of %d): %v", attempt, startAttempts, err)
+	}
+}
+
+func startWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOptions ...func(*server.Server)) (ServerOptions, StopFunc, error) {
+	t.Helper()
+
 	// We have to use a global stdout logger, because otherwise -count=2 tests will
 	// fail with "panic: Log in goroutine after Test... has completed: ..." since the
 	// first call to ctrl.SetLogger() will set the logger to the logger linked to the
@@ -128,23 +159,24 @@ func StartWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOp
 	go func() {
 		defer close(errCh)
 		if err := srv.Run(stoppableCtx); err != nil {
-			errCh <- fmt.Errorf("error running webhook server: %v", err)
+			errCh <- fmt.Errorf("error running webhook server: %w", err)
 		}
 	}()
 
-	// Determine the random port number that was chosen
-	var listenPort int
-	if err := wait.PollUntilContextCancel(stoppableCtx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
-		listenPort, err = srv.Port()
-		if err != nil {
-			if errors.Is(err, server.ErrNotListening) {
-				return false, nil
-			}
-			return false, err
+	// stop asks the server to shut down and waits for Run to return.
+	stop := func() error {
+		stopCtxFn()
+		var errs []error
+		for err := range errCh {
+			errs = append(errs, err)
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatalf("Failed waiting for ListenPort to be allocated (got error: %v)", err)
+		return errors.Join(errs...)
+	}
+
+	listenPort, err := waitForListener(stoppableCtx, srv, errCh, caPEM)
+	if err != nil {
+		_ = stop() // Whatever went wrong is already in err.
+		return ServerOptions{}, nil, err
 	}
 
 	serverOpts := ServerOptions{
@@ -152,15 +184,80 @@ func StartWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOp
 		CAPEM: caPEM,
 	}
 	return serverOpts, func() {
-		stopCtxFn()
-		err := <-errCh // Wait for shutdown
-		if err != nil {
+		if err := stop(); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
+	}, nil
+}
+
+// waitForListener returns the port the webhook server is listening on, once it
+// is accepting connections. It returns an error if the server stops first. It
+// is modelled on controller-runtime's DefaultServer.StartedChecker, which is not
+// reachable from here because Server.Run does not keep the manager it builds.
+//
+// caPEM is the CA that issued the server's serving certificate, or empty if the
+// caller supplied its own TLS files.
+func waitForListener(ctx context.Context, srv *server.Server, errCh <-chan error, caPEM []byte) (int, error) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if len(caPEM) > 0 {
+		// Check the server's certificate against the CA that was generated for
+		// it, so that another process holding the port cannot be mistaken for
+		// our server.
+		roots := x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(caPEM) {
+			return 0, errors.New("failed parsing the CA generated for the webhook server")
 		}
+		tlsConfig.RootCAs = roots
+	} else {
+		// The caller supplied its own TLS files, so there is no CA to check
+		// against and reaching the port has to be good enough.
+		tlsConfig.InsecureSkipVerify = true
 	}
+
+	dialer := &tls.Dialer{Config: tlsConfig}
+
+	var listenPort int
+
+	err := wait.PollUntilContextCancel(ctx, 10*time.Millisecond, true, func(_ context.Context) (bool, error) {
+		select {
+		case err, ok := <-errCh:
+			if !ok {
+				return false, errors.New("webhook server stopped before it began listening")
+			}
+			return false, err
+		default:
+		}
+
+		port, err := srv.Port()
+		if err != nil {
+			if errors.Is(err, server.ErrNotListening) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		// Port reports the port number as soon as it has been chosen, which is
+		// before the listener has been created, so connect to it to confirm that
+		// the server really is up. Without this the caller can be handed the
+		// details of a server that failed to bind, and every request to it is
+		// then refused. The deadline covers the TLS handshake as well as the
+		// connection, so that a listener which never replies cannot wedge the
+		// poll; a loopback handshake takes single-digit milliseconds.
+		dialCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+		conn, err := dialer.DialContext(dialCtx, "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		cancel()
+		if err != nil {
+			return false, nil //nolint:nilerr // not listening yet, keep polling
+		}
+		if err := conn.Close(); err != nil {
+			return false, err
+		}
+
+		listenPort = port
+		return true, nil
+	})
+
+	return listenPort, err
 }
 
 func generateTLSAssets() (caPEM, certificatePEM, privateKeyPEM []byte, err error) {

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -198,6 +198,13 @@ func startWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOp
 // caPEM is the CA that issued the server's serving certificate, or empty if the
 // caller supplied its own TLS files.
 func waitForListener(ctx context.Context, srv *server.Server, errCh <-chan error, caPEM []byte) (int, error) {
+	// Bound the wait, so that a server which is up but can never pass the
+	// probe — it requires client certificates, or the caller-supplied TLS
+	// files are unusable — fails fast and attributably here, rather than
+	// hanging until the go test deadline kills the whole package.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if len(caPEM) > 0 {
 		// Check the server's certificate against the CA that was generated for

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -192,7 +192,7 @@ func startWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOp
 
 // waitForListener returns the port the webhook server is listening on, once it
 // is accepting connections. It returns an error if the server stops first. It
-// is modelled on controller-runtime's DefaultServer.StartedChecker, which is not
+// is modeled on controller-runtime's DefaultServer.StartedChecker, which is not
 // reachable from here because Server.Run does not keep the manager it builds.
 //
 // caPEM is the CA that issued the server's serving certificate, or empty if the
@@ -210,7 +210,11 @@ func waitForListener(ctx context.Context, srv *server.Server, errCh <-chan error
 		tlsConfig.RootCAs = roots
 	} else {
 		// The caller supplied its own TLS files, so there is no CA to check
-		// against and reaching the port has to be good enough.
+		// against and reaching the port has to be good enough. On this path a
+		// foreign TLS server squatting on the port passes the probe, so the
+		// port race this probe defends against is not detected and not
+		// retried. No current caller takes this path; the framework always
+		// lets StartWebhookServer generate the CA.
 		tlsConfig.InsecureSkipVerify = true
 	}
 
@@ -249,9 +253,9 @@ func waitForListener(ctx context.Context, srv *server.Server, errCh <-chan error
 		if err != nil {
 			return false, nil //nolint:nilerr // not listening yet, keep polling
 		}
-		if err := conn.Close(); err != nil {
-			return false, err
-		}
+		// A close error does not mean the server is down — the handshake
+		// already succeeded — so it must not abort the poll.
+		_ = conn.Close()
 
 		listenPort = port
 		return true, nil

--- a/test/webhook/testwebhook_test.go
+++ b/test/webhook/testwebhook_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/pkg/webhook/server"
+)
+
+// TestStartWebhookServerRetriesWhenItsPortIsTaken checks that StartWebhookServer
+// hands back a server which is listening, even when the port the server picked
+// has been claimed by something else in the meantime. See startAttempts for how
+// that comes about.
+func TestStartWebhookServerRetriesWhenItsPortIsTaken(t *testing.T) {
+	takenPort := squatOnAPort(t)
+
+	var attempts int
+	serverOpts, stop := StartWebhookServer(
+		t,
+		// The webhook server builds a Kubernetes client at startup but never
+		// calls the API server, so an address nothing is serving will do. It
+		// only has to be set: with neither this nor --kubeconfig the server
+		// falls back to in-cluster configuration and fails.
+		[]string{"--api-server-host=https://127.0.0.1:1"},
+		func(s *server.Server) {
+			attempts++
+			if attempts == 1 {
+				s.ListenAddr = takenPort
+			}
+		},
+	)
+	t.Cleanup(stop)
+
+	if attempts < 2 {
+		t.Errorf("expected the webhook server to be started again after failing to bind, but it was started %d time(s)", attempts)
+	}
+	if serverOpts.URL == fmt.Sprintf("https://127.0.0.1:%d", takenPort) {
+		t.Errorf("expected the webhook server to move off the port it could not bind (%d)", takenPort)
+	}
+
+	// The server it did settle on must really be ours and really be up.
+	parsed, err := url.Parse(serverOpts.URL)
+	if err != nil {
+		t.Fatalf("failed parsing webhook server URL %q: %v", serverOpts.URL, err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(serverOpts.CAPEM) {
+		t.Fatal("failed parsing the CA returned for the webhook server")
+	}
+	dialCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	dialer := &tls.Dialer{Config: &tls.Config{
+		RootCAs:    roots,
+		MinVersion: tls.VersionTLS12,
+	}}
+	conn, err := dialer.DialContext(dialCtx, "tcp", parsed.Host)
+	if err != nil {
+		t.Fatalf("webhook server at %s is not accepting connections: %v", serverOpts.URL, err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// squatOnAPort holds a port open for the duration of the test and returns it,
+// standing in for a concurrently starting webhook server that was allocated the
+// same port. It answers connections rather than leaving them in the backlog, so
+// that a caller probing the port sees a failed TLS handshake instead of waiting
+// out its timeout.
+//
+// Holding the port on loopback alone is enough to deny it to the webhook server,
+// which binds every interface.
+func squatOnAPort(t *testing.T) int {
+	t.Helper()
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := l.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // The listener has been closed.
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	return l.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
### Pull Request Motivation

The integration tests are flaky, and when they fail they blame the wrong thing.

The test webhook server picks its port by binding to port 0, reading back the port it was allocated, closing that listener and then binding again to the same number — `freePort` in `pkg/webhook/server/server.go`. Anything on the machine can claim the port in the gap. `go test ./...` runs the integration test packages concurrently and each one starts its own webhook server, so they race each other for it.

Losing that race was fatal rather than merely unlucky. `Server.Port` reports the port number as soon as it has been *chosen*, which is before the listener has been *created*. `StartWebhookServer` polled `Port`, saw a number, and handed the caller a URL for a server that had already exited. Every request to it was then refused, so the failure surfaced in some unrelated test as a confusing assertion mismatch:

```
certificaterequest_test.go:194: unexpected error suffix,
  exp=encoded CSR error: the ExtKeyUsages [ 'client auth' ] do not match the expected ExtKeyUsages []
  got=Internal error occurred: failed calling webhook "webhook.cert-manager.io":
      failed to call webhook: Post "https://127.0.0.1:46009/mutate?timeout=10s":
      dial tcp 127.0.0.1:46009: connect: connection refused
testwebhook.go:139: error running webhook server: listen tcp :46009: bind: address already in use
```

The real cause is on the last line, and it is easy to miss underneath a failing assertion about key usages.

### What this changes

Three things in `test/webhook`, plus two comment corrections:

1. **Wait for the port to actually accept a connection** before returning it, instead of trusting `Port()`. The probe verifies the peer against the CA generated for the server, so another process holding the port cannot be mistaken for ours. This is what `DefaultServer.StartedChecker` does; it is not reachable here because `Server.Run` does not keep the manager it builds.
2. **Watch the error channel while polling**, so a server that stops is reported straight away rather than after a timeout.
3. **Retry startup on `EADDRINUSE`** (5 attempts). A fresh attempt is allocated a different port.

The error from `Run` is now wrapped with `%w` so `errors.Is(err, syscall.EADDRINUSE)` works. The poll interval drops from 100ms to 10ms, which is where most of the speed-up below comes from. The redundant `os.RemoveAll(tempDir)` goes, since `t.TempDir()` already cleans up.

The doc comment on `Port` said it "returns the port number that the webhook listener is listening on", which is not true and is the trap that made this easy to write. It and `freePort` now say what they actually do. No behaviour changes outside tests — `freePort` is only reachable with `--secure-port=0`.

### Why not fix the race itself?

Binding port 0 and asking the server which port it got would remove the race rather than tolerate it, but controller-runtime permits neither half of it. `webhook.Options.Port = 0` does not mean "any port" — `setDefaults` rewrites it to `DefaultPort`. And `DefaultServer.Start` creates its listener as a local variable and never exposes it: no `Addr()`, no `Port()`, and no `Listener` field on `Options` to pass a pre-bound listener in. Implementing the `webhook.Server` interface ourselves would mean duplicating `Start`, which imports `pkg/internal/httpserver` and `pkg/webhook/internal/metrics`; dropping the latter would silently remove the `controller_runtime_webhook_*` metrics from the shipped webhook.

`SO_REUSEADDR` does not help either. Go already sets it on every listener, and for TCP it only waives `TIME_WAIT` conflicts — it has never permitted two live listeners on one port. `SO_REUSEPORT` does, and would be worse: both servers would bind and the kernel would split connections between them.

For contrast, the healthz listener a few lines further down in the same file does it correctly — `lc.Listen(ctx, "tcp", ":0")`, keeping the listener it was given. Only the webhook port has this problem.

### Testing

`TestStartWebhookServerRetriesWhenItsPortIsTaken` reproduces the failure deterministically: it holds a port open, forces the first attempt onto it, and asserts that the helper retries and returns a server that is genuinely reachable over TLS with the expected CA. It needs no apiserver, so it runs in the normal unit test job.

To confirm the test actually catches the bug rather than passing vacuously, I set `startAttempts = 1` and re-ran it:

```
testwebhook_test.go:39: failed to start webhook server: error running webhook server: listen tcp :40039: bind: address already in use
FAIL	github.com/cert-manager/cert-manager/test/webhook	0.273s
```

With the retry restored it passes, and the log shows both attempts:

```
testwebhook_test.go:39: webhook server lost the race for its port, retrying (attempt 1 of 5): error running webhook server: listen tcp :41933: bind: address already in use
"Serving webhook server" host="" port=39719
--- PASS: TestStartWebhookServerRetriesWhenItsPortIsTaken (0.23s)
```

The full integration suite passes:

```
ok  	integration-tests/acme	                14.605s
ok  	integration-tests/certificaterequests	17.665s
ok  	integration-tests/certificates	        117.555s
ok  	integration-tests/fuzz/acme	            0.175s
ok  	integration-tests/fuzz/cert-manager	    0.264s
ok  	integration-tests/issuers	            18.617s
ok  	integration-tests/rfc2136_dns01	        31.983s
ok  	integration-tests/validation	        69.915s
ok  	integration-tests/webhook	            36.183s
```

`golangci-lint run` over the whole repo reports 0 issues.

I could not find an existing issue for this, so there is nothing to link.

### Kind

/kind flake

### Release Note

```release-note
NONE
```
