### PR TITLE
fix: ServerSideApply defects in certificate-shim and issuing controller

### DIFF
--- a/internal/controller/certificates/apply.go
+++ b/internal/controller/certificates/apply.go
@@ -35,6 +35,16 @@ import (
 // call.
 // Always sets Force Apply to true.
 func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, crt *cmapi.Certificate) error {
+	return apply(ctx, cl, fieldManager, crt, true)
+}
+
+// ApplyNonForced is Apply without Force: a field owned by another field manager
+// fails the call with a 409 Conflict instead of being taken over.
+func ApplyNonForced(ctx context.Context, cl cmclient.Interface, fieldManager string, crt *cmapi.Certificate) error {
+	return apply(ctx, cl, fieldManager, crt, false)
+}
+
+func apply(ctx context.Context, cl cmclient.Interface, fieldManager string, crt *cmapi.Certificate, force bool) error {
 	crtData, err := serializeApply(crt)
 	if err != nil {
 		return err
@@ -42,7 +52,7 @@ func Apply(ctx context.Context, cl cmclient.Interface, fieldManager string, crt 
 
 	_, err = cl.CertmanagerV1().Certificates(crt.Namespace).Patch(
 		ctx, crt.Name, apitypes.ApplyPatchType, crtData,
-		metav1.PatchOptions{Force: new(true), FieldManager: fieldManager},
+		metav1.PatchOptions{Force: &force, FieldManager: fieldManager},
 	)
 
 	return err

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -146,19 +146,12 @@ func SyncFnFor(
 		}
 
 		for _, crt := range newCrts {
-			// Create with FieldManager records ownership as operation:Update.
-			// Use Apply under SSA so create ownership matches updates (operation:Apply).
 			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-				err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            crt.Name,
-						Namespace:       crt.Namespace,
-						Labels:          crt.Labels,
-						OwnerReferences: crt.OwnerReferences,
-						Annotations:     extraAnnotations,
-					},
-					Spec: crt.Spec,
-				})
+				// Apply, not Create, so the Certificate is born owned by an
+				// operation:Apply entry that the update path can prune from.
+				// Not forced, so a Certificate the shim does not own conflicts
+				// rather than being adopted; the error requeues the item.
+				err = internalcertificates.ApplyNonForced(ctx, cmClient, fieldManager, crt)
 			} else {
 				_, err = cmClient.CertmanagerV1().Certificates(crt.Namespace).Create(ctx, crt, metav1.CreateOptions{FieldManager: fieldManager})
 			}
@@ -171,16 +164,7 @@ func SyncFnFor(
 		for _, crt := range updateCrts {
 
 			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
-				err = internalcertificates.Apply(ctx, cmClient, fieldManager, &cmapi.Certificate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            crt.Name,
-						Namespace:       crt.Namespace,
-						Labels:          crt.Labels,
-						OwnerReferences: crt.OwnerReferences,
-						Annotations:     extraAnnotations,
-					},
-					Spec: crt.Spec,
-				})
+				err = internalcertificates.Apply(ctx, cmClient, fieldManager, crt)
 			} else {
 				_, err = cmClient.CertmanagerV1().Certificates(crt.Namespace).Update(ctx, crt, metav1.UpdateOptions{})
 			}
@@ -416,12 +400,14 @@ func buildCertificates(
 		//
 		delete(labels, applysetLabel)
 
+		// annotations is one map shared by every Certificate built in this loop,
+		// so clone it: setIssuerSpecificConfig below writes into crt.Annotations.
 		crt := &cmapi.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            secretRef.Name,
 				Namespace:       secretRef.Namespace,
 				Labels:          labels,
-				Annotations:     annotations,
+				Annotations:     maps.Clone(annotations),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ingLike, controllerGVK)},
 			},
 			Spec: cmapi.CertificateSpec{
@@ -472,21 +458,22 @@ func buildCertificates(
 				continue
 			}
 
+			// An Apply declares only the fields this manager owns, so crt goes
+			// out as built. An Update replaces the whole object, so the shim's
+			// fields have to be merged into a copy of the live Certificate.
+			if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
+				updateCrts = append(updateCrts, crt)
+				continue
+			}
+
 			updateCrt := existingCrt.DeepCopy()
 
 			updateCrt.Spec = crt.Spec
 			updateCrt.Labels = crt.Labels
 
-			// extra annotation wanted but none set
-			if len(updateCrt.GetAnnotations()) == 0 && len(annotations) > 0 {
-				updateCrt.SetAnnotations(annotations)
+			if len(crt.GetAnnotations()) > 0 {
+				updateCrt.SetAnnotations(mergeAnnotations(updateCrt.GetAnnotations(), crt.GetAnnotations()))
 			}
-			// update append extra annotations
-			if len(updateCrt.GetAnnotations()) > 0 && len(annotations) > 0 {
-				updateCrt.SetAnnotations(mergeAnnotations(updateCrt.GetAnnotations(), annotations))
-			}
-
-			setIssuerSpecificConfig(crt, ingLike)
 
 			updateCrts = append(updateCrts, updateCrt)
 		} else {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -19,20 +19,22 @@ package shimhelper
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	coretesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -40,6 +42,7 @@ import (
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
@@ -3360,17 +3363,28 @@ func TestSync(t *testing.T) {
 				},
 			},
 			CertificateLister: []runtime.Object{
-				buildCertificate("existing-crt",
-					gen.DefaultTestNamespace,
-					buildGatewayOwnerReferences("gateway-name"),
-				),
+				func() *cmapi.Certificate {
+					crt := buildCertificate("existing-crt",
+						gen.DefaultTestNamespace,
+						buildGatewayOwnerReferences("gateway-name"),
+					)
+					// An annotation the shim does not manage. The Update below
+					// replaces the whole object, so it has to carry it.
+					crt.Annotations = map[string]string{"user.io/keep": "me"}
+					return crt
+				}(),
 			},
 			DefaultIssuerKind: "Issuer",
 			ExpectedEvents:    []string{`Normal UpdateCertificate Successfully updated Certificate "existing-crt"`},
 			ExpectedUpdate: []*cmapi.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "existing-crt",
+						Name: "existing-crt",
+						Annotations: map[string]string{
+							cmacme.ACMECertificateHTTP01ParentRefName: "gateway-name",
+							cmacme.ACMECertificateHTTP01ParentRefKind: "Gateway",
+							"user.io/keep": "me",
+						},
 						Namespace:       gen.DefaultTestNamespace,
 						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
 					},
@@ -3447,8 +3461,9 @@ func TestSync(t *testing.T) {
 			ExpectedUpdate: []*cmapi.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cert-secret-name",
-						Namespace: gen.DefaultTestNamespace,
+						Name:        "cert-secret-name",
+						Namespace:   gen.DefaultTestNamespace,
+						Annotations: buildParentRefAnnotations(),
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
@@ -3682,6 +3697,7 @@ func TestSync(t *testing.T) {
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
 						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+						Annotations:     buildParentRefAnnotations(),
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -4656,55 +4672,26 @@ func TestSync(t *testing.T) {
 	})
 }
 
-// matchRootCertificateApply validates a root-resource Certificate Apply patch
-// (verb, patch type, options) and then runs check on the unmarshaled object.
-func matchRootCertificateApply(check func(applied cmapi.Certificate) error) testpkg.ActionMatchFn {
-	return func(_, actual coretesting.Action) error {
-		patchAction, ok := actual.(coretesting.PatchAction)
-		if !ok {
-			return fmt.Errorf("expected PatchAction, got %T", actual)
-		}
-		if patchAction.GetVerb() != "patch" {
-			return fmt.Errorf("expected patch, got %q", patchAction.GetVerb())
-		}
-		if patchAction.GetPatchType() != types.ApplyPatchType {
-			return fmt.Errorf("expected ApplyPatchType, got %q", patchAction.GetPatchType())
-		}
-		if patchAction.GetSubresource() != "" {
-			return fmt.Errorf("expected root resource Apply, got subresource %q", patchAction.GetSubresource())
-		}
-		optsGetter, ok := actual.(interface{ GetPatchOptions() metav1.PatchOptions })
-		if !ok {
-			return fmt.Errorf("expected GetPatchOptions on action, got %T", actual)
-		}
-		opts := optsGetter.GetPatchOptions()
-		if opts.FieldManager != testpkg.FieldManager {
-			return fmt.Errorf("expected FieldManager %q, got %q", testpkg.FieldManager, opts.FieldManager)
-		}
-		if opts.Force == nil || !*opts.Force {
-			return fmt.Errorf("expected Force=true, got %v", opts.Force)
-		}
-
-		var applied cmapi.Certificate
-		if err := json.Unmarshal(patchAction.GetPatch(), &applied); err != nil {
-			return fmt.Errorf("unmarshal Apply patch: %w", err)
-		}
-		return check(applied)
-	}
+// mustSerializeApply renders the bytes internalcertificates.Apply sends for crt.
+func mustSerializeApply(t *testing.T, crt *cmapi.Certificate) []byte {
+	t.Helper()
+	crt = crt.DeepCopy()
+	crt.TypeMeta = metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()}
+	crt.Status = cmapi.CertificateStatus{}
+	data, err := json.Marshal(crt)
+	require.NoError(t, err)
+	return data
 }
 
-// TestSync_ServerSideApplyCreate checks Certificate create uses Apply under SSA.
-func TestSync_ServerSideApplyCreate(t *testing.T) {
+// TestSync_ServerSideApply checks the payloads the shim writes with the
+// ServerSideApply feature gate enabled.
+func TestSync_ServerSideApply(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
 
 	acmeClusterIssuer := gen.ClusterIssuer("issuer-name",
 		gen.SetIssuerACME(cmacme.ACMEIssuer{}))
-	revisionHistoryLimit := int32(7)
-	expectedAnnotations := map[string]string{"example.com/foo": "bar"}
-	expectedLabels := map[string]string{"my-test-label": "should-be-applied"}
-	expectedOwnerRefs := buildIngressOwnerReferences("ingress-name")
 
-	ing := &networkingv1.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ingress-name",
 			Namespace: gen.DefaultTestNamespace,
@@ -4728,187 +4715,287 @@ func TestSync_ServerSideApplyCreate(t *testing.T) {
 		},
 	}
 
-	b := &testpkg.Builder{
-		T:                  t,
-		CertManagerObjects: []runtime.Object{acmeClusterIssuer},
-		ExpectedEvents:     []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
-		ExpectedActions: []testpkg.Action{
-			testpkg.NewCustomMatch(
-				coretesting.NewPatchActionWithOptions(
-					cmapi.SchemeGroupVersion.WithResource("certificates"),
-					gen.DefaultTestNamespace,
-					"example-com-tls",
-					types.ApplyPatchType,
-					[]byte(`{}`),
-					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
-				),
-				matchRootCertificateApply(func(applied cmapi.Certificate) error {
-					if applied.Name != "example-com-tls" {
-						return fmt.Errorf("unexpected name %q", applied.Name)
-					}
-					if applied.Spec.RevisionHistoryLimit == nil || *applied.Spec.RevisionHistoryLimit != revisionHistoryLimit {
-						return fmt.Errorf("expected revisionHistoryLimit=%d in Apply Spec, got %v", revisionHistoryLimit, applied.Spec.RevisionHistoryLimit)
-					}
-					if applied.Spec.SecretName != "example-com-tls" {
-						return fmt.Errorf("unexpected secretName %q", applied.Spec.SecretName)
-					}
-					if !reflect.DeepEqual(applied.Spec.DNSNames, []string{"example.com"}) {
-						return fmt.Errorf("unexpected dnsNames %v", applied.Spec.DNSNames)
-					}
-					if !reflect.DeepEqual(applied.Spec.IssuerRef, cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"}) {
-						return fmt.Errorf("unexpected issuerRef %#v", applied.Spec.IssuerRef)
-					}
-					if !reflect.DeepEqual(applied.Spec.Usages, cmapi.DefaultKeyUsages()) {
-						return fmt.Errorf("unexpected usages %v", applied.Spec.Usages)
-					}
-					if !reflect.DeepEqual(applied.Labels, expectedLabels) {
-						return fmt.Errorf("expected Ingress labels on create Apply, got %v", applied.Labels)
-					}
-					if !reflect.DeepEqual(applied.OwnerReferences, expectedOwnerRefs) {
-						return fmt.Errorf("unexpected OwnerReferences %#v", applied.OwnerReferences)
-					}
-					if !reflect.DeepEqual(applied.Annotations, expectedAnnotations) {
-						return fmt.Errorf("unexpected create Apply annotations: %v", applied.Annotations)
-					}
-					return nil
-				}),
-			),
-		},
-	}
-	b.Init()
-	defer b.Stop()
-
-	sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controllerpkg.IngressShimOptions{
-		DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
-		ExtraCertificateAnnotations:       []string{"example.com/foo"},
-	}, testpkg.FieldManager)
-	b.Start()
-
-	err := sync(t.Context(), ing)
-	assert.NoError(t, err)
-	assert.NoError(t, b.AllEventsCalled())
-	assert.NoError(t, b.AllActionsExecuted())
-}
-
-// TestSync_ServerSideApplyUpdate checks Certificate update uses Apply under SSA.
-func TestSync_ServerSideApplyUpdate(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
-
-	acmeClusterIssuer := gen.ClusterIssuer("issuer-name",
-		gen.SetIssuerACME(cmacme.ACMEIssuer{}))
-	revisionHistoryLimit := int32(7)
-	expectedAnnotations := map[string]string{"example.com/foo": "bar"}
-	expectedLabels := map[string]string{"my-test-label": "should-be-applied"}
-	expectedOwnerRefs := buildIngressOwnerReferences("ingress-name")
-
-	ing := &networkingv1.Ingress{
+	// A Gateway with no extra annotations configured: the only annotations the
+	// shim writes are the issuer-specific parentRef ones.
+	gateway := &gwapi.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ingress-name",
+			Name:      "gateway-name",
 			Namespace: gen.DefaultTestNamespace,
-			Labels: map[string]string{
-				"my-test-label": "should-be-applied",
-			},
 			Annotations: map[string]string{
 				cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
-				cmapi.RevisionHistoryLimitAnnotationKey:     "7",
-				"example.com/foo":                           "bar",
 			},
-			UID: types.UID("ingress-name"),
+			UID: types.UID("gateway-name"),
 		},
-		Spec: networkingv1.IngressSpec{
-			TLS: []networkingv1.IngressTLS{
+		Spec: gwapi.GatewaySpec{
+			GatewayClassName: "test-gateway",
+			Listeners: []gwapi.Listener{
 				{
-					Hosts:      []string{"example.com"},
-					SecretName: "example-com-tls",
+					Hostname: ptrHostname("example.com"),
+					Port:     443,
+					Protocol: gwapi.HTTPSProtocolType,
+					TLS: &gwapi.ListenerTLSConfig{
+						Mode: new(gwapi.TLSModeTerminate),
+						CertificateRefs: []gwapi.SecretObjectReference{
+							{
+								Group: new(gwapi.Group("core")),
+								Kind:  new(gwapi.Kind("Secret")),
+								Name:  "example-com-tls",
+							},
+						},
+					},
 				},
 			},
 		},
 	}
 
-	existingCrt := &cmapi.Certificate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "example-com-tls",
-			Namespace:       gen.DefaultTestNamespace,
-			OwnerReferences: buildIngressOwnerReferences("ingress-name"),
-			Labels: map[string]string{
-				"stale-label": "remove-me",
-			},
-			Annotations: map[string]string{
-				"user.io/keep": "me",
-			},
-		},
-		Spec: cmapi.CertificateSpec{
-			DNSNames:   []string{"example.com"},
-			SecretName: "example-com-tls",
-			IssuerRef: cmmeta.IssuerReference{
-				Name: "issuer-name",
-				Kind: "ClusterIssuer",
-			},
-			Usages:               cmapi.DefaultKeyUsages(),
-			RevisionHistoryLimit: new(int32(1)),
-		},
+	type testT struct {
+		IngressLike                 metav1.Object
+		ExtraCertificateAnnotations []string
+		CertManagerObjects          []runtime.Object
+		// Created in the API server under another field manager and hidden from
+		// the lister, so sync takes the create path against an object it does
+		// not own.
+		UncachedCertificate   *cmapi.Certificate
+		ExpectedActions       []testpkg.Action
+		ExpectedEvents        []string
+		ExpectedConflictError bool
 	}
 
-	b := &testpkg.Builder{
-		T:                  t,
-		CertManagerObjects: []runtime.Object{acmeClusterIssuer, existingCrt},
-		ExpectedEvents:     []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
-		ExpectedActions: []testpkg.Action{
-			testpkg.NewCustomMatch(
-				coretesting.NewPatchActionWithOptions(
+	tests := map[string]testT{
+		"ingress create uses a non-forced Apply": {
+			IngressLike:                 ingress,
+			ExtraCertificateAnnotations: []string{"example.com/foo"},
+			CertManagerObjects:          []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:              []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewPatchActionWithOptions(
 					cmapi.SchemeGroupVersion.WithResource("certificates"),
 					gen.DefaultTestNamespace,
 					"example-com-tls",
 					types.ApplyPatchType,
-					[]byte(`{}`),
+					mustSerializeApply(t, &cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "example-com-tls",
+							Namespace:       gen.DefaultTestNamespace,
+							Labels:          map[string]string{"my-test-label": "should-be-applied"},
+							Annotations:     map[string]string{"example.com/foo": "bar"},
+							OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						},
+						Spec: cmapi.CertificateSpec{
+							DNSNames:             []string{"example.com"},
+							SecretName:           "example-com-tls",
+							IssuerRef:            cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+							Usages:               cmapi.DefaultKeyUsages(),
+							RevisionHistoryLimit: new(int32(7)),
+						},
+					}),
+					metav1.PatchOptions{Force: new(false), FieldManager: testpkg.FieldManager},
+				)),
+			},
+		},
+		"ingress create surfaces the conflict with a Certificate the shim does not own": {
+			IngressLike:                 ingress,
+			ExtraCertificateAnnotations: []string{"example.com/foo"},
+			CertManagerObjects:          []runtime.Object{acmeClusterIssuer},
+			UncachedCertificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com-tls",
+					Namespace: gen.DefaultTestNamespace,
+				},
+				Spec: cmapi.CertificateSpec{
+					DNSNames:   []string{"hand.example.com"},
+					SecretName: "example-com-tls",
+					IssuerRef:  cmmeta.IssuerReference{Name: "hand-made-issuer", Kind: "Issuer"},
+				},
+			},
+			ExpectedConflictError: true,
+			ExpectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					mustSerializeApply(t, &cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "example-com-tls",
+							Namespace:       gen.DefaultTestNamespace,
+							Labels:          map[string]string{"my-test-label": "should-be-applied"},
+							Annotations:     map[string]string{"example.com/foo": "bar"},
+							OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						},
+						Spec: cmapi.CertificateSpec{
+							DNSNames:             []string{"example.com"},
+							SecretName:           "example-com-tls",
+							IssuerRef:            cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+							Usages:               cmapi.DefaultKeyUsages(),
+							RevisionHistoryLimit: new(int32(7)),
+						},
+					}),
+					metav1.PatchOptions{Force: new(false), FieldManager: testpkg.FieldManager},
+				)),
+			},
+		},
+		"ingress update applies the full spec": {
+			IngressLike:                 ingress,
+			ExtraCertificateAnnotations: []string{"example.com/foo"},
+			CertManagerObjects: []runtime.Object{
+				acmeClusterIssuer,
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						Labels:          map[string]string{"stale-label": "remove-me"},
+						Annotations:     map[string]string{"user.io/keep": "me"},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:             []string{"example.com"},
+						SecretName:           "example-com-tls",
+						IssuerRef:            cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+						Usages:               cmapi.DefaultKeyUsages(),
+						RevisionHistoryLimit: new(int32(1)),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					mustSerializeApply(t, &cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "example-com-tls",
+							Namespace:       gen.DefaultTestNamespace,
+							Labels:          map[string]string{"my-test-label": "should-be-applied"},
+							Annotations:     map[string]string{"example.com/foo": "bar"},
+							OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+						},
+						Spec: cmapi.CertificateSpec{
+							DNSNames:             []string{"example.com"},
+							SecretName:           "example-com-tls",
+							IssuerRef:            cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+							Usages:               cmapi.DefaultKeyUsages(),
+							RevisionHistoryLimit: new(int32(7)),
+						},
+					}),
 					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
-				),
-				matchRootCertificateApply(func(applied cmapi.Certificate) error {
-					if applied.Name != "example-com-tls" {
-						return fmt.Errorf("unexpected name %q", applied.Name)
-					}
-					if applied.Spec.RevisionHistoryLimit == nil || *applied.Spec.RevisionHistoryLimit != revisionHistoryLimit {
-						return fmt.Errorf("expected revisionHistoryLimit=%d in update Apply Spec, got %v", revisionHistoryLimit, applied.Spec.RevisionHistoryLimit)
-					}
-					if applied.Spec.SecretName != "example-com-tls" {
-						return fmt.Errorf("unexpected secretName %q", applied.Spec.SecretName)
-					}
-					if !reflect.DeepEqual(applied.Spec.DNSNames, []string{"example.com"}) {
-						return fmt.Errorf("unexpected dnsNames %v", applied.Spec.DNSNames)
-					}
-					if !reflect.DeepEqual(applied.Spec.IssuerRef, cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"}) {
-						return fmt.Errorf("unexpected issuerRef %#v", applied.Spec.IssuerRef)
-					}
-					if !reflect.DeepEqual(applied.Spec.Usages, cmapi.DefaultKeyUsages()) {
-						return fmt.Errorf("unexpected usages %v", applied.Spec.Usages)
-					}
-					if !reflect.DeepEqual(applied.Labels, expectedLabels) {
-						return fmt.Errorf("expected Ingress labels on update Apply, got %v", applied.Labels)
-					}
-					if !reflect.DeepEqual(applied.OwnerReferences, expectedOwnerRefs) {
-						return fmt.Errorf("unexpected OwnerReferences %#v", applied.OwnerReferences)
-					}
-					if !reflect.DeepEqual(applied.Annotations, expectedAnnotations) {
-						return fmt.Errorf("unexpected update Apply annotations: %v", applied.Annotations)
-					}
-					return nil
-				}),
-			),
+				)),
+			},
+		},
+		// extractExtraAnnotations returns nil when --extra-certificate-annotations
+		// is not configured, and the payload used to be built from it.
+		"gateway create sends parentRef annotations when no extra annotations are configured": {
+			IngressLike:        gateway,
+			CertManagerObjects: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:     []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					mustSerializeApply(t, &cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "example-com-tls",
+							Namespace:       gen.DefaultTestNamespace,
+							Annotations:     buildParentRefAnnotations(),
+							OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+						},
+						Spec: cmapi.CertificateSpec{
+							DNSNames:   []string{"example.com"},
+							SecretName: "example-com-tls",
+							IssuerRef:  cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+							Usages:     cmapi.DefaultKeyUsages(),
+						},
+					}),
+					metav1.PatchOptions{Force: new(false), FieldManager: testpkg.FieldManager},
+				)),
+			},
+		},
+		"gateway update sends parentRef annotations when no extra annotations are configured": {
+			IngressLike: gateway,
+			CertManagerObjects: []runtime.Object{
+				acmeClusterIssuer,
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+						Annotations:     map[string]string{"user.io/keep": "me"},
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"stale.example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef:  cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+						Usages:     cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "example-com-tls"`},
+			ExpectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewPatchActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					gen.DefaultTestNamespace,
+					"example-com-tls",
+					types.ApplyPatchType,
+					mustSerializeApply(t, &cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "example-com-tls",
+							Namespace:       gen.DefaultTestNamespace,
+							Annotations:     buildParentRefAnnotations(),
+							OwnerReferences: buildGatewayOwnerReferences("gateway-name"),
+						},
+						Spec: cmapi.CertificateSpec{
+							DNSNames:   []string{"example.com"},
+							SecretName: "example-com-tls",
+							IssuerRef:  cmmeta.IssuerReference{Name: "issuer-name", Kind: "ClusterIssuer"},
+							Usages:     cmapi.DefaultKeyUsages(),
+						},
+					}),
+					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
+				)),
+			},
 		},
 	}
-	b.Init()
-	defer b.Stop()
 
-	sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, b.SharedInformerFactory.Certmanager().V1().Certificates().Lister(), controllerpkg.IngressShimOptions{
-		DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
-		ExtraCertificateAnnotations:       []string{"example.com/foo"},
-	}, testpkg.FieldManager)
-	b.Start()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := &testpkg.Builder{
+				T:                  t,
+				CertManagerObjects: test.CertManagerObjects,
+				ExpectedActions:    test.ExpectedActions,
+				ExpectedEvents:     test.ExpectedEvents,
+			}
+			b.Init()
+			defer b.Stop()
 
-	err := sync(t.Context(), ing)
-	assert.NoError(t, err)
-	assert.NoError(t, b.AllEventsCalled())
-	assert.NoError(t, b.AllActionsExecuted())
+			lister := b.SharedInformerFactory.Certmanager().V1().Certificates().Lister()
+			if test.UncachedCertificate != nil {
+				_, err := b.CMClient.CertmanagerV1().Certificates(test.UncachedCertificate.Namespace).
+					Create(t.Context(), test.UncachedCertificate, metav1.CreateOptions{FieldManager: "kubectl"})
+				require.NoError(t, err)
+				b.FakeCMClient().ClearActions()
+				lister = cmlisters.NewCertificateLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}))
+			}
+
+			sync := SyncFnFor(b.Recorder, logr.Discard(), b.CMClient, lister, controllerpkg.IngressShimOptions{
+				DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
+				ExtraCertificateAnnotations:       test.ExtraCertificateAnnotations,
+			}, testpkg.FieldManager)
+			b.Start()
+
+			err := sync(t.Context(), test.IngressLike)
+			if test.ExpectedConflictError {
+				assert.Truef(t, apierrors.IsConflict(err), "expected a conflict error, got: %v", err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, b.AllEventsCalled())
+			assert.NoError(t, b.AllActionsExecuted())
+		})
+	}
 }
 
 func TestIssuerForIngress(t *testing.T) {

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -417,6 +417,10 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 // an appropriate event. The reason and message of the Issuing condition will be that of
 // the CertificateRequest condition passed.
 func (c *controller) failIssueCertificate(ctx context.Context, log logr.Logger, crt *cmapi.Certificate, condition *cmapi.CertificateRequestCondition) error {
+	// ProcessItem hands us the lister object, so mutate a copy: the trigger
+	// controller reads these counters from that same shared cache.
+	crt = crt.DeepCopy()
+
 	nowTime := metav1.NewTime(c.clock.Now())
 	crt.Status.LastFailureTime = &nowTime
 
@@ -433,7 +437,6 @@ func (c *controller) failIssueCertificate(ctx context.Context, log logr.Logger, 
 	message = fmt.Sprintf("The certificate request has failed to complete and will be retried: %s",
 		condition.Message)
 
-	crt = crt.DeepCopy()
 	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionFalse, reason, message)
 
 	if err := c.updateOrApplyStatus(ctx, crt, false); err != nil {

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -1650,58 +1650,22 @@ func TestIssuingController(t *testing.T) {
 	}
 }
 
-// applyStatusFieldMap returns the status object from an ApplyStatus JSON patch.
-func applyStatusFieldMap(t *testing.T, patch []byte) map[string]any {
-	t.Helper()
-	var root map[string]any
-	require.NoError(t, json.Unmarshal(patch, &root))
-	status, ok := root["status"].(map[string]any)
-	require.True(t, ok, "ApplyStatus patch missing status object")
-	return status
-}
-
 // TestIssuingController_ServerSideApplyFailedIssuanceAttempts checks ApplyStatus
 // includes failedIssuanceAttempts on failure and omits it on success.
 func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
 
-	nextPrivateKeySecretName := "next-private-key"
-	baseCert := gen.Certificate("test",
-		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
-		gen.SetCertificateGeneration(3),
-		gen.SetCertificateSecretName("output"),
-		gen.SetCertificateRenewBefore(&metav1.Duration{Duration: time.Hour * 36}),
-		gen.SetCertificateDNSNames("example.com"),
-		gen.SetCertificateRevision(1),
-		gen.SetCertificateNextPrivateKeySecretName(nextPrivateKeySecretName),
-	)
-	exampleBundle := testcrypto.MustCreateCryptoBundle(t, baseCert.DeepCopy(), fixedClock)
+	fixture := failedIssuanceFixture(t)
+	exampleBundle := fixture.bundle
+	issuingCert := fixture.issuingCert
+	nextPrivateKeySecret := fixture.nextPrivateKeySecret
 	metaFixedClockStart := metav1.NewTime(fixedClockStart)
-
-	issuingCert := gen.CertificateFrom(baseCert.DeepCopy(),
-		gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
-			Type:               cmapi.CertificateConditionIssuing,
-			Status:             cmmeta.ConditionTrue,
-			ObservedGeneration: 3,
-			LastTransitionTime: &metaFixedClockStart,
-		}),
-	)
-
-	nextPrivateKeySecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nextPrivateKeySecretName,
-			Namespace: exampleBundle.Certificate.Namespace,
-		},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-		},
-	}
 
 	type testT struct {
 		builder                 *testpkg.Builder
 		certificate             *cmapi.Certificate
 		expSecretUpdateDataCall *internal.SecretData
-		assertApplyStatus       func(t *testing.T, patch []byte)
+		expApplyStatusPatch     []byte
 	}
 
 	tests := map[string]testT{
@@ -1710,45 +1674,26 @@ func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{
 					gen.CertificateFrom(issuingCert),
-					gen.CertificateRequestFrom(exampleBundle.CertificateRequestFailed,
-						gen.AddCertificateRequestAnnotations(map[string]string{
-							cmapi.CertificateRequestRevisionAnnotationKey: "2",
-						}),
-						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
-							Type:    cmapi.CertificateRequestConditionReady,
-							Status:  cmmeta.ConditionFalse,
-							Reason:  cmapi.CertificateRequestReasonFailed,
-							Message: "The certificate request failed because of reasons",
-						}),
-					),
+					fixture.failedRequest,
 				},
 				KubeObjects: []runtime.Object{nextPrivateKeySecret},
 				ExpectedEvents: []string{
 					"Warning Failed The certificate request has failed to complete and will be retried: The certificate request failed because of reasons",
 				},
 			},
-			assertApplyStatus: func(t *testing.T, patch []byte) {
-				t.Helper()
-				var applied cmapi.Certificate
-				require.NoError(t, json.Unmarshal(patch, &applied))
-				require.NotNil(t, applied.Status.FailedIssuanceAttempts)
-				assert.Equal(t, 1, *applied.Status.FailedIssuanceAttempts)
-				require.NotNil(t, applied.Status.LastFailureTime)
-				require.NotNil(t, applied.Status.Revision)
-				assert.Equal(t, 1, *applied.Status.Revision)
-				require.Len(t, applied.Status.Conditions, 1)
-				assert.Equal(t, cmapi.CertificateConditionIssuing, applied.Status.Conditions[0].Type)
-				assert.Equal(t, cmmeta.ConditionFalse, applied.Status.Conditions[0].Status)
-				assert.Equal(t, "Failed", applied.Status.Conditions[0].Reason)
-
-				status := applyStatusFieldMap(t, patch)
-				for _, key := range []string{"failedIssuanceAttempts", "lastFailureTime", "revision", "conditions"} {
-					_, ok := status[key]
-					assert.Truef(t, ok, "expected status.%s present in ApplyStatus patch", key)
-				}
-				_, ok := status["nextPrivateKeySecretName"]
-				assert.False(t, ok, "expected status.nextPrivateKeySecretName absent from ApplyStatus patch")
-			},
+			expApplyStatusPatch: mustSerializeApplyStatus(t, exampleBundle.Certificate, cmapi.CertificateStatus{
+				Conditions: []cmapi.CertificateCondition{{
+					Type:               cmapi.CertificateConditionIssuing,
+					Status:             cmmeta.ConditionFalse,
+					LastTransitionTime: &metaFixedClockStart,
+					Reason:             "Failed",
+					Message:            "The certificate request has failed to complete and will be retried: The certificate request failed because of reasons",
+					ObservedGeneration: 3,
+				}},
+				LastFailureTime:        &metaFixedClockStart,
+				Revision:               new(1),
+				FailedIssuanceAttempts: new(1),
+			}),
 		},
 		"success ApplyStatus omits failedIssuanceAttempts and lastFailureTime": {
 			certificate: exampleBundle.Certificate,
@@ -1791,27 +1736,17 @@ func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
 				IssuerKind:      "Issuer",
 				IssuerGroup:     "foo.io",
 			},
-			assertApplyStatus: func(t *testing.T, patch []byte) {
-				t.Helper()
-				var applied cmapi.Certificate
-				require.NoError(t, json.Unmarshal(patch, &applied))
-				require.NotNil(t, applied.Status.Revision)
-				assert.Equal(t, 2, *applied.Status.Revision)
-				require.Len(t, applied.Status.Conditions, 1)
-				assert.Equal(t, cmapi.CertificateConditionIssuing, applied.Status.Conditions[0].Type)
-				assert.Equal(t, cmmeta.ConditionFalse, applied.Status.Conditions[0].Status)
-				assert.Equal(t, "Issued", applied.Status.Conditions[0].Reason)
-
-				status := applyStatusFieldMap(t, patch)
-				for _, key := range []string{"revision", "conditions"} {
-					_, ok := status[key]
-					assert.Truef(t, ok, "expected status.%s present in ApplyStatus patch", key)
-				}
-				for _, key := range []string{"failedIssuanceAttempts", "lastFailureTime", "nextPrivateKeySecretName"} {
-					_, ok := status[key]
-					assert.Falsef(t, ok, "expected status.%s absent from ApplyStatus patch", key)
-				}
-			},
+			expApplyStatusPatch: mustSerializeApplyStatus(t, exampleBundle.Certificate, cmapi.CertificateStatus{
+				Conditions: []cmapi.CertificateCondition{{
+					Type:               cmapi.CertificateConditionIssuing,
+					Status:             cmmeta.ConditionFalse,
+					LastTransitionTime: &metaFixedClockStart,
+					Reason:             "Issued",
+					Message:            "The certificate has been successfully issued",
+					ObservedGeneration: 3,
+				}},
+				Revision: new(2),
+			}),
 		},
 	}
 
@@ -1822,42 +1757,15 @@ func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
 			test.builder.T = t
 
 			test.builder.ExpectedActions = []testpkg.Action{
-				testpkg.NewCustomMatch(
-					coretesting.NewPatchSubresourceActionWithOptions(
-						cmapi.SchemeGroupVersion.WithResource("certificates"),
-						exampleBundle.Certificate.Namespace,
-						exampleBundle.Certificate.Name,
-						types.ApplyPatchType,
-						[]byte(`{}`),
-						metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
-						"status",
-					),
-					func(_, actual coretesting.Action) error {
-						patchAction, ok := actual.(coretesting.PatchAction)
-						if !ok {
-							return fmt.Errorf("expected PatchAction, got %T", actual)
-						}
-						if patchAction.GetPatchType() != types.ApplyPatchType {
-							return fmt.Errorf("expected ApplyPatchType, got %q", patchAction.GetPatchType())
-						}
-						if patchAction.GetSubresource() != "status" {
-							return fmt.Errorf("expected status subresource, got %q", patchAction.GetSubresource())
-						}
-						optsGetter, ok := actual.(interface{ GetPatchOptions() metav1.PatchOptions })
-						if !ok {
-							return fmt.Errorf("expected GetPatchOptions on action, got %T", actual)
-						}
-						opts := optsGetter.GetPatchOptions()
-						if opts.FieldManager != testpkg.FieldManager {
-							return fmt.Errorf("expected FieldManager %q, got %q", testpkg.FieldManager, opts.FieldManager)
-						}
-						if opts.Force == nil || !*opts.Force {
-							return fmt.Errorf("expected Force=true, got %v", opts.Force)
-						}
-						test.assertApplyStatus(t, patchAction.GetPatch())
-						return nil
-					},
-				),
+				testpkg.NewAction(coretesting.NewPatchSubresourceActionWithOptions(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					exampleBundle.Certificate.Namespace,
+					exampleBundle.Certificate.Name,
+					types.ApplyPatchType,
+					test.expApplyStatusPatch,
+					metav1.PatchOptions{Force: new(true), FieldManager: testpkg.FieldManager},
+					"status",
+				)),
 			}
 
 			test.builder.InitWithRESTConfig()
@@ -1889,4 +1797,135 @@ func TestIssuingController_ServerSideApplyFailedIssuanceAttempts(t *testing.T) {
 			test.builder.CheckAndFinish(err)
 		})
 	}
+}
+
+// TestIssuingController_FailIssuanceDoesNotMutateInformerCache checks that a
+// failed issuance is not recorded on the Certificate in the shared informer
+// cache. The gate is pinned both ways because the status write is an update or
+// a patch depending on it, which changes the client verb the reactor matches.
+func TestIssuingController_FailIssuanceDoesNotMutateInformerCache(t *testing.T) {
+	tests := map[string]struct {
+		serverSideApply bool
+		failedVerb      string
+	}{
+		"UpdateStatus, ServerSideApply disabled": {serverSideApply: false, failedVerb: "update"},
+		"ApplyStatus, ServerSideApply enabled":   {serverSideApply: true, failedVerb: "patch"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, test.serverSideApply)
+
+			fixture := failedIssuanceFixture(t)
+
+			fixedClock.SetTime(fixedClockStart)
+			b := &testpkg.Builder{
+				T:                  t,
+				Clock:              fixedClock,
+				CertManagerObjects: []runtime.Object{fixture.issuingCert, fixture.failedRequest},
+				KubeObjects:        []runtime.Object{fixture.nextPrivateKeySecret},
+			}
+			b.InitWithRESTConfig()
+			defer b.Stop()
+
+			w := controllerWrapper{}
+			_, _, err := w.Register(b.Context)
+			require.NoError(t, err)
+			w.controller.localTemporarySigner = testLocalTemporarySignerFn(fixture.bundle.LocalTemporaryCertificateBytes)
+
+			// Fail the status write, so the failure never reaches the API
+			// server and the cache is the only place it could have landed.
+			var failedWriteCalled bool
+			b.FakeCMClient().PrependReactor(test.failedVerb, "certificates", func(coretesting.Action) (bool, runtime.Object, error) {
+				failedWriteCalled = true
+				return true, nil, errors.New("simulated status write failure")
+			})
+
+			b.Start()
+
+			err = w.controller.ProcessItem(t.Context(), types.NamespacedName{
+				Namespace: fixture.bundle.Certificate.Namespace,
+				Name:      fixture.bundle.Certificate.Name,
+			})
+			require.Error(t, err)
+			require.True(t, failedWriteCalled, "the reactor must match the verb the status write actually uses")
+
+			cached, err := b.SharedInformerFactory.Certmanager().V1().Certificates().
+				Lister().Certificates(fixture.bundle.Certificate.Namespace).Get(fixture.bundle.Certificate.Name)
+			require.NoError(t, err)
+			assert.Nil(t, cached.Status.FailedIssuanceAttempts, "failed issuance attempts must not be written to the informer cache")
+			assert.Nil(t, cached.Status.LastFailureTime, "last failure time must not be written to the informer cache")
+		})
+	}
+}
+
+// failedIssuanceObjects is the set of objects a failed-issuance test needs: a
+// Certificate mid-issuance at revision 1, the failed CertificateRequest for
+// revision 2, and the Secret holding the next private key.
+type failedIssuanceObjects struct {
+	bundle               testcrypto.CryptoBundle
+	issuingCert          *cmapi.Certificate
+	failedRequest        *cmapi.CertificateRequest
+	nextPrivateKeySecret *corev1.Secret
+}
+
+func failedIssuanceFixture(t *testing.T) failedIssuanceObjects {
+	t.Helper()
+
+	const nextPrivateKeySecretName = "next-private-key"
+	baseCert := gen.Certificate("test",
+		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
+		gen.SetCertificateGeneration(3),
+		gen.SetCertificateSecretName("output"),
+		gen.SetCertificateRenewBefore(&metav1.Duration{Duration: time.Hour * 36}),
+		gen.SetCertificateDNSNames("example.com"),
+		gen.SetCertificateRevision(1),
+		gen.SetCertificateNextPrivateKeySecretName(nextPrivateKeySecretName),
+	)
+	bundle := testcrypto.MustCreateCryptoBundle(t, baseCert.DeepCopy(), fixedClock)
+	metaFixedClockStart := metav1.NewTime(fixedClockStart)
+
+	return failedIssuanceObjects{
+		bundle: bundle,
+		issuingCert: gen.CertificateFrom(baseCert.DeepCopy(),
+			gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+				Type:               cmapi.CertificateConditionIssuing,
+				Status:             cmmeta.ConditionTrue,
+				ObservedGeneration: 3,
+				LastTransitionTime: &metaFixedClockStart,
+			}),
+		),
+		failedRequest: gen.CertificateRequestFrom(bundle.CertificateRequestFailed,
+			gen.AddCertificateRequestAnnotations(map[string]string{
+				cmapi.CertificateRequestRevisionAnnotationKey: "2",
+			}),
+			gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+				Type:    cmapi.CertificateRequestConditionReady,
+				Status:  cmmeta.ConditionFalse,
+				Reason:  cmapi.CertificateRequestReasonFailed,
+				Message: "The certificate request failed because of reasons",
+			}),
+		),
+		nextPrivateKeySecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nextPrivateKeySecretName,
+				Namespace: bundle.Certificate.Namespace,
+			},
+			Data: map[string][]byte{
+				corev1.TLSPrivateKeyKey: bundle.PrivateKeyBytes,
+			},
+		},
+	}
+}
+
+// mustSerializeApplyStatus renders the bytes internalcertificates.ApplyStatus sends.
+func mustSerializeApplyStatus(t *testing.T, crt *cmapi.Certificate, status cmapi.CertificateStatus) []byte {
+	t.Helper()
+	data, err := json.Marshal(&cmapi.Certificate{
+		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: crt.Namespace, Name: crt.Name},
+		Status:     status,
+	})
+	require.NoError(t, err)
+	return data
 }

--- a/test/integration/certificates/status_scalar_apply_test.go
+++ b/test/integration/certificates/status_scalar_apply_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package certificates
 
 import (
-	"encoding/json"
 	"testing"
+	"time"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
@@ -28,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apitypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cert-manager/cert-manager/integration-tests/framework"
 )
@@ -120,6 +120,8 @@ func Test_StatusScalarApply(t *testing.T) {
 
 		otherAttempts := 3
 		t.Log("second field manager ApplyStatus claims failedIssuanceAttempts")
+		// A second Apply manager. Managers are keyed by operation too, so the
+		// Update to Apply case is a separate subtest below.
 		applyCertificateStatus(t, otherCMClient, otherFieldManager, namespace, name, cmapi.CertificateStatus{
 			FailedIssuanceAttempts: &otherAttempts,
 		})
@@ -143,6 +145,70 @@ func Test_StatusScalarApply(t *testing.T) {
 		require.NotNil(t, crt.Status.Revision)
 		assert.Equal(t, 2, *crt.Status.Revision)
 	})
+
+	// Scalars written by UpdateStatus before the ServerSideApply gate was
+	// enabled stay owned by an operation:Update entry, which an omitting
+	// ApplyStatus does not prune. Ownership moves once Apply writes them.
+	t.Run("omit does not clear scalars owned by an Update manager, until Apply claims them", func(t *testing.T) {
+		const (
+			namespace = "test-status-scalar-apply-update-owner"
+			name      = "omit-keeps-update-owned-scalars"
+		)
+
+		t.Log("creating test Namespace")
+		_, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		createEmptyCertificate(t, issuingCMClient, namespace, name)
+
+		t.Log("UpdateStatus sets the scalar failure fields, as the pre-gate code path did")
+		crt, err := issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		attempts := 2
+		now := metav1.Now()
+		crt.Status.FailedIssuanceAttempts = &attempts
+		crt.Status.LastFailureTime = &now
+		crt.Status.Revision = new(1)
+		_, err = issuingCMClient.CertmanagerV1().Certificates(namespace).UpdateStatus(t.Context(), crt, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		t.Log("ApplyStatus omitting the scalar failure fields does not clear them")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			Revision: new(2),
+		})
+
+		crt, err = issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, crt.Status.FailedIssuanceAttempts, "an Update-owned scalar must survive an omitting Apply")
+		assert.Equal(t, 2, *crt.Status.FailedIssuanceAttempts)
+		require.NotNil(t, crt.Status.LastFailureTime)
+
+		t.Log("ApplyStatus including the scalar failure fields takes ownership of them")
+		nextAttempts := 3
+		// Distinct timestamp: an apply writing a field the value it already
+		// holds does not take ownership, so a same-second metav1.Now() would
+		// not exercise the transfer.
+		nextNow := metav1.NewTime(now.Add(time.Hour))
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			FailedIssuanceAttempts: &nextAttempts,
+			LastFailureTime:        &nextNow,
+			Revision:               new(2),
+		})
+
+		t.Log("a later omitting ApplyStatus now clears them")
+		applyCertificateStatus(t, issuingCMClient, issuingFieldManager, namespace, name, cmapi.CertificateStatus{
+			Revision: new(3),
+		})
+
+		crt, err = issuingCMClient.CertmanagerV1().Certificates(namespace).Get(t.Context(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, crt.Status.FailedIssuanceAttempts, "the stale state must self-heal once Apply has claimed the field")
+		assert.Nil(t, crt.Status.LastFailureTime)
+		require.NotNil(t, crt.Status.Revision)
+		assert.Equal(t, 3, *crt.Status.Revision)
+	})
 }
 
 func createEmptyCertificate(t *testing.T, cmClient cmclient.Interface, namespace, name string) {
@@ -159,17 +225,11 @@ func createEmptyCertificate(t *testing.T, cmClient cmclient.Interface, namespace
 	require.NoError(t, err)
 }
 
+// applyCertificateStatus calls the same ApplyStatus the controllers call.
 func applyCertificateStatus(t *testing.T, cmClient cmclient.Interface, fieldManager, namespace, name string, status cmapi.CertificateStatus) {
 	t.Helper()
-	patch, err := json.Marshal(&cmapi.Certificate{
-		TypeMeta:   metav1.TypeMeta{Kind: cmapi.CertificateKind, APIVersion: cmapi.SchemeGroupVersion.Identifier()},
+	require.NoError(t, internalcertificates.ApplyStatus(t.Context(), cmClient, fieldManager, &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
 		Status:     status,
-	})
-	require.NoError(t, err)
-	_, err = cmClient.CertmanagerV1().Certificates(namespace).Patch(
-		t.Context(), name, apitypes.ApplyPatchType, patch,
-		metav1.PatchOptions{Force: new(true), FieldManager: fieldManager}, "status",
-	)
-	require.NoError(t, err)
+	}))
 }


### PR DESCRIPTION
### Pull Request Motivation

Resolves the [post-merge review](https://github.com/cert-manager/cert-manager/pull/8793#pullrequestreview-5080612240) of #8793.

Each of the nine review comments is answered below:

- incorporated as suggested

**[r3906257985](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257985), apply-patch matcher asserts nothing.** Both matchers replaced with exact-bytes `testpkg.NewAction` built from typed values; the two SSA test functions collapse into the existing table.

**[r3906257992](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257992), integration test re-implements ApplyStatus.** `applyCertificateStatus` now delegates to `internalcertificates.ApplyStatus`.

**[Review body](https://github.com/cert-manager/cert-manager/pull/8793#pullrequestreview-5080612240), `failIssueCertificate` mutates the informer cache.** `DeepCopy` moved above the mutations. Worth adding: `trigger_controller.go` reads those fields from the same cache, so a failed status write already skewed backoff on its own.

**[r3906257957](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257957), full-spec force ownership.** Release note added, no code change. `issuerRef.group` is a further field `certNeedsUpdate` skips.

**[r3906257931](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257931), annotations dropped from the apply payload.** Fixed with `Apply(..., crt)` as suggested. `crt` carries no `resourceVersion`, so `buildCertificates` appends it directly under the gate, dropping the `ObjectMeta` literal, the `DeepCopy` and the per-gate annotation branch. Two nearby defects: extras were merged rather than `crt.Annotations`, so the non-SSA update path dropped them too, and the second `setIssuerSpecificConfig` call was dead.

- took a different approach

**[r3906257948](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257948), forced Apply on create removes the AlreadyExists guard.** The create path is a non-forced Apply that handles the conflict: a Certificate the shim does not own conflicts rather than being adopted, and the error requeues so the `buildCertificates` guards run once it is cached. `Create` is not an option, it records the shim's fields under an `operation:Update` entry the update path can never prune from, so a label removed from the Ingress would survive forever. This also satisfies inteon's [request](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3651021106) for Apply on create. `Apply` hardcoded `Force: true`, hence the `ApplyNonForced` sibling.

**[r3906257968](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257968), stale status after enabling the gate.** Release-noted, no migration code. The mechanism is as described. A frozen old `lastFailureTime` does not extend backoff, `shouldBackoffReissuingOnFailure` returns `false, 0` once `durationSinceFailure >= delay`, but the stale count survives one more failure: `failIssueCertificate` increments what it read, so the first failure after the flip writes stale + 1 and backs off from that. The next success clears it. A one-time clear would need permanent `managedFields` introspection in `ProcessItem` and cannot separate stale state from state written just before a restart.

- deferred to follow-up issues

**[r3906257979](https://github.com/cert-manager/cert-manager/pull/8793#discussion_r3906257979), hand-maintained apply whitelists drift.** Migrating four controllers to the generated apply configurations is not cherry-pickable alongside #8793. Issue to follow, with the three known drift instances.

**[Review body](https://github.com/cert-manager/cert-manager/pull/8793#pullrequestreview-5080612240), applyset label deleted from the cached map.** `delete(labels, applysetLabel)` is untouched. Issue to follow, covering both the process-wide label stripping and the data race.

### E2E Verification

Field ownership on the create path, measured against a real API server:

- `Create` plus a forced Apply omitting a shim-set label leaves the label present, because the Update entry still owns it
- a non-forced Apply on create, then the same omitting Apply, prunes it
- a foreign object conflicts while the shim's own unchanged object applies cleanly, so the guard holds and upgrades are unaffected

A forced Apply reclaims ownership only for a field it sets with a changed value, never for a removed field.

Without the fix, on released v1.21.1:

- `revisionHistoryLimit` stays stuck at 7 where this branch gives 3
- the annotations are never added on update
- the double count reproduces with the gate off, the released default, as `1,2,3,4,5,6,7` after a single failure, against `1` here

With the fix:

- annotations are present on create and on updates triggered by a spec or label change, `certNeedsUpdate` compares no annotations, so an annotation-only edit still does not trigger one
- e2e ACME issuance against pebble works with an Issuer that omits `parentRefs`, and the solver HTTPRoute is parented purely from the annotations
- a hand-made Certificate is left untouched, and the create-path conflict surfaces with no success event
- `failedIssuanceAttempts` increments once per failure and clears on success
- the shim owns only its own annotations
- `revisionHistoryLimit` still propagates on update

### Kind

/kind bug

### Release Note

```release-note
Fix HTTP-01 stalling for Gateways whose Issuer relies on the ingress-shim for `parentRefs`, and a failed issuance being counted twice, which lengthened the retry backoff. With `ServerSideApply` enabled the shim now owns the whole Certificate spec it derives, so manual edits to those fields are reverted; set them through the ing-like resource's annotations. Enabling that gate where `status.failedIssuanceAttempts` is already set keeps the old value until the next successful issuance.
```

_Note: The release note covers only what a released version exhibits. Both regressions were introduced by #8793 and never shipped, so they are deliberately absent from it._
