### PR TITLE
Re-check certificate readiness at expiry time

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -159,6 +159,14 @@ func NewController(
 		issuerInformer.Informer().HasSynced,
 	}
 
+	// ClusterIssuers are only watched when running cluster-wide.
+	var clusterIssuerLister cmlisters.ClusterIssuerLister
+	if ctx.Namespace == "" {
+		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
+		mustSync = append(mustSync, clusterIssuerInformer.Informer().HasSynced)
+		clusterIssuerLister = clusterIssuerInformer.Lister()
+	}
+
 	return &controller{
 		policyChain:              chain,
 		certificateLister:        certificateInformer.Lister(),
@@ -168,6 +176,8 @@ func NewController(
 		recorder:                 ctx.Recorder,
 		accountRegistry:          ctx.ACMEAccountRegistry,
 		issuerLister:             issuerInformer.Lister(),
+		clusterIssuerLister:      clusterIssuerLister,
+		helper:                   issuer.NewHelper(issuerInformer.Lister(), clusterIssuerLister),
 		gatherer: &policies.Gatherer{
 			CertificateRequestLister: certificateRequestInformer.Lister(),
 			SecretLister:             secretsInformer.Lister(),
@@ -457,14 +467,6 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Type
 		BuildReadyConditionFromChain,
 	)
 	c.controller = ctrl
-
-	if ctx.Namespace == "" {
-		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1().ClusterIssuers()
-		mustSync = append(mustSync, clusterIssuerInformer.Informer().HasSynced)
-		c.clusterIssuerLister = clusterIssuerInformer.Lister()
-	}
-
-	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 
 	return queue, mustSync, err
 }

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -94,6 +94,11 @@ type controller struct {
 	helper             issuer.Helper
 	clock              clock.Clock
 	scheduledWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
+
+	// expiryWorkQueue re-checks a Certificate when it expires. It is separate
+	// from scheduledWorkQueue because each queue holds only one timer per key,
+	// so sharing would mean expiry and ARI checks cancelling each other.
+	expiryWorkQueue scheduler.ScheduledWorkQueue[types.NamespacedName]
 }
 
 // readyConditionFunc is custom function type that builds certificate's Ready condition
@@ -187,6 +192,7 @@ func NewController(
 		fieldManager:          ctx.FieldManager,
 		clock:                 ctx.Clock,
 		scheduledWorkQueue:    scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
+		expiryWorkQueue:       scheduler.NewScheduledWorkQueue(ctx.Clock, queue.Add),
 	}, queue, mustSync, nil
 }
 
@@ -266,9 +272,38 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		log.V(logf.DebugLevel).Info("updating status fields", "notAfter",
 			klog.SafePtr(crt.Status.NotAfter), "notBefore", klog.SafePtr(crt.Status.NotBefore), "renewalTime",
 			klog.SafePtr(crt.Status.RenewalTime))
-		return c.updateOrApplyStatus(ctx, crt)
+		if err := c.updateOrApplyStatus(ctx, crt); err != nil {
+			return err
+		}
 	}
+
+	c.scheduleRecheckAtExpiry(log, key, crt.Status.NotAfter)
+
 	return nil
+}
+
+// scheduleRecheckAtExpiry re-processes the Certificate just after it expires.
+//
+// Readiness depends on the clock, but the controller only reconciles on watch
+// events. A Certificate whose renewal is stuck gets no events, so it keeps
+// reporting Ready=True long after expiry. We re-arm on every reconcile because
+// the timers are in memory and are lost on restart.
+func (c *controller) scheduleRecheckAtExpiry(log logr.Logger, key types.NamespacedName, notAfter *metav1.Time) {
+	if notAfter == nil {
+		c.expiryWorkQueue.Forget(key)
+		return
+	}
+
+	// Wake up just after NotAfter, so the clock has definitely passed it.
+	recheckIn := notAfter.Time.Sub(c.clock.Now()) + time.Second
+	if recheckIn <= 0 {
+		// Already expired, and this reconcile has just set the condition.
+		c.expiryWorkQueue.Forget(key)
+		return
+	}
+
+	log.V(logf.DebugLevel).Info("scheduling re-check at certificate expiry", "notAfter", notAfter.Time, "recheckIn", recheckIn)
+	c.expiryWorkQueue.Add(key, recheckIn)
 }
 
 func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) time.Time {

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -848,6 +850,64 @@ func TestReadinessForARI(t *testing.T) {
 
 			if err := builder.AllActionsExecuted(); err != nil {
 				builder.T.Error(err)
+			}
+		})
+	}
+}
+
+// recordingScheduledQueue records scheduled delays so tests can assert on
+// them without waiting.
+type recordingScheduledQueue struct {
+	added  []time.Duration
+	forgot int
+}
+
+func (q *recordingScheduledQueue) Add(_ types.NamespacedName, duration time.Duration) {
+	q.added = append(q.added, duration)
+}
+
+func (q *recordingScheduledQueue) Forget(_ types.NamespacedName) {
+	q.forgot++
+}
+
+func TestScheduleRecheckAtExpiry(t *testing.T) {
+	now := time.Date(2025, 8, 4, 13, 0, 0, 0, time.UTC)
+	key := types.NamespacedName{Namespace: "testns", Name: "test"}
+
+	tests := map[string]struct {
+		notAfter   *metav1.Time
+		wantAdded  []time.Duration
+		wantForgot int
+	}{
+		"schedules a re-check just after a future expiry": {
+			notAfter:  &metav1.Time{Time: now.Add(time.Hour)},
+			wantAdded: []time.Duration{time.Hour + time.Second},
+		},
+		"does not schedule a re-check for an already expired certificate": {
+			notAfter:   &metav1.Time{Time: now.Add(-time.Hour)},
+			wantForgot: 1,
+		},
+		"does not schedule a re-check when the expiry is unknown": {
+			notAfter:   nil,
+			wantForgot: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			queue := &recordingScheduledQueue{}
+			c := &controller{
+				clock:           fakeclock.NewFakeClock(now),
+				expiryWorkQueue: queue,
+			}
+
+			c.scheduleRecheckAtExpiry(logr.Discard(), key, test.notAfter)
+
+			if !reflect.DeepEqual(queue.added, test.wantAdded) {
+				t.Errorf("expected scheduled delays %v, got %v", test.wantAdded, queue.added)
+			}
+			if queue.forgot != test.wantForgot {
+				t.Errorf("expected %d calls to Forget, got %d", test.wantForgot, queue.forgot)
 			}
 		})
 	}

--- a/test/integration/certificates/readiness_controller_test.go
+++ b/test/integration/certificates/readiness_controller_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/readiness"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/cert-manager/cert-manager/integration-tests/framework"
+)
+
+// TestReadinessController_ExpiryWithoutEvents checks that a Certificate stops
+// reporting Ready=True once it expires, even when nothing else changes.
+//
+// This is the case reported in issue #7895: renewal is stuck, so the readiness
+// controller never sees a watch event and the Certificate looks healthy long
+// after it expired.
+func TestReadinessController_ExpiryWithoutEvents(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	t.Cleanup(stopFn)
+
+	fakeClock := &fakeclock.FakeClock{}
+	fakeClock.SetTime(time.Now())
+
+	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
+
+	namespace := "testns-readiness-expiry"
+	secretName := "example"
+	certName := "testcrt"
+
+	now := fakeClock.Now()
+	notBefore := now
+	notAfter := now.Add(3 * time.Hour)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	if _, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: certName, Namespace: namespace},
+		Spec: cmapi.CertificateSpec{
+			SecretName: secretName,
+			CommonName: "example.com",
+			IssuerRef:  cmmeta.IssuerReference{Name: "testissuer"}, // doesn't need to exist
+		},
+	}
+
+	sk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skBytes := pki.EncodePKCS1PrivateKey(sk)
+	x509CertBytes := selfSignCertificateWithNotBeforeAfter(t, skBytes, cert, notBefore, notAfter)
+
+	_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: skBytes,
+			corev1.TLSCertKey:       x509CertBytes,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controllerContext := &controllerpkg.Context{
+		Scheme:                    scheme,
+		Client:                    kubeClient,
+		KubeSharedInformerFactory: factory,
+		CMClient:                  cmCl,
+		SharedInformerFactory:     cmFactory,
+		Clock:                     fakeClock,
+		ContextOptions:            controllerpkg.ContextOptions{},
+		Recorder:                  framework.NewEventRecorder(t, scheme),
+		FieldManager:              "cert-manager-certificates-readiness-test",
+	}
+	ctrl, queue, mustSync, err := readiness.NewController(
+		logf.Log,
+		controllerContext,
+		policies.NewReadinessPolicyChain(fakeClock),
+		pki.RenewalTime,
+		readiness.BuildReadyConditionFromChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := controllerpkg.NewController(
+		"readiness_test",
+		metrics.New(logf.Log, clock.RealClock{}),
+		ctrl.ProcessItem,
+		mustSync,
+		nil,
+		queue,
+	)
+	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopController()
+
+	if _, err := cmCl.CertmanagerV1().Certificates(namespace).Create(t.Context(), cert, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Waiting for the Certificate to become Ready")
+	waitForReadyCondition(t, t.Context(), cmCl, namespace, certName, cmmeta.ConditionTrue, readiness.ReadyReason)
+
+	// Nothing else changes here: no Secret update, no CertificateRequest, no
+	// edit to the Certificate. Only a re-check the controller scheduled for
+	// itself can wake it up.
+	t.Log("Advancing the clock past the certificate's expiry")
+	fakeClock.SetTime(notAfter.Add(2 * time.Second))
+
+	t.Log("Waiting for the Certificate to report that it has expired")
+	waitForReadyCondition(t, t.Context(), cmCl, namespace, certName, cmmeta.ConditionFalse, policies.Expired)
+}
+
+// waitForReadyCondition polls until the Ready condition matches status and reason.
+func waitForReadyCondition(t *testing.T, ctx context.Context, cmCl cmclient.Interface, namespace, name string, status cmmeta.ConditionStatus, reason string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	var last *cmapi.CertificateCondition
+	err := wait.PollUntilContextCancel(ctx, 200*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		crt, err := cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		last = apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady)
+		if last == nil {
+			return false, nil
+		}
+		return last.Status == status && last.Reason == reason, nil
+	})
+	if err != nil {
+		t.Fatalf("expected Ready condition with status %q and reason %q, last seen %+v: %v", status, reason, last, err)
+	}
+}


### PR DESCRIPTION
### Pull Request Motivation

Fixes #7895, where a Certificate keeps reporting `Ready=True` after the certificate in its Secret has expired.

**Note on overlap:** #8529 is already open against this issue and takes the same broad approach. I am not trying to talk over it — @rohansood10 got there first. What this PR adds is an integration test that actually reproduces the bug, which is what #8529 has been stuck on: @hjoshi123 could not confirm the fix on a real cluster, and the PR has no test that shows the Ready condition flipping. Happy to close this in favour of #8529 if the test is ported across, or to have this rebased on top of it — maintainers' call.

#### The bug

The readiness policy chain ends in `CurrentCertificateHasExpired`, so the Ready condition depends on the wall clock. But the readiness controller only reconciles on watch events. When a renewal is stuck (a failing ACME challenge, a deleted issuer), nothing about the Certificate, its Secret or its CertificateRequests changes, so no event ever arrives and the stale `Ready=True` stands until an informer resync or a restart. That matches the reports on the issue, including "only restart of cert-manager fixed the state".

#### The fix

Schedule a re-check at `NotAfter`, re-armed on every reconcile since the timers are in-memory and lost on restart.

This uses a second `ScheduledWorkQueue` rather than the existing one, because a `ScheduledWorkQueue` keeps one timer per key and the existing one is already used for ARI polling — sharing it would have the two cancelling each other. Using `scheduler` rather than `queue.AddAfter` also matters for testability: the readiness queue is built without a `Clock`, so client-go defaults it to `RealClock` and `AddAfter` cannot be driven by the fake clock the other controller integration tests rely on.

#### Prerequisite commit

The first commit fixes a separate nil pointer dereference. `helper` was only ever set in `controllerWrapper.Register`, never in the exported `NewController`, so any caller outside the package got a controller that panicked on the first Certificate with a decodable certificate in its Secret:

```
panic: runtime error: invalid memory address or nil pointer dereference
readiness.(*controller).useARIForRenewal ... readiness_controller.go:284
readiness.(*controller).ProcessItem ... readiness_controller.go:227
```

`test/integration/certificates/generates_new_private_key_per_request_test.go` already calls `NewController` and only survives because its Secrets have no decodable `tls.crt`. This is almost certainly why there was no readiness integration test until now, and it had to be fixed before one could be written.

#### Testing

The new integration test follows the `trigger_controller_test.go` pattern: the Certificate goes Ready, the fake clock advances past `NotAfter`, and nothing else is touched — no Secret write, no CertificateRequest, no edit to the Certificate. (The existing trigger test calls `applyTestCondition` to force an event; not doing that is the point here.)

With the expiry re-check removed it fails with exactly the symptom from the issue:

```
expected Ready condition with status "False" and reason "Expired", last seen
&{Type:Ready Status:True Reason:Ready Message:Certificate is up to date and has not expired}
```

The full `test/integration/certificates` suite and `./pkg/controller/...` unit tests pass, and golangci-lint is clean on both modules.

### Kind

/kind bug

### Release Note

```release-note
Fixed a bug where a Certificate would continue to report `Ready=True` after its certificate had expired, if no other change triggered the readiness controller.
```
