### PR TITLE
Deflake notAfter assertions in CSR signing tests

### DIFF
--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
-	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -468,6 +467,13 @@ func TestCA_Sign(t *testing.T) {
 	}
 	testCSR := generateCSR(t, testpk)
 
+	// Lower bound for the NotBefore of any certificate signed during this
+	// test. Truncated because NotBefore is truncated to a whole second when
+	// the certificate is serialized to ASN.1 [1].
+	//
+	//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
+	signStart := time.Now().Truncate(time.Second)
+
 	tests := map[string]struct {
 		givenCASecret    *corev1.Secret
 		givenCAIssuer    cmapi.GenericIssuer
@@ -492,28 +498,15 @@ func TestCA_Sign(t *testing.T) {
 				}),
 			),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
-				// Although there is less than 1µs between the time.Now
-				// call made by the certificate template func (in the "pki"
-				// package) and the time.Now below, rounding or truncating
-				// will always end up with a flaky test. This is due to the
-				// rounding made to the notAfter value when serializing the
-				// certificate to ASN.1 [1].
-				//
-				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-				//
-				// So instead of using a truncation or rounding in order to
-				// check the time, we use a delta of 1 second. One entire
-				// second is totally overkill since, as detailed above, the
-				// delay is probably less than a microsecond. But that will
-				// do for now!
-				//
-				// Note that we do have a plan to fix this. We want to be
-				// injecting a time (instead of time.Now) to the template
-				// functions. This work is being tracked in this issue:
-				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(30 * time.Minute)
-				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
-				assert.LessOrEqualf(t, deltaSec, 1., "expected a time delta lower than 1 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+				// NotBefore and NotAfter are set from a single time.Now
+				// call by the certificate template func (in the "pki"
+				// package), so the validity period of the signed
+				// certificate is exactly the requested duration. Comparing
+				// NotAfter against a fresh time.Now here instead would
+				// flake when the test runs slowly:
+				// https://github.com/cert-manager/cert-manager/issues/9246
+				assert.Equal(t, 30*time.Minute, got.NotAfter.Sub(got.NotBefore))
+				assert.WithinRange(t, got.NotBefore, signStart, time.Now())
 			},
 		},
 		"when the CertificateRequest has the isCA field set, it should appear on the signed ca": {

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
-	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -604,6 +603,13 @@ func TestCA_Sign(t *testing.T) {
 	}
 	testCSR := generateCSR(t, testpk)
 
+	// Lower bound for the NotBefore of any certificate signed during this
+	// test. Truncated because NotBefore is truncated to a whole second when
+	// the certificate is serialized to ASN.1 [1].
+	//
+	//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
+	signStart := time.Now().Truncate(time.Second)
+
 	tests := map[string]struct {
 		givenCASecret    *corev1.Secret
 		givenCAIssuer    cmapi.GenericIssuer
@@ -621,28 +627,15 @@ func TestCA_Sign(t *testing.T) {
 				gen.SetCertificateSigningRequestDuration("30m"),
 			),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
-				// Although there is less than 1µs between the time.Now
-				// call made by the certificate template func (in the "pki"
-				// package) and the time.Now below, rounding or truncating
-				// will always end up with a flaky test. This is due to the
-				// rounding made to the notAfter value when serializing the
-				// certificate to ASN.1 [1].
-				//
-				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-				//
-				// So instead of using a truncation or rounding in order to
-				// check the time, we use a delta of 2 seconds. One entire
-				// second is totally overkill since, as detailed above, the
-				// delay is probably less than a microsecond. But that will
-				// do for now!
-				//
-				// Note that we do have a plan to fix this. We want to be
-				// injecting a time (instead of time.Now) to the template
-				// functions. This work is being tracked in this issue:
-				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(30 * time.Minute)
-				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
-				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+				// NotBefore and NotAfter are set from a single time.Now
+				// call by the certificate template func (in the "pki"
+				// package), so the validity period of the signed
+				// certificate is exactly the requested duration. Comparing
+				// NotAfter against a fresh time.Now here instead would
+				// flake when the test runs slowly:
+				// https://github.com/cert-manager/cert-manager/issues/9246
+				assert.Equal(t, 30*time.Minute, got.NotAfter.Sub(got.NotBefore))
+				assert.WithinRange(t, got.NotBefore, signStart, time.Now())
 			},
 		},
 		"when the CertificateSigningRequest has the expiration seconds field set, it should appear as notAfter on the signed ca": {
@@ -656,28 +649,10 @@ func TestCA_Sign(t *testing.T) {
 				gen.SetCertificateSigningRequestExpirationSeconds(654),
 			),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
-				// Although there is less than 1µs between the time.Now
-				// call made by the certificate template func (in the "pki"
-				// package) and the time.Now below, rounding or truncating
-				// will always end up with a flaky test. This is due to the
-				// rounding made to the notAfter value when serializing the
-				// certificate to ASN.1 [1].
-				//
-				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-				//
-				// So instead of using a truncation or rounding in order to
-				// check the time, we use a delta of 2 seconds. One entire
-				// second is totally overkill since, as detailed above, the
-				// delay is probably less than a microsecond. But that will
-				// do for now!
-				//
-				// Note that we do have a plan to fix this. We want to be
-				// injecting a time (instead of time.Now) to the template
-				// functions. This work is being tracked in this issue:
-				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(654 * time.Second)
-				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
-				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+				// See the duration test above for why this assertion is
+				// exact.
+				assert.Equal(t, 654*time.Second, got.NotAfter.Sub(got.NotBefore))
+				assert.WithinRange(t, got.NotBefore, signStart, time.Now())
 			},
 		},
 		"when the CertificateSigningRequest has the isCA field set, it should appear on the signed ca": {

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"errors"
-	"math"
 	"testing"
 	"time"
 
@@ -642,6 +641,13 @@ func TestSign(t *testing.T) {
 		gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 	)
 
+	// Lower bound for the NotBefore of any certificate signed during this
+	// test. Truncated because NotBefore is truncated to a whole second when
+	// the certificate is serialized to ASN.1 [1].
+	//
+	//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
+	signStart := time.Now().Truncate(time.Second)
+
 	tests := map[string]struct {
 		csr              *certificatesv1.CertificateSigningRequest
 		issuer           *cmapi.Issuer
@@ -658,28 +664,15 @@ func TestSign(t *testing.T) {
 			),
 			issuer: baseIssuer,
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
-				// Although there is less than 1µs between the time.Now
-				// call made by the certificate template func (in the "pki"
-				// package) and the time.Now below, rounding or truncating
-				// will always end up with a flaky test. This is due to the
-				// rounding made to the notAfter value when serializing the
-				// certificate to ASN.1 [1].
-				//
-				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-				//
-				// So instead of using a truncation or rounding in order to
-				// check the time, we use a delta of 2 seconds. One entire
-				// second is totally overkill since, as detailed above, the
-				// delay is probably less than a microsecond. But that will
-				// do for now!
-				//
-				// Note that we do have a plan to fix this. We want to be
-				// injecting a time (instead of time.Now) to the template
-				// functions. This work is being tracked in this issue:
-				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(30 * time.Minute)
-				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
-				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+				// NotBefore and NotAfter are set from a single time.Now
+				// call by the certificate template func (in the "pki"
+				// package), so the validity period of the signed
+				// certificate is exactly the requested duration. Comparing
+				// NotAfter against a fresh time.Now here instead would
+				// flake when the test runs slowly:
+				// https://github.com/cert-manager/cert-manager/issues/9246
+				assert.Equal(t, 30*time.Minute, got.NotAfter.Sub(got.NotBefore))
+				assert.WithinRange(t, got.NotBefore, signStart, time.Now())
 			},
 		},
 		"when the CertificateSigningRequest has the expiration seconds field set, it should appear as notAfter on the signed certificate": {
@@ -693,28 +686,10 @@ func TestSign(t *testing.T) {
 			),
 			issuer: baseIssuer,
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
-				// Although there is less than 1µs between the time.Now
-				// call made by the certificate template func (in the "pki"
-				// package) and the time.Now below, rounding or truncating
-				// will always end up with a flaky test. This is due to the
-				// rounding made to the notAfter value when serializing the
-				// certificate to ASN.1 [1].
-				//
-				//  [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
-				//
-				// So instead of using a truncation or rounding in order to
-				// check the time, we use a delta of 2 seconds. One entire
-				// second is totally overkill since, as detailed above, the
-				// delay is probably less than a microsecond. But that will
-				// do for now!
-				//
-				// Note that we do have a plan to fix this. We want to be
-				// injecting a time (instead of time.Now) to the template
-				// functions. This work is being tracked in this issue:
-				// https://github.com/cert-manager/cert-manager/issues/3738
-				expectNotAfter := time.Now().UTC().Add(444 * time.Second)
-				deltaSec := math.Abs(expectNotAfter.Sub(got.NotAfter).Seconds())
-				assert.LessOrEqualf(t, deltaSec, 2., "expected a time delta lower than 2 second. Time expected='%s', got='%s'", expectNotAfter.String(), got.NotAfter.String())
+				// See the duration test above for why this assertion is
+				// exact.
+				assert.Equal(t, 444*time.Second, got.NotAfter.Sub(got.NotBefore))
+				assert.WithinRange(t, got.NotBefore, signStart, time.Now())
 			},
 		},
 		"when the CertificateSigningRequest has the isCA field set, it should appear on the signed certificate": {


### PR DESCRIPTION
Fixes #9246

`TestCA_Sign` and `TestSign` compared the signed certificate's `notAfter` against a fresh `time.Now()` with a 2-second tolerance, so they failed whenever the controller fixture took more than 2 seconds between signing and asserting on a loaded CI node ([example](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/9232/pull-cert-manager-release-1.21-make-test/2094669692022034432)).

The assertions can be made exact instead:

- `NotBefore` and `NotAfter` are set from a single `time.Now()` call in [`pki.CertificateTemplateOverrideDuration`](https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/util/pki/certificatetemplate.go#L55-L61), and both are truncated to whole seconds when the certificate is serialised, so `NotAfter - NotBefore` on the parsed certificate is *exactly* the requested duration. This is the property the tests actually care about: the `duration`/`expirationSeconds` field flows through to the certificate's validity period.
- A deterministic `assert.WithinRange` check that `NotBefore` lies between the start of the test (truncated to a second) and `time.Now()` keeps the old assertion's guarantee that the validity period is anchored to the signing time, with no wall-clock tolerance at all.

This removes the delta workaround (and its long comment referencing #3738) from all five affected test cases — the two `duration` variants had the same latent flake as the two `expirationSeconds` variants named in the issue, and `pkg/controller/certificaterequests/ca` still had the original 2021 copy of the comment (f6cb6b8787440e6b26d3f4051ebdeee30dba9ec5) with an even tighter 1-second tolerance.

I considered `testing/synctest` to freeze `time.Now()`, but wrapping the whole controller fixture (informers, work queues) in a synctest bubble is fragile, and the exact assertions above make it unnecessary.

*with claude fable-5*

