### PR TITLE
Only consume next private key Secrets owned by the Certificate

### DIFF
--- a/pkg/controller/certificates/issuing/fuzz_test.go
+++ b/pkg/controller/certificates/issuing/fuzz_test.go
@@ -39,7 +39,6 @@ var (
 )
 
 func init() {
-	nextPrivateKeySecretName := "next-private-key"
 	baseCert = gen.Certificate("test",
 		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
 		gen.SetCertificateGeneration(3),

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -214,9 +214,9 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	// Fetch and parse the 'next private key secret'
-	nextPrivateKeySecret, err := c.secretLister.Secrets(crt.Namespace).Get(*crt.Status.NextPrivateKeySecretName)
+	nextPrivateKeySecret, err := certificates.GetNextPrivateKeySecret(c.secretLister.Secrets(crt.Namespace), crt)
 	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("Next private key secret does not exist, waiting for keymanager controller")
+		log.V(logf.DebugLevel).Info("Next private key secret does not exist or is not owned by this Certificate, waiting for keymanager controller")
 		// If secret does not exist, do nothing (keymanager will handle this).
 		return nil
 	}

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -207,13 +207,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return c.ensureSecretData(ctx, log, crt)
 	}
 
-	if crt.Status.NextPrivateKeySecretName == nil ||
-		len(*crt.Status.NextPrivateKeySecretName) == 0 {
-		// Do nothing if the next private key secret name is not set
-		return nil
-	}
-
-	// Fetch and parse the 'next private key secret'
+	// Fetch and parse the 'next private key secret'. An unset name is reported as
+	// not found, the same as a Secret we must not use.
 	nextPrivateKeySecret, err := certificates.GetNextPrivateKeySecret(c.secretLister.Secrets(crt.Namespace), crt)
 	if apierrors.IsNotFound(err) {
 		log.V(logf.DebugLevel).Info("Next private key secret does not exist or is not owned by this Certificate, waiting for keymanager controller")

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -55,6 +55,25 @@ func testLocalTemporarySignerFn(b []byte) localTemporarySignerFn {
 	}
 }
 
+const nextPrivateKeySecretName = "next-private-key"
+
+// nextPrivateKeySecretMeta builds the ObjectMeta that the keymanager
+// controller gives to a next private key Secret: the next-private-key label,
+// and a controller owner reference back to the Certificate. The issuing
+// controller only consumes Secrets carrying both, so fixtures must set them.
+func nextPrivateKeySecretMeta(crt *cmapi.Certificate) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: crt.Namespace,
+		Name:      nextPrivateKeySecretName,
+		Labels: map[string]string{
+			cmapi.IsNextPrivateKeySecretLabelKey: "true",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+		},
+	}
+}
+
 func TestIssuingController(t *testing.T) {
 	type testT struct {
 		builder *testpkg.Builder
@@ -68,8 +87,6 @@ func TestIssuingController(t *testing.T) {
 
 		expectedErr bool
 	}
-
-	nextPrivateKeySecretName := "next-private-key"
 
 	baseCert := gen.Certificate("test",
 		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
@@ -121,6 +138,44 @@ func TestIssuingController(t *testing.T) {
 				KubeObjects:     []runtime.Object{},
 				ExpectedActions: []testpkg.Action{},
 			},
+			expectedErr: false,
+		},
+
+		"if certificate is in Issuing state but NextPrivateKeySecretName names a Secret it does not own, do nothing": {
+			// A principal with access only to the certificates/status
+			// subresource must not be able to make the controller read an
+			// unrelated Secret and copy its private key into spec.secretName.
+			//
+			// Everything else here matches the successful issuance case below,
+			// so the only reason nothing happens is that the Secret named by
+			// status.nextPrivateKeySecretName carries neither the
+			// cert-manager.io/next-private-key label nor a controller owner
+			// reference back to this Certificate.
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					issuingCert.DeepCopy(),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestReady,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
+			},
+			// No expSecretUpdateDataCall: the private key must not be copied
+			// into spec.secretName.
 			expectedErr: false,
 		},
 
@@ -212,10 +267,7 @@ func TestIssuingController(t *testing.T) {
 				},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -244,10 +296,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -275,10 +324,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -327,10 +373,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -411,10 +454,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: []byte("bad key"),
 						},
@@ -437,10 +477,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
 						},
@@ -466,10 +503,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							// Replaced after this request's CSR was built.
 							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
@@ -499,10 +533,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							// Replaced after this request's CSR was built.
 							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
@@ -532,10 +563,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -562,10 +590,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -589,10 +614,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -616,10 +638,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -663,10 +682,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -720,10 +736,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -778,10 +791,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -840,10 +850,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -881,10 +888,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -916,10 +920,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -965,10 +966,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1011,10 +1009,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1063,10 +1058,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1108,10 +1100,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1167,10 +1156,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1222,10 +1208,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1280,10 +1263,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1338,10 +1318,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1390,10 +1367,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1448,10 +1422,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1506,10 +1477,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1553,10 +1521,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1603,10 +1568,7 @@ func TestIssuingController(t *testing.T) {
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nextPrivateKeySecretName,
-							Namespace: exampleBundle.Certificate.Namespace,
-						},
+						ObjectMeta: nextPrivateKeySecretMeta(exampleBundle.Certificate),
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
 						},
@@ -1905,7 +1867,6 @@ type failedIssuanceObjects struct {
 func failedIssuanceFixture(t *testing.T) failedIssuanceObjects {
 	t.Helper()
 
-	const nextPrivateKeySecretName = "next-private-key"
 	baseCert := gen.Certificate("test",
 		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
 		gen.SetCertificateGeneration(3),
@@ -1940,10 +1901,7 @@ func failedIssuanceFixture(t *testing.T) failedIssuanceObjects {
 			}),
 		),
 		nextPrivateKeySecret: &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      nextPrivateKeySecretName,
-				Namespace: bundle.Certificate.Namespace,
-			},
+			ObjectMeta: nextPrivateKeySecretMeta(bundle.Certificate),
 			Data: map[string][]byte{
 				corev1.TLSPrivateKeyKey: bundle.PrivateKeyBytes,
 			},

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -58,15 +58,17 @@ func testLocalTemporarySignerFn(b []byte) localTemporarySignerFn {
 const nextPrivateKeySecretName = "next-private-key"
 
 // nextPrivateKeySecretMeta builds the ObjectMeta that the keymanager
-// controller gives to a next private key Secret: the next-private-key label,
-// and a controller owner reference back to the Certificate. The issuing
-// controller only consumes Secrets carrying both, so fixtures must set them.
+// controller gives to a next private key Secret: the labels it sets, and a
+// controller owner reference back to the Certificate. The issuing controller
+// only consumes Secrets carrying the next-private-key label and that owner
+// reference, so fixtures must set them.
 func nextPrivateKeySecretMeta(crt *cmapi.Certificate) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Namespace: crt.Namespace,
 		Name:      nextPrivateKeySecretName,
 		Labels: map[string]string{
-			cmapi.IsNextPrivateKeySecretLabelKey: "true",
+			cmapi.IsNextPrivateKeySecretLabelKey:      "true",
+			cmapi.PartOfCertManagerControllerLabelKey: "true",
 		},
 		OwnerReferences: []metav1.OwnerReference{
 			*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -393,20 +393,38 @@ func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.C
 		s.GenerateName = crt.Name + "-"
 	}
 
-	s, err = c.coreClient.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
+	created, err := c.coreClient.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
 
 	// We only get to this code path if both NextPrivateKeySecretName is set AND
-	// we counted zero secrets. If we get an IsAlreadyExists error it means our
-	// cache was outdated and there _is_ a secret.
+	// we counted zero secrets. An IsAlreadyExists error therefore means either
+	// our cache was outdated and there _is_ a secret of ours, or the name in
+	// the status field belongs to a Secret we do not own.
 	if apierrors.IsAlreadyExists(err) && name != "" {
-		return c.coreClient.CoreV1().Secrets(crt.Namespace).Get(ctx, name, metav1.GetOptions{})
+		existing, err := c.coreClient.CoreV1().Secrets(crt.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if certificates.IsNextPrivateKeySecret(existing, crt) {
+			return existing, nil
+		}
+
+		// The name in status.nextPrivateKeySecretName belongs to a Secret we do
+		// not own. Anyone able to write the certificates/status subresource can
+		// put an arbitrary name there, and the consumers of the field refuse a
+		// Secret we do not own. We must not adopt it, and reusing the name would
+		// fail here on every reconcile, so create the Secret under a generated
+		// name instead. The caller writes that name back to the status field,
+		// which is what lets issuance recover.
+		s.Name = ""
+		s.GenerateName = crt.Name + "-"
+		return c.coreClient.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	return s, nil
+	return created, nil
 }
 
 // controllerWrapper wraps the `controller` structure to make it implement

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -135,18 +134,6 @@ func NewController(
 	}, queue, mustSync, nil
 }
 
-// isNextPrivateKeyLabelSelector is a label selector used to match Secret
-// resources with the `cert-manager.io/next-private-key: "true"` label.
-var isNextPrivateKeyLabelSelector labels.Selector
-
-func init() {
-	r, err := labels.NewRequirement(cmapi.IsNextPrivateKeySecretLabelKey, selection.Equals, []string{"true"})
-	if err != nil {
-		panic(err)
-	}
-	isNextPrivateKeyLabelSelector = labels.NewSelector().Add(*r)
-}
-
 func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) error {
 	log := logf.FromContext(ctx).WithValues("key", key)
 	ctx = logf.NewContext(ctx, log)
@@ -170,7 +157,9 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	cminternal.SetRuntimeDefaults_Certificate(crt)
 
 	// Discover all 'owned' secrets that have the `next-private-key` label
-	secrets, err := certificates.ListSecretsMatchingPredicates(c.secretLister.Secrets(crt.Namespace), isNextPrivateKeyLabelSelector, predicate.ResourceOwnedBy[*corev1.Secret](crt))
+	secrets, err := certificates.ListSecretsMatchingPredicates(c.secretLister.Secrets(crt.Namespace), labels.Everything(), func(s *corev1.Secret) bool {
+		return certificates.IsNextPrivateKeySecret(s, crt)
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -233,9 +233,12 @@ func TestProcessItem(t *testing.T) {
 				), relaxedSecretMatcher),
 			},
 		},
-		// TODO: in this case we should adapt the controller behaviour to unset the nextPrivateKeySecretName to
-		//  gracefully recover
-		"error if an existing Secret exists and is named as status.nextPrivateKeySecretName but it is not owned by the Certificate": {
+		// The name in status.nextPrivateKeySecretName cannot be trusted: writing
+		// the certificates/status subresource is a weaker permission than
+		// reading Secrets. The keymanager must not adopt a Secret it does not
+		// own, and must not keep retrying the same name, because the consumers
+		// of the field reject that Secret and issuance would never recover.
+		"create a secret under a generated name if status.nextPrivateKeySecretName names a Secret not owned by the Certificate": {
 			certificate: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
 				Status: cmapi.CertificateStatus{
@@ -249,13 +252,15 @@ func TestProcessItem(t *testing.T) {
 				},
 			},
 			secrets:        []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "fixed-name"}}},
-			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "fixed-name"`},
+			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "test-notrandom"`},
 			expectedActions: []testpkg.Action{
 				testpkg.NewAction(coretesting.NewGetAction(
 					cmapi.SchemeGroupVersion.WithResource("certificates"),
 					"testns",
 					"test",
 				)),
+				// Creating under the name taken from the status field fails,
+				// because the unrelated Secret already occupies that name.
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -273,6 +278,40 @@ func TestProcessItem(t *testing.T) {
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
 					"fixed-name",
+				)),
+				// The occupying Secret is not ours, so a new one is created
+				// under a generated name.
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       "testns",
+							GenerateName:    "test-",
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true", cmapi.PartOfCertManagerControllerLabelKey: "true"},
+							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
+						},
+						Data: map[string][]byte{"tls.key": nil},
+					},
+				), relaxedSecretMatcher),
+				// The status field is repointed at the new Secret, which is
+				// what lets the requestmanager and issuing controllers proceed.
+				testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"status",
+					"testns",
+					&cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+						Status: cmapi.CertificateStatus{
+							NextPrivateKeySecretName: new("test-notrandom"),
+							Conditions: []cmapi.CertificateCondition{
+								{
+									Type:   cmapi.CertificateConditionIssuing,
+									Status: cmmeta.ConditionTrue,
+								},
+							},
+						},
+					},
 				)),
 			},
 		},

--- a/pkg/controller/certificates/requestmanager/fuzz_test.go
+++ b/pkg/controller/certificates/requestmanager/fuzz_test.go
@@ -96,7 +96,7 @@ func FuzzProcessItem(f *testing.F) {
 				return
 			}
 			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: certificate.Namespace, Name: "secret"},
+				ObjectMeta: nextPrivateKeySecretMeta(certificate, "secret"),
 				Data:       map[string][]byte{corev1.TLSPrivateKeyKey: globalBundle.privateKeyBytes},
 			}
 		} else {
@@ -104,7 +104,7 @@ func FuzzProcessItem(f *testing.F) {
 				gen.SetCertificateNextPrivateKeySecretName("secret"),
 				gen.SetCertificateStatusCondition(cmapiv1.CertificateCondition{Type: cmapiv1.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}))
 			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: globalBundle.certificate.Namespace, Name: "secret"},
+				ObjectMeta: nextPrivateKeySecretMeta(certificate, "secret"),
 				Data:       map[string][]byte{corev1.TLSPrivateKeyKey: globalBundle.privateKeyBytes},
 			}
 		}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -167,9 +167,9 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		log.V(logf.DebugLevel).Info("status.nextPrivateKeySecretName not yet set, waiting for keymanager before processing certificate")
 		return nil
 	}
-	nextPrivateKeySecret, err := c.secretLister.Secrets(crt.Namespace).Get(*crt.Status.NextPrivateKeySecretName)
+	nextPrivateKeySecret, err := certificates.GetNextPrivateKeySecret(c.secretLister.Secrets(crt.Namespace), crt)
 	if apierrors.IsNotFound(err) {
-		log.V(logf.DebugLevel).Info("nextPrivateKeySecretName Secret resource does not exist, waiting for keymanager to create it before continuing")
+		log.V(logf.DebugLevel).Info("nextPrivateKeySecretName Secret resource does not exist or is not owned by this Certificate, waiting for keymanager to create it before continuing")
 		return nil
 	}
 	if err != nil {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -162,11 +162,8 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return nil
 	}
 
-	// Check for and fetch the 'status.nextPrivateKeySecretName' secret
-	if crt.Status.NextPrivateKeySecretName == nil {
-		log.V(logf.DebugLevel).Info("status.nextPrivateKeySecretName not yet set, waiting for keymanager before processing certificate")
-		return nil
-	}
+	// Check for and fetch the 'status.nextPrivateKeySecretName' secret. An unset
+	// name is reported as not found, the same as a Secret we must not use.
 	nextPrivateKeySecret, err := certificates.GetNextPrivateKeySecret(c.secretLister.Secrets(crt.Namespace), crt)
 	if apierrors.IsNotFound(err) {
 		log.V(logf.DebugLevel).Info("nextPrivateKeySecretName Secret resource does not exist or is not owned by this Certificate, waiting for keymanager to create it before continuing")

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -78,6 +78,23 @@ func relaxedCertificateRequestMatcher(l coretesting.Action, r coretesting.Action
 	return nil
 }
 
+// nextPrivateKeySecretMeta builds the ObjectMeta that the keymanager
+// controller gives to a next private key Secret: the next-private-key label,
+// and a controller owner reference back to the Certificate. The requestmanager
+// controller only consumes Secrets carrying both, so fixtures must set them.
+func nextPrivateKeySecretMeta(crt *cmapi.Certificate, name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: crt.Namespace,
+		Name:      name,
+		Labels: map[string]string{
+			cmapi.IsNextPrivateKeySecretLabelKey: "true",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+		},
+	}
+}
+
 func TestProcessItem(t *testing.T) {
 	bundle1 := mustCreateCryptoBundle(t, &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -185,7 +202,7 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if status.nextPrivateKeySecretName contains no data": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists-but-empty"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists-but-empty"),
 				},
 			},
 			certificate: gen.CertificateFrom(bundle1.certificate,
@@ -193,10 +210,25 @@ func TestProcessItem(t *testing.T) {
 				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
 			),
 		},
+		"do nothing if status.nextPrivateKeySecretName names a Secret not owned by the Certificate": {
+			// A principal with access only to the certificates/status
+			// subresource must not be able to make the controller read an
+			// unrelated Secret and copy its private key into spec.secretName.
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "not-ours"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("not-ours"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue}),
+			),
+		},
 		"do nothing if status.nextPrivateKeySecretName contains invalid data": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists-but-invalid"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists-but-invalid"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: []byte("invalid")},
 				},
 			},
@@ -211,7 +243,7 @@ func TestProcessItem(t *testing.T) {
 			},
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle1.certificate.Namespace, Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -235,7 +267,7 @@ func TestProcessItem(t *testing.T) {
 		"create a CertificateRequest if none exists": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle3.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
 				},
 			},
@@ -258,7 +290,7 @@ func TestProcessItem(t *testing.T) {
 		"create a CertificateRequest if none exists (with long name)": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle3.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
 				},
 			},
@@ -284,7 +316,7 @@ func TestProcessItem(t *testing.T) {
 		"create a CertificateRequest if none exists (with long name and very large revision)": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle3.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
 				},
 			},
@@ -310,7 +342,7 @@ func TestProcessItem(t *testing.T) {
 		"delete the owned CertificateRequest and create a new one if existing one does not have the annotation": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
@@ -343,7 +375,7 @@ func TestProcessItem(t *testing.T) {
 		"delete the owned CertificateRequest and create a new one if existing one contains invalid annotation": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
@@ -376,7 +408,7 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if existing CertificateRequest is valid for the spec": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -397,7 +429,7 @@ func TestProcessItem(t *testing.T) {
 		"should delete requests that contain invalid CSR data": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -431,7 +463,7 @@ func TestProcessItem(t *testing.T) {
 		"should ignore requests that do not have a revision of 'current + 1' and create a new one": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
@@ -470,7 +502,7 @@ func TestProcessItem(t *testing.T) {
 		"should delete request for the current revision if public keys do not match": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
@@ -512,7 +544,7 @@ func TestProcessItem(t *testing.T) {
 		"should delete request for the current revision if public keys do not match (with explicit revision)": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle2.privateKeyBytes},
 				},
 			},
@@ -555,7 +587,7 @@ func TestProcessItem(t *testing.T) {
 		"should recreate the CertificateRequest if the CSR is not signed by the stored private key": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateRSA(t)},
 				},
 			},
@@ -589,7 +621,7 @@ func TestProcessItem(t *testing.T) {
 		"should recreate the CertificateRequest if the CSR does not match requirements on spec": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -624,7 +656,7 @@ func TestProcessItem(t *testing.T) {
 		"should do nothing if request has an up to date CSR and it is still pending": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -649,7 +681,7 @@ func TestProcessItem(t *testing.T) {
 		"should record a Warning event if multiple owned and up to date CertificateRequests for the current revision exist": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -681,7 +713,7 @@ func TestProcessItem(t *testing.T) {
 		"should recreate the CertificateRequest if the current 'next' CertificateRequest failed during previous issuance cycle": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -717,7 +749,7 @@ func TestProcessItem(t *testing.T) {
 		"should do nothing if the CertificateRequest that is valid for spec has failed during this issuance cycle": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle1.certificate, "exists"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
 				},
 			},
@@ -744,7 +776,7 @@ func TestProcessItem(t *testing.T) {
 			},
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists-for-nameconstraints-test"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle3.certificate, "exists-for-nameconstraints-test"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle3.privateKeyBytes},
 				},
 			},
@@ -774,7 +806,7 @@ func TestProcessItem(t *testing.T) {
 		"do nothing if the next private key does not match spec.privateKey.algorithm, waiting for the keymanager": {
 			secrets: []runtime.Object{
 				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: bundle3.certificate.Namespace, Name: "exists-with-mismatched-key"},
+					ObjectMeta: nextPrivateKeySecretMeta(bundle3.certificate, "exists-with-mismatched-key"),
 					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: mustGenerateECDSA(t)},
 				},
 			},

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -79,15 +79,17 @@ func relaxedCertificateRequestMatcher(l coretesting.Action, r coretesting.Action
 }
 
 // nextPrivateKeySecretMeta builds the ObjectMeta that the keymanager
-// controller gives to a next private key Secret: the next-private-key label,
-// and a controller owner reference back to the Certificate. The requestmanager
-// controller only consumes Secrets carrying both, so fixtures must set them.
+// controller gives to a next private key Secret: the labels it sets, and a
+// controller owner reference back to the Certificate. The requestmanager controller
+// only consumes Secrets carrying the next-private-key label and that owner
+// reference, so fixtures must set them.
 func nextPrivateKeySecretMeta(crt *cmapi.Certificate, name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Namespace: crt.Namespace,
 		Name:      name,
 		Labels: map[string]string{
-			cmapi.IsNextPrivateKeySecretLabelKey: "true",
+			cmapi.IsNextPrivateKeySecretLabelKey:      "true",
+			cmapi.PartOfCertManagerControllerLabelKey: "true",
 		},
 		OwnerReferences: []metav1.OwnerReference{
 			*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),

--- a/pkg/controller/certificates/secrets.go
+++ b/pkg/controller/certificates/secrets.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// IsNextPrivateKeySecret reports whether secret is one the keymanager
+// controller created for crt: it must carry the
+// `cert-manager.io/next-private-key` label and have crt as its controller.
+//
+// This is the invariant the keymanager maintains and every consumer of
+// status.nextPrivateKeySecretName relies on, so it lives in one place.
+func IsNextPrivateKeySecret(secret *corev1.Secret, crt *cmapi.Certificate) bool {
+	return secret.Labels[cmapi.IsNextPrivateKeySecretLabelKey] == "true" && metav1.IsControlledBy(secret, crt)
+}
+
+// GetNextPrivateKeySecret returns the Secret named by
+// crt.Status.NextPrivateKeySecretName, but only if that Secret is one that the
+// keymanager controller created for this Certificate: it must carry the
+// `cert-manager.io/next-private-key` label and have crt as its controller.
+//
+// The name alone must not be trusted. status.nextPrivateKeySecretName is
+// writable by any principal with access to the certificates/status
+// subresource, which is a weaker permission than reading Secrets in the
+// namespace. Without this check, such a principal can name any Secret in the
+// namespace and have its private key copied into spec.secretName.
+//
+// A Secret that exists but fails these checks is reported as not found, so
+// that callers wait for the keymanager controller to reconcile the field back
+// to a Secret it owns, exactly as they do when the Secret is absent.
+func GetNextPrivateKeySecret(lister corelisters.SecretNamespaceLister, crt *cmapi.Certificate) (*corev1.Secret, error) {
+	if crt.Status.NextPrivateKeySecretName == nil || *crt.Status.NextPrivateKeySecretName == "" {
+		return nil, apierrors.NewNotFound(corev1.Resource("secrets"), "")
+	}
+
+	name := *crt.Status.NextPrivateKeySecretName
+	secret, err := lister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if !IsNextPrivateKeySecret(secret, crt) {
+		return nil, apierrors.NewNotFound(corev1.Resource("secrets"), name)
+	}
+
+	return secret, nil
+}

--- a/pkg/controller/certificates/secrets.go
+++ b/pkg/controller/certificates/secrets.go
@@ -36,9 +36,8 @@ func IsNextPrivateKeySecret(secret *corev1.Secret, crt *cmapi.Certificate) bool 
 }
 
 // GetNextPrivateKeySecret returns the Secret named by
-// crt.Status.NextPrivateKeySecretName, but only if that Secret is one that the
-// keymanager controller created for this Certificate: it must carry the
-// `cert-manager.io/next-private-key` label and have crt as its controller.
+// crt.Status.NextPrivateKeySecretName, but only if IsNextPrivateKeySecret
+// accepts it. An unset or empty name is reported as not found.
 //
 // The name alone must not be trusted. status.nextPrivateKeySecretName is
 // writable by any principal with access to the certificates/status

--- a/pkg/controller/certificates/secrets_test.go
+++ b/pkg/controller/certificates/secrets_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+func TestGetNextPrivateKeySecret(t *testing.T) {
+	crt := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cert",
+			Namespace: "testns",
+			UID:       "cert-uid",
+		},
+		Status: cmapi.CertificateStatus{
+			NextPrivateKeySecretName: new("next-pk"),
+		},
+	}
+
+	// ownedSecret is what the keymanager controller creates: labelled, and with
+	// crt as its controller.
+	ownedSecret := func() *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "next-pk",
+				Namespace: "testns",
+				Labels: map[string]string{
+					cmapi.IsNextPrivateKeySecretLabelKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+				},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		secret   *corev1.Secret
+		crt      *cmapi.Certificate
+		wantName string
+		// wantNotFound is true when the Secret must be rejected, whether it is
+		// absent or fails the ownership checks.
+		wantNotFound bool
+	}{
+		"returns a Secret owned by and labelled for the Certificate": {
+			secret:   ownedSecret(),
+			crt:      crt,
+			wantName: "next-pk",
+		},
+		"rejects a Secret with no owner reference": {
+			// An unrelated Secret in the same namespace, named by a principal
+			// with access only to the certificates/status subresource.
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "next-pk", Namespace: "testns"},
+			},
+			crt:          crt,
+			wantNotFound: true,
+		},
+		"rejects a Secret labelled but owned by a different Certificate": {
+			secret: func() *corev1.Secret {
+				s := ownedSecret()
+				other := crt.DeepCopy()
+				other.Name = "other-cert"
+				other.UID = "other-uid"
+				s.OwnerReferences = []metav1.OwnerReference{
+					*metav1.NewControllerRef(other, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+				}
+				return s
+			}(),
+			crt:          crt,
+			wantNotFound: true,
+		},
+		"rejects a Secret whose owner reference is not a controller reference": {
+			// metav1.IsControlledBy only accepts an owner reference with
+			// controller: true. A plain owner reference is not enough.
+			secret: func() *corev1.Secret {
+				s := ownedSecret()
+				s.OwnerReferences[0].Controller = new(false)
+				return s
+			}(),
+			crt:          crt,
+			wantNotFound: true,
+		},
+		"rejects a Secret owned by the Certificate but missing the label": {
+			secret: func() *corev1.Secret {
+				s := ownedSecret()
+				s.Labels = nil
+				return s
+			}(),
+			crt:          crt,
+			wantNotFound: true,
+		},
+		"rejects a Secret that does not exist": {
+			secret:       nil,
+			crt:          crt,
+			wantNotFound: true,
+		},
+		"rejects when nextPrivateKeySecretName is unset": {
+			secret: ownedSecret(),
+			crt: func() *cmapi.Certificate {
+				c := crt.DeepCopy()
+				c.Status.NextPrivateKeySecretName = nil
+				return c
+			}(),
+			wantNotFound: true,
+		},
+		"rejects when nextPrivateKeySecretName is empty": {
+			secret: ownedSecret(),
+			crt: func() *cmapi.Certificate {
+				c := crt.DeepCopy()
+				c.Status.NextPrivateKeySecretName = new("")
+				return c
+			}(),
+			wantNotFound: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var objects []runtime.Object
+			if test.secret != nil {
+				objects = append(objects, test.secret)
+			}
+			factory := coreinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(objects...), 0)
+			lister := factory.Core().V1().Secrets().Lister()
+			if test.secret != nil {
+				if err := factory.Core().V1().Secrets().Informer().GetIndexer().Add(test.secret); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := GetNextPrivateKeySecret(lister.Secrets("testns"), test.crt)
+
+			if test.wantNotFound {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected a NotFound error, got err=%v secret=%v", err, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.Name != test.wantName {
+				t.Errorf("expected Secret %q, got %v", test.wantName, got)
+			}
+		})
+	}
+}

--- a/pkg/controller/certificates/secrets_test.go
+++ b/pkg/controller/certificates/secrets_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	coreinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
@@ -141,11 +140,9 @@ func TestGetNextPrivateKeySecret(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			var objects []runtime.Object
-			if test.secret != nil {
-				objects = append(objects, test.secret)
-			}
-			factory := coreinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(objects...), 0)
+			// The factory is never started, so the informer's indexer is what the
+			// lister reads. Seed it directly.
+			factory := coreinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
 			lister := factory.Core().V1().Secrets().Lister()
 			if test.secret != nil {
 				if err := factory.Core().V1().Secrets().Informer().GetIndexer().Add(test.secret); err != nil {

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/cert-manager/integration-tests/framework"
@@ -112,20 +113,6 @@ func TestIssuingController(t *testing.T) {
 	// Encode the private key as PKCS#1, the default format
 	skBytes := utilpki.EncodePKCS1PrivateKey(sk)
 
-	// Store new private key in secret
-	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nextPrivateKeySecretName,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: skBytes,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create Certificate
 	crt := gen.Certificate(crtName,
 		gen.SetCertificateNamespace(namespace),
@@ -143,6 +130,11 @@ func TestIssuingController(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The issuing controller only consumes a next private key Secret that the
+	// keymanager controller created for this Certificate, so the Secret needs
+	// the Certificate as its owner and cannot be created any earlier.
+	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
 	if err != nil {
@@ -318,22 +310,6 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Store new private key in secret
-	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nextPrivateKeySecretName,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			// store PKCS#1 bytes so we can ensure they are correctly converted to
-			// PKCS#8 later on
-			corev1.TLSPrivateKeyKey: skBytesPKCS1,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create Certificate
 	crt := gen.Certificate(crtName,
 		gen.SetCertificateNamespace(namespace),
@@ -352,6 +328,11 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The issuing controller only consumes a next private key Secret that the
+	// keymanager controller created for this Certificate, so the Secret needs
+	// the Certificate as its owner and cannot be created any earlier.
+	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytesPKCS1)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
 	if err != nil {
@@ -525,20 +506,6 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	// Encode the private key as PKCS#1, the default format
 	skBytes := utilpki.EncodePKCS1PrivateKey(sk)
 
-	// Store new private key in secret
-	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nextPrivateKeySecretName,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: skBytes,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create Certificate
 	crt := gen.Certificate(crtName,
 		gen.SetCertificateNamespace(namespace),
@@ -556,6 +523,11 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The issuing controller only consumes a next private key Secret that the
+	// keymanager controller created for this Certificate, so the Secret needs
+	// the Certificate as its owner and cannot be created any earlier.
+	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
 	if err != nil {
@@ -758,20 +730,6 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 	// Encode the private key as PKCS#1, the default format
 	pkBytes := utilpki.EncodePKCS1PrivateKey(pk)
 
-	// Store new private key in secret
-	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nextPrivateKeySecretName,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: pkBytes,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create Certificate
 	crt := gen.Certificate(crtName,
 		gen.SetCertificateNamespace(namespace),
@@ -789,6 +747,11 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The issuing controller only consumes a next private key Secret that the
+	// keymanager controller created for this Certificate, so the Secret needs
+	// the Certificate as its owner and cannot be created any earlier.
+	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, pkBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, pk)
 	if err != nil {
@@ -1080,4 +1043,31 @@ func Test_IssuingController_OwnerReference(t *testing.T) {
 		require.NoError(t, err)
 		return apiequality.Semantic.DeepEqual(secret.OwnerReferences, []metav1.OwnerReference{*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate"))})
 	}, time.Second*3, time.Millisecond*10, "expected Secret to have owner reference options to Certificate reverse: %#+v", secret.OwnerReferences)
+}
+
+// createNextPrivateKeySecret stores skBytes in a Secret that looks like one the
+// keymanager controller created for crt: it carries the
+// cert-manager.io/next-private-key label and has crt as its controller. The
+// issuing controller ignores any Secret that fails those checks.
+func createNextPrivateKeySecret(t *testing.T, kubeClient kubernetes.Interface, crt *cmapi.Certificate, name string, skBytes []byte) {
+	t.Helper()
+
+	_, err := kubeClient.CoreV1().Secrets(crt.Namespace).Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: crt.Namespace,
+			Labels: map[string]string{
+				cmapi.IsNextPrivateKeySecretLabelKey: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+			},
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: skBytes,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -131,9 +131,7 @@ func TestIssuingController(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The issuing controller only consumes a next private key Secret that the
-	// keymanager controller created for this Certificate, so the Secret needs
-	// the Certificate as its owner and cannot be created any earlier.
+	// Must come after the Certificate exists: the Secret needs it as owner.
 	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
@@ -329,9 +327,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The issuing controller only consumes a next private key Secret that the
-	// keymanager controller created for this Certificate, so the Secret needs
-	// the Certificate as its owner and cannot be created any earlier.
+	// Must come after the Certificate exists: the Secret needs it as owner.
 	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytesPKCS1)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
@@ -524,9 +520,7 @@ func Test_IssuingController_SecretTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The issuing controller only consumes a next private key Secret that the
-	// keymanager controller created for this Certificate, so the Secret needs
-	// the Certificate as its owner and cannot be created any earlier.
+	// Must come after the Certificate exists: the Secret needs it as owner.
 	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, skBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, sk)
@@ -748,9 +742,7 @@ func Test_IssuingController_AdditionalOutputFormats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The issuing controller only consumes a next private key Secret that the
-	// keymanager controller created for this Certificate, so the Secret needs
-	// the Certificate as its owner and cannot be created any earlier.
+	// Must come after the Certificate exists: the Secret needs it as owner.
 	createNextPrivateKeySecret(t, kubeClient, crt, nextPrivateKeySecretName, pkBytes)
 
 	csrPEM, err := gen.CSRWithSignerForCertificate(crt, pk)
@@ -1046,9 +1038,9 @@ func Test_IssuingController_OwnerReference(t *testing.T) {
 }
 
 // createNextPrivateKeySecret stores skBytes in a Secret that looks like one the
-// keymanager controller created for crt: it carries the
-// cert-manager.io/next-private-key label and has crt as its controller. The
-// issuing controller ignores any Secret that fails those checks.
+// keymanager controller created for crt: it carries the labels the keymanager
+// sets and has crt as its controller. The issuing controller ignores any Secret
+// that is not labelled cert-manager.io/next-private-key and owned by crt.
 func createNextPrivateKeySecret(t *testing.T, kubeClient kubernetes.Interface, crt *cmapi.Certificate, name string, skBytes []byte) {
 	t.Helper()
 
@@ -1057,7 +1049,8 @@ func createNextPrivateKeySecret(t *testing.T, kubeClient kubernetes.Interface, c
 			Name:      name,
 			Namespace: crt.Namespace,
 			Labels: map[string]string{
-				cmapi.IsNextPrivateKeySecretLabelKey: "true",
+				cmapi.IsNextPrivateKeySecretLabelKey:      "true",
+				cmapi.PartOfCertManagerControllerLabelKey: "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),


### PR DESCRIPTION
If you can write a Certificate's `status` subresource, you can obtain a private key you are not allowed to read.

Point `status.nextPrivateKeySecretName` at any TLS Secret in the namespace. cert-manager signs a CSR with that Secret's private key, has the issuer sign it, and writes the key and the new certificate into the Certificate's `spec.secretName`. You chose `spec.secretName`, so you can read it. You now hold a working certificate and key pair built on a key that was never yours.

The [requestmanager](https://github.com/cert-manager/cert-manager/blob/v1.21.0/pkg/controller/certificates/requestmanager/requestmanager_controller.go#L168) and [issuing](https://github.com/cert-manager/cert-manager/blob/v1.21.0/pkg/controller/certificates/issuing/issuing_controller.go#L215) controllers use the private key from the Secret named by that field without checking that the Secret belongs to the Certificate. The [keymanager controller](https://github.com/cert-manager/cert-manager/blob/v1.21.0/pkg/controller/certificates/keymanager/keymanager_controller.go#L173), which creates those Secrets, only ever considers Secrets carrying the `cert-manager.io/next-private-key` label and a controller owner reference back to the Certificate. The two consumers bypass that invariant by trusting the status field.

Writing `certificates/status` is a weaker permission than reading Secrets. You need read access to the Secret you name in `spec.secretName`, and none at all to the Secret you steal from.

<details>
<summary>In a default install this is not a privilege escalation</summary>

The chart grants `certificates/status: update` through the aggregated `cert-manager-edit` role, and Kubernetes' own `system:aggregate-to-edit` already grants full read and write on `secrets` in the namespace. Anyone reaching that rule can read the Secret directly. The exposure is for hand-built Roles that grant Certificate and Certificate status write without Secret read.

The grant is deliberate. f6d8c4fb5 (#4954) added it so namespace admins can trigger a manual renewal, which is what `cmctl renew` does. The fix therefore belongs in the controllers rather than in the chart.
</details>

This also stops a corrupted or hand-edited status from making cert-manager consume an unrelated Secret. The behaviour dates from 9e2d6a514 (July 2020), first released in v0.16.0.

<details>
<summary>What changed</summary>

`IsNextPrivateKeySecret` states the invariant, and everything that relies on it now goes through that one function: `GetNextPrivateKeySecret` for the two consumers, and the keymanager's own list of candidate Secrets. A Secret that exists but fails the check is reported as not found, so callers wait for the keymanager to repoint the field at a Secret it owns. That is what they already do when the Secret is absent, so there are no new error paths.

Recovery needs a keymanager change, which this PR also makes. The keymanager used to create its Secret under the name already in the status field, and adopt whatever Secret occupied that name. Both trusted the field. It now never creates under a name taken from the status field. `createNewPrivateKeySecret` always uses `generateName`. Before creating, it checks whether the named Secret is one it created on an earlier reconcile whose status write has not reached the cache yet, which is the duplicate-Secret race that #8579 guarded against. A named Secret that is not ours gets a `NotOwned` Warning event and is ignored.

Creating under a free name from the status field was unsafe on its own. The name could be the `spec.secretName` of a Certificate that has not issued yet. This Certificate would then own that Secret, and later delete it or sign with its key.

When the keymanager already owns a Secret but the status field names something else, it now repoints the field at the Secret it owns instead of deleting the Secret. Deleting it let a status writer force a key rotation on demand, and raced the Secret informer after the keymanager's own status write. The `rotationPolicy: Never` path that cannot make a next private key now clears the field rather than leaving a stale or untrusted name in it.

`IsNextPrivateKeySecret` also rejects the Secret named by `spec.secretName`. `spec.secretTemplate.labels` can put the `next-private-key` label on it, and `--enable-certificate-owner-ref` gives it the controller reference, after which the keymanager would delete the served certificate on every Ready transition. Reserving `cert-manager.io/*` label keys in validation would be the cleaner fix, but that is a breaking change, so I have left it for a follow-up.

`GetNextPrivateKeySecret` resolves the name with a label-selected LIST rather than a GET. With `SecretsFilteredCaching` on, a GET for an unlabeled Secret is answered by a live API request that returns the whole Secret, private key included, only for the ownership check to discard it.

The test fixtures built next private key Secrets with neither the label nor the owner reference, so they did not match what the keymanager produces in a real cluster. They now go through helpers that set both, which is most of the diff. The integration tests create the Secret after the Certificate, because the owner reference needs the Certificate's UID.
</details>

<details>
<summary>How I checked the tests actually catch the bug</summary>

With `metav1.IsControlledBy` removed from `IsNextPrivateKeySecret`, so that the label alone is checked, exactly these fail, and no others:

- `TestGetNextPrivateKeySecret/rejects a Secret labeled but owned by a different Certificate` and `.../rejects a Secret whose owner reference is not a controller reference`
- `TestProcessItem/create a secret under a generated name if status.nextPrivateKeySecretName names a Secret not owned by the Certificate` (keymanager)
- `TestProcessItem/do nothing if status.nextPrivateKeySecretName names a Secret not owned by the Certificate` (requestmanager)
- `TestIssuingController/if certificate is in Issuing state but NextPrivateKeySecretName names a Secret it does not own, do nothing`, with `expected secretUpdateData func to be called: false was called: true`. That is the private key being copied into `spec.secretName`.

The controller fixtures give the Certificate a UID and give the foreign Secret the label plus a controller reference to a Certificate with a different UID, so the owner UID comparison is the only thing rejecting it.
</details>

Reported by @the-vibe-dev.

### Kind

/kind bug

### Release Note

```release-note
The `requestmanager` and `issuing` controllers now only consume the Secret named by `status.nextPrivateKeySecretName` when it carries the `cert-manager.io/next-private-key` label and is owned by the Certificate, matching the invariant the `keymanager` controller already enforces. Previously a principal able to write the `certificates/status` subresource, but not to read Secrets, could name any Secret in the namespace and have its private key copied into `spec.secretName`. The `keymanager` controller no longer creates the next private key Secret under the name in `status.nextPrivateKeySecretName`. It always uses a generated name, records a `NotOwned` Warning event when the field names a Secret it does not own, and repoints the field at the Secret it owns rather than deleting that Secret when the two disagree. The Secret named by `spec.secretName` is never treated as a next private key Secret, even if `spec.secretTemplate` labels it as one.
```

[Claude Opus 5, Claude Fable 5.1]

