### PR TITLE
Fix flaky goroutine-leak test in pkg/scheduler

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -50,12 +50,24 @@ func Test_afterFunc(t *testing.T) {
 			cancel()
 		}
 
-		// We don't know when the goroutines will actually finish.
-		time.Sleep(100 * time.Millisecond)
+		// The cancelled goroutines exit asynchronously, so poll instead of
+		// sleeping a fixed amount: on a loaded machine 10000 of them can take
+		// seconds to be scheduled and exit, whereas a real leak never comes
+		// back down and still fails once the deadline passes.
+		const tolerance = 100
+		deadline := time.Now().Add(30 * time.Second)
+		actual := runtime.NumGoroutine()
+		for actual-expected > tolerance && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+			actual = runtime.NumGoroutine()
+		}
 
-		t.Logf("%d goroutines before, %d goroutines after", expected, runtime.NumGoroutine())
+		t.Logf("%d goroutines before, %d goroutines after", expected, actual)
 
-		assert.InDelta(t, expected, runtime.NumGoroutine(), 100)
+		// Only an increase is a failure. Tests sharing this binary run
+		// concurrently, so the baseline can include goroutines that have since
+		// exited, leaving fewer at the end than there were at the start.
+		assert.LessOrEqual(t, actual-expected, tolerance, "afterFunc leaked goroutines: cancel() did not stop them all")
 	})
 
 	t.Run("f is called after roughly 100 milliseconds", func(t *testing.T) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -54,20 +54,18 @@ func Test_afterFunc(t *testing.T) {
 		// sleeping a fixed amount: on a loaded machine 10000 of them can take
 		// seconds to be scheduled and exit, whereas a real leak never comes
 		// back down and still fails once the deadline passes.
+		//
+		// Only an increase is a failure. Nothing runs concurrently with this
+		// test in this binary, but under `go test -count=N` the baseline of a
+		// run can include still-draining goroutines from the previous run,
+		// which later exit, leaving fewer goroutines at the end than at the
+		// start.
 		const tolerance = 100
-		deadline := time.Now().Add(30 * time.Second)
-		actual := runtime.NumGoroutine()
-		for actual-expected > tolerance && time.Now().Before(deadline) {
-			time.Sleep(10 * time.Millisecond)
-			actual = runtime.NumGoroutine()
-		}
+		assert.Eventually(t, func() bool {
+			return runtime.NumGoroutine()-expected <= tolerance
+		}, 30*time.Second, 10*time.Millisecond, "afterFunc leaked goroutines: cancel() did not stop them all")
 
-		t.Logf("%d goroutines before, %d goroutines after", expected, actual)
-
-		// Only an increase is a failure. Tests sharing this binary run
-		// concurrently, so the baseline can include goroutines that have since
-		// exited, leaving fewer at the end than there were at the start.
-		assert.LessOrEqual(t, actual-expected, tolerance, "afterFunc leaked goroutines: cancel() did not stop them all")
+		t.Logf("%d goroutines before, %d goroutines after", expected, runtime.NumGoroutine())
 	})
 
 	t.Run("f is called after roughly 100 milliseconds", func(t *testing.T) {


### PR DESCRIPTION
### Pull Request Motivation

`Test_afterFunc/stop_works` in `pkg/scheduler` is flaky on a loaded machine, and fails in a way that looks alarming — it reports thousands of "leaked" goroutines when nothing has leaked.

The test starts 10000 `afterFunc` goroutines, cancels them all, then sleeps a fixed 100 ms before comparing `runtime.NumGoroutine()` against a baseline taken at the start:

```go
for _, cancel := range cancels {
	cancel()
}

// We don't know when the goroutines will actually finish.
time.Sleep(100 * time.Millisecond)

assert.InDelta(t, expected, runtime.NumGoroutine(), 100)
```

Those goroutines exit asynchronously. `cancel()` returning does not mean the goroutine has been scheduled and run to completion, so on a busy machine 100 ms is nowhere near long enough for 10000 of them to drain. The comment even acknowledges we don't know when they will finish, and then sleeps a fixed amount anyway.

Reproducing it turned up a **second, independent problem**. `assert.InDelta` fails in *both* directions, but this is a leak check where only an increase matters. Nothing runs concurrently with this subtest in this binary — `pkg/scheduler` has a single test file with no `t.Parallel()`, and this is the first subtest of the first test — but under repeated in-process runs (`-test.count=N`, or a test runner's rerun-on-fail) the baseline of one run can include still-draining goroutines left over from the previous run. Those exit during the run, leaving *fewer* goroutines at the end than at the start, and failing the two-sided assertion. (An earlier revision of this description blamed concurrent tests in the same binary; @maelvls pointed out that was wrong — Go only runs tests concurrently across packages, which are separate binaries.)

I hit both directions within a single `-test.count=8` run, which is what convinced me the two-sidedness was worth fixing as well as the sleep.

### The change

- Poll with `assert.Eventually` (30 s deadline, 10 ms tick) for the goroutine count to come back down, instead of sleeping a fixed amount. A genuine leak never recovers, so it still fails once the deadline passes — the test does not become unfailable. testify evaluates the condition once immediately before entering the tick loop, so there is no added latency on the happy path.
- The polled condition is a one-sided upper bound (`actual - expected <= tolerance`) rather than a two-sided delta, and the failure carries an explanatory message.

The tolerance of 100 and the 10000 goroutines are unchanged, so what the test checks is the same; only how long it is willing to wait, and the direction it cares about, have changed.

### How I tested it

To imitate a loaded CI machine I built the test binary first, then pinned it to a single saturated core:

```bash
go test -c -o sched.test ./pkg/scheduler/
for i in $(seq 8); do taskset -c 0 bash -c 'while :; do :; done' & done
taskset -c 0 ./sched.test -test.run 'Test_afterFunc/stop_works' -test.count=N -test.v
```

| | Result |
|---|---|
| Before, `-test.count=8` | **2 failed.** One run 1494 goroutines *above* the baseline, the next 1494 *below* it — both failure modes. |
| After (`assert.Eventually`), `-test.count=15` | **15 passed.** One adjacent pair of runs logged `3 goroutines before, 13 goroutines after` then `13 goroutines before, 3 goroutines after` — the residue mechanism described above, caught in the act. |
| After, whole package `-count=5`, no contention | `ok github.com/cert-manager/cert-manager/pkg/scheduler 23.428s` |

The "before" failures look like this, and are the reason the flake is easy to misread as a real leak:

```
scheduler_test.go:56: 3 goroutines before, 1497 goroutines after
    Error: Max difference between 3 and 1497 allowed is 100, but difference was -1494
scheduler_test.go:56: 1497 goroutines before, 3 goroutines after
    Error: Max difference between 1497 and 3 allowed is 100, but difference was 1494
```

I also checked the test can still **catch a real leak**, rather than merely having been made unfailable. Temporarily replacing the `case <-cancelCh:` in `afterFunc` with a case that never fires:

```
scheduler_test.go:64:
    Error:      	Condition never satisfied
    Test:       	Test_afterFunc/stop_works
    Messages:   	afterFunc leaked goroutines: cancel() did not stop them all
scheduler_test.go:68: 3 goroutines before, 10003 goroutines after
--- FAIL: Test_afterFunc/stop_works (30.07s)
```

That injection was reverted; the diff touches only `scheduler_test.go`.

### Related

[#4856](https://github.com/cert-manager/cert-manager/issues/4856) and [#4843](https://github.com/cert-manager/cert-manager/pull/4843) covered the *sibling* subtest, "f is called after roughly 100 milliseconds", whose delta was widened for much the same reason. This PR is about the goroutine-leak subtest, which was left alone at the time.

While in here I noticed that `go test -race ./pkg/scheduler/` fails `TestAdd` on master today. Digging into it turned up more than a mock locking bug: the mock clock has not actually been injected since #4233 — `Add` calls the package-level `afterFunc` rather than the `s.afterFunc` field the tests set — so `TestAdd`/`TestForget` run on the real clock and the mock's `warp()` races the real-timer callbacks. Now filed with full analysis as #9248; deliberately left out of this PR to keep the change focused.

### Kind

/kind flake

### Release Note

```release-note
NONE
```

*with claude fable-5*
