### PR TITLE
Deflake certificate-shim controller register tests

### DIFF
--- a/pkg/controller/certificate-shim/gateways/controller_test.go
+++ b/pkg/controller/certificate-shim/gateways/controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -214,25 +217,41 @@ func Test_controller_Register(t *testing.T) {
 			// We have no way of knowing when the informers will be done adding
 			// items to the queue due to the "shared informer" architecture:
 			// Start(stop) does not allow you to wait for the informers to be
-			// done.
+			// done. So wait generously for the expected Add calls to arrive,
+			// then allow a short grace period for unexpected extra calls
+			// before the final comparison.
+			assert.Eventually(t, func() bool {
+				return len(mock.addCalls()) >= len(test.expectAddCalls)
+			}, wait.ForeverTestTimeout, 10*time.Millisecond)
 			time.Sleep(50 * time.Millisecond)
 
 			// We only expect 0 or 1 keys received in the queue, or 2 keys when
 			// we have to create a Gateway before deleting or updating it.
-			assert.Equal(t, test.expectAddCalls, mock.callsToAdd)
+			assert.Equal(t, test.expectAddCalls, mock.addCalls())
 		})
 	}
 }
 
 type mockWorkqueue struct {
 	t          *testing.T
+	mu         sync.Mutex
 	callsToAdd []types.NamespacedName
 }
 
 var _ workqueue.TypedInterface[types.NamespacedName] = &mockWorkqueue{}
 
 func (m *mockWorkqueue) Add(arg0 types.NamespacedName) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.callsToAdd = append(m.callsToAdd, arg0)
+}
+
+// addCalls returns a snapshot of the Add calls received so far. The informers
+// call Add from their own goroutines, so the mutex is required.
+func (m *mockWorkqueue) addCalls() []types.NamespacedName {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.callsToAdd)
 }
 
 func (m *mockWorkqueue) AddAfter(arg0 types.NamespacedName, arg1 time.Duration) {

--- a/pkg/controller/certificate-shim/ingresses/controller_test.go
+++ b/pkg/controller/certificate-shim/ingresses/controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kclient "k8s.io/client-go/kubernetes"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -163,9 +164,15 @@ func Test_controller_Register(t *testing.T) {
 			// We have no way of knowing when the informers will be done adding
 			// items to the queue due to the "shared informer" architecture:
 			// Start(stop) does not allow you to wait for the informers to be
-			// done. To work around that, we do a second queue.Get and expect it
-			// to be nil.
-			time.AfterFunc(50*time.Millisecond, queue.ShutDown)
+			// done. So we shut the queue down shortly *after* the expected key
+			// arrives: the short delay exists only to catch unexpected extra
+			// keys. The generous backstop timer makes the test fail rather
+			// than hang if the expected key never arrives.
+			backstop := time.AfterFunc(wait.ForeverTestTimeout, queue.ShutDown)
+			defer backstop.Stop()
+			if test.expectRequeueKey == (types.NamespacedName{}) {
+				time.AfterFunc(50*time.Millisecond, queue.ShutDown)
+			}
 
 			var gotKeys []types.NamespacedName
 			for {
@@ -176,6 +183,9 @@ func Test_controller_Register(t *testing.T) {
 					break
 				}
 				gotKeys = append(gotKeys, gotKey)
+				if gotKey == test.expectRequeueKey {
+					time.AfterFunc(50*time.Millisecond, queue.ShutDown)
+				}
 			}
 			assert.Equal(t, 0, queue.Len(), "queue should be empty")
 

--- a/pkg/controller/certificate-shim/listenerset/controller_test.go
+++ b/pkg/controller/certificate-shim/listenerset/controller_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package controller
 
 import (
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 	gwclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -205,10 +209,19 @@ func Test_controller_Register(t *testing.T) {
 
 			test.givenCall(t, b.CMClient, b.GWClient, b.Context.GWShared.Gateway().V1().ListenerSets().Lister())
 
-			require.Eventually(t, func() bool {
-				require.Subsetf(t, test.expectAddCalls, mock.callsToAdd, "unexpected calls to workqueue.Add: got %v, want subset of %v", mock.callsToAdd, test.expectAddCalls)
-				return true
-			}, 2*time.Second, 10*time.Millisecond)
+			// The informers deliver events asynchronously, so wait generously
+			// for the expected Add calls to arrive, then allow a short grace
+			// period for unexpected extra calls before the final check. The
+			// order of calls across different informers is not deterministic,
+			// and a late Gateway 'Add' event can legitimately enqueue a
+			// duplicate key via the parent index, hence Subset rather than
+			// an exact comparison.
+			assert.Eventually(t, func() bool {
+				return len(mock.addCalls()) >= len(test.expectAddCalls)
+			}, wait.ForeverTestTimeout, 10*time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
+			calls := mock.addCalls()
+			assert.Subsetf(t, test.expectAddCalls, calls, "unexpected calls to workqueue.Add: got %v, want subset of %v", calls, test.expectAddCalls)
 		})
 	}
 }
@@ -291,13 +304,24 @@ func Test_inheritAnnotations(t *testing.T) {
 
 type mockWorkqueue struct {
 	t          *testing.T
+	mu         sync.Mutex
 	callsToAdd []types.NamespacedName
 }
 
 var _ workqueue.TypedInterface[types.NamespacedName] = &mockWorkqueue{}
 
 func (m *mockWorkqueue) Add(arg0 types.NamespacedName) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.callsToAdd = append(m.callsToAdd, arg0)
+}
+
+// addCalls returns a snapshot of the Add calls received so far. The informers
+// call Add from their own goroutines, so the mutex is required.
+func (m *mockWorkqueue) addCalls() []types.NamespacedName {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.callsToAdd)
 }
 
 func (m *mockWorkqueue) AddAfter(arg0 types.NamespacedName, arg1 time.Duration) {


### PR DESCRIPTION
Fixes #9249

The `Test_controller_Register` test in `pkg/controller/certificate-shim/ingresses` shut its workqueue down on a fixed 50ms timer, so on a loaded CI node the shared informers had not always delivered the expected event before the queue was drained (seen on #9211). The queue is now shut down shortly *after* the expected key arrives — the short delay only exists to catch unexpected extra keys — with `wait.ForeverTestTimeout` as a backstop so a broken handler fails the test rather than hanging it. The timer dated from #4149.

While verifying the fix with `go test -race -count=20 ./pkg/controller/certificate-shim/...`, the race detector flagged the sibling `listenerset` test (added in #8394): it polls the mock workqueue's `callsToAdd` slice while the informer goroutines are still appending to it. The `gateways` test has the same unsynchronised read plus its own fixed 50ms sleep before asserting. Both siblings now guard the mock with a mutex, wait generously for the expected `Add` calls to arrive, and only then apply the original short grace period for unexpected extras.

The `listenerset` test keeps its `Subset` assertion rather than an exact comparison: the order of `Add` calls across different informers is not deterministic, and a late Gateway `Added` event can legitimately enqueue a duplicate key via the parent index ([controller.go#L89-L110](https://github.com/cert-manager/cert-manager/blob/39cf357c14bf8aa6751f0ecb1ae56c3c994c9a56/pkg/controller/certificate-shim/listenerset/controller.go#L89-L110)).

Verified with `go test -race -count=20` on all three packages: `ingresses`, `gateways` and `listenerset` all pass.

*with claude fable-5*
