### PR TITLE
Fix "algorith" typo in the internal SignatureAlgorithm comment

### DIFF
--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -239,7 +239,7 @@ type CertificateSpec struct {
 	// encoding and the rotation policy.
 	PrivateKey *CertificatePrivateKey
 
-	// Signature algorith to use.
+	// Signature algorithm to use.
 	SignatureAlgorithm SignatureAlgorithm
 
 	// Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.


### PR DESCRIPTION
PR #7789 fixed this comment in `pkg/apis/certmanager/v1/types_certificate.go`, but the internal hub copy in `internal/apis/certmanager/types_certificate.go` still reads `Signature algorith to use.`

The two are now consistent (the generated CRDs and openapi already carry the correct spelling, since they are generated from the external version).

Comment only, no functional change.