### PR TITLE
fix(scheduler): keep a newer timer for the same key from being cancelled (#9269)

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -63,16 +63,22 @@ type ScheduledWorkQueue[T comparable] interface {
 	// Add will add an item to this queue, executing the ProcessFunc after the
 	// Duration has come (since the time Add was called). If an existing Timer
 	// for obj already exists, the previous timer will be cancelled.
+	// An Add made while ProcessFunc is still running for obj is kept: the
+	// fired timer's cleanup never cancels it.
 	Add(T, time.Duration)
 
 	// Forget will cancel the timer for the given object, if the timer exists.
 	Forget(T)
 }
 
+type workEntry struct {
+	cancel func()
+}
+
 type scheduledWorkQueue[T comparable] struct {
 	processFunc ProcessFunc[T]
 	clock       clock.Clock
-	work        map[T]func()
+	work        map[T]*workEntry
 	workLock    sync.Mutex
 }
 
@@ -81,7 +87,7 @@ func NewScheduledWorkQueue[T comparable](clock clock.Clock, processFunc ProcessF
 	return &scheduledWorkQueue[T]{
 		processFunc: processFunc,
 		clock:       clock,
-		work:        make(map[T]func()),
+		work:        make(map[T]*workEntry),
 		workLock:    sync.Mutex{},
 	}
 }
@@ -89,19 +95,22 @@ func NewScheduledWorkQueue[T comparable](clock clock.Clock, processFunc ProcessF
 // Add will add an item to this queue, executing the ProcessFunc after the
 // Duration has come (since the time Add was called). If an existing Timer for
 // obj already exists, the previous timer will be cancelled.
+// An Add made while ProcessFunc is still running for obj is kept: the
+// fired timer's cleanup never cancels it.
 func (s *scheduledWorkQueue[T]) Add(obj T, duration time.Duration) {
 	s.workLock.Lock()
 	defer s.workLock.Unlock()
 
-	if cancel, ok := s.work[obj]; ok {
-		cancel()
-		delete(s.work, obj)
+	if entry, ok := s.work[obj]; ok {
+		entry.cancel()
 	}
 
-	s.work[obj] = afterFunc(s.clock, duration, func() {
-		defer s.Forget(obj)
+	entry := &workEntry{}
+	entry.cancel = afterFunc(s.clock, duration, func() {
+		defer s.forgetIfOwned(obj, entry)
 		s.processFunc(obj)
 	})
+	s.work[obj] = entry
 }
 
 // Forget will cancel the timer for the given object, if the timer exists.
@@ -109,8 +118,20 @@ func (s *scheduledWorkQueue[T]) Forget(obj T) {
 	s.workLock.Lock()
 	defer s.workLock.Unlock()
 
-	if cancel, ok := s.work[obj]; ok {
-		cancel()
+	if entry, ok := s.work[obj]; ok {
+		entry.cancel()
+		delete(s.work, obj)
+	}
+}
+
+// forgetIfOwned removes the work entry for obj only if it is still the
+// entry that the fired timer installed. A newer Add for the same obj
+// replaces the entry, and a fired timer's cleanup must not remove it.
+func (s *scheduledWorkQueue[T]) forgetIfOwned(obj T, entry *workEntry) {
+	s.workLock.Lock()
+	defer s.workLock.Unlock()
+
+	if s.work[obj] == entry {
 		delete(s.work, obj)
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -99,3 +99,46 @@ func TestConcurrentAdd(t *testing.T) {
 		synctest.Wait()
 	})
 }
+
+// TestAddDuringCallbackKeepsNewerTimer reproduces #9269: a newer Add for
+// the same object must not be cancelled by the fired timer's deferred
+// cleanup.
+func TestAddDuringCallbackKeepsNewerTimer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var calls []string
+
+		release := make(chan struct{})
+		queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj string) {
+			mu.Lock()
+			first := len(calls) == 0
+			mu.Unlock()
+			if first {
+				// Hold the callback open so the map entry can be replaced
+				// while the fired timer's cleanup is still pending.
+				<-release
+			}
+			mu.Lock()
+			calls = append(calls, obj)
+			mu.Unlock()
+		})
+
+		queue.Add("obj", time.Second)
+
+		time.Sleep(time.Second)
+		synctest.Wait() // timer fired; callback is now blocked on release
+
+		queue.Add("obj", time.Minute) // replaces the entry
+		close(release)
+		synctest.Wait() // the first callback's cleanup has run
+		assert.Len(t, queue.(*scheduledWorkQueue[string]).work, 1)
+
+		time.Sleep(time.Minute)
+		synctest.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, []string{"obj", "obj"}, calls)
+		assert.Empty(t, queue.(*scheduledWorkQueue[string]).work)
+	})
+}


### PR DESCRIPTION
### What

The timer callback cleaned itself up with a deferred `Forget(obj)`, which cancels whatever entry is in the work map at the time it runs, not necessarily the timer that just fired. All three callers reschedule from their reconcile loop, and a concurrent `Add(obj, d2)` landing between `processFunc` returning and the deferred `Forget` taking the lock had its timer cancelled and deleted, silently losing the reschedule until the next informer resync.

### Fix

- `work` stores `*workEntry` pointers; each timer captures its own entry.
- The fired timer's cleanup is `forgetIfOwned`, which removes the map entry only while the map still points at that timer's entry. A newer `Add` for the same object replaces the pointer, so the older timer's cleanup leaves it untouched.
- `Add`'s replacement branch no longer deletes the key (it is reassigned under the same lock).
- Public `Forget` semantics are unchanged; the guarantee is documented on the exported `Add` docs.

### Test

`TestAddDuringCallbackKeepsNewerTimer` (synctest) holds the first callback open while a newer `Add` replaces the entry. It asserts the map still holds the newer entry after the first callback's cleanup, and that it is empty once both timers have fired. It fails against the old `Forget` cleanup (dropped reschedule), against an ownership check that never matches (map leak), and against one that always matches (unreachable live timer).

### Verification

- `go test -race ./pkg/scheduler/ -count=10` passes (whole package).
- `gofmt` and `go vet` clean.

Rebased on master after #9267.

Fixes #9269

```release-note
Fixed a race in pkg/scheduler where the cleanup of a fired timer could cancel a newer timer scheduled for the same object, silently dropping a rescheduled poll.
```
