### PR TITLE
Add design: reuse Venafi access tokens across reconciles

### DIFF
--- a/design/20260905.venafi-access-token-reuse.md
+++ b/design/20260905.venafi-access-token-reuse.md
@@ -1,0 +1,474 @@
+# Reuse Venafi access tokens across reconciles
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Where the token requests come from](#where-the-token-requests-come-from)
+  - [Earlier attempts](#earlier-attempts)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Step 1: delete the duplicate verification](#step-1-delete-the-duplicate-verification)
+  - [Step 2: a client registry on the controller context](#step-2-a-client-registry-on-the-controller-context)
+  - [Step 3: token lifecycle inside the client](#step-3-token-lifecycle-inside-the-client)
+  - [What each caller does](#what-each-caller-does)
+  - [Metrics and logging](#metrics-and-logging)
+  - [Documentation](#documentation)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Supported Versions](#supported-versions)
+- [Production Readiness](#production-readiness)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Prior art](#prior-art)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [ ] This design doc has been discussed and approved
+- [ ] Test plan has been agreed upon and the tests implemented
+- [ ] Feature gate status has been agreed upon (no feature gate, see [Graduation Criteria](#graduation-criteria))
+- [ ] Graduation criteria is in place if required
+- [ ] User-facing documentation has been PR-ed against the release branch in [cert-manager/website][]
+
+[cert-manager/website]: https://github.com/cert-manager/website
+
+## Summary
+
+cert-manager asks CyberArk Certificate Manager Self-Hosted (TPP) for a new OAuth access token on every Issuer reconcile and on every CertificateRequest it signs.
+With username and password credentials each of those is a new access grant in TPP.
+Users see the grant list grow without limit and the audit log fill up.
+This is [cert-manager#7585][].
+
+We propose to keep one authenticated Venafi client per Issuer for the life of the controller, in a registry on the controller context, in the same way the ACME account registry keeps one ACME client per Issuer.
+The client requests a token once, renews it with the refresh token shortly before it expires, and falls back to the password grant only when the refresh fails.
+The client is rebuilt when the Issuer spec or its credentials Secret change.
+
+The first step, deleting a duplicate `VerifyCredentials()` call, needs no design and can merge on its own.
+
+[cert-manager#7585]: https://github.com/cert-manager/cert-manager/issues/7585
+
+## Motivation
+
+### Where the token requests come from
+
+Three call sites build a new Venafi client, and building a client authenticates:
+
+- The issuers and clusterissuers controllers call `Setup()` on every reconcile. `Setup()` builds a client at [setup.go line 51][setup-build] and then calls `VerifyCredentials()` again at [setup.go line 56][setup-verify].
+- The certificaterequests controller builds a client for every `Sign()`, at [certificaterequests/venafi/venafi.go line 85][cr-build].
+- The certificatesigningrequests controller does the same, at [certificatesigningrequests/venafi/venafi.go line 105][csr-build].
+
+`New()` calls `VerifyCredentials()` before it returns, at [venaficlient.go line 181][new-verify].
+For a username and password Issuer, `VerifyCredentials()` calls `GetRefreshToken`, which is the password grant, and then `Authenticate`, which makes a second HTTP call to read the identity, at [venaficlient.go lines 525 to 560][verify-password].
+
+So each Issuer reconcile costs two password grants and each signed CertificateRequest costs one.
+The issuer factory says a new issuer instance is cheap and need not be cached, at [factory.go lines 66 to 70][factory-comment].
+That was true before the instance authenticated in its constructor.
+
+A static `access-token` Secret avoids the grants but not the calls: every client build still verifies the token with a `GET`.
+The docs also tell users not to enable refresh tokens for that token, at [venafi.md line 150][docs-no-refresh], because cert-manager cannot renew it.
+
+[setup-build]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/issuer/venafi/setup.go#L51
+[setup-verify]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/issuer/venafi/setup.go#L56
+[cr-build]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/controller/certificaterequests/venafi/venafi.go#L85
+[csr-build]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/controller/certificatesigningrequests/venafi/venafi.go#L105
+[new-verify]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/issuer/venafi/client/venaficlient.go#L181
+[verify-password]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/issuer/venafi/client/venaficlient.go#L525-L560
+[factory-comment]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/issuer/factory.go#L66-L70
+[docs-no-refresh]: https://github.com/cert-manager/website/blob/29017e8a3f20d25a87377883228bb7f7869d6f10/content/docs/configuration/venafi.md#L150
+
+### Earlier attempts
+
+**[cert-manager#7906][]** stores the access token in a field on the `*Venafi` client.
+Every caller rebuilds that client, so the field only skips the second call inside `Setup()`.
+The fallback to the password grant when a cached token is rejected is unreachable, and the refresh token and expiry are discarded.
+The review on that PR has the details.
+
+**[cert-manager#8808][]** first included a per-Issuer `tokenCache` keyed by Issuer UID, wired in through a `NewCachingBuilder()`.
+Reviewers asked for it to be split out so that the metrics and `AuthFailed` condition could merge on their own, and it was removed in commit [912f581a][tokencache-removed].
+No follow-up PR was opened.
+Two review comments from that thread shape this design:
+
+- The `*Venafi` struct held by the certificaterequests controller is a singleton, so a cache on it is shared by every Issuer; a cache must be keyed per Issuer.
+- Keying by Issuer alone is not enough: if the credentials Secret is rotated, a cached token from the old credentials must not be reused.
+
+[cert-manager#7906]: https://github.com/cert-manager/cert-manager/pull/7906
+[cert-manager#8808]: https://github.com/cert-manager/cert-manager/pull/8808
+[tokencache-removed]: https://github.com/cert-manager/cert-manager/commit/912f581ad
+
+### Goals
+
+- A username and password Issuer requests one access grant when the controller starts, or when its credentials change, and renews it with the refresh token from then on.
+- A CertificateRequest sign makes no authentication calls when the Issuer already holds a valid token.
+- Rotating the credentials Secret, or changing the Issuer spec, takes effect on the next reconcile without a restart.
+- A revoked or expired token is detected and replaced without operator action.
+- Authentication failures still set the `AuthFailed` reason on the Issuer's `Ready` condition, and the OAuth token metrics count real token requests.
+- Concurrent CertificateRequest workers on the same Issuer never race on the token.
+
+### Non-Goals
+
+- Accepting a `refresh-token` key in the Secret alongside a static `access-token`.
+  Users who want renewal can switch to username and password.
+  This can be added later without changing the design here.
+- Sharing one client between two Issuers with the same credentials.
+  The key is the Issuer UID; two Issuers get two clients.
+- Changing the Vault issuer, which logs in on every reconcile in the same way.
+  The registry pattern here could be reused for it later.
+- Revoking tokens when cert-manager shuts down.
+
+## Proposal
+
+Three steps, each its own PR:
+
+1. Delete the second `VerifyCredentials()` call in `Setup()`.
+   `New()` has already verified the same instance.
+   This halves the grants per Issuer reconcile today and removes a duplicate metrics sample and log line.
+2. Add a `VenafiClientRegistry` to `controller.Context`, next to `ACMEAccountRegistry`.
+   The three call sites ask the registry for the Issuer's client instead of calling `client.New`.
+   The registry builds a client on first use and rebuilds it when the Issuer spec or credentials Secret change.
+3. Make the client own its token lifecycle.
+   It records the token expiry and refresh token from the grant response, refreshes before expiry, falls back to the password grant when the refresh fails, and drops its token when TPP rejects it.
+
+### User Stories
+
+**Story 1.** A platform team runs one ClusterIssuer with username and password credentials and issues a few hundred certificates a day.
+Today TPP records hundreds of new grants a day for the `cert-manager.io` application.
+After this change TPP records one grant per controller start and one refresh per token lifetime.
+
+**Story 2.** The same team rotates the TPP password.
+They update the Secret.
+The issuers controller sees the Secret event, the registry compares the new credentials hash with the cached one, builds a new client, and the ClusterIssuer stays Ready.
+CertificateRequests reconciled in between use the old token, which TPP still honours until it expires or is revoked.
+
+**Story 3.** A TPP administrator revokes the grant cert-manager is using.
+The next `RequestCertificate` fails with `401`.
+The client drops its token and returns an error; the CertificateRequest is retried with backoff and the next attempt takes a new grant.
+If the credentials themselves are now wrong, the next Issuer reconcile sets `Ready=False` with reason `AuthFailed`, as today.
+
+### Notes/Constraints/Caveats
+
+**TPP's token endpoints are not standard OAuth 2.0.**
+The password grant is a JSON `POST` to `vedauth/authorize/oauth`, the refresh is a `POST` to `vedauth/authorize/token`, and verification is a `GET` to `vedauth/authorize/verify`, see [tpp.go lines 391 to 396][tpp-urls].
+`golang.org/x/oauth2` cannot drive them directly.
+We follow the `TokenSource` shape suggested in #7585, one method that returns a valid token, but implement it with vcert's connector methods.
+
+**vcert already holds the token.**
+`tpp.Connector` stores the access token in an unexported field, at [connector.go line 46][vcert-token-field], and sets it in `Authenticate`, `VerifyAccessToken` and the refresh branch.
+The client does not copy that token.
+It keeps only what vcert discards: the expiry, the refresh token and its expiry, from [OauthGetRefreshTokenResponse][vcert-grant-resp] and [OauthRefreshAccessTokenResponse][vcert-refresh-resp].
+
+**The Ready condition lags a revocation.**
+Today every Issuer reconcile verifies the token, so a revoked grant shows on the Issuer within one resync.
+With a cached client the Issuer reconcile does not call TPP unless the token is due for renewal.
+Revocation is detected on the next sign, or the next renewal, whichever comes first.
+`Setup()` still calls `Ping()` on every reconcile, so an unreachable TPP is still reported.
+
+**Old tokens are not revoked.**
+When the registry replaces a client the old token stays valid in TPP until it expires.
+Revoking it would need `RevokeAccessToken`, at [connector.go line 277][vcert-revoke], and a failure there should not block the new client.
+Left out for now; see Non-Goals.
+
+**Static access tokens have no refresh path.**
+For an `access-token` Secret the client verifies the token once at build time, records the expiry from `OauthVerifyTokenResponse.Expires`, and reuses it.
+When it expires the Issuer goes `AuthFailed` and the user must supply a new token, as today.
+
+[tpp-urls]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/tpp.go#L391-L396
+[vcert-token-field]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/connector.go#L46
+[vcert-grant-resp]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/tpp.go#L243-L252
+[vcert-refresh-resp]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/tpp.go#L264-L271
+[vcert-revoke]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/connector.go#L277
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| A rotated Secret is not noticed and the old token is used until it expires. | The registry key includes a hash of the Secret data it reads. The issuers controller already re-queues an Issuer when its Secret changes. |
+| A revoked token is reused and every sign fails. | On an auth error from any vcert call the client drops its token, so the next call re-authenticates. A second failure surfaces as `AuthFailed`. |
+| Two workers refresh the same token at once and TPP invalidates one. | One mutex per client around the token state. A refresh holds it; concurrent signs wait. |
+| The registry grows when Issuers are deleted. | `RemoveClient` on Issuer deletion. The ACME registry does not do this today, so the same fix applies there. |
+| A long-running token is a bigger prize if the controller is compromised. | The token is already in memory today for the length of a reconcile, and the password that mints it is in the Secret. No new exposure. |
+| TPP returns no expiry in the grant response. | Treat a zero `Expires` as "verify before every use", which is today's behavior. |
+
+## Design Details
+
+### Step 1: delete the duplicate verification
+
+Remove [setup.go lines 56 to 58][setup-verify].
+`New()` returns an error when verification fails, and `Setup()` wraps that error with `%w`, so the `AuthFailedError` check in the deferred function still works.
+No other change.
+
+### Step 2: a client registry on the controller context
+
+Add to `pkg/issuer/venafi/client`:
+
+```go
+// Registry keeps one authenticated client per Issuer for the life of the
+// controller. It is safe for concurrent use.
+type Registry interface {
+	// ClientFor returns the client for the Issuer, building a new one when
+	// none exists or when the Issuer spec or its credentials Secret changed.
+	ClientFor(namespace string, secretsLister internalinformers.SecretLister, issuer cmapi.GenericIssuer, logger logr.Logger) (Interface, error)
+
+	// RemoveClient forgets the client for an Issuer UID.
+	RemoveClient(uid string)
+}
+```
+
+The registry holds `map[string]entry` under a `sync.RWMutex`, keyed by Issuer UID.
+Each entry stores the client and the inputs it was built from:
+
+```go
+type stableOptions struct {
+	issuerUID       string
+	generation      int64            // Issuer metadata.generation
+	credentialsHash [sha256.Size]byte // sha256 over the Secret data keys the client reads
+	caBundleHash    [sha256.Size]byte // sha256 over the CA bundle Secret or ConfigMap, when set
+}
+```
+
+`ClientFor` reads the Secret through the lister, computes the options, and compares them with the cached entry.
+A match returns the cached client.
+A mismatch, or no entry, builds a new client with `New()` and stores it.
+This is the shape of `ensureClient` in the ACME registry, at [registry.go line 137][acme-ensure].
+
+`metrics` and `userAgent` are passed to the registry constructor, not to `ClientFor`, since they are the same for every call.
+
+Wire it in `pkg/controller/context.go` next to [ACMEAccountRegistry][context-acme]:
+
+```go
+VenafiClientRegistry: venaficlient.NewRegistry(venaficlient.New, metrics, restConfig.UserAgent),
+```
+
+`VenafiClientBuilder` stays as the type of `New`, so tests keep injecting fakes.
+
+[acme-ensure]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/acme/accounts/registry.go#L137
+[context-acme]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/controller/context.go#L107-L109
+
+### Step 3: token lifecycle inside the client
+
+Add to `Venafi`:
+
+```go
+type Venafi struct {
+	// ... existing fields
+
+	mu           sync.Mutex
+	tokenExpiry  time.Time // zero means unknown: verify before use
+	refreshToken string
+	refreshUntil time.Time
+}
+```
+
+Replace the TPP branch of `VerifyCredentials()` with a method that every operation calls first:
+
+```go
+// ensureToken makes sure the connector holds a token that is valid for at
+// least renewBefore. It is a no-op when the current token is fresh.
+func (v *Venafi) ensureToken(now time.Time) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if !v.tokenExpiry.IsZero() && now.Before(v.tokenExpiry.Add(-renewBefore)) {
+		return nil
+	}
+
+	switch {
+	case v.config.Credentials.AccessToken != "":
+		return v.verifyStaticToken()
+	case v.refreshToken != "" && now.Before(v.refreshUntil):
+		if err := v.refresh(); err == nil {
+			return nil
+		}
+		// fall through to the password grant on any refresh error
+		fallthrough
+	case v.config.Credentials.User != "" && v.config.Credentials.Password != "":
+		return v.passwordGrant()
+	}
+	return AuthFailedError{Err: errors.New("no TPP credentials configured")}
+}
+```
+
+- `passwordGrant` calls `GetRefreshToken` and stores `Expires`, `Refresh_token` and `Refresh_until` from the response, then `Authenticate` with the access token, as today.
+- `refresh` calls `RefreshAccessToken`, at [connector.go line 225][vcert-refresh], stores the new expiry and refresh token, then `Authenticate` with the new access token.
+- `verifyStaticToken` calls `VerifyAccessToken` and stores `Expires` from the response.
+- `renewBefore` is 10% of the token lifetime, capped at one hour.
+  TPP tokens are typically valid for days, so this refreshes once per lifetime with margin for clock skew.
+
+`RequestCertificate`, `RetrieveCertificate` and `ReadZoneConfiguration` call `ensureToken` first.
+When a vcert call returns an auth error, the client sets `tokenExpiry` to zero so the next call re-authenticates, and returns the error.
+It does not retry inside the same call; the controllers already retry with backoff.
+
+The Cloud and NGTS branches keep their current logic but run through the same `ensureToken` guard.
+NGTS mints a token on every `Authenticate`, at [ngts/connector.go lines 165 to 171][ngts-auth], and returns `ExpiresIn`, at [ngts/oauth.go line 14][ngts-resp], so it gets the same reuse for free.
+The Cloud API key does not expire; its check runs once per client build.
+
+`VerifyCredentials()` becomes `ensureToken(time.Now())` and stays on the `Interface` so the CSR path and tests keep working.
+`New()` keeps calling it, so a client is never returned unauthenticated.
+
+[vcert-refresh]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/connector.go#L225
+[ngts-auth]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/ngts/connector.go#L165-L171
+[ngts-resp]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/ngts/oauth.go#L14
+
+### What each caller does
+
+| Caller | Today | After |
+| --- | --- | --- |
+| `Setup()` in the issuers controllers | build client (grant), verify again (grant), ping | `ClientFor` (grant only on first use or change), ping |
+| `Sign()` in certificaterequests | build client (grant), request, retrieve | `ClientFor` (no call), request, retrieve |
+| `Sign()` in certificatesigningrequests | same as above | same as above |
+| Issuer deleted | nothing | `RemoveClient(uid)` from the issuers controller |
+
+`Setup()` no longer calls `VerifyCredentials()` at all.
+A cached client that has gone bad is found by the next sign, which drops the token, and by the next `Setup()`, which calls `ClientFor` and gets a client whose `ensureToken` fails with `AuthFailedError`.
+
+### Metrics and logging
+
+No new metrics.
+`certmanager_venafi_oauth_token_requests_total` and the duration histogram move from `VerifyCredentials` into `passwordGrant`, `refresh` and `verifyStaticToken`, so they count real token requests instead of client builds.
+Add a `grant_type` label with values `password`, `refresh_token` and `verify`.
+This is a label addition on an existing metric, not a rename.
+
+The "Venafi OAuth token request failed" error log stays on the failure path.
+
+### Documentation
+
+Update `content/docs/configuration/venafi.md` on the website:
+
+- Remove the note at line 150 that tells users not to enable refresh tokens.
+  For username and password Issuers, refresh tokens are now used.
+  For static tokens, say the token is verified once and must be replaced before it expires.
+- Replace the note at line 195, "cert-manager does not use refresh tokens", with a description of the new behavior: one grant per start or credential change, refreshed before expiry.
+- Add an upgrade note in the release notes for the first minor that ships step 3.
+
+### Test Plan
+
+**Unit tests** in `pkg/issuer/venafi/client`.
+
+Add a small `httptest` TPP server in the package.
+None exists today; the current tests stub the vcert connector through the `connector` interface.
+The server handles the four auth endpoints and `vedsdk/Identity/Self`, counts calls per endpoint, and can be told to return `401` for the next verify or refresh.
+With it:
+
+- Two `ensureToken` calls within the token lifetime make one password grant.
+- A call after the renewal point makes one refresh and no password grant.
+- A refresh that returns `401` is followed by one password grant in the same `ensureToken` call.
+- A `401` from `RequestCertificate` clears the expiry, and the next call re-authenticates.
+- A static token is verified once; a second call makes no request.
+- `go test -race` with ten goroutines calling `ensureToken` on one client at the renewal point: one refresh, no race.
+
+A property-based test with `hegel` over a random sequence of `sign`, `advance clock`, `revoke` and `rotate Secret` steps, asserting that the number of password grants equals `1 + revocations + rotations` and that no sign is ever made with an expired token.
+
+**Registry tests** in the same package.
+
+- Same Issuer, same Secret: one build.
+- Same Issuer, changed Secret data: two builds.
+- Same Issuer, changed `generation`: two builds.
+- `RemoveClient` then `ClientFor`: two builds.
+
+**Controller tests.**
+
+- `setup_test.go`: `Setup()` no longer calls `VerifyCredentials()`; a registry error sets `AuthFailed`.
+- `certificaterequests/venafi`: `Sign()` obtains the client from the registry; the existing fake client tests continue to pass.
+
+**End-to-end.**
+The TPP e2e suite in `test/e2e/suite/issuers/venafi/tpp` runs against a real TPP when configured.
+Add one case that issues three certificates and asserts, through the metrics endpoint, that `certmanager_venafi_oauth_token_requests_total{grant_type="password"}` increased by one.
+
+### Graduation Criteria
+
+No feature gate.
+The change is internal, the API does not change, and the fallback on a rejected token restores today's behavior.
+The token metrics give operators a way to confirm the change worked.
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade.** No action.
+Users who set a short token validity in TPP to limit the grant pile-up can now set a longer one.
+
+**Downgrade.** Returns to one grant per reconcile.
+No state is persisted, so nothing to clean up.
+
+### Supported Versions
+
+All Kubernetes versions supported by cert-manager.
+vcert v5.13.7, which is already pinned, has every method used here.
+
+## Production Readiness
+
+### How can this feature be enabled / disabled for an existing cert-manager installation?
+
+It cannot be disabled.
+Step 1 and step 2 are pure reductions in calls.
+Step 3 falls back to today's password grant whenever a cached or refreshed token fails.
+
+### Does this feature depend on any specific services running in the cluster?
+
+No.
+
+### Will enabling / using this feature result in new API calls?
+
+No new Kubernetes API calls.
+The registry reads Secrets through the existing lister.
+TPP calls drop from two per Issuer reconcile plus one per sign to one per token lifetime.
+
+### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+No.
+
+### Will enabling / using this feature result in significant increase of resource usage?
+
+One client per Venafi Issuer stays in memory.
+A `tpp.Connector` is an HTTP client and a few strings.
+The ACME registry already does the same for ACME Issuers.
+
+## Drawbacks
+
+- Auth failures show up on the Issuer later than today, because the Issuer reconcile no longer calls TPP unless a renewal is due.
+- One more long-lived cache to reason about, with the invalidation rules above.
+- Tokens the registry replaces are not revoked and stay valid in TPP until they expire.
+
+## Alternatives
+
+**Keep #7906.**
+It caches on the per-reconcile client, so it saves one call per Issuer reconcile and none per sign.
+Step 1 gets the same saving by deleting a line.
+
+**A per-Issuer token cache with `NewCachingBuilder`, as in #8808 before it was removed.**
+Close to step 2, but keyed by UID alone, so a rotated Secret keeps serving the old token, and it stored the token beside vcert's copy rather than the expiry and refresh token vcert throws away.
+Reviewers also asked for it as a separate PR, which this design is.
+
+**Cache the token, not the client.**
+A token cache keyed by Issuer and credentials, with each reconcile still building a `tpp.Connector` and calling `Authenticate` with the cached token.
+`Authenticate` with an access token makes an identity `GET` on every call, at [connector.go lines 174 to 177][vcert-auth-token], so this still costs one TPP call per sign.
+Caching the client removes it.
+
+**`golang.org/x/oauth2.TokenSource`, as suggested in #7585.**
+The interface shape is right and `ensureToken` follows it.
+The library's `ReuseTokenSource` cannot be used because TPP's endpoints and JSON bodies are not OAuth 2.0 token endpoints.
+
+**`go418/concurrentcache`, as suggested on #8808.**
+It prevents two misses for the same key from building two clients at once.
+The registry mutex already serialises builds, and a duplicate build on a cold start is one extra grant.
+Not worth a dependency.
+
+**Tell users to use a static access token.**
+This is the workaround today.
+It moves the renewal problem onto the user and the docs tell them to disable refresh tokens, so the token has a hard end date.
+
+[vcert-auth-token]: https://github.com/Venafi/vcert/blob/v5.13.7/pkg/venafi/tpp/connector.go#L174-L177
+
+## Prior art
+
+- ACME account registry: one client per Issuer UID on `controller.Context`, rebuilt when the stable options change, at [registry.go lines 87 to 96][acme-stable]. Step 2 copies its shape.
+- `#8808`'s `tokenCache` and `NewCachingBuilder`, at [commit bbd74cba][tokencache-before], for a per-Issuer cache in this package.
+- vcert CLI keeps the refresh token and calls `RefreshAccessToken` when the access token expires, which is the flow step 3 automates inside the controller.
+- `golang.org/x/oauth2.ReuseTokenSource` for the "refresh a little before expiry, under a mutex" pattern.
+
+[acme-stable]: https://github.com/cert-manager/cert-manager/blob/663ae8d631a7b5254de1e1f5e30d33fcec8ffbbf/pkg/acme/accounts/registry.go#L87-L96
+[tokencache-before]: https://github.com/cert-manager/cert-manager/blob/bbd74cbafada5f0663db09b213f72e5813d68128/pkg/issuer/venafi/client/tokencache.go


### PR DESCRIPTION
Design for fixing #7585 properly, after reviewing #7906.

In brief:

- cert-manager builds and authenticates a new Venafi client on every Issuer reconcile and every CertificateRequest sign. For a username/password Issuer that is a new TPP access grant each time.
- Step 1, no design needed: delete the second `VerifyCredentials()` call in `pkg/issuer/venafi/setup.go`. `New()` has already verified the same instance. This halves the grants per Issuer reconcile.
- Step 2: a `VenafiClientRegistry` on `controller.Context`, next to `ACMEAccountRegistry`, keyed by Issuer UID and rebuilt when the Issuer generation or the credentials Secret data change. The three call sites ask the registry for the client instead of calling `client.New`.
- Step 3: the client owns its token lifecycle. It keeps the expiry and refresh token that vcert discards, refreshes shortly before expiry, falls back to the password grant when the refresh fails, and drops its token when TPP rejects it.
- No feature gate. No API change.

The document explains why #7906 does not fix the issue (the cache lives on a client every caller rebuilds) and why the per-Issuer `tokenCache` in #8808 was removed before merge and never resubmitted. It also covers NGTS, which mints a token on every `Authenticate` and gets the same reuse for free.

Refs #7585, #7906, #8808.

### Kind

/kind design

### Release Note

```release-note
NONE
```

[Claude Fable 5.1]
