### PR TITLE
Add design: disable the ACME HTTP-01 solver and drop its RBAC

### DIFF
--- a/design/20260905.disable-acme-http01-solver.md
+++ b/design/20260905.disable-acme-http01-solver.md
@@ -1,0 +1,395 @@
+# Disable the ACME HTTP-01 solver and drop its RBAC
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Why the first attempt failed](#why-the-first-attempt-failed)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Controller configuration](#controller-configuration)
+  - [Controller changes](#controller-changes)
+  - [Helm chart changes](#helm-chart-changes)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Supported Versions](#supported-versions)
+- [Production Readiness](#production-readiness)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Prior art](#prior-art)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [ ] This design doc has been discussed and approved
+- [ ] Test plan has been agreed upon and the tests implemented
+- [ ] Feature gate status has been agreed upon (no feature gate, see [Graduation Criteria](#graduation-criteria))
+- [ ] Graduation criteria is in place if required
+- [ ] User-facing documentation has been PR-ed against the release branch in [cert-manager/website][]
+
+[cert-manager/website]: https://github.com/cert-manager/website
+
+## Summary
+
+The cert-manager controller can create Pods, Services, Ingresses and HTTPRoutes in every namespace.
+It needs those permissions only to solve ACME HTTP-01 challenges.
+Users who never use HTTP-01 want to remove them, because a compromised controller could use `create pods` to escalate to cluster admin.
+This is [cert-manager#7598][].
+
+We propose one setting, on by default, that controls the HTTP-01 solver in the controller and the matching RBAC rules in the Helm chart.
+Turning it off disables the solver and removes the rules together.
+When the solver is off the controller does not start the Pod and Service informers, so it needs no read access to those resources either.
+HTTP-01 Challenges created while the solver is off fail with a clear reason instead of hanging.
+
+[cert-manager#7598]: https://github.com/cert-manager/cert-manager/issues/7598
+
+## Motivation
+
+The `-controller-challenges` ClusterRole grants `create` and `delete` on Pods and Services cluster-wide, and `create`, `update` and `delete` on Ingresses and HTTPRoutes.
+See [rbac.yaml lines 211 to 226][rbac-http01-rules].
+Only the HTTP-01 solver uses these verbs.
+The DNS-01 solver needs only the rules that are already duplicated at the bottom of the same role.
+
+Today the only way to remove these rules is `global.rbac.create=false`, which removes every Role and ClusterRole.
+Users then have to maintain a full copy of cert-manager's RBAC themselves.
+
+[rbac-http01-rules]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/deploy/charts/cert-manager/templates/rbac.yaml#L211-L226
+
+### Why the first attempt failed
+
+[cert-manager#7666][] added `global.rbac.disableHTTPChallengesRole`, which removed the HTTP-01 RBAC rules but changed nothing in the controller.
+It shipped in v1.18.0-alpha.0 and was reverted in [cert-manager#7836][] after users reported [cert-manager#7827][]: DNS-01 challenges stopped working.
+
+The cause is in the challenges controller, not the chart:
+
+- `Register` always creates metadata-only informers for Pods and Services, at [controller.go lines 106 to 107][register-informers].
+- It always adds their `HasSynced` functions to `mustSync`, at [controller.go lines 112 to 119][register-mustsync].
+- The controller base waits for every `mustSync` function before it processes any item, at [controller.go line 100][wait-for-cache-sync].
+- The informer factory is always started, at [app/controller.go line 266][start-metadata-factory].
+
+Without `list` and `watch` on Pods and Services those informers never sync, so the challenges controller never processes any Challenge, DNS-01 included.
+The reflector also logs a forbidden error every few seconds.
+
+[cert-manager#7823][] tried to fix this by adding `get`, `list` and `watch` on Pods and Services back into the DNS-01 role.
+That works, but it grants read access to every Pod's metadata in the cluster and keeps two cluster-wide watches running for a feature that is switched off.
+It solves the symptom rather than the cause.
+This design supersedes that PR.
+
+[cert-manager#7666]: https://github.com/cert-manager/cert-manager/pull/7666
+[cert-manager#7836]: https://github.com/cert-manager/cert-manager/pull/7836
+[cert-manager#7827]: https://github.com/cert-manager/cert-manager/issues/7827
+[cert-manager#7823]: https://github.com/cert-manager/cert-manager/pull/7823
+[register-informers]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/controller/acmechallenges/controller.go#L106-L107
+[register-mustsync]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/controller/acmechallenges/controller.go#L112-L119
+[wait-for-cache-sync]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/controller/controller.go#L100
+[start-metadata-factory]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/cmd/controller/app/controller.go#L266
+
+### Goals
+
+- A user who does not use HTTP-01 can install cert-manager with Helm and get a controller ServiceAccount that has no access to Pods or Services, and no write access to Ingresses or HTTPRoutes.
+- With the solver off, DNS-01 challenges keep working and the controller logs no RBAC errors.
+- With the solver off, an HTTP-01 Challenge fails fast with a reason that names the switch.
+- With the solver off, the controller uses less memory because it no longer caches Pod and Service metadata.
+- The default behavior does not change.
+
+### Non-Goals
+
+- Rejecting Issuers that configure an HTTP-01 solver when the solver is off.
+  The webhook does not know the controller configuration.
+  See [Notes/Constraints/Caveats](#notesconstraintscaveats).
+- Disabling the DNS-01 solver.
+  It needs no permissions beyond those the orders and issuers controllers already have.
+- Splitting cert-manager into one Deployment and ServiceAccount per controller.
+  See [Alternatives](#alternatives).
+- Reducing the Secrets permissions.
+  Those are shared by many controllers and are tracked separately.
+
+## Proposal
+
+Add a boolean to the controller configuration, `acmeHTTP01Config.enabled`, with the flag `--enable-acme-http01-solver`.
+Both default to `true`.
+
+Add a Helm value `acmesolver.enabled`, default `true`.
+The `acmesolver` section already holds every HTTP-01 solver setting: the image and the runtime class name.
+When `acmesolver.enabled` is `false` the chart:
+
+1. passes `--enable-acme-http01-solver=false` to the controller;
+2. omits the HTTP-01 rules from the `-controller-challenges` ClusterRole;
+3. omits the `--acme-http01-solver-image` argument, since no solver Pods will be created.
+
+When the controller starts with the solver off it:
+
+1. does not create the Pod and Service metadata informers, and does not add them to `mustSync`;
+2. does not build the HTTP-01 `Solver`, so no Ingress or HTTPRoute lister is registered by the challenges controller;
+3. marks any HTTP-01 Challenge as `Errored` with reason `HTTP-01 solver is disabled (--enable-acme-http01-solver=false)` and emits a Warning Event.
+
+### User Stories
+
+**Story 1.** An EKS platform team issues certificates from a private CA and from Let's Encrypt with the Route53 DNS-01 solver.
+Their security policy forbids cluster-wide `create pods`.
+They set `acmesolver.enabled=false` in their Helm values.
+The controller ServiceAccount loses access to Pods and Services, DNS-01 issuance continues, and the team removes a custom RBAC overlay they had been maintaining.
+
+**Story 2.** A developer on that cluster creates an Issuer with an `http01` solver.
+The Order and Challenge are created as normal.
+The Challenge moves to `Errored` within seconds with a reason that names the disabled switch, and a Warning Event appears on the Challenge.
+The developer switches to `dns01` or asks the platform team to enable HTTP-01.
+
+### Notes/Constraints/Caveats
+
+**The webhook cannot reject HTTP-01 Issuers.**
+The webhook runs in a separate Deployment and does not read the controller configuration.
+An Issuer with only `http01` solvers is accepted and becomes Ready.
+The failure surfaces on the Challenge.
+This matches how the Gateway API solver behaves today: `Present` returns an error when `GatewaySolverEnabled` is false, at [http.go line 128][gateway-disabled].
+
+**Ingress read access stays.**
+The ingress-shim controller needs `get`, `list` and `watch` on Ingresses and HTTPRoutes.
+Only the `create`, `update` and `delete` verbs move behind the switch.
+
+**The Challenge does not retry.**
+A Challenge in `Errored` state is final and the controller stops reconciling it, see [IsFinalState][is-final-state].
+If an administrator later enables the solver, the Order and Certificate retry through the normal issuance backoff, which creates a new Challenge.
+
+**Existing HTTP-01 Challenges at switch-off time.**
+A Challenge that was `Presented` before the switch was turned off cannot be cleaned up, because the controller no longer has permission to delete the solver Pod.
+The controller still removes the finalizer so the Challenge can be deleted, and logs the resources it could not clean up.
+The Helm value documentation tells administrators to wait for in-flight HTTP-01 Orders to finish before turning the solver off.
+
+[is-final-state]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/acme/util.go#L33-L38
+[gateway-disabled]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/issuer/acme/http/http.go#L128
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| A user sets the Helm value against an older controller image and hits the #7827 failure again. | The chart passes a new flag. An older controller rejects unknown flags and exits, so the failure is immediate and the log names the flag. |
+| A user turns the solver off while HTTP-01 Challenges are in flight and leaks solver Pods. | Documented in the Helm value. The finalizer is still removed so the Challenge does not hang. |
+| Chart and controller flag drift, for example the RBAC is removed but the flag is not passed. | Both are driven by the same Helm value in the same template. A helm-unittest snapshot covers both outputs. |
+| Confusion between `acmesolver.enabled` and disabling ACME altogether. | The value comment says explicitly that DNS-01 continues to work. |
+
+## Design Details
+
+### Controller configuration
+
+Add to `ACMEHTTP01Config` in `pkg/apis/config/controller/v1alpha1/types.go`, which is at [types.go line 199][acme-http01-config]:
+
+```go
+type ACMEHTTP01Config struct {
+	// Enabled controls whether the controller solves ACME HTTP-01 challenges.
+	// When false, the controller does not watch Pods or Services, does not
+	// create Pods, Services, Ingresses or HTTPRoutes, and marks HTTP-01
+	// Challenges as Errored. Defaults to true.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// ... existing fields
+}
+```
+
+Add the flag in `cmd/controller/app/options/options.go` next to the other `--acme-http01-solver-*` flags:
+
+```go
+fs.BoolVar(&c.ACMEHTTP01Config.Enabled, "enable-acme-http01-solver", c.ACMEHTTP01Config.Enabled, ""+
+	"Whether to solve ACME HTTP-01 challenges. Set to false if you only use DNS-01, "+
+	"so that cert-manager does not need permission to create Pods, Services, Ingresses or HTTPRoutes.")
+```
+
+Default `true` in `defaults.go` and in the scheme defaulting functions, with a conversion for the internal type.
+
+[acme-http01-config]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/apis/config/controller/v1alpha1/types.go#L199
+
+### Controller changes
+
+**`pkg/controller/context.go`.**
+Expose the setting on `Context` as `HTTP01SolverEnabled bool`, next to `GatewaySolverEnabled`.
+Keep building the metadata informer factory unconditionally.
+An informer factory with no registered informers is cheap and `Start` on it is a no-op, so no change is needed in `cmd/controller/app/controller.go`.
+
+**`pkg/controller/acmechallenges/controller.go`.**
+Wrap the HTTP-01 informer registration in the same shape as the existing Gateway API block at [lines 121 to 124][register-gateway]:
+
+```go
+if ctx.HTTP01SolverEnabled {
+	podInformer := ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
+	serviceInformer := ctx.HTTP01ResourceMetadataInformersFactory.ForResource(corev1.SchemeGroupVersion.WithResource("services"))
+	ingressInformer := ctx.KubeSharedInformerFactory.Ingresses()
+	mustSync = append(mustSync,
+		podInformer.Informer().HasSynced,
+		serviceInformer.Informer().HasSynced,
+		ingressInformer.Informer().HasSynced,
+	)
+	if ctx.GatewaySolverEnabled {
+		mustSync = append(mustSync, ctx.GWShared.Gateway().V1().HTTPRoutes().Informer().HasSynced)
+	}
+	c.httpSolver, err = http.NewSolver(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+}
+```
+
+`c.httpSolver` stays `nil` when the solver is off.
+
+**`pkg/controller/acmechallenges/sync.go`.**
+In `Sync`, before `solverFor` at the top of the reconcile, add:
+
+```go
+if ch.Spec.Type == cmacme.ACMEChallengeTypeHTTP01 && c.httpSolver == nil {
+	ch.Status.State = cmacme.Errored
+	ch.Status.Reason = "HTTP-01 solver is disabled (--enable-acme-http01-solver=false)"
+	c.recorder.Event(ch, corev1.EventTypeWarning, reasonSolverDisabled, ch.Status.Reason)
+	return nil
+}
+```
+
+The existing status update at the end of `Sync` persists the change.
+The orders controller already treats an `Errored` Challenge as a failed Order, see [acmeorders/sync.go line 199][orders-failed].
+
+In `finalize`, when the solver is nil, log the Challenge's solver resources that cannot be cleaned up and remove the finalizer.
+
+**`pkg/issuer/acme/http/http.go`.**
+`NewSolver` is unchanged.
+It is simply not called when the solver is off.
+
+[orders-failed]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/controller/acmeorders/sync.go#L199
+[register-gateway]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/pkg/controller/acmechallenges/controller.go#L121-L124
+
+### Helm chart changes
+
+**`values.yaml`.**
+Add to the existing `acmesolver` section:
+
+```yaml
+acmesolver:
+  # Whether to solve ACME HTTP-01 challenges. Set to false if you only use
+  # DNS-01 solvers. cert-manager then does not need permission to create
+  # Pods, Services, Ingresses or HTTPRoutes, and the chart omits those RBAC
+  # rules. DNS-01 and all non-ACME issuers continue to work. Wait for any
+  # in-flight HTTP-01 Orders to finish before setting this to false.
+  enabled: true
+```
+
+**`templates/deployment.yaml`.**
+Follow the `disableAutoApproval` pattern at [deployment.yaml line 152][deploy-disable-auto-approval]:
+
+```yaml
+{{- if .Values.acmesolver.enabled }}
+- --acme-http01-solver-image={{ ... }}
+{{- else }}
+- --enable-acme-http01-solver=false
+{{- end }}
+```
+
+**`templates/rbac.yaml`.**
+Wrap the `# HTTP01 rules` block and the `route.openshift.io` rule in `{{- if .Values.acmesolver.enabled }}`.
+Do not rename or split the ClusterRole.
+#7666 renamed it, which forces Helm to delete and recreate the role and binding on upgrade for every user.
+Gating rules inside the existing role has no effect on users who keep the default.
+
+Remove the `# DNS01 rules (duplicated above)` block, which is a verbatim copy of the Secrets rule earlier in the same role.
+
+[deploy-disable-auto-approval]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/deploy/charts/cert-manager/templates/deployment.yaml#L152
+
+### Test Plan
+
+**Unit tests.**
+
+- `acmechallenges` `Register` with the solver off: no Pod or Service informer is registered on the metadata factory and `mustSync` contains no Pod, Service or Ingress entry.
+- `acmechallenges` `Sync` with the solver off: an HTTP-01 Challenge becomes `Errored` with the documented reason and a Warning Event, and a DNS-01 Challenge is processed as before.
+- `acmechallenges` `finalize` with the solver off: the finalizer is removed from a `Presented` HTTP-01 Challenge.
+- Controller configuration: defaulting sets `enabled` to `true`, conversion round-trips, and `--enable-acme-http01-solver=false` is parsed.
+
+**Helm unit tests** in `deploy/charts/cert-manager/tests/controller`.
+
+- Snapshot with `acmesolver.enabled=false`: the Deployment has the new flag and no image flag, and the challenges ClusterRole has no Pod, Service, Ingress, HTTPRoute or `routes/custom-host` rule.
+- Snapshot with the default: unchanged from today.
+
+**End-to-end test.**
+Add one e2e case in the existing ACME DNS-01 suite that runs only when the framework is configured with `acmesolver.enabled=false`.
+Add a Prow presubmit variant, or a step in an existing job, that installs the chart with `acmesolver.enabled=false` and runs the DNS-01 and CA issuer suites.
+This proves the reverted #7666 failure does not come back: with the RBAC removed, DNS-01 issuance still completes and the controller log contains no `is forbidden` lines.
+The HTTP-01 suites are skipped in that variant.
+
+### Graduation Criteria
+
+No feature gate.
+This is a configuration option that defaults to the current behavior.
+Feature gates guard code paths whose design may still change; here the path is the existing one with parts skipped.
+The Helm value follows `disableAutoApproval`, which also shipped without a gate.
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade.** Defaults keep today's behavior. No action needed.
+
+**Downgrade of the chart** with `acmesolver.enabled=false` set: the old chart ignores the value, restores the RBAC, and runs the controller with HTTP-01 on. Harmless.
+
+**Chart with `acmesolver.enabled=false` and an older controller image**: the controller exits on the unknown flag. The Deployment does not become Ready and the log names the flag.
+
+### Supported Versions
+
+All Kubernetes versions supported by cert-manager. No new API is used.
+
+## Production Readiness
+
+### How can this feature be enabled / disabled for an existing cert-manager installation?
+
+Set `acmesolver.enabled` in Helm values, or the flag or configuration field for other install methods. Turning the solver back on requires no other steps. Turning it off should wait for in-flight HTTP-01 Orders.
+
+### Does this feature depend on any specific services running in the cluster?
+
+No.
+
+### Will enabling / using this feature result in new API calls?
+
+No. It removes two cluster-wide LIST and WATCH streams.
+
+### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+No.
+
+### Will enabling / using this feature result in significant increase of resource usage?
+
+No. Memory drops because Pod and Service metadata is no longer cached. The metadata-only cache was introduced in [cert-manager#5976][] to reduce this cost; turning the solver off removes it.
+
+[cert-manager#5976]: https://github.com/cert-manager/cert-manager/pull/5976
+
+## Drawbacks
+
+- One more configuration knob and one more code path to keep working.
+- Users can put themselves in a state where an Issuer is Ready but its Challenges always fail. The Challenge reason and Event make this visible.
+
+## Alternatives
+
+**Chart-only change, as in #7666.**
+Fails as described above. The controller must know the solver is off.
+
+**Add read access back to the DNS-01 role, as in #7823.**
+Keeps two cluster-wide watches and grants metadata read on every Pod in the cluster to a controller that will never use it. Fixes the symptom only.
+
+**Detect missing permissions with a SelfSubjectAccessReview at startup.**
+The controller could skip the informers when it finds it cannot list Pods. This needs no new flag, but it turns an RBAC mistake into a silent behavior change, and a partial RBAC state, for example `list` allowed but `create` denied, is still broken. Explicit configuration is safer.
+
+**Reuse `--controllers`.**
+The challenges controller handles both DNS-01 and HTTP-01, so `--controllers=*,-challenges` disables both. Splitting it into two controllers is a larger change with no other benefit.
+
+**Read the setting from `.Values.config`.**
+The chart could inspect `config.acmeHTTP01Config.enabled` and gate RBAC on it. This is fragile: `config` is free-form, it may be supplied through `extraArgs`, and the chart would need to know the controller configuration schema. A dedicated value is the existing pattern.
+
+**One Deployment and ServiceAccount per controller.**
+kube-controller-manager does this with `--use-service-account-credentials`. It would let each controller carry only its own RBAC. It is a much larger change to the chart and to leader election, and it does not remove the HTTP-01 permissions unless the solver can also be turned off, so it does not replace this proposal.
+
+## Prior art
+
+- `disableAutoApproval` in the chart: one value that both removes a ClusterRole and changes controller arguments. [rbac.yaml line 499][rbac-disable-auto-approval] and [deployment.yaml line 152][deploy-disable-auto-approval].
+- Gateway API gating: the challenges controller adds the HTTPRoute informer to `mustSync` only when `GatewaySolverEnabled`, and the Gateway informer factory is started only when the feature is on, at [app/controller.go line 273][start-gw-factory].
+- [Kubernetes controller roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#controller-roles): one ClusterRole per controller, bound to a per-controller ServiceAccount when `--use-service-account-credentials` is set.
+- [cert-manager#5976][]: metadata-only informers for Pods and Services, which this design turns off entirely when unused.
+
+[rbac-disable-auto-approval]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/deploy/charts/cert-manager/templates/rbac.yaml#L499
+[start-gw-factory]: https://github.com/cert-manager/cert-manager/blob/663ae8d63af3dd27ac96c3a7e0e08bfdb5df2fb7/cmd/controller/app/controller.go#L273


### PR DESCRIPTION
Design for fixing #7598 properly, after #7666 was reverted in #7836.

In brief:

- A controller setting, `acmeHTTP01Config.enabled` / `--enable-acme-http01-solver`, default `true`. When `false` the challenges controller does not register the Pod and Service metadata informers or the HTTP-01 solver, so it needs no access to Pods or Services and DNS-01 keeps working. HTTP-01 Challenges are marked `Errored` with a reason that names the setting.
- A Helm value, `acmesolver.enabled`, default `true`. When `false` the chart passes the flag and omits the HTTP-01 rules from the `-controller-challenges` ClusterRole, following the `disableAutoApproval` pattern. No ClusterRole is renamed or split.
- No feature gate. Defaults keep today's behaviour.

The document explains why #7666 failed (the controller waited for informers it no longer had permission to run, so DNS-01 stopped, #7827) and why #7823 treats the symptom. It supersedes #7823.

Refs #7598, #7666, #7836, #7827, #7823.

### Kind

/kind design

### Release Note

```release-note
NONE
```

[Claude Fable 5.1]
