### PR TITLE
[release-1.20] Ignore x/crypto ssh CVEs in trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,12 @@ CVE-2020-8559
 # sub-package; we only use x/crypto for SSH and other unrelated packages. No fixed version exists because the
 # advisory is a permanent deprecation notice, not a code bug.
 GO-2026-5932
+
+# CVE-2026-56855 (GO-2026-6355) and CVE-2026-78662 (GO-2026-6354) are deadlocks in the golang.org/x/crypto/ssh
+# connection multiplexer, triggered by a malicious SSH peer after a connection is established. cert-manager does
+# not import golang.org/x/crypto/ssh. The only importer is github.com/Venafi/vcert/v5/pkg/util, which calls
+# ssh.NewPublicKey and ssh.MarshalAuthorizedKey to format a public key and never opens an SSH connection.
+# The fixed version, x/crypto v0.56.0, requires go 1.26.0 and cannot be adopted on release-1.20, which builds
+# with go 1.25.0 (see https://github.com/cert-manager/cert-manager/pull/9264).
+CVE-2026-56855
+CVE-2026-78662


### PR DESCRIPTION
## Motivation

All four `ci-cert-manager-release-1.20-trivy-test-*` jobs for the cainjector, controller, startupapicheck and webhook images are failing on [testgrid](https://testgrid.k8s.io/cert-manager-periodics-release-1.20). Trivy flags two CVEs in `golang.org/x/crypto v0.55.0`:

- [CVE-2026-56855](https://pkg.go.dev/vuln/GO-2026-6355): a malicious SSH peer can deadlock an established connection with crafted channel messages.
- [CVE-2026-78662](https://pkg.go.dev/vuln/GO-2026-6354): a malicious SSH peer can deadlock a connection by flooding requests to a channel that is not yet established.

Both are in `golang.org/x/crypto/ssh`. The fix is in `v0.56.0`, which requires `go 1.26.0`. Renovate proposed that bump in #9264 and we closed it: it would raise the `go` directive on release-1.20 from `1.25.0` and break `make verify` and `make test`. The fix is already in on release-1.21 (#9265) and master (#9259).

## Change

Add both CVEs to `.trivyignore`, following #8983.

## Why this is safe

cert-manager does not import `golang.org/x/crypto/ssh`. The only importer in the release-1.20 module graph is vcert, whose [`sshKeyGenerator.go`](https://github.com/Venafi/vcert/blob/v5.12.3/pkg/util/sshKeyGenerator.go) calls `ssh.NewPublicKey` and `ssh.MarshalAuthorizedKey` to format a public key. It never opens an SSH connection, so the vulnerable multiplexer code is unreachable.

<details>
<summary>Evidence</summary>

```
$ git grep -n '"golang.org/x/crypto/ssh' upstream/release-1.20 -- '*.go'
(no results)

$ grep -rln 'golang.org/x/crypto/ssh' $GOMODCACHE/github.com/!venafi/vcert/v5@v5.12.3 --include=*.go | grep -v _test
.../pkg/util/sshKeyGenerator.go

$ grep -rhoE 'ssh\.[A-Z][A-Za-z]*' $GOMODCACHE/github.com/!venafi/vcert/v5@v5.12.3 --include=*.go | sort | uniq -c
      1 ssh.MarshalAuthorizedKey
      1 ssh.NewPublicKey
```

</details>

## Testing

There is no trivy presubmit, only the periodic jobs, so CI on this PR does not exercise the change. Verified locally with the pinned trivy (v0.69.2) from the repo root:

```
$ _bin/tools/trivy fs --scanners vuln --exit-code 1 --ignorefile .trivyignore cmd/controller
exit=0

$ _bin/tools/trivy fs --scanners vuln --exit-code 1 --ignorefile /dev/null cmd/controller
exit=1  # CVE-2026-56855, CVE-2026-78662, GO-2026-5932
```

## Release Note

```release-note
NONE
```

[Claude Fable 5.1]
