### PR TITLE
docs: document OpenShift incompatibility with ACMEHTTP01IngressPathTypeExact

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -459,6 +459,8 @@ config:
     AllAlpha: false # ALPHA - default=false
     AllBeta: false # BETA - default=false
     ACMEHTTP01IngressPathTypeExact: true # BETA - default=true
+    # ⚠ Set to false if using OpenShift's built-in Ingress-to-Route conversion,
+    # which does not support pathType: Exact.
     ExperimentalCertificateSigningRequestControllers: false # ALPHA - default=false
     ExperimentalGatewayAPISupport: true # BETA - default=true
     LiteralCertificateSubject: true # BETA - default=true

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -459,7 +459,7 @@ config:
     AllAlpha: false # ALPHA - default=false
     AllBeta: false # BETA - default=false
     ACMEHTTP01IngressPathTypeExact: true # BETA - default=true
-    # ⚠ Set to false if using OpenShift's built-in Ingress-to-Route conversion,
+    # Set to false if using OpenShift's built-in Ingress-to-Route conversion,
     # which does not support pathType: Exact.
     ExperimentalCertificateSigningRequestControllers: false # ALPHA - default=false
     ExperimentalGatewayAPISupport: true # BETA - default=true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -303,7 +303,7 @@ enableCertificateOwnerRef: false
 #      AllAlpha: false # ALPHA - default=false
 #      AllBeta: false # BETA - default=false
 #      ACMEHTTP01IngressPathTypeExact: true # BETA - default=true
-#      # ⚠ Set to false if using OpenShift's built-in Ingress-to-Route conversion,
+#      # Set to false if using OpenShift's built-in Ingress-to-Route conversion,
 #      # which does not support pathType: Exact.
 #      ExperimentalCertificateSigningRequestControllers: false # ALPHA - default=false
 #      ExperimentalGatewayAPISupport: true # BETA - default=true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -303,6 +303,8 @@ enableCertificateOwnerRef: false
 #      AllAlpha: false # ALPHA - default=false
 #      AllBeta: false # BETA - default=false
 #      ACMEHTTP01IngressPathTypeExact: true # BETA - default=true
+#      # ⚠ Set to false if using OpenShift's built-in Ingress-to-Route conversion,
+#      # which does not support pathType: Exact.
 #      ExperimentalCertificateSigningRequestControllers: false # ALPHA - default=false
 #      ExperimentalGatewayAPISupport: true # BETA - default=true
 #      LiteralCertificateSubject: true # BETA - default=true

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -187,7 +187,8 @@ const (
 	// parsing. This allows HTTP01 challenges to be solved when using standards
 	// compliant Ingress controllers such as Cilium. The old default
 	// `ImplementationSpecific`` can be reinstated by disabling this feature gate.
-	// You may need to disable the feature for compatibility with ingress-nginx.
+	// You may need to disable the feature for compatibility with ingress-nginx
+	// or OpenShift's Ingress-to-Route conversion (route-controller-manager).
 	// See: https://cert-manager.io/docs/releases/release-notes/release-notes-1.18
 	ACMEHTTP01IngressPathTypeExact featuregate.Feature = "ACMEHTTP01IngressPathTypeExact"
 


### PR DESCRIPTION
## What does this pull request do?
Documents the incompatibility between OpenShift's built-in Ingress-to-Route conversion and the `ACMEHTTP01IngressPathTypeExact` feature gate.

Since cert-manager v1.18 defaults `ACMEHTTP01IngressPathTypeExact` to `true`, HTTP-01 challenges can fail on OpenShift clusters using `route-controller-manager`, which does not support converting Ingress resources with `pathType: Exact` into Routes.

This change adds documentation warnings so users running OpenShift know they may need to set:
`ACMEHTTP01IngressPathTypeExact: false`

**Changes**
- Updated the feature gate documentation to mention OpenShift compatibility concerns.
- Added warnings to the Helm chart README template and values file explaining when to disable the feature.

**Related issue**
Fixes #9210

**Testing**
Documentation-only change. No code changes or runtime behavior modified.

```release-note
Document that OpenShift's route-controller-manager is incompatible with the ACMEHTTP01IngressPathTypeExact feature gate.
```