### PR TITLE
Treat a NotFound delete as done when cleaning up solver ingresses

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -314,6 +314,12 @@ func (s *Solver) cleanupIngresses(ctx context.Context, ch *cmacme.Challenge) err
 
 			log.V(logf.DebugLevel).Info("deleting ingress resource")
 			err := s.Client.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
+			if k8sErrors.IsNotFound(err) {
+				// the lister can be behind the API server, so an ingress that
+				// is already gone is the state we wanted anyway
+				log.V(logf.DebugLevel).Info("ingress resource already deleted")
+				continue
+			}
 			if err != nil {
 				log.V(logf.WarnLevel).Info("failed to delete ingress resource", "error", err)
 				errs = append(errs, err)

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -475,6 +476,34 @@ func TestCleanupIngresses(t *testing.T) {
 				if diff := cmp.Diff(expectedIng, actualIng); diff != "" {
 					t.Errorf("expected did not match actual (-want +got):\n%s", diff)
 				}
+			},
+		},
+		"should not return an error if the ingress is already gone": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "example.com",
+					Token:   "abcd",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+								Class: new("nginx"),
+							},
+						},
+					},
+				},
+			},
+			Err: false,
+			PreFn: func(t *testing.T, s *solverFixture) {
+				ing, err := s.Solver.createIngress(t.Context(), s.Challenge, "fakeservice")
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				s.testResources[createdIngressKey] = ing
+
+				// the lister still has the ingress, the API server no longer does
+				s.Builder.FakeKubeClient().PrependReactor("delete", "ingresses", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, k8sErrors.NewNotFound(networkingv1.Resource("ingresses"), ing.Name)
+				})
 			},
 		},
 		"should return an error if a delete fails": {

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -492,17 +491,15 @@ func TestCleanupIngresses(t *testing.T) {
 					},
 				},
 			},
-			Err: false,
 			PreFn: func(t *testing.T, s *solverFixture) {
 				ing, err := s.Solver.createIngress(t.Context(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				s.testResources[createdIngressKey] = ing
 
 				// the lister still has the ingress, the API server no longer does
 				s.Builder.FakeKubeClient().PrependReactor("delete", "ingresses", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, k8sErrors.NewNotFound(networkingv1.Resource("ingresses"), ing.Name)
+					return true, nil, apierrors.NewNotFound(networkingv1.Resource("ingresses"), ing.Name)
 				})
 			},
 		},

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -148,6 +149,12 @@ func (s *Solver) cleanupPods(ctx context.Context, ch *cmacme.Challenge) error {
 		log.V(logf.InfoLevel).Info("deleting pod resource")
 
 		err := s.Client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if k8sErrors.IsNotFound(err) {
+			// the lister can be behind the API server, so a pod that is
+			// already gone is the state we wanted anyway
+			log.V(logf.DebugLevel).Info("pod resource already deleted")
+			continue
+		}
 		if err != nil {
 			log.V(logf.WarnLevel).Info("failed to delete pod resource", "error", err)
 			errs = append(errs, fmt.Errorf("error deleting pod: %w", err))

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -939,3 +939,71 @@ func validateContainerResources(t *testing.T, container corev1.Container, expect
 		}
 	}
 }
+
+func TestCleanupPods(t *testing.T) {
+	testNamespace := "foo"
+	chal := &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
+		Spec: cmacme.ChallengeSpec{
+			DNSName: "example.com",
+			Token:   "token",
+			Key:     "key",
+			Solver: cmacme.ACMEChallengeSolver{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+				},
+			},
+		},
+	}
+	podMeta := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cm-acme-http-solver-fghij",
+			Namespace:       testNamespace,
+			Labels:          podLabels(chal),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
+		},
+	}
+
+	tests := map[string]struct {
+		deleteErr   error
+		expectedErr bool
+	}{
+		// The metadata lister has the pod but the API server does not, which
+		// is what a delete that already happened looks like from here.
+		"should not return an error if the pod is already gone": {},
+		"should return an error if a delete fails": {
+			deleteErr:   fmt.Errorf("simulated error"),
+			expectedErr: true,
+		},
+	}
+
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := &testpkg.Builder{
+				T:                      t,
+				PartialMetadataObjects: []runtime.Object{podMeta},
+			}
+			builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:   builder.Context,
+				podLister: builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods")).Lister(),
+			}
+			if scenario.deleteErr != nil {
+				builder.FakeKubeClient().PrependReactor("delete", "pods", func(action coretesting.Action) (bool, runtime.Object, error) {
+					return true, nil, scenario.deleteErr
+				})
+			}
+			builder.Start()
+			defer builder.Stop()
+
+			err := s.cleanupPods(t.Context(), chal)
+			if err != nil && !scenario.expectedErr {
+				t.Errorf("expected no error, got: %v", err)
+			}
+			if err == nil && scenario.expectedErr {
+				t.Error("expected an error, got none")
+			}
+		})
+	}
+}

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -163,6 +164,12 @@ func (s *Solver) cleanupServices(ctx context.Context, ch *cmacme.Challenge) erro
 		log.V(logf.DebugLevel).Info("deleting service resource")
 
 		err := s.Client.CoreV1().Services(service.Namespace).Delete(ctx, service.Name, metav1.DeleteOptions{})
+		if k8sErrors.IsNotFound(err) {
+			// the lister can be behind the API server, so a service that is
+			// already gone is the state we wanted anyway
+			log.V(logf.DebugLevel).Info("service resource already deleted")
+			continue
+		}
 		if err != nil {
 			log.V(logf.WarnLevel).Info("failed to delete pod resource", "error", err)
 			errs = append(errs, err)

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -350,6 +351,74 @@ func TestBuildServiceExtraLabels(t *testing.T) {
 			test.Setup(t)
 			resp, err := test.Solver.createService(t.Context(), test.Challenge)
 			test.Finish(t, resp, err)
+		})
+	}
+}
+
+func TestCleanupServices(t *testing.T) {
+	testNamespace := "foo"
+	chal := &cmacme.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
+		Spec: cmacme.ChallengeSpec{
+			DNSName: "example.com",
+			Token:   "token",
+			Key:     "key",
+			Solver: cmacme.ACMEChallengeSolver{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+				},
+			},
+		},
+	}
+	serviceMeta := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cm-acme-http-solver-abcde",
+			Namespace:       testNamespace,
+			Labels:          podLabels(chal),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(chal, challengeGvk)},
+		},
+	}
+
+	tests := map[string]struct {
+		deleteErr   error
+		expectedErr bool
+	}{
+		// The metadata lister has the service but the API server does not, which
+		// is what a delete that already happened looks like from here.
+		"should not return an error if the service is already gone": {},
+		"should return an error if a delete fails": {
+			deleteErr:   fmt.Errorf("simulated error"),
+			expectedErr: true,
+		},
+	}
+
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := &testpkg.Builder{
+				T:                      t,
+				PartialMetadataObjects: []runtime.Object{serviceMeta},
+			}
+			builder.InitWithRESTConfig()
+			s := &Solver{
+				Context:       builder.Context,
+				serviceLister: builder.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services")).Lister(),
+			}
+			if scenario.deleteErr != nil {
+				builder.FakeKubeClient().PrependReactor("delete", "services", func(action coretesting.Action) (bool, runtime.Object, error) {
+					return true, nil, scenario.deleteErr
+				})
+			}
+			builder.Start()
+			defer builder.Stop()
+
+			err := s.cleanupServices(t.Context(), chal)
+			if err != nil && !scenario.expectedErr {
+				t.Errorf("expected no error, got: %v", err)
+			}
+			if err == nil && scenario.expectedErr {
+				t.Error("expected an error, got none")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #9223.

`cleanupIngresses` gets its candidates from the ingress lister, which can be behind the API server. If another actor, or an earlier pass of the same cleanup, already removed a solver ingress, the delete comes back `NotFound` and that gets folded into the aggregate error even though the ingress is gone, which is the state the cleanup wanted. The named-ingress branch a few lines down already treats `IsNotFound` on the get as a finished cleanup, so this makes the two branches agree.

Other delete errors still go into the aggregate.

`cleanupPods` and `cleanupServices` run in the same `CleanUp` aggregate and had the identical loop with no NotFound handling, so after review they get the same treatment. Those two read from the metadata informer rather than the typed client, which makes the race easy to reproduce in a test: seed a `PartialObjectMetadata` and leave the typed client empty, and the lister hands back an object whose delete returns NotFound.

The ingress test case sits beside the existing "should return an error if a delete fails" one and uses the same reactor mechanism. `TestCleanupPods` and `TestCleanupServices` are new, each with an already-gone case and a delete-fails case. On the first commit the three already-gone cases fail with `ingresses.networking.k8s.io "cm-acme-http-solver-..." not found`, `error deleting pod: pods "cm-acme-http-solver-fghij" not found`, and the service equivalent.

`go test ./pkg/issuer/acme/http/...` passes.

```release-note
Fixed HTTP-01 solver cleanup so that a solver ingress, pod or service that has already been deleted no longer fails the cleanup with a NotFound error.
```
