### PR TITLE
Add design: publish the ACME webhook API as its own Go module

### DIFF
--- a/design/20260905.acme-webhook-api-module.md
+++ b/design/20260905.acme-webhook-api-module.md
@@ -1,0 +1,336 @@
+# Publish the ACME webhook API as its own Go module
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [The new module](#the-new-module)
+  - [How the core module depends on it](#how-the-core-module-depends-on-it)
+  - [Changing the API types](#changing-the-api-types)
+  - [Tagging at release time](#tagging-at-release-time)
+  - [Repository tooling](#repository-tooling)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Supported Versions](#supported-versions)
+- [Production Readiness](#production-readiness)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Open questions](#open-questions)
+- [Prior art](#prior-art)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [ ] This design doc has been discussed and approved
+- [ ] Test plan has been agreed upon and the tests implemented
+- [ ] Feature gate status has been agreed upon (no feature gate, see [Graduation Criteria](#graduation-criteria))
+- [ ] Graduation criteria is in place if required
+- [ ] User-facing documentation has been PR-ed against the release branch in [cert-manager/website][]
+
+[cert-manager/website]: https://github.com/cert-manager/website
+
+## Summary
+
+The Go types for the ACME DNS-01 webhook API live in the core cert-manager module.
+Anyone who imports them takes on every dependency of cert-manager.
+This is [cert-manager#9026][].
+
+We propose a new Go module rooted at `pkg/acme/webhook/apis`.
+It holds the `acme` and `acme/v1alpha1` packages and depends only on `k8s.io/apimachinery` and `k8s.io/apiextensions-apiserver`.
+Import paths do not change.
+The core module requires the new module at a real version, and each cert-manager release tags it.
+
+[cert-manager#9026]: https://github.com/cert-manager/cert-manager/issues/9026
+
+## Motivation
+
+The webhook API is how cert-manager talks to out-of-tree DNS-01 solvers.
+It is four Go types in [types.go][], plus scheme registration.
+The package has [133 known importers on pkg.go.dev][importers].
+Almost all of them are DNS provider webhooks built from [cert-manager/webhook-example][].
+
+Today the only way to get those types is to require the whole core module.
+The reporter of [cert-manager#9026][] wants the types without the rest.
+Measured at the commit this design is written against:
+
+| Module graph                                          | Modules in `go list -m all` |
+|-------------------------------------------------------|----------------------------:|
+| Core cert-manager module                              | 421                         |
+| Proposed module (apimachinery + apiextensions)        | 129                         |
+| Same, if `Config` were `json.RawMessage` (not proposed) | 65                        |
+
+The [2023 module design][gomod-design] already anticipated this.
+Its addendum says that module proliferation is the groundwork for splitting API packages into their own modules.
+
+[types.go]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/acme/webhook/apis/acme/v1alpha1/types.go
+[importers]: https://pkg.go.dev/github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1?tab=importedby
+[cert-manager/webhook-example]: https://github.com/cert-manager/webhook-example
+[gomod-design]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/design/20230302.gomod.md#L311-L319
+
+### Goals
+
+- A consumer can require the webhook API types without requiring the core cert-manager module.
+- Existing import paths keep working, so none of the 133 importers has to change code.
+- Each cert-manager release publishes a matching version of the new module.
+- The repository tooling (`make test`, `make verify`, codegen, `cmrel validate-gomod`) keeps working.
+
+### Non-Goals
+
+- Moving the `Solver` interface in `pkg/acme/webhook`, or the server in `pkg/acme/webhook/cmd`, out of the core module.
+  Both depend on `k8s.io/apiserver`, so a module containing them would be almost as heavy as core.
+- Changing the API types. `v1alpha1` stays as it is, including the `apiextensionsv1.JSON` config field.
+- Splitting `pkg/apis` (the CRD types) into a module. That is a much larger change and deserves its own design.
+- Moving the API to a new repository.
+
+## Proposal
+
+Add a `go.mod` at `pkg/acme/webhook/apis` with module path `github.com/cert-manager/cert-manager/pkg/acme/webhook/apis`.
+The two packages under it keep their import paths.
+
+The core module requires the new module at a real, published version.
+It does not use a local `replace`, so the core module stays importable.
+
+Changes to the API types therefore take two pull requests: one to change the types, one to bump the core module to the new version.
+The types have not changed in substance since 2023, so this cost is small.
+
+At release time the release manager pushes a second tag, `pkg/acme/webhook/apis/v1.X.Y`, at the same commit as `v1.X.Y`.
+
+### User Stories
+
+#### Story 1: a client that only needs the types
+
+A project wants to send `ChallengePayload` requests to existing DNS-01 webhooks, or to serve the API from a different HTTP stack.
+It requires `github.com/cert-manager/cert-manager/pkg/acme/webhook/apis` and nothing else from cert-manager.
+Its module graph shrinks from 421 modules to 129.
+
+#### Story 2: an existing webhook built from webhook-example
+
+The webhook imports `pkg/acme/webhook`, `pkg/acme/webhook/cmd` and `pkg/acme/webhook/apis/acme/v1alpha1` ([main.go lines 11 to 13][webhook-example-imports]).
+It keeps requiring the core module, because `cmd` lives there.
+After the next `go get -u` its `go.mod` gains an indirect requirement on the new module.
+Nothing else changes.
+
+[webhook-example-imports]: https://github.com/cert-manager/webhook-example/blob/8a9f428c8dc3856099baa48eec1cda30a8acdf73/main.go#L11-L13
+
+#### Story 3: a maintainer changes the API types
+
+1. Open a PR that edits `pkg/acme/webhook/apis/acme/v1alpha1/types.go` and regenerates deepcopy. Merge it.
+2. Open a PR that runs `go get github.com/cert-manager/cert-manager/pkg/acme/webhook/apis@<merge commit>` in the core module, then uses the new field. Merge it.
+
+Renovate opens the second PR itself once a tag exists, because the new module is an ordinary Go dependency of core.
+
+### Notes/Constraints/Caveats
+
+**The module path is long.**
+A module must be rooted at an ancestor of the packages it contains.
+The shortest ancestor that excludes the `k8s.io/apiserver` dependency is `pkg/acme/webhook/apis`.
+Tags are therefore `pkg/acme/webhook/apis/v1.X.Y`.
+
+**The config field keeps `apiextensionsv1.JSON`.**
+Every webhook decodes its config through that type, for example [webhook-example line 139][webhook-example-loadconfig].
+Replacing it with `json.RawMessage` would halve the module graph again but would break every importer at compile time.
+That is a change for a future API version, not this design.
+
+**Kubernetes dependencies must match.**
+The new module and the core module both require `k8s.io/apimachinery`.
+Renovate already groups Kubernetes bumps across all modules in the repository, so they move together.
+
+[webhook-example-loadconfig]: https://github.com/cert-manager/webhook-example/blob/8a9f428c8dc3856099baa48eec1cda30a8acdf73/main.go#L139
+
+### Risks and Mitigations
+
+**Risk: a maintainer forgets the tag at release time.**
+Consumers would still resolve a pseudo-version, so nothing breaks, but `go get` would not find `v1.X.Y`.
+Mitigation: add the tag to the release-process checklist, and add a `cmrel` check that fails `cmrel publish` when the tag is missing.
+
+**Risk: the core module requires a stale version of the types.**
+The core module can only see fields that exist in the version it requires.
+Mitigation: this is enforced by the compiler. A PR that uses a new field without bumping the requirement does not build.
+
+**Risk: `go test ./...` from the repository root no longer covers the new module.**
+The [2023 module design][gomod-design] accepted this for the binary modules.
+Mitigation: `make test-unit` gains one line for the new module, see [Repository tooling](#repository-tooling).
+
+## Design Details
+
+### The new module
+
+```text
+pkg/acme/webhook/apis
+├── go.mod
+├── go.sum
+└── acme
+    ├── doc.go
+    └── v1alpha1
+        ├── doc.go
+        ├── register.go
+        ├── types.go
+        └── zz_generated.deepcopy.go
+```
+
+```gomod
+module github.com/cert-manager/cert-manager/pkg/acme/webhook/apis
+
+go 1.26.0
+
+require (
+	k8s.io/apiextensions-apiserver v0.37.0
+	k8s.io/apimachinery v0.37.0
+)
+```
+
+The Go version and the Kubernetes versions match the core module.
+No source file moves or changes.
+
+### How the core module depends on it
+
+Four packages in core import the types today:
+
+- [pkg/api/scheme.go line 26][core-scheme], which adds the types to the global scheme.
+- [pkg/issuer/acme/dns/webhook/webhook.go line 31][core-webhook-client], the client the controller uses to call webhooks.
+- [pkg/issuer/acme/dns/dns.go line 33][core-dns] and [pkg/issuer/acme/dns/rfc2136/provider.go line 31][core-rfc2136].
+
+The core `go.mod` gains:
+
+```gomod
+require github.com/cert-manager/cert-manager/pkg/acme/webhook/apis v1.X.Y
+```
+
+No `replace`.
+The binary modules under `cmd/` and the test modules under `test/` already replace the core module with `../../` ([cmd/webhook/go.mod line 9][cmd-webhook-replace]).
+They inherit the requirement on the new module through core and need no change.
+
+This is the pattern cmctl used from v1.12 to v1.14, in the other direction.
+Its `go.mod` explains the trade-off in [cmd/ctl/go.mod lines 9 to 13 at cmd/ctl/v1.14.7][cmctl-note], and the bump PRs looked like [cert-manager#7078][].
+
+[core-scheme]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/api/scheme.go#L26
+[core-webhook-client]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/issuer/acme/dns/webhook/webhook.go#L31
+[core-dns]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/issuer/acme/dns/dns.go#L33
+[core-rfc2136]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/pkg/issuer/acme/dns/rfc2136/provider.go#L31
+[cmd-webhook-replace]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/cmd/webhook/go.mod#L9
+[cmctl-note]: https://github.com/cert-manager/cert-manager/blob/cmd/ctl/v1.14.7/cmd/ctl/go.mod#L9-L13
+[cert-manager#7078]: https://github.com/cert-manager/cert-manager/pull/7078
+
+### Changing the API types
+
+Locally, `make go-workspace` writes a `go.work` that lists every module in the repository ([make/_shared/go/01_mod.mk line 30][go-workspace]).
+With it, a single checkout builds core against the local types, so a developer can prototype both halves at once.
+`go.work` is git-ignored and CI does not use it, so CI always builds core against the published version.
+
+For merging, the two-PR flow in [Story 3](#story-3-a-maintainer-changes-the-api-types) applies.
+The first PR does not need a tag; the second can require a pseudo-version of the merge commit.
+
+[go-workspace]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/make/_shared/go/01_mod.mk#L30
+
+### Tagging at release time
+
+The release process gains one line next to the existing `git tag`:
+
+```bash
+git tag -m"$RELEASE_VERSION" $RELEASE_VERSION
+git tag -m"$RELEASE_VERSION" "pkg/acme/webhook/apis/$RELEASE_VERSION"
+git push origin $RELEASE_VERSION "pkg/acme/webhook/apis/$RELEASE_VERSION"
+```
+
+The core module at `v1.X.Y` may require an older version of the new module.
+That is fine: the module contents at both versions are identical unless the types changed during the cycle, and if they changed, the second PR already bumped core.
+
+A later improvement is for `cmrel` to create the extra tag, so the release manager cannot forget it.
+
+### Repository tooling
+
+**`cmrel validate-gomod`** runs in `make ci-presubmit` ([make/ci.mk line 17][ci-validate-gomod]).
+At the pinned cmrel version it:
+
+- treats every `go.mod` under the repository as a submodule that must be replaced with a local path ([validate_gomod.go line 270][cmrel-submodule-replace]);
+- rejects any local replace in the core module ([line 305][cmrel-no-core-replace]);
+- rejects a core requirement on a submodule that is not replaced ([line 357][cmrel-require-not-replaced]).
+
+The second and third rules contradict each other for a module that core requires at a real version.
+cmrel needs a `--published-modules` flag naming modules that core may require without a replace, and that no module may replace.
+This is a small change in [cert-manager/release][], done before the cert-manager PR.
+
+**Codegen.** [hack/k8s-codegen.sh line 50][codegen-input] passes the `v1alpha1` package to `deepcopy-gen` by import path, from the core module.
+Once the package lives in another module, that path resolves to the module cache, not the working tree.
+The script must run `deepcopy-gen` inside `pkg/acme/webhook/apis` for that package, or set `GOWORK` to the workspace file.
+The `openapi-gen` step for `pkg/acme/webhook/openapi` stays in core and reads the required version, which is what CI builds against anyway.
+
+**Tests and lint.** `make test-unit` and `make test-ci` list each module explicitly in `make/test.mk`; add the new module.
+`verify-golangci-lint` and `verify-govulncheck` already loop over every `go.mod` and need no change.
+`generate-go-mod-tidy` likewise.
+
+**Renovate.** No change. The gomod manager picks up the new `go.mod` and proposes bumps of core's requirement on it when tags appear.
+
+[ci-validate-gomod]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/make/ci.mk#L17
+[cmrel-submodule-replace]: https://github.com/cert-manager/release/blob/e3cbe5171488/cmd/cmrel/cmd/validate_gomod.go#L270-L276
+[cmrel-no-core-replace]: https://github.com/cert-manager/release/blob/e3cbe5171488/cmd/cmrel/cmd/validate_gomod.go#L305
+[cmrel-require-not-replaced]: https://github.com/cert-manager/release/blob/e3cbe5171488/cmd/cmrel/cmd/validate_gomod.go#L357
+[cert-manager/release]: https://github.com/cert-manager/release
+[codegen-input]: https://github.com/cert-manager/cert-manager/blob/dbffefd648579f4e6b000d75a4701817a5d6d67b/hack/k8s-codegen.sh#L50
+
+### Test Plan
+
+- `make verify` and `make test-unit` pass with the new module present.
+- A throwaway module outside the repository that requires only the new module builds, and `go list -m all` shows no cert-manager core module.
+- `cmrel validate-gomod` with the new flag accepts the repository layout, and rejects a local replace of the new module in core.
+- After the first tagged release, `go get github.com/cert-manager/cert-manager/pkg/acme/webhook/apis@v1.X.Y` resolves.
+
+### Graduation Criteria
+
+No feature gate. This is a build and packaging change with no runtime effect.
+
+### Upgrade / Downgrade Strategy
+
+No runtime effect on clusters.
+
+For Go consumers: a `go get -u` of the core module adds an indirect requirement on the new module.
+Nothing else changes for them.
+
+### Supported Versions
+
+Master only. Release branches keep the single-module layout.
+Backporting would add a new release-time step to every supported branch for no user benefit.
+
+## Production Readiness
+
+Not applicable. No new runtime behaviour.
+
+## Drawbacks
+
+- Two PRs to change the API types. The types last changed in substance in 2023, so this is rare.
+- One more tag per release, and one more thing for `cmrel` to validate.
+- Most existing webhooks gain nothing, because they also import `pkg/acme/webhook/cmd` from core.
+  The benefit goes to consumers that speak the API without using cert-manager's server library.
+
+## Alternatives
+
+| Option | Import paths | Consumer module graph | Cost to us |
+|--------|-------------|----------------------|-----------|
+| Do nothing; consumers copy the four types | unchanged | minimal | none, but each consumer re-implements the wire format |
+| **Nested module at `pkg/acme/webhook/apis` (proposed)** | unchanged | 129 modules | cmrel flag, codegen tweak, one tag per release |
+| Nested module at `pkg/acme/webhook` | unchanged | close to core, because of `k8s.io/apiserver` | same as proposed, without the benefit |
+| Nested module with a local `replace` in core, as OpenTelemetry does ([go.mod lines 22 to 24 at v1.37.0][otel-replace]) | unchanged | 129 modules | one PR per change, but cmrel forbids core replaces for a reason: importers of core see the published version, not the working tree, so core at HEAD can silently depend on unpublished types |
+| New repository `cert-manager/acme-webhook-api`, old packages become type aliases | new paths, old paths still work | smallest | new repo, CI, OWNERS, release process; alias shim in core |
+| Drop `apiextensionsv1.JSON` for `json.RawMessage` in a `v1beta1` | unchanged for v1alpha1 | 65 modules | breaks every webhook's `loadConfig`; out of scope, but a natural follow-up once the module exists |
+
+[otel-replace]: https://github.com/open-telemetry/opentelemetry-go/blob/v1.37.0/go.mod#L22-L24
+
+## Open questions
+
+- What does the reporter of [cert-manager#9026][] build? If it is a server, the `Solver` interface in `pkg/acme/webhook` is one file that depends only on `client-go/rest`, and could join the module. This design leaves it in core until there is a concrete need.
+- Should the tag be created by `cmrel` from the start, rather than by hand? Doing it by hand first keeps the cmrel change small.
+
+## Prior art
+
+- [design/20230302.gomod.md][gomod-design]: the module split that created `cmd/*` and `test/*` modules, and named API modules as the next step.
+- cmctl in v1.12 to v1.14: a nested module requiring the core module at a real version, with bump PRs such as [cert-manager#7078][].
+- [Kubernetes staging](https://github.com/kubernetes/kubernetes/tree/master/staging): API modules published from the main repository. Kubernetes uses a publishing bot and separate repositories, which is heavier than we need.
+- [OpenTelemetry Go](https://github.com/open-telemetry/opentelemetry-go/blob/v1.37.0/go.mod): nested `trace` and `metric` modules required at real versions and tagged together on release.


### PR DESCRIPTION
Design for #9026.

In brief:

- A new Go module rooted at `pkg/acme/webhook/apis`, holding the `acme` and `acme/v1alpha1` packages. Import paths do not change, so none of the 133 known importers has to change code.
- The module depends only on `k8s.io/apimachinery` and `k8s.io/apiextensions-apiserver`. Its module graph is 129 modules against 421 for core.
- The core module requires it at a real version, with no local `replace`, the way cmctl required core in v1.12 to v1.14. Changing the types takes two PRs. The types last changed in substance in 2023.
- Each release pushes a second tag, `pkg/acme/webhook/apis/v1.X.Y`, at the same commit.
- Tooling: `cmrel validate-gomod` needs a flag for modules that core may require without a replace, `hack/k8s-codegen.sh` must run `deepcopy-gen` inside the new module, and `make/test.mk` gains one line.
- No feature gate. No runtime change.

The document explains why the module cannot be rooted at `pkg/acme/webhook` (that pulls in `k8s.io/apiserver`), why the `apiextensionsv1.JSON` config field stays (every webhook's `loadConfig` takes it), and why the OpenTelemetry pattern of a local `replace` in core is not used.

Refs #9026.

### Kind

/kind design

### Release Note

```release-note
NONE
```

[Claude Fable 5.1]
