### PR TITLE
Run dynamic authority tests in a synctest bubble

### DIFF
--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-logr/logr/testr"
@@ -73,7 +74,17 @@ func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAu
 	return da
 }
 
+// The dynamic authority tests run in a synctest bubble so that the timeouts
+// below are measured in the bubble's synthetic time: they can only fire once
+// every goroutine is durably blocked and no informer event is still in
+// flight. This makes the tests immune to slow scheduling on loaded CI nodes;
+// the timeout fires only if rotation provably cannot happen.
+// See https://github.com/cert-manager/cert-manager/issues/8754
 func TestDynamicAuthority(t *testing.T) {
+	synctest.Test(t, testDynamicAuthority)
+}
+
+func testDynamicAuthority(t *testing.T) {
 	fake := kubefake.NewClientset()
 
 	da := testAuthority(t, "authority", fake)
@@ -135,6 +146,10 @@ func TestDynamicAuthority(t *testing.T) {
 }
 
 func TestDynamicAuthorityMulti(t *testing.T) {
+	synctest.Test(t, testDynamicAuthorityMulti)
+}
+
+func testDynamicAuthorityMulti(t *testing.T) {
 	fake := kubefake.NewClientset()
 
 	authorities := make([]*DynamicAuthority, 0)

--- a/pkg/server/tls/authority/authority_test.go
+++ b/pkg/server/tls/authority/authority_test.go
@@ -80,6 +80,14 @@ func testAuthority(t *testing.T, name string, cs *kubefake.Clientset) *DynamicAu
 // flight. This makes the tests immune to slow scheduling on loaded CI nodes;
 // the timeout fires only if rotation provably cannot happen.
 // See https://github.com/cert-manager/cert-manager/issues/8754
+//
+// The tradeoff: these tests depend on every goroutine in the informer path
+// (reflector, SharedInformerFactory, the fake clientset watch, wait.Poll*)
+// blocking durably inside the bubble. If a future client-go change blocks
+// non-durably instead (a syscall, I/O, or a package-level sync.WaitGroup),
+// the synthetic timers never fire and these tests hang until the go test
+// binary timeout kills the package with a goroutine dump. If that happens
+// after a dependency bump, this is why.
 func TestDynamicAuthority(t *testing.T) {
 	synctest.Test(t, testDynamicAuthority)
 }


### PR DESCRIPTION
Fixes #8754

This is the test-only companion to #9241, as discussed in [this review thread](https://github.com/cert-manager/cert-manager/pull/9241#discussion_r3904116370) — cc @inteon.

`TestDynamicAuthorityMulti` flaked when the watched authority's informer event was not delivered and processed within the 5s timeout. [Measurements on the issue](https://github.com/cert-manager/cert-manager/issues/8754#issuecomment-5492558356) put the wait at p50 423ms / max 2.7s of that budget on an idle machine, so a loaded CI node can plausibly exceed it.

Rather than raising the timeout (which only moves the flake threshold), this wraps both dynamic authority tests in [`synctest.Test`](https://pkg.go.dev/testing/synctest#Test) so the timeouts are measured in the bubble's synthetic time. In a bubble, `time.After` can only fire once every goroutine is durably blocked — i.e. once no informer event is still in flight and rotation provably cannot happen. Slow scheduling can no longer fail the tests, and a genuine failure to rotate fails deterministically and immediately instead of flakily. Verified with `go test -race -count=5`; the informer machinery (reflector, `SharedInformerFactory`, `wait.PollUntilContextCancel`, fake clientset) blocks durably in the bubble with no hangs.

Relationship to #9241: complementary rather than competing. This PR makes the *tests* immune to scheduler slowness; #9241 makes the *authority* independent of informer event delivery after losing the CA Secret create race (defence in depth on current client-go, where [the fake's List/Watch gap is closed since v0.36.0](https://github.com/kubernetes/client-go/blob/v0.37.0/testing/fixture.go#L440-L453)). Happy to land both, or just this one if maintainers prefer not to change non-test code for a test flake.

**Kind**

/kind flake

**Release Note**

```release-note
NONE
```

*with claude fable-5*
