### PR TITLE
fix(scheduler): drop the mock clock and drive tests with synctest (#9248)

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -74,9 +74,6 @@ type scheduledWorkQueue[T comparable] struct {
 	clock       clock.Clock
 	work        map[T]func()
 	workLock    sync.Mutex
-
-	// Testing purposes.
-	afterFunc func(clock.Clock, time.Duration, func()) func()
 }
 
 // NewScheduledWorkQueue will create a new workqueue with the given processFunc
@@ -86,8 +83,6 @@ func NewScheduledWorkQueue[T comparable](clock clock.Clock, processFunc ProcessF
 		clock:       clock,
 		work:        make(map[T]func()),
 		workLock:    sync.Mutex{},
-
-		afterFunc: afterFunc,
 	}
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -17,227 +17,85 @@ limitations under the License.
 package scheduler
 
 import (
-	"runtime"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/clock"
 )
 
-func Test_afterFunc(t *testing.T) {
-	// Note that re-implementing AfterFunc is not a good idea, since testing it
-	// is tricky as seen in time_test.go in the standard library. We will just
-	// focus on two important cases: "f" should be run after the duration
-
-	t.Run("stop works", func(t *testing.T) {
-		// This test makes sure afterFunc does not leak goroutines.
-		//
-		// This test may be run concurrently to other tests, so we want to avoid
-		// being affected by the goroutines from other tests. To do that, we start a
-		// huge number of afterFunc and check that the number of goroutines before
-		// and after more or less match.
-		expected := runtime.NumGoroutine()
-		var cancels []func()
-		for i := 1; i <= 10000; i++ {
-			cancels = append(cancels, afterFunc(clock.RealClock{}, 1*time.Hour, func() {
-				t.Errorf("should never be called")
-			}))
-		}
-
-		for _, cancel := range cancels {
-			cancel()
-		}
-
-		// The cancelled goroutines exit asynchronously, so poll instead of
-		// sleeping a fixed amount: on a loaded machine 10000 of them can take
-		// seconds to be scheduled and exit, whereas a real leak never comes
-		// back down and still fails once the deadline passes.
-		//
-		// Only an increase is a failure. Nothing runs concurrently with this
-		// test in this binary, but under `go test -count=N` the baseline of a
-		// run can include still-draining goroutines from the previous run,
-		// which later exit, leaving fewer goroutines at the end than at the
-		// start.
-		const tolerance = 100
-		assert.Eventually(t, func() bool {
-			return runtime.NumGoroutine()-expected <= tolerance
-		}, 30*time.Second, 10*time.Millisecond, "afterFunc leaked goroutines: cancel() did not stop them all")
-
-		t.Logf("%d goroutines before, %d goroutines after", expected, runtime.NumGoroutine())
-	})
-
-	t.Run("f is called after roughly 100 milliseconds", func(t *testing.T) {
-		var end time.Time
-		wait := make(chan struct{})
-
-		start := time.Now()
-
-		expectedDuration := 100 * time.Millisecond
-
-		afterFunc(clock.RealClock{}, expectedDuration, func() {
-			end = time.Now()
-			close(wait)
-		})
-
-		<-wait
-
-		elapsed := end.Sub(start)
-
-		assert.InDelta(t, expectedDuration, elapsed, float64(500*time.Millisecond))
-		assert.GreaterOrEqual(t, elapsed, expectedDuration)
-	})
-}
-
 func TestAdd(t *testing.T) {
-	after := newMockAfter()
-
-	var wg sync.WaitGroup
-	type testT struct {
-		obj      string
-		duration time.Duration
-	}
-	tests := []testT{
-		{"test500", time.Millisecond * 500},
-		{"test1000", time.Second * 1},
-		{"test3000", time.Second * 3},
-	}
-	for _, test := range tests {
-		wg.Add(1)
-		t.Run(test.obj, func(test testT) func(*testing.T) {
-			waitSubtest := make(chan struct{})
-			return func(t *testing.T) {
-				startTime := after.currentTime
+	for _, d := range []time.Duration{500 * time.Millisecond, time.Second, 3 * time.Second} {
+		t.Run(d.String(), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+				var mu sync.Mutex
+				var firedAt time.Time
 				queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj string) {
-					defer wg.Done()
-					durationEarly := test.duration - after.currentTime.Sub(startTime)
-
-					if durationEarly > 0 {
-						t.Errorf("got queue item %.2f seconds too early", float64(durationEarly)/float64(time.Second))
-					}
-					if obj != test.obj {
-						t.Errorf("expected obj '%+v' but got obj '%+v'", test.obj, obj)
-					}
-					waitSubtest <- struct{}{}
+					mu.Lock()
+					defer mu.Unlock()
+					firedAt = time.Now()
 				})
-				queue.(*scheduledWorkQueue[string]).afterFunc = after.AfterFunc
-				queue.Add(test.obj, test.duration)
-				after.warp(test.duration + time.Millisecond)
-				<-waitSubtest
-			}
-		}(test))
-	}
+				queue.Add("obj", d)
 
-	wg.Wait()
+				time.Sleep(d - time.Nanosecond)
+				synctest.Wait()
+				mu.Lock()
+				assert.True(t, firedAt.IsZero(), "fired early")
+				mu.Unlock()
+
+				time.Sleep(time.Nanosecond)
+				synctest.Wait()
+				mu.Lock()
+				assert.Equal(t, start.Add(d), firedAt)
+				mu.Unlock()
+			})
+		})
+	}
 }
 
 func TestForget(t *testing.T) {
-	after := newMockAfter()
+	synctest.Test(t, func(t *testing.T) {
+		queue := NewScheduledWorkQueue(clock.RealClock{}, func(string) {
+			t.Error("scheduled function should never be called")
+		})
+		queue.Add("obj", time.Second)
+		queue.Forget("obj")
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		// synctest.Test also fails if the afterFunc goroutine is still parked when this returns.
+	})
+}
 
-	var wg sync.WaitGroup
-	type testT struct {
-		obj      string
-		duration time.Duration
-	}
-	tests := []testT{
-		{"test500", time.Millisecond * 500},
-		{"test1000", time.Second * 1},
-		{"test3000", time.Second * 3},
-	}
-	for _, test := range tests {
-		wg.Add(1)
-		t.Run(test.obj, func(test testT) func(*testing.T) {
-			return func(t *testing.T) {
-				defer wg.Done()
-				queue := NewScheduledWorkQueue(clock.RealClock{}, func(_ string) {
-					t.Errorf("scheduled function should never be called")
-				})
-				queue.(*scheduledWorkQueue[string]).afterFunc = after.AfterFunc
-				queue.Add(test.obj, test.duration)
-				queue.Forget(test.obj)
-				after.warp(test.duration * 2)
-			}
-		}(test))
-	}
-
-	wg.Wait()
+func TestAfterFuncStop(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		for range 10000 {
+			cancel := afterFunc(clock.RealClock{}, time.Hour, func() { t.Error("should never be called") })
+			cancel()
+		}
+	})
 }
 
 // TestConcurrentAdd checks that if we add the same item concurrently, it
 // doesn't end up hitting a data-race / leaking a timer.
 func TestConcurrentAdd(t *testing.T) {
-	after := newMockAfter()
-
-	var wg sync.WaitGroup
-	queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj int) {
-		t.Fatalf("should not be called, but was called with %v", obj)
-	})
-	queue.(*scheduledWorkQueue[int]).afterFunc = after.AfterFunc
-
-	for range 1000 {
-		wg.Go(func() {
-			queue.Add(1, 1*time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		var wg sync.WaitGroup
+		queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj int) {
+			t.Errorf("should not be called, but was called with %v", obj)
 		})
-	}
-	wg.Wait()
 
-	queue.Forget(1)
-	after.warp(5 * time.Second)
-}
-
-type timerQueueItem struct {
-	f       func()
-	t       time.Time
-	run     bool
-	stopped bool
-}
-
-func (tq *timerQueueItem) Stop() bool {
-	stopped := tq.stopped
-	tq.stopped = true
-	return stopped
-}
-
-type mockAfter struct {
-	lock        *sync.Mutex
-	currentTime time.Time
-	queue       []*timerQueueItem
-}
-
-func newMockAfter() *mockAfter {
-	return &mockAfter{
-		queue: make([]*timerQueueItem, 0),
-		lock:  &sync.Mutex{},
-	}
-}
-
-func (m *mockAfter) AfterFunc(c clock.Clock, d time.Duration, f func()) func() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	item := &timerQueueItem{
-		f: f,
-		t: m.currentTime.Add(d),
-	}
-	m.queue = append(m.queue, item)
-	return func() {
-		item.Stop()
-	}
-}
-
-func (m *mockAfter) warp(d time.Duration) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.currentTime = m.currentTime.Add(d)
-	for _, item := range m.queue {
-		if item.run || item.stopped {
-			continue
+		for range 1000 {
+			wg.Go(func() {
+				queue.Add(1, 1*time.Second)
+			})
 		}
+		wg.Wait()
 
-		if item.t.Before(m.currentTime) {
-			item.run = true
-			go item.f()
-		}
-	}
+		queue.Forget(1)
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+	})
 }


### PR DESCRIPTION
### What

Deletes the dead `afterFunc` test hook and rewrites the scheduler tests with `testing/synctest`.

The `afterFunc` field on `scheduledWorkQueue` has been dead since it was added for testing in #4233: `Add` never routed through it, so the tests silently ran against real timers, and `TestAdd` raced on the mock clock state under `-race`.

Rather than wiring the hook up, this removes it. With Go 1.26 the tests drive the real `afterFunc` through `clock.RealClock` (a thin wrapper over `time.NewTimer`) inside a synctest bubble, so time is deterministic and race-free.

### Why synctest instead of wiring the mock

- The mock (`mockAfter` / `timerQueueItem`) carried its own unsynchronised bookkeeping that #9248 flagged (`Stop` writes without a lock, `currentTime` read unlocked).
- The old `TestAdd` "too early" check could never fire (it compared against how far `warp` advanced, always -1ms). The synctest version asserts the exact fire time and fails on a `duration/2` mutation with "fired early".
- Goroutine leaks are caught by synctest itself (a goroutine parked on its timer fails the test), so the `runtime.NumGoroutine` counting goes away.

### Changes

- `pkg/scheduler/scheduler.go`: remove the dead `afterFunc` field.
- `pkg/scheduler/scheduler_test.go`: port `TestAdd`, `TestForget`, `TestConcurrentAdd` to synctest; replace the goroutine-counting `Test_afterFunc/stop_works` with `TestAfterFuncStop`; delete `mockAfter`/`timerQueueItem`.

### Verification

`go test -race ./pkg/scheduler/ -count=10` passes. Mutation checks: scheduling `duration/2` fails with "fired early"; a `cancel()` that does not close `cancelCh` fails with a synctest deadlock.

Fixes #9248

```release-note
NONE
```
