### PR TITLE
fix(acme): make the custom DNS server rotation counter atomic (#9273)

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -272,9 +273,11 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 
 	if len(dnsServers) != 0 {
 		transport.DialContext = func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
-			// we need to increment a counter to iterate through the dns servers as the dialer will not
-			// return an error if the dns server is not responding.
-			counter := 0
+			// This Dial ignores the resolv.conf address that the resolver passes
+			// in, so we rotate through dnsServers ourselves. Without this, every
+			// resolver retry would hit the same server. The counter is atomic
+			// because the resolver dials from parallel A and AAAA goroutines.
+			var counter atomic.Uint32
 			dialer := &net.Dialer{
 				Timeout: 3 * time.Second,
 				Resolver: &net.Resolver{
@@ -283,8 +286,7 @@ func testReachability(ctx context.Context, url *url.URL, key string, dnsServers 
 						d := net.Dialer{
 							Timeout: 3 * time.Second,
 						}
-						s := dnsServers[counter%len(dnsServers)]
-						counter++
+						s := dnsServers[int(counter.Add(1)-1)%len(dnsServers)]
 						return d.DialContext(ctx, network, s)
 					},
 				},

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -109,6 +109,51 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 		t.Fatalf("Failed to resolve %s: %v", u.Host, err)
 	}
 
+	handleDNS := func(called *int32) func(dns.ResponseWriter, *dns.Msg) {
+		return func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+
+			if r.Opcode != dns.OpcodeQuery {
+				return
+			}
+			for _, q := range m.Question {
+				if q.Name != u.Host+"." {
+					continue
+				}
+				switch q.Qtype {
+				case dns.TypeA:
+					t.Logf("A Query for %s\n", q.Name)
+					atomic.StoreInt32(called, 1)
+					for _, ip := range ips {
+						if strings.Contains(ip.String(), ":") {
+							continue
+						}
+						rr, err := dns.NewRR(fmt.Sprintf("%s A %s", q.Name, ip))
+						if err == nil {
+							m.Answer = append(m.Answer, rr)
+						}
+					}
+				case dns.TypeAAAA:
+					t.Logf("AAAA Query for %s\n", q.Name)
+					atomic.StoreInt32(called, 1)
+					for _, ip := range ips {
+						if !strings.Contains(ip.String(), ":") {
+							continue
+						}
+						rr, err := dns.NewRR(fmt.Sprintf("%s AAAA %s", q.Name, ip))
+						if err == nil {
+							m.Answer = append(m.Answer, rr)
+						}
+					}
+				}
+			}
+			if err := w.WriteMsg(m); err != nil {
+				t.Errorf("failed to write DNS response: %v", err)
+			}
+		}
+	}
+
 	dnsServerStarted := make(chan struct{})
 	dnsServerCalled := int32(0)
 
@@ -121,48 +166,7 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 
 	mux := &dns.ServeMux{}
 	server.Handler = mux
-	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
-		m := new(dns.Msg)
-		m.SetReply(r)
-
-		if r.Opcode != dns.OpcodeQuery {
-			return
-		}
-		for _, q := range m.Question {
-			if q.Name != u.Host+"." {
-				continue
-			}
-			switch q.Qtype {
-			case dns.TypeA:
-				t.Logf("A Query for %s\n", q.Name)
-				atomic.StoreInt32(&dnsServerCalled, 1)
-				for _, ip := range ips {
-					if strings.Contains(ip.String(), ":") {
-						continue
-					}
-					rr, err := dns.NewRR(fmt.Sprintf("%s A %s", q.Name, ip))
-					if err == nil {
-						m.Answer = append(m.Answer, rr)
-					}
-				}
-			case dns.TypeAAAA:
-				t.Logf("AAAA Query for %s\n", q.Name)
-				atomic.StoreInt32(&dnsServerCalled, 1)
-				for _, ip := range ips {
-					if !strings.Contains(ip.String(), ":") {
-						continue
-					}
-					rr, err := dns.NewRR(fmt.Sprintf("%s AAAA %s", q.Name, ip))
-					if err == nil {
-						m.Answer = append(m.Answer, rr)
-					}
-				}
-			}
-		}
-		if err := w.WriteMsg(m); err != nil {
-			t.Errorf("failed to write DNS response: %v", err)
-		}
-	})
+	mux.HandleFunc(".", handleDNS(&dnsServerCalled))
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
@@ -170,37 +174,72 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 		}
 	}()
 
-	// Wait for server to have started
+	dnsServer2Started := make(chan struct{})
+	dnsServer2Called := int32(0)
+
+	server2 := &dns.Server{Addr: "127.0.0.1:15354", Net: "udp", NotifyStartedFunc: func() { close(dnsServer2Started) }}
+	defer func() {
+		if err := server2.Shutdown(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	mux2 := &dns.ServeMux{}
+	server2.Handler = mux2
+	mux2.HandleFunc(".", handleDNS(&dnsServer2Called))
+
+	go func() {
+		if err := server2.ListenAndServe(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Wait for both servers to have started
 	<-dnsServerStarted
+	<-dnsServer2Started
 
 	key := "there is no key"
 
 	tests := []struct {
-		name            string
-		dnsServers      []string
-		dnsServerCalled bool
+		name             string
+		dnsServers       []string
+		dnsServer1Called bool
+		dnsServer2Called bool
 	}{
 		{
-			name:            "custom dns servers",
-			dnsServers:      []string{"127.0.0.1:15353"},
-			dnsServerCalled: true,
+			name:             "custom dns servers",
+			dnsServers:       []string{"127.0.0.1:15353"},
+			dnsServer1Called: true,
+			dnsServer2Called: false,
 		},
 		{
-			name:            "system dns servers",
-			dnsServerCalled: false,
+			name:             "two custom dns servers",
+			dnsServers:       []string{"127.0.0.1:15353", "127.0.0.1:15354"},
+			dnsServer1Called: true,
+			dnsServer2Called: true,
+		},
+		{
+			name:             "system dns servers",
+			dnsServer1Called: false,
+			dnsServer2Called: false,
 		},
 	}
 
 	for _, tt := range tests {
 		atomic.StoreInt32(&dnsServerCalled, 0)
+		atomic.StoreInt32(&dnsServer2Called, 0)
 		err = testReachability(t.Context(), u, key, tt.dnsServers, "cert-manager-test")
 		switch {
 		case err == nil:
 			t.Errorf("Expected error for testReachability, but got none")
 		case strings.Contains(err.Error(), key):
-			called := atomic.LoadInt32(&dnsServerCalled) == 1
-			if called != tt.dnsServerCalled {
-				t.Errorf("Expected DNS server called: %v, but got %v", tt.dnsServerCalled, called)
+			called1 := atomic.LoadInt32(&dnsServerCalled) == 1
+			called2 := atomic.LoadInt32(&dnsServer2Called) == 1
+			if called1 != tt.dnsServer1Called {
+				t.Errorf("Expected DNS server 1 called: %v, but got %v", tt.dnsServer1Called, called1)
+			}
+			if called2 != tt.dnsServer2Called {
+				t.Errorf("Expected DNS server 2 called: %v, but got %v", tt.dnsServer2Called, called2)
 			}
 		default:
 			t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
### What

`go test -race ./pkg/issuer/acme/http/` fails on TestReachabilityCustomDnsServers: the DNS-server rotation counter in `testReachability` is a plain int captured by the `Resolver.Dial` closure, and Go's resolver calls `Dial` from concurrent goroutines (parallel A/AAAA lookups), so the read at `counter%len(dnsServers)` races with the `counter++` write.

### Fix

The counter is now an `atomic.Uint32` and the round-robin index is derived with `counter.Add(1)-1`, preserving the rotation order (first dial uses `dnsServers[0]`, second uses `dnsServers[1]`, and so on). The counter is scoped to a single DialContext call, so no wider state change is needed. The comment above the counter now states why it exists: the Dial ignores the resolv.conf address the resolver passes in, so the rotation is done here, and the counter must be atomic because the resolver dials from parallel A and AAAA goroutines.

### Test

TestReachabilityCustomDnsServers now starts a second UDP server on 127.0.0.1:15354 and a "two custom dns servers" case asserts that both servers receive at least one query (no assumption about which server answers first, since the A/AAAA dial order depends on goroutine scheduling).

### Verification

- With the fix: `go test -race ./pkg/issuer/acme/http/ -count=1` passes.
- Without the fix (plain int restored): TestReachabilityCustomDnsServers fails under `-race` in under a second with the same data race.
- `gofmt` and `go vet` clean.

Part of #9266 (pkg/issuer/acme/http is the 1-race entry in its table).

Fixes #9273

```release-note
Fixed a data race in the ACME HTTP-01 self-check that could occur when custom DNS servers were configured.
```
