### PR TITLE
[release-1.21] fix(ari): issuer checks in secret for ari

### DIFF
--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -36,6 +36,7 @@ import (
 
 	cmmeta "github.com/cert-manager/cert-manager/internal/apis/meta"
 	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 )
@@ -159,15 +160,14 @@ func SecretKeystoreFormatMismatch(input Input) (string, string, bool) {
 // SecretIssuerAnnotationsMismatch - When the issuer annotations are defined,
 // it must match the issuer ref.
 func SecretIssuerAnnotationsMismatch(input Input) (string, string, bool) {
-	name, ok1 := input.Secret.Annotations[cmapi.IssuerNameAnnotationKey]
-	kind, ok2 := input.Secret.Annotations[cmapi.IssuerKindAnnotationKey]
-	group, ok3 := input.Secret.Annotations[cmapi.IssuerGroupAnnotationKey]
-	if (ok1 || ok2 || ok3) && // only check if an annotation is present
-		name != input.Certificate.Spec.IssuerRef.Name ||
-		!issuerKindsEqual(kind, input.Certificate.Spec.IssuerRef.Kind) ||
-		!issuerGroupsEqual(group, input.Certificate.Spec.IssuerRef.Group) {
+	if !apiutil.SecretIssuerAnnotationsMatch(input.Secret, input.Certificate.Spec.IssuerRef) {
+		name := input.Secret.Annotations[cmapi.IssuerNameAnnotationKey]
+		kind := input.Secret.Annotations[cmapi.IssuerKindAnnotationKey]
+		group := input.Secret.Annotations[cmapi.IssuerGroupAnnotationKey]
+
 		return IncorrectIssuer, fmt.Sprintf("Issuing certificate as Secret was previously issued by %q", formatIssuerRef(name, kind, group)), true
 	}
+
 	return "", "", false
 }
 
@@ -347,31 +347,6 @@ func formatIssuerRef(name, kind, group string) string {
 		kind = "Issuer"
 	}
 	return fmt.Sprintf("%s.%s/%s", kind, group, name)
-}
-
-const (
-	defaultIssuerKind  = "Issuer"
-	defaultIssuerGroup = "cert-manager.io"
-)
-
-func issuerKindsEqual(l, r string) bool {
-	if l == "" {
-		l = defaultIssuerKind
-	}
-	if r == "" {
-		r = defaultIssuerKind
-	}
-	return l == r
-}
-
-func issuerGroupsEqual(l, r string) bool {
-	if l == "" {
-		l = defaultIssuerGroup
-	}
-	if r == "" {
-		r = defaultIssuerGroup
-	}
-	return l == r
 }
 
 // SecretSecretTemplateMismatch will inspect the given Secret's Annotations

--- a/pkg/api/util/issuers.go
+++ b/pkg/api/util/issuers.go
@@ -19,6 +19,9 @@ package util
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -60,4 +63,50 @@ func IssuerKind(ref cmmeta.IssuerReference) string {
 		return cmapi.IssuerKind
 	}
 	return ref.Kind
+}
+
+// IssuerGroup returns the API group of the issuer for a certificate.
+func IssuerGroup(ref cmmeta.IssuerReference) string {
+	if ref.Group == "" {
+		return certmanager.GroupName
+	}
+	return ref.Group
+}
+
+// SecretIssuerAnnotationsMatch reports whether the issuer recorded in the
+// Secret's cert-manager annotations is the same issuer resource as issuerRef.
+//
+// A Secret carrying none of the issuer annotations has no verifiable
+// provenance — it is typically pre-created by the user and may hold a
+// certificate from another CA. It nevertheless matches a ref whose kind and
+// group are the defaults (Issuer / cert-manager.io), and only mismatches
+// refs to other kinds or groups.
+//
+// Annotations that are present are compared against issuerRef with the usual
+// kind/group defaulting; a nil Secret returns false.
+func SecretIssuerAnnotationsMatch(secret *corev1.Secret, issuerRef cmmeta.IssuerReference) bool {
+	if secret == nil {
+		return false
+	}
+
+	name, hasName := secret.Annotations[cmapi.IssuerNameAnnotationKey]
+	kind, hasKind := secret.Annotations[cmapi.IssuerKindAnnotationKey]
+	group, hasGroup := secret.Annotations[cmapi.IssuerGroupAnnotationKey]
+
+	if (hasName || hasKind || hasGroup) && name != issuerRef.Name {
+		return false
+	}
+	return IssuerKindsEqual(kind, issuerRef.Kind) && IssuerGroupsEqual(group, issuerRef.Group)
+}
+
+// IssuerKindsEqual returns true if the two issuer reference kinds are equal,
+// taking into account the defaulting of an empty kind to "Issuer".
+func IssuerKindsEqual(l, r string) bool {
+	return IssuerKind(cmmeta.IssuerReference{Kind: l}) == IssuerKind(cmmeta.IssuerReference{Kind: r})
+}
+
+// IssuerGroupsEqual returns true if the two issuer reference groups are equal,
+// taking into account the defaulting of an empty group to "cert-manager.io".
+func IssuerGroupsEqual(l, r string) bool {
+	return IssuerGroup(cmmeta.IssuerReference{Group: l}) == IssuerGroup(cmmeta.IssuerReference{Group: r})
 }

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -850,11 +851,19 @@ func isARIReplacesRejection(err error) bool {
 	if errors.Is(err, acmeapi.ErrCADoesNotSupportARI) {
 		return true
 	}
+
 	var ae *acmeapi.Error
-	if errors.As(err, &ae) {
-		if ae.ProblemType == "urn:ietf:params:acme:error:alreadyReplaced" {
-			return true
-		}
+
+	if !errors.As(err, &ae) {
+		return false
+	}
+
+	if ae.ProblemType == "urn:ietf:params:acme:error:alreadyReplaced" {
+		return true
+	}
+
+	if ae.ProblemType == "urn:ietf:params:acme:error:malformed" && strings.Contains(strings.ToLower(ae.Detail), "replaces") {
+		return true
 	}
 	return false
 }

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -357,6 +357,12 @@ func (a *ACME) resolveReplacesCertID(ctx context.Context, cr *cmapi.CertificateR
 		log.V(logf.DebugLevel).Info("could not resolve Secret for ARI replaces", "error", err)
 		return ""
 	}
+
+	if !apiutil.SecretIssuerAnnotationsMatch(secret, cr.Spec.IssuerRef) {
+		log.V(logf.DebugLevel).Info("skipping ARI replaces: Secret issuer annotations do not match CertificateRequest issuerRef", "secret", secret.Name, "issuerRef", cr.Spec.IssuerRef)
+		return ""
+	}
+
 	pemBytes, ok := secret.Data[corev1.TLSCertKey]
 	if !ok || len(pemBytes) == 0 {
 		return ""

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
@@ -43,6 +44,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 	testlisters "github.com/cert-manager/cert-manager/test/unit/listers"
+	acmeapi "github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
 
 var (
@@ -687,6 +689,7 @@ func Test_buildOrder(t *testing.T) {
 		csr                   *x509.CertificateRequest
 		enableDurationFeature bool
 		profile               string
+		replaces              string
 	}
 	tests := []struct {
 		name    string
@@ -726,10 +729,21 @@ func Test_buildOrder(t *testing.T) {
 				gen.SetOrderProfile("shortlived")),
 			wantErr: false,
 		},
+		{
+			name: "Building with replaces",
+			args: args{
+				cr:       cr,
+				csr:      csr,
+				replaces: "wohgioegjewjg.wogjrpwojg",
+			},
+			want: gen.OrderFrom(baseOrder,
+				gen.SetOrderReplacesID("wohgioegjewjg.wogjrpwojg")),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildOrder(tt.args.cr, tt.args.csr, tt.args.enableDurationFeature, tt.args.profile, "")
+			got, err := buildOrder(tt.args.cr, tt.args.csr, tt.args.enableDurationFeature, tt.args.profile, tt.args.replaces)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildOrder() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -789,4 +803,182 @@ func Test_buildOrder(t *testing.T) {
 				orderTwo.Name)
 		}
 	})
+}
+
+func Test_resolveReplacesCertID(t *testing.T) {
+	const (
+		certificateName = "test-cert"
+		secretName      = "test-cert-tls"
+	)
+
+	// A leaf signed by a CA. CreateCertificate derives a SubjectKeyId for IsCA
+	// templates and copies it to the leaf's AuthorityKeyId, which is what
+	// acmeapi.CertificateARIID requires.
+	rootPK, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootTmpl := &x509.Certificate{
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "root"},
+		NotBefore:             fixedClockStart,
+		NotAfter:              fixedClockStart.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		PublicKey:             rootPK.Public(),
+		IsCA:                  true,
+	}
+	_, rootCert, err := pki.SignCertificate(rootTmpl, rootTmpl, rootPK.Public(), rootPK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafPK, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafCSRPEM := generateCSR(t, leafPK, "example.com", "example.com")
+	leafTmpl, err := pki.CertificateTemplateFromCSRPEM(
+		leafCSRPEM,
+		pki.CertificateTemplateOverrideDuration(time.Hour),
+		pki.CertificateTemplateValidateAndOverrideBasicConstraints(false, nil),
+		pki.CertificateTemplateValidateAndOverrideKeyUsages(0, nil),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafBundle, err := pki.SignCSRTemplate([]*x509.Certificate{rootCert}, rootPK, leafTmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := pki.DecodeX509CertificateBytes(leafBundle.ChainPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCertID, err := acmeapi.CertificateARIID(leaf)
+	if err != nil {
+		t.Fatalf("test fixture leaf has no usable ARI CertID: %v", err)
+	}
+
+	issuerRef := func(name, kind string) cmmeta.IssuerReference {
+		return cmmeta.IssuerReference{Name: name, Kind: kind, Group: certmanager.GroupName}
+	}
+	issuerAnnotations := func(name, kind string) map[string]string {
+		return map[string]string{
+			cmapiv1.IssuerNameAnnotationKey:  name,
+			cmapiv1.IssuerKindAnnotationKey:  kind,
+			cmapiv1.IssuerGroupAnnotationKey: certmanager.GroupName,
+		}
+	}
+	secretFor := func(annotations map[string]string, data map[string][]byte) *corev1.Secret {
+		s := gen.Secret(secretName, gen.SetSecretData(data))
+		if annotations != nil {
+			s = gen.SecretFrom(s, gen.SetSecretAnnotations(annotations))
+		}
+		return s
+	}
+
+	certificate := gen.Certificate(certificateName,
+		gen.SetCertificateSecretName(secretName),
+	)
+	validData := map[string][]byte{corev1.TLSCertKey: leafBundle.ChainPEM}
+	crAnnotations := map[string]string{cmapiv1.CertificateNameKey: certificateName}
+
+	tests := map[string]struct {
+		crIssuerRef   cmmeta.IssuerReference
+		crAnnotations map[string]string
+		certificate   *cmapiv1.Certificate
+		secret        *corev1.Secret
+		want          string
+	}{
+		"returns the CertID when the Secret was issued by the same issuer": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			secret:        secretFor(issuerAnnotations("letsencrypt", "ClusterIssuer"), validData),
+			want:          wantCertID,
+		},
+		"returns empty when the Secret was issued by a different issuer name": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			secret:        secretFor(issuerAnnotations("digicert-acme", "ClusterIssuer"), validData),
+			want:          "",
+		},
+		"returns empty when the Secret was issued by a different issuer kind": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			secret:        secretFor(issuerAnnotations("letsencrypt", "Issuer"), validData),
+			want:          "",
+		},
+		"returns empty when the CertificateRequest has no certificate-name annotation": {
+			crIssuerRef: issuerRef("letsencrypt", "ClusterIssuer"),
+			certificate: certificate,
+			secret:      secretFor(issuerAnnotations("letsencrypt", "ClusterIssuer"), validData),
+			want:        "",
+		},
+		"returns empty when the parent Certificate does not exist": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			secret:        secretFor(issuerAnnotations("letsencrypt", "ClusterIssuer"), validData),
+			want:          "",
+		},
+		"returns empty when the Secret does not exist": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			want:          "",
+		},
+		"returns empty when the Secret has no tls.crt": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			secret: secretFor(issuerAnnotations("letsencrypt", "ClusterIssuer"),
+				map[string][]byte{corev1.TLSPrivateKeyKey: []byte("key")}),
+			want: "",
+		},
+		"returns empty when tls.crt cannot be decoded": {
+			crIssuerRef:   issuerRef("letsencrypt", "ClusterIssuer"),
+			crAnnotations: crAnnotations,
+			certificate:   certificate,
+			secret: secretFor(issuerAnnotations("letsencrypt", "ClusterIssuer"),
+				map[string][]byte{corev1.TLSCertKey: []byte("not a certificate")}),
+			want: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var kubeObjects []runtime.Object
+			if test.secret != nil {
+				kubeObjects = append(kubeObjects, test.secret)
+			}
+			var cmObjects []runtime.Object
+			if test.certificate != nil {
+				cmObjects = append(cmObjects, test.certificate)
+			}
+
+			builder := &testpkg.Builder{
+				T:                  t,
+				KubeObjects:        kubeObjects,
+				CertManagerObjects: cmObjects,
+			}
+			builder.Init()
+			defer builder.Stop()
+
+			// NewACME must run before Start so the informers it requests from
+			// the shared factories are actually started and synced.
+			a := NewACME(builder.Context).(*ACME)
+			builder.Start()
+
+			cr := gen.CertificateRequest("test-cr",
+				gen.SetCertificateRequestCSR(leafCSRPEM),
+				gen.SetCertificateRequestIssuer(test.crIssuerRef),
+				gen.SetCertificateRequestAnnotations(test.crAnnotations),
+			)
+
+			assert.Equal(t, test.want, a.resolveReplacesCertID(t.Context(), cr))
+		})
+	}
 }

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -223,7 +223,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 		var renewalTime *metav1.Time
 		if utilfeature.DefaultFeatureGate.Enabled(feature.ACMEUseARI) {
-			renewalTime = c.useARIForRenewal(ctx, crt, x509cert, key)
+			renewalTime = c.useARIForRenewal(ctx, crt, x509cert, input.Secret, key)
 		}
 
 		// If there is no renewal time from ARI or if the featuregate is disabled.
@@ -277,9 +277,16 @@ func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) t
 	return now.Add(d + jit)
 }
 
-func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificate, x509cert *x509.Certificate, key types.NamespacedName) *metav1.Time {
+func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificate, x509cert *x509.Certificate, secret *corev1.Secret, key types.NamespacedName) *metav1.Time {
 	genericIssuer, err := c.helper.GetGenericIssuer(crt.Spec.IssuerRef, crt.Namespace)
 	if err != nil || genericIssuer == nil || genericIssuer.GetSpec().ACME == nil {
+		return nil
+	}
+
+	if !apiutil.SecretIssuerAnnotationsMatch(secret, crt.Spec.IssuerRef) {
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, policies.ARIError, "Secret %s/%s does not have matching issuer annotations for Certificate %s/%s", secret.Namespace, secret.Name, crt.Namespace, crt.Name)
+
+		crt.Status.ACME = nil
 		return nil
 	}
 

--- a/pkg/util/pki/match.go
+++ b/pkg/util/pki/match.go
@@ -30,7 +30,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/pkg/util"
 )
@@ -244,49 +244,14 @@ func RequestMatchesSpec(req *cmapi.CertificateRequest, spec cmapi.CertificateSpe
 	// and there will be a mis-match if the Certificate has the default
 	// group/kind set but the CertificateRequest does not.
 	if req.Spec.IssuerRef.Name != spec.IssuerRef.Name ||
-		!issuerKindsEqual(req.Spec.IssuerRef.Kind, spec.IssuerRef.Kind) ||
-		!issuerGroupsEqual(req.Spec.IssuerRef.Group, spec.IssuerRef.Group) {
+		!apiutil.IssuerKindsEqual(req.Spec.IssuerRef.Kind, spec.IssuerRef.Kind) ||
+		!apiutil.IssuerGroupsEqual(req.Spec.IssuerRef.Group, spec.IssuerRef.Group) {
 		violations = append(violations, "spec.issuerRef")
 	}
 
 	// TODO: check spec.EncodeBasicConstraintsInRequest and spec.EncodeUsagesInRequest
 
 	return violations, nil
-}
-
-// These defaults are also applied at runtime by the cert-manager
-// CertificateRequest controller.
-const (
-	// defaultIssuerKind is the default value for an IssuerRef's kind field
-	// if it is not specified.
-	defaultIssuerKind = cmapi.IssuerKind
-	// defaultIssuerGroup is the default value for an IssuerRef's group field
-	// if it is not specified.
-	defaultIssuerGroup = certmanager.GroupName
-)
-
-// issuerKindsEqual returns true if the two issuer reference kinds are equal,
-// taking into account the defaulting of the kind to "Issuer".
-func issuerKindsEqual(l, r string) bool {
-	if l == "" {
-		l = defaultIssuerKind
-	}
-	if r == "" {
-		r = defaultIssuerKind
-	}
-	return l == r
-}
-
-// issuerGroupsEqual returns true if the two issuer reference groups are equal,
-// taking into account defaulting of the group to "cert-manager.io".
-func issuerGroupsEqual(l, r string) bool {
-	if l == "" {
-		l = defaultIssuerGroup
-	}
-	if r == "" {
-		r = defaultIssuerGroup
-	}
-	return l == r
 }
 
 func matchOtherNames(extension []pkix.Extension, specOtherNames []cmapi.OtherName) (bool, error) {


### PR DESCRIPTION
Manual cherry-pick of #9124 (fixes #9074) for v1.21.2; the automated cherry-pick [failed with conflicts](https://github.com/cert-manager/cert-manager/pull/9124#issuecomment-5489697338).

Two deliberate deviations from the master commit while resolving the conflicts:

- Kept the `ACMEUseARI` feature-gate wrapper around `useARIForRenewal` in the readiness controller, which `release-1.21` [still has](https://github.com/cert-manager/cert-manager/blob/v1.21.1/pkg/controller/certificates/readiness/readiness_controller.go#L226); on master it was removed by the per-issuer ARI work.
- Dropped the `acmeutil.ARIEnabledForIssuer` check: that function was added by the per-issuer ARI feature ([`pkg/acme/util.go` on master](https://github.com/cert-manager/cert-manager/blob/d0417368d1fd050a6a5b2ad5972a48f91e35ea84/pkg/acme/util.go#L59), commit 932a47ac6) which is not on `release-1.21` — the global feature gate covers enablement there. The `SecretIssuerAnnotationsMatch` check, the substance of the fix, is picked unchanged.

`go build ./...` and the unit tests for all seven touched packages pass locally.

```release-note
Fixed a bug where `replaces` field was being populated for the wrong issuer on issuer changes
```

/assign wallrj

*with claude fable-5*