### PR TITLE
Deflake TestDynamicAuthority

### DIFF
--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -121,8 +122,17 @@ func TestDynamicAuthority(t *testing.T) {
 
 	waitForRotationAndSign(false)
 
-	secret, err := fake.CoreV1().Secrets(da.SecretNamespace).Get(t.Context(), da.SecretName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	// The rotation notification does not guarantee that the authority has
+	// recreated the Secret yet: it may be a stale buffered notification from
+	// the initial CA creation, left unconsumed because Sign succeeded
+	// immediately above, and Sign works from in-memory CA data. Poll until
+	// the recreated Secret is visible.
+	var secret *corev1.Secret
+	require.Eventually(t, func() bool {
+		var err error
+		secret, err = fake.CoreV1().Secrets(da.SecretNamespace).Get(t.Context(), da.SecretName, metav1.GetOptions{})
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond)
 
 	secret.Data = map[string][]byte{
 		"tls.crt": []byte("test"),


### PR DESCRIPTION
Fixes #9242, a flake in `TestDynamicAuthority` seen in [this `ci-cert-manager-master-make-test` run](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-master-make-test/2094757393165455360) on master.

After deleting the CA Secret the test waits for a rotation notification and then did a one-shot `Get` of the Secret. But the notification can be a stale buffered event from the initial CA creation: the watch channel [has a buffer of one](https://github.com/cert-manager/cert-manager/blob/93f0e779d669e5a8bdd1b82609736a77112b5789/pkg/server/tls/authority/authority_test.go#L82), the preceding wait [returns early when `Sign` succeeds immediately](https://github.com/cert-manager/cert-manager/blob/93f0e779d669e5a8bdd1b82609736a77112b5789/pkg/server/tls/authority/authority_test.go#L95-L102) without consuming it, and `Sign` keeps working after the delete because it [signs with in-memory CA data](https://github.com/cert-manager/cert-manager/blob/93f0e779d669e5a8bdd1b82609736a77112b5789/pkg/server/tls/authority/authority.go#L190-L196). So receiving a notification does not prove the authority has recreated the Secret, and on a loaded machine the `Get` loses the race — see #9242 for the full analysis.

The fix polls for the recreated Secret with `require.Eventually`, the same approach #9198 took for the `TestDynamicSource_FailingSign` flakes. Draining the channel before the delete instead would still be racy, because the initial notification can arrive after the drain.

Verified with `go test -race -count=10 ./pkg/server/tls/authority/` and `GOMAXPROCS=1 go test -race -run 'TestDynamicAuthority$' -count=20 ./pkg/server/tls/authority/`. I could not reproduce the failure locally even on unpatched master, but instrumenting the test confirmed the stale notification is buffered before the delete and consumed before the Secret is recreated.

/kind cleanup

```release-note
NONE
```

*with claude fable-5*
