### PR TITLE
Recover DynamicAuthority when the CA Secret create race is lost

### DIFF
--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -396,7 +396,10 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 				cmmeta.TLSCAKey:         certBytes,
 			},
 		}, metav1.CreateOptions{})
-		if err != nil && apierrors.IsAlreadyExists(err) {
+		if err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
 			// Another controller created the Secret before we did. Our informer
 			// cache does not have it yet, so read the Secret back directly
 			// instead of waiting for the informer event: this makes us ready
@@ -414,7 +417,8 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 			return nil
 		}
 		d.log.V(logf.InfoLevel).Info("Created new root CA Secret")
-		return err
+		d.notifyWatches(certBytes, pkBytes)
+		return nil
 	}
 
 	if s.Data == nil {
@@ -427,6 +431,7 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 		return err
 	}
 	d.log.V(logf.InfoLevel).Info("Updated existing root CA Secret")
+	d.notifyWatches(certBytes, pkBytes)
 	return nil
 }
 

--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -397,9 +397,22 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 			},
 		}, metav1.CreateOptions{})
 		if err != nil && apierrors.IsAlreadyExists(err) {
-			// another controller has created the secret, we expect a watch event
-			// to trigger another call to ensureCA
-			d.log.V(logf.DebugLevel).Info("Failed to create new root CA Secret, another controller has created it, waiting for watch event")
+			// Another controller created the Secret before we did. Our informer
+			// cache does not have it yet, and the create event may never be
+			// delivered (e.g. if it occurred between the reflector's initial
+			// List and its Watch being registered), so read the Secret back
+			// directly instead of waiting for a watch event that might not
+			// arrive.
+			d.log.V(logf.DebugLevel).Info("Another controller has created the root CA Secret, reading it back")
+			s, err := d.client.Get(ctx, d.SecretName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if required, reason := caRequiresRegeneration(s); required {
+				d.log.V(logf.InfoLevel).Info("Will regenerate CA", "reason", reason)
+				return d.regenerateCA(ctx, s)
+			}
+			d.notifyWatches(s.Data[corev1.TLSCertKey], s.Data[corev1.TLSPrivateKeyKey])
 			return nil
 		}
 		d.log.V(logf.InfoLevel).Info("Created new root CA Secret")

--- a/pkg/server/tls/authority/authority.go
+++ b/pkg/server/tls/authority/authority.go
@@ -398,11 +398,9 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 		}, metav1.CreateOptions{})
 		if err != nil && apierrors.IsAlreadyExists(err) {
 			// Another controller created the Secret before we did. Our informer
-			// cache does not have it yet, and the create event may never be
-			// delivered (e.g. if it occurred between the reflector's initial
-			// List and its Watch being registered), so read the Secret back
-			// directly instead of waiting for a watch event that might not
-			// arrive.
+			// cache does not have it yet, so read the Secret back directly
+			// instead of waiting for the informer event: this makes us ready
+			// immediately and recovers even if the event is delayed or missed.
 			d.log.V(logf.DebugLevel).Info("Another controller has created the root CA Secret, reading it back")
 			s, err := d.client.Get(ctx, d.SecretName, metav1.GetOptions{})
 			if err != nil {

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -32,7 +32,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
@@ -179,6 +181,56 @@ func TestDynamicAuthorityMulti(t *testing.T) {
 	}
 
 	waitForRotationAndSign()
+}
+
+// TestEnsureCARecoversFromMissedWatchEvent verifies that an authority which
+// loses the race to create the CA Secret recovers even if its informer never
+// delivers an event for the Secret: ensureCA must read the Secret back from
+// the API and notify watches itself.
+// See https://github.com/cert-manager/cert-manager/issues/8754
+func TestEnsureCARecoversFromMissedWatchEvent(t *testing.T) {
+	fake := kubefake.NewClientset()
+
+	// Both authorities have permanently empty informer caches, simulating an
+	// informer that missed the Secret's create event.
+	newAuthority := func(name string) *DynamicAuthority {
+		emptyIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		return &DynamicAuthority{
+			SecretNamespace: "test-namespace",
+			SecretName:      "test-secret",
+			CommonName:      "test-common-name",
+			CADuration:      365 * 24 * time.Hour,
+			LeafDuration:    7 * 24 * time.Hour,
+			log:             testr.NewWithOptions(t, testr.Options{Verbosity: 3}).WithName(name),
+			lister:          corelisters.NewSecretLister(emptyIndexer).Secrets("test-namespace"),
+			client:          fake.CoreV1().Secrets("test-namespace"),
+		}
+	}
+
+	// The winner creates the CA Secret.
+	winner := newAuthority("winner")
+	assert.NoError(t, winner.ensureCA(t.Context()))
+
+	// The loser's Create fails with AlreadyExists and no watch event will
+	// ever arrive; ensureCA must still leave it able to sign.
+	loser := newAuthority("loser")
+	output := make(chan struct{}, 1)
+	loser.WatchRotation(output)
+	defer loser.StopWatchingRotation(output)
+
+	assert.NoError(t, loser.ensureCA(t.Context()))
+
+	select {
+	case <-output:
+	default:
+		t.Fatal("expected a rotation notification after losing the create race")
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	assert.NoError(t, err)
+	cert, err := loser.Sign(&x509.Certificate{PublicKey: privateKey.Public()})
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
 }
 
 func Test__caRequiresRegeneration(t *testing.T) {

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -207,9 +207,17 @@ func TestEnsureCARecoversFromMissedWatchEvent(t *testing.T) {
 		}
 	}
 
-	// The winner creates the CA Secret.
+	// The winner creates the CA Secret and must notify its own watches from
+	// the data it just wrote, without waiting for an informer event either.
 	winner := newAuthority("winner")
+	winnerOutput := make(chan struct{}, 1)
+	winner.WatchRotation(winnerOutput)
 	assert.NoError(t, winner.ensureCA(t.Context()))
+	select {
+	case <-winnerOutput:
+	default:
+		t.Fatal("expected a rotation notification after winning the create race")
+	}
 
 	// The loser's Create fails with AlreadyExists and no watch event will
 	// ever arrive; ensureCA must still leave it able to sign.


### PR DESCRIPTION
Fixes #8754

When several `DynamicAuthority` instances race to create the CA Secret, the losers get `AlreadyExists` and [return without notifying watches](https://github.com/cert-manager/cert-manager/blob/93f0e779d1dfe7d0b3ab29eba033b4b1a165ef05/pkg/server/tls/authority/authority.go#L399-L404), relying on an informer event to load the winner's Secret. The watched authority in `TestDynamicAuthorityMulti` therefore only becomes ready once an informer event is delivered and processed. The measurements in [this comment on the issue](https://github.com/cert-manager/cert-manager/issues/8754#issuecomment-5492558356) put that at p50 423ms / max 2.7s of the test's 5s budget on an idle machine, so a loaded CI node can plausibly exceed it.

At the time the linked flake occurred, an informer event could also be missed entirely, wedging the authority forever: master was then on client-go v0.35.4, whose fake clientset [ignored the watch resourceVersion](https://github.com/kubernetes/client-go/blob/v0.35.4/testing/fixture.go#L356-L372), so an object created between the reflector's List and Watch was never delivered, and the 10s safety-net poll re-entered the same dead path (empty cache → `NotFound` → `Create` → `AlreadyExists`) without ever notifying. Since client-go v0.36.0 the fake [delivers existing objects newer than the watch's resourceVersion](https://github.com/kubernetes/client-go/blob/v0.37.0/testing/fixture.go#L440-L453), closing that gap, and a real apiserver never had it because [the reflector watches from the List's resourceVersion](https://github.com/kubernetes/client-go/blob/v0.37.0/tools/cache/reflector.go#L590) — thanks @inteon for prompting the version check. See [this review thread](https://github.com/cert-manager/cert-manager/pull/9241#discussion_r3904116370) for the details.

The fix makes the authority self-healing: on `AlreadyExists`, read the Secret back with a live client `Get` and process it directly — notify watches if it is valid, regenerate it if not. The losing authority becomes ready during its first `ensureCA` call, so the test no longer depends on event delivery timing at all, and the periodic poll becomes an effective safety net against any future missed-event scenario rather than a no-op.

The new test `TestEnsureCARecoversFromMissedWatchEvent` pins the recovery behaviour directly (Secret present in the API, informer cache empty) and fails on master with "expected a rotation notification after losing the create race". Verified with `go test -race -count=10` over the package.

**Kind**

/kind flake

**Release Note**

```release-note
The webhook's dynamic CA authority now reads the CA Secret back immediately after losing the race to create it, instead of waiting for an informer event.
```

*with claude fable-5*
