### PR TITLE
Support K8s 1.37 in E2E test cluster script

### DIFF
--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -105,10 +105,10 @@ if printenv K8S_VERSION >/dev/null && [ -n "$K8S_VERSION" ]; then
 fi
 
 case "$k8s_version" in
-1.33*) image=$KIND_IMAGE_K8S_133 ;;
 1.34*) image=$KIND_IMAGE_K8S_134 ;;
 1.35*) image=$KIND_IMAGE_K8S_135 ;;
 1.36*) image=$KIND_IMAGE_K8S_136 ;;
+1.37*) image=$KIND_IMAGE_K8S_137 ;;
 v*) printf "${red}${redcross}Error${end}: Kubernetes version must be given without the leading 'v'\n" >&2 && exit 1 ;;
 *) printf "${red}${redcross}Error${end}: unsupported Kubernetes version ${yel}${k8s_version}${end}\n" >&2 && exit 1 ;;
 esac


### PR DESCRIPTION
### Pull Request Motivation

Prepares for adding Kubernetes 1.37 to the E2E test matrix, as discussed on Slack.

The Renovate bump to kind v0.33.0 (https://github.com/cert-manager/cert-manager/commit/62fd1164f) regenerated `make/kind_images.sh`, which added the v1.37.0 node image and removed v1.33 — kind v0.33.0 no longer ships a 1.33 image ([release notes](https://github.com/kubernetes-sigs/kind/releases/tag/v0.33.0)). But `make/cluster.sh` was not updated, so since then:

- `K8S_VERSION=1.33` expands the now-undefined `KIND_IMAGE_K8S_133` to an empty image, so the `pull-cert-manager-master-e2e-v1-33` jobs are broken
- `K8S_VERSION=1.37` is rejected as unsupported

This swaps the 1.33 case for a 1.37 case, following the prior art in https://github.com/cert-manager/cert-manager/commit/4eefe4fd1 which did the same when 1.34 was added.

Verified locally:

```console
$ K8S_VERSION=1.37 ./make/cluster.sh --show-image
docker.io/kindest/node@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
$ K8S_VERSION=1.33 ./make/cluster.sh --show-image
❌  Error: unsupported Kubernetes version 1.33
```

A follow-up PR to cert-manager/testing will replace 1.33 with 1.37 in the master job matrix.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```

*with claude fable-5*
