### PR TITLE
fix(certificates): recover from a CertificateRequest with a failureTime but no Ready condition

### DIFF
--- a/internal/controller/certificates/incomplete_request.go
+++ b/internal/controller/certificates/incomplete_request.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+)
+
+// IsIncompleteFailure reports whether req has failed without saying so: a
+// failureTime and no Ready condition. No in-tree issuer produces that state; an
+// external issuer writing the two in separate updates can stop between them.
+// Denied and InvalidRequest are decisions of their own and keep their branches.
+func IsIncompleteFailure(req *cmapi.CertificateRequest) bool {
+	return req.Status.FailureTime != nil &&
+		apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady) == nil &&
+		!apiutil.CertificateRequestIsDenied(req) &&
+		!apiutil.CertificateRequestHasInvalidRequest(req)
+}
+
+// IncompleteFailureIsFromPreviousIssuance reports whether an incomplete failure
+// predates the issuance in progress. creationTimestamp is checked as well: it
+// comes from the API server and failureTime from the issuer, so an issuer whose
+// clock is behind stamps a request it has just created with a time before the
+// transition, and recycling on that alone would never pace the retry.
+func IncompleteFailureIsFromPreviousIssuance(req *cmapi.CertificateRequest, issuing *cmapi.CertificateCondition) bool {
+	return issuing != nil && issuing.LastTransitionTime != nil &&
+		req.Status.FailureTime.Before(issuing.LastTransitionTime) &&
+		req.CreationTimestamp.Time.Before(issuing.LastTransitionTime.Time)
+}

--- a/internal/controller/certificates/incomplete_request_test.go
+++ b/internal/controller/certificates/incomplete_request_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func TestIsIncompleteFailure(t *testing.T) {
+	failureTime := metav1.NewTime(time.Now())
+	condition := func(t cmapi.CertificateRequestConditionType) gen.CertificateRequestModifier {
+		return gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{Type: t, Status: cmmeta.ConditionTrue})
+	}
+
+	tests := map[string]struct {
+		mods []gen.CertificateRequestModifier
+		want bool
+	}{
+		"a failureTime and no Ready condition": {
+			mods: []gen.CertificateRequestModifier{gen.SetCertificateRequestFailureTime(failureTime)},
+			want: true,
+		},
+		"no failureTime": {
+			want: false,
+		},
+		"a Ready condition, whatever it says, is the existing branches' business": {
+			mods: []gen.CertificateRequestModifier{gen.SetCertificateRequestFailureTime(failureTime), condition(cmapi.CertificateRequestConditionReady)},
+			want: false,
+		},
+		"denied": {
+			mods: []gen.CertificateRequestModifier{gen.SetCertificateRequestFailureTime(failureTime), condition(cmapi.CertificateRequestConditionDenied)},
+			want: false,
+		},
+		"invalid": {
+			mods: []gen.CertificateRequestModifier{gen.SetCertificateRequestFailureTime(failureTime), condition(cmapi.CertificateRequestConditionInvalidRequest)},
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, IsIncompleteFailure(gen.CertificateRequest("test", test.mods...)))
+		})
+	}
+}
+
+func TestIncompleteFailureIsFromPreviousIssuance(t *testing.T) {
+	transition := metav1.NewTime(time.Now())
+	issuing := &cmapi.CertificateCondition{
+		Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &transition,
+	}
+	request := func(failure, creation time.Duration) *cmapi.CertificateRequest {
+		return gen.CertificateRequest("test",
+			gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(failure))),
+			func(cr *cmapi.CertificateRequest) { cr.CreationTimestamp = metav1.NewTime(transition.Add(creation)) },
+		)
+	}
+
+	tests := map[string]struct {
+		req     *cmapi.CertificateRequest
+		issuing *cmapi.CertificateCondition
+		want    bool
+	}{
+		"both timestamps predate the transition": {
+			req: request(-time.Hour, -2*time.Hour), issuing: issuing, want: true,
+		},
+		"failed during this issuance": {
+			req: request(time.Minute, time.Second), issuing: issuing, want: false,
+		},
+		// An issuer whose clock is behind stamps a request it has just created
+		// with a time before the transition.
+		"created during this issuance but stamped with an older failureTime": {
+			req: request(-time.Hour, 2*time.Second), issuing: issuing, want: false,
+		},
+		"no Issuing condition": {
+			req: request(-time.Hour, -2*time.Hour), issuing: nil, want: false,
+		},
+		"an Issuing condition with no transition time is no evidence": {
+			req:     request(-time.Hour, -2*time.Hour),
+			issuing: &cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue},
+			want:    false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, IncompleteFailureIsFromPreviousIssuance(test.req, test.issuing))
+		})
+	}
+}

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -308,6 +308,15 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 		return nil
 	}
 
+	// The same for a request that failed without saying so. Waiting rather than
+	// failing is what stops the previous issuance's failure being counted a
+	// second time on the retry the trigger controller has just started.
+	if internalcertificates.IsIncompleteFailure(req) &&
+		internalcertificates.IncompleteFailureIsFromPreviousIssuance(req, certIssuingCond) {
+		log.V(logf.InfoLevel).Info("Found an incomplete CertificateRequest from previous issuance, waiting for it to be deleted...")
+		return nil
+	}
+
 	// Now check if CertificateRequest is in any of the final states so that
 	// this issuance can be completed as either succeeded or failed. Failed
 	// issuance will be retried with a delay (the logic for that lives in
@@ -340,19 +349,18 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 	if crReadyCond == nil {
 		if req.Status.FailureTime != nil {
-			// The CertificateRequest has a failureTime but no Ready condition.
-			// This is not reachable via the in-tree issuers, which always set
-			// both in the same update, but can happen with an external issuer
-			// writing failureTime and the Ready condition in separate updates,
-			// or with a partially applied status. Neither this controller nor
-			// the requestmanager controller can make progress from this state
-			// (the requestmanager only cleans up a CertificateRequest whose
-			// Ready condition reason is Failed), so surface it loudly rather
-			// than waiting silently forever.
-			message := fmt.Sprintf("CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", req.Name)
-			log.V(logf.ErrorLevel).Info(message)
-			c.recorder.Event(crt, corev1.EventTypeWarning, reasonStalled, message)
-			return nil
+			// A failureTime with no Ready condition. The in-tree issuers set
+			// both in one update, but an external issuer writing them
+			// separately can stop between them. #9128 made this visible;
+			// failing the issuance is what hands it to the trigger
+			// controller's backoff, after which the requestmanager controller
+			// replaces the request.
+			return c.failIssueCertificate(ctx, log, crt, &cmapi.CertificateRequestCondition{
+				Type:    cmapi.CertificateRequestConditionReady,
+				Status:  cmmeta.ConditionFalse,
+				Reason:  reasonStalled,
+				Message: fmt.Sprintf("CertificateRequest %s/%s (UID %s) has a failureTime but no Ready condition", req.Namespace, req.Name, req.UID),
+			})
 		}
 		log.V(logf.DebugLevel).Info("CertificateRequest does not have Ready condition, waiting...")
 		return nil

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -94,6 +94,28 @@ func TestIssuingController(t *testing.T) {
 		}),
 	)
 
+	// incompleteRequest builds the state this fix is about: a
+	// CertificateRequest for the revision being issued that has a failureTime
+	// and no Ready condition. The UID is pinned because it reaches the message,
+	// and the creationTimestamp because it decides which issuance it belongs to.
+	const incompleteRequestUID = "incomplete-request-uid"
+	incompleteRequest := func(failureTime, creation time.Time, mods ...gen.CertificateRequestModifier) *cmapi.CertificateRequest {
+		return gen.CertificateRequestFrom(exampleBundle.CertificateRequest, append([]gen.CertificateRequestModifier{
+			gen.AddCertificateRequestAnnotations(map[string]string{
+				cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+			}),
+			gen.SetCertificateRequestFailureTime(metav1.Time{Time: failureTime}),
+			func(cr *cmapi.CertificateRequest) {
+				cr.Status.Conditions = nil
+				cr.UID = incompleteRequestUID
+				cr.CreationTimestamp = metav1.NewTime(creation)
+			},
+		}, mods...)...)
+	}
+	incompleteFailureMessage := fmt.Sprintf(
+		"The certificate request has failed to complete and will be retried: CertificateRequest %s/%s (UID %s) has a failureTime but no Ready condition",
+		exampleBundle.CertificateRequest.Namespace, exampleBundle.CertificateRequest.Name, incompleteRequestUID)
+
 	tests := map[string]testT{
 		"if certificate is not in Issuing state, then do nothing": {
 			certificate: exampleBundle.Certificate,
@@ -481,6 +503,33 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		// #9116's ordering: a request whose CSR no longer matches the next
+		// private key is the request manager's to replace, and this issuance
+		// must not be failed for it.
+		"if certificate is in Issuing state, one incomplete CertificateRequest, but the private key stored in the Secret does not match that creating the CSR, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					incompleteRequest(metaFixedClockStart.Time.Add(time.Second), metaFixedClockStart.Time.Add(time.Second)),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							// Replaced after this request's CSR was built.
+							corev1.TLSPrivateKeyKey: exampleBundleAlt.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents:  []string{},
+			},
+			expectedErr: false,
+		},
 		"if certificate is in Issuing state, one CertificateRequest that was denied, but the private key stored in the Secret does not match that creating the CSR, do nothing": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{
@@ -514,22 +563,62 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
-		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, emit a Stalled event": {
+		// #9128 made this state visible with an Event. Failing the issuance is
+		// what hands it to the existing backoff and recycling.
+		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, fail the issuance": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{
 					gen.CertificateFrom(issuingCert),
-					gen.CertificateRequestFrom(exampleBundle.CertificateRequest,
-						// Explicit, so the case keeps covering the missing condition.
-						func(cr *cmapi.CertificateRequest) { cr.Status.Conditions = nil },
-						gen.AddCertificateRequestAnnotations(map[string]string{
-							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
-						}),
-						// After the Issuing transition, so this is the "stalled
-						// during the current attempt" case, not the earlier
-						// "failed during a previous issuance" case handled above.
-						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Second)}),
-					)},
+					// Stamped after the Issuing transition, so it belongs to
+					// the attempt in progress.
+					incompleteRequest(metaFixedClockStart.Time.Add(time.Second), metaFixedClockStart.Time.Add(time.Second)),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						exampleBundle.Certificate.Namespace,
+						gen.CertificateFrom(exampleBundle.Certificate,
+							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+								Type:               cmapi.CertificateConditionIssuing,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "Stalled",
+								Message:            incompleteFailureMessage,
+								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
+							}),
+							gen.SetCertificateLastFailureTime(metaFixedClockStart),
+							gen.SetCertificateIssuanceAttempts(new(1)),
+						),
+					)),
+				},
+				ExpectedEvents: []string{
+					"Warning Stalled " + incompleteFailureMessage,
+				},
+			},
+			expectedErr: false,
+		},
+		// The retry the trigger controller has just started must not count the
+		// previous issuance's failure again; the request manager recycles it.
+		"if certificate is in Issuing state, one incomplete CertificateRequest from a previous issuance, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					incompleteRequest(metaFixedClockStart.Time.Add(-time.Hour), metaFixedClockStart.Time.Add(-2*time.Hour)),
+				},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -542,8 +631,155 @@ func TestIssuingController(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{},
+			},
+			expectedErr: false,
+		},
+		// creationTimestamp comes from the API server and failureTime from the
+		// issuer, so an issuer whose clock is behind stamps a request it has
+		// just created with a time before the transition. Counting it here is
+		// what stops the request manager recycling it every round unpaced.
+		"if certificate is in Issuing state, one incomplete CertificateRequest created during this issuance but stamped with an older failureTime, fail the issuance": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					incompleteRequest(metaFixedClockStart.Time.Add(-time.Hour), metaFixedClockStart.Time.Add(2*time.Second)),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						exampleBundle.Certificate.Namespace,
+						gen.CertificateFrom(exampleBundle.Certificate,
+							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+								Type:               cmapi.CertificateConditionIssuing,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "Stalled",
+								Message:            incompleteFailureMessage,
+								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
+							}),
+							gen.SetCertificateLastFailureTime(metaFixedClockStart),
+							gen.SetCertificateIssuanceAttempts(new(1)),
+						),
+					)),
+				},
 				ExpectedEvents: []string{
-					fmt.Sprintf("Warning Stalled CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", exampleBundle.CertificateRequest.Name),
+					"Warning Stalled " + incompleteFailureMessage,
+				},
+			},
+			expectedErr: false,
+		},
+		// Denied and InvalidRequest are decisions of their own. Recycling a
+		// request that carries one only gets the same answer again, so they
+		// keep their priority over the incomplete-failure handling above.
+		"if certificate is in Issuing state, one denied CertificateRequest with no Ready condition and an older failureTime, report denial": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					incompleteRequest(metaFixedClockStart.Time.Add(-time.Hour), metaFixedClockStart.Time.Add(-2*time.Hour),
+						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:    cmapi.CertificateRequestConditionDenied,
+							Status:  cmmeta.ConditionTrue,
+							Reason:  "DeniedReason",
+							Message: "The certificate request has been denied",
+						}),
+					),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						exampleBundle.Certificate.Namespace,
+						gen.CertificateFrom(exampleBundle.Certificate,
+							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+								Type:               cmapi.CertificateConditionIssuing,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "DeniedReason",
+								Message:            "The certificate request has failed to complete and will be retried: The certificate request has been denied",
+								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
+							}),
+							gen.SetCertificateLastFailureTime(metaFixedClockStart),
+							gen.SetCertificateIssuanceAttempts(new(1)),
+						),
+					)),
+				},
+				ExpectedEvents: []string{
+					"Warning DeniedReason The certificate request has failed to complete and will be retried: The certificate request has been denied",
+				},
+			},
+			expectedErr: false,
+		},
+		"if certificate is in Issuing state, one invalid CertificateRequest with no Ready condition and an older failureTime, report the invalid request": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					incompleteRequest(metaFixedClockStart.Time.Add(-time.Hour), metaFixedClockStart.Time.Add(-2*time.Hour),
+						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:    cmapi.CertificateRequestConditionInvalidRequest,
+							Status:  cmmeta.ConditionTrue,
+							Reason:  "InvalidRequest",
+							Message: "The certificate request is invalid",
+						}),
+					),
+				},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						exampleBundle.Certificate.Namespace,
+						gen.CertificateFrom(exampleBundle.Certificate,
+							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
+								Type:               cmapi.CertificateConditionIssuing,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "InvalidRequest",
+								Message:            "The certificate request has failed to complete and will be retried: The certificate request is invalid",
+								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
+							}),
+							gen.SetCertificateLastFailureTime(metaFixedClockStart),
+							gen.SetCertificateIssuanceAttempts(new(1)),
+						),
+					)),
+				},
+				ExpectedEvents: []string{
+					"Warning InvalidRequest The certificate request has failed to complete and will be retried: The certificate request is invalid",
 				},
 			},
 			expectedErr: false,

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -264,7 +265,12 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 		// re-tried. In practice no more than one CertificateRequest is
 		// expected at this point.
 		crReadyCond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
-		if crReadyCond == nil || crReadyCond.Status != cmmeta.ConditionFalse || crReadyCond.Reason != cmapi.CertificateRequestReasonFailed {
+		failed := crReadyCond != nil && crReadyCond.Status == cmmeta.ConditionFalse && crReadyCond.Reason == cmapi.CertificateRequestReasonFailed
+		// An external issuer can leave a request with a failureTime and no
+		// Ready condition. It has failed as surely as a Ready=False/Failed
+		// one, so it is recycled on the same terms.
+		incomplete := internalcertificates.IsIncompleteFailure(req)
+		if !failed && !incomplete {
 			remaining = append(remaining, req)
 			continue
 		}
@@ -281,7 +287,16 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 		// same revision). If it is a CertificateRequest that failed
 		// during the previous issuance, then it should be deleted so
 		// that we create a new one for this issuance.
-		if req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) {
+		var previousIssuance bool
+		if incomplete {
+			// creationTimestamp has to predate the transition as well, so an
+			// issuer whose clock is behind cannot have a request it has just
+			// created recycled before its failure is counted.
+			previousIssuance = internalcertificates.IncompleteFailureIsFromPreviousIssuance(req, certIssuingCond)
+		} else {
+			previousIssuance = req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime)
+		}
+		if previousIssuance {
 			log.V(logf.DebugLevel).Info("Found a failed CertificateRequest for previous issuance of this revision, deleting...")
 			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -125,6 +125,24 @@ func TestProcessItem(t *testing.T) {
 		Reason:             cmapi.CertificateRequestReasonFailed,
 		LastTransitionTime: &metav1.Time{Time: fixedNow.Time.Add(1 * time.Minute)},
 	}
+	// incompleteRequest builds a CertificateRequest for the revision being
+	// issued that has a failureTime and no Ready condition. The creationTimestamp
+	// is pinned because it decides which issuance the request belongs to.
+	incompleteRequest := func(failureTime, creation time.Time, mods ...gen.CertificateRequestModifier) *cmapi.CertificateRequest {
+		return gen.CertificateRequestFrom(bundle1.certificateRequest, append([]gen.CertificateRequestModifier{
+			gen.SetCertificateRequestName("test-6"),
+			gen.SetCertificateRequestAnnotations(map[string]string{
+				cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+				cmapi.CertificateRequestRevisionAnnotationKey:   "6",
+			}),
+			gen.SetCertificateRequestFailureTime(metav1.Time{Time: failureTime}),
+			func(cr *cmapi.CertificateRequest) {
+				cr.Status.Conditions = nil
+				cr.CreationTimestamp = metav1.NewTime(creation)
+			},
+		}, mods...)...)
+	}
+
 	tests := map[string]struct {
 		// key that should be passed to ProcessItem.
 		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
@@ -735,6 +753,119 @@ func TestProcessItem(t *testing.T) {
 					}),
 					gen.AddCertificateRequestStatusCondition(failedCRConditionThisIssuance),
 					gen.SetCertificateRequestFailureTime(metav1.Time{Time: fixedNow.Time.Add(1 * time.Minute)}),
+				),
+			},
+		},
+		// A CertificateRequest that failed without saying so is recycled on the
+		// same terms as a Ready=False/Failed one: only once the issuing
+		// controller has counted the failure, which the Issuing transition
+		// records.
+		"should recreate the CertificateRequest if the current 'next' CertificateRequest is an incomplete failure from a previous issuance cycle": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				incompleteRequest(fixedNow.Time.Add(-time.Hour), fixedNow.Time.Add(-2*time.Hour)),
+			},
+			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "test-6"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "test-6")),
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+					gen.CertificateRequestFrom(bundle1.certificateRequest,
+						gen.SetCertificateRequestName("test-6"),
+						gen.SetCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+							cmapi.CertificateRequestRevisionAnnotationKey:   "6",
+						}),
+					)), relaxedCertificateRequestMatcher),
+			},
+		},
+		// Kept, so that the issuing controller records the failure and the
+		// trigger controller's backoff paces the retry.
+		"should do nothing if the incomplete CertificateRequest failed during this issuance cycle": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				incompleteRequest(fixedNow.Time.Add(time.Minute), fixedNow.Time.Add(time.Second)),
+			},
+		},
+		// creationTimestamp comes from the API server and failureTime from the
+		// issuer, so an issuer whose clock is behind stamps a request it has
+		// just created with a time before the transition. Recycling on
+		// failureTime alone would recreate it every round with no failure
+		// recorded to pace it.
+		"should do nothing if the incomplete CertificateRequest was created during this issuance but stamped with an older failureTime": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				incompleteRequest(fixedNow.Time.Add(-time.Hour), fixedNow.Time.Add(2*time.Second)),
+			},
+		},
+		// Denied and InvalidRequest are decisions of their own: a replacement
+		// only gets the same answer, so they are not recycled here.
+		"should do nothing if the CertificateRequest with no Ready condition and an older failureTime is denied": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				incompleteRequest(fixedNow.Time.Add(-time.Hour), fixedNow.Time.Add(-2*time.Hour),
+					gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+						Type: cmapi.CertificateRequestConditionDenied, Status: cmmeta.ConditionTrue, Reason: "DeniedReason",
+					}),
+				),
+			},
+		},
+		"should do nothing if the CertificateRequest with no Ready condition and an older failureTime is invalid": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				incompleteRequest(fixedNow.Time.Add(-time.Hour), fixedNow.Time.Add(-2*time.Hour),
+					gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+						Type: cmapi.CertificateRequestConditionInvalidRequest, Status: cmmeta.ConditionTrue, Reason: "InvalidRequest",
+					}),
 				),
 			},
 		},

--- a/test/integration/certificates/stalled_request_recovery_test.go
+++ b/test/integration/certificates/stalled_request_recovery_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/cert-manager/internal/controller/certificates/policies"
+	"github.com/cert-manager/cert-manager/internal/controller/feature"
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/issuing"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/keymanager"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/requestmanager"
+	"github.com/cert-manager/cert-manager/pkg/controller/certificates/trigger"
+	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
+	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
+	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/clock"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/cert-manager/cert-manager/integration-tests/framework"
+)
+
+// TestStalledRequestRecovery covers an issuance that no controller used to be
+// willing to change: a CertificateRequest that an external issuer left with a
+// failureTime and no Ready condition. The issuing controller waited for a
+// condition that never arrived, the request manager only recycled a request
+// whose Ready reason was Failed, and the trigger controller does nothing while
+// the Certificate is Issuing.
+//
+// Only the whole lifecycle shows the stall is gone. A Warning event, an
+// Issuing condition set to False, or a delete call are each reachable without
+// the Certificate ever being issued, so this drives the issuance from the
+// stalled request through the backoff to a certificate in the Secret.
+func TestStalledRequestRecovery(t *testing.T) {
+	// The status write is an update or an apply depending on the feature gate,
+	// and the two paths reach the stalled request through different code.
+	//
+	// The private key decides who removes the request. The keymanager drops
+	// the next private key when an issuance ends, so with the default rotation
+	// policy the next issuance has a new one and the stalled request no longer
+	// matches it: the request manager removes it as a mismatch, before it ever
+	// reaches the recycling path. Only a reused key leaves a request that
+	// matches everything and can be removed for no reason but its own state.
+	for _, serverSideApply := range []bool{false, true} {
+		for _, reuseKey := range []bool{false, true} {
+			name := "UpdateStatus"
+			if serverSideApply {
+				name = "ServerSideApply"
+			}
+			if reuseKey {
+				name += "/ReusedPrivateKey"
+			} else {
+				name += "/RotatedPrivateKey"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, serverSideApply)
+				testStalledRequestRecovery(t, reuseKey)
+			})
+		}
+	}
+}
+
+func testStalledRequestRecovery(t *testing.T, reuseKey bool) {
+	const (
+		namespace  = "test-stalled-request-recovery"
+		crtName    = "stalled"
+		secretName = "stalled-tls"
+		// The production defaults, reached by moving the clock rather than by
+		// waiting them out.
+		backoff    = time.Hour
+		maxBackoff = 32 * time.Hour
+	)
+
+	config, stopFn := framework.RunControlPlane(t)
+	t.Cleanup(stopFn)
+
+	// The backoff here is an hour away, so a fake clock is the only way to
+	// reach it. apiutil.Clock has to agree with it: the
+	// Issuing transition that a failureTime is compared against is stamped
+	// through that global, not through the controller's own clock.
+	fakeClock := fakeclock.NewFakeClock(time.Now())
+	apiutil.Clock = fakeClock
+	t.Cleanup(func() { apiutil.Clock = clock.RealClock{} })
+
+	kubeClient, factory, cmCl, cmFactory, scheme := framework.NewClients(t, config)
+
+	// One context per controller, because a shared field manager would hide
+	// exactly the server-side apply ownership this test is here to exercise.
+	newContext := func(name string) *controllerpkg.Context {
+		return &controllerpkg.Context{
+			Scheme:                    scheme,
+			Client:                    kubeClient,
+			KubeSharedInformerFactory: factory,
+			CMClient:                  cmCl,
+			SharedInformerFactory:     cmFactory,
+			Clock:                     fakeClock,
+			ContextOptions: controllerpkg.ContextOptions{
+				CertificateOptions: controllerpkg.CertificateOptions{
+					CertificateRequestMinimumBackoffDuration: backoff,
+					CertificateRequestMaximumBackoffDuration: maxBackoff,
+				},
+			},
+			Recorder:     framework.NewEventRecorder(t, scheme),
+			FieldManager: "cert-manager-certificates-" + name + "-test",
+		}
+	}
+
+	// A reconcile reads the clock, works out how long is left, and only then
+	// arms its timer. A clock jump landing between those two makes the timer
+	// target a time the test will never reach, so jumps wait for reconciles in
+	// flight. Reconciles still run concurrently with each other.
+	var clockMu sync.RWMutex
+	setControllerTime := func(now time.Time) {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		fakeClock.SetTime(now)
+	}
+
+	newController := func(name string, processItem func(context.Context, types.NamespacedName) error, queue workqueue.TypedRateLimitingInterface[types.NamespacedName], mustSync []cache.InformerSynced, err error) controllerpkg.Interface {
+		t.Helper()
+		require.NoError(t, err)
+		guarded := func(ctx context.Context, key types.NamespacedName) error {
+			clockMu.RLock()
+			defer clockMu.RUnlock()
+			return processItem(ctx, key)
+		}
+		return controllerpkg.NewController(name, metrics.New(logf.Log, clock.RealClock{}), guarded, mustSync, nil, queue)
+	}
+
+	triggerCtx := newContext("trigger")
+	triggerCtrl, triggerQueue, triggerSync, triggerErr := trigger.NewController(logf.Log, triggerCtx, policies.NewTriggerPolicyChain(fakeClock).Evaluate)
+	keyCtx := newContext("key-manager")
+	keyCtrl, keyQueue, keySync, keyErr := keymanager.NewController(logf.Log, keyCtx)
+	reqCtx := newContext("request-manager")
+	reqCtrl, reqQueue, reqSync, reqErr := requestmanager.NewController(logf.Log, reqCtx)
+	issuingCtx := newContext("issuing")
+	issuingCtrl, issuingQueue, issuingSync, issuingErr := issuing.NewController(logf.Log, issuingCtx)
+
+	stopControllers := framework.StartInformersAndControllers(t, factory, cmFactory,
+		newController("trigger_test", triggerCtrl.ProcessItem, triggerQueue, triggerSync, triggerErr),
+		newController("keymanager_test", keyCtrl.ProcessItem, keyQueue, keySync, keyErr),
+		newController("requestmanager_test", reqCtrl.ProcessItem, reqQueue, reqSync, reqErr),
+		newController("issuing_test", issuingCtrl.ProcessItem, issuingQueue, issuingSync, issuingErr),
+	)
+	t.Cleanup(stopControllers)
+
+	_, err := kubeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	certificateMods := []gen.CertificateModifier{
+		gen.SetCertificateNamespace(namespace),
+		gen.SetCertificateCommonName("stalled.example.com"),
+		gen.SetCertificateSecretName(secretName),
+		gen.SetCertificateIssuer(cmmeta.IssuerReference{Name: "testissuer", Kind: "Issuer", Group: "foo.io"}),
+	}
+	if reuseKey {
+		// A rotation policy of Never makes the keymanager reuse the key in the
+		// target Secret, so both issuances share one and the stalled request
+		// still matches the second. Seeded here because the policy only reuses
+		// a key that already exists.
+		sk, err := utilpki.GenerateRSAPrivateKey(2048)
+		require.NoError(t, err)
+		_, err = kubeClient.CoreV1().Secrets(namespace).Create(t.Context(), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName},
+			Data:       map[string][]byte{corev1.TLSPrivateKeyKey: utilpki.EncodePKCS1PrivateKey(sk)},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		certificateMods = append(certificateMods, func(crt *cmapi.Certificate) {
+			crt.Spec.PrivateKey = &cmapi.CertificatePrivateKey{RotationPolicy: cmapi.RotationPolicyNever}
+		})
+	}
+
+	t.Log("creating the Certificate, which the trigger, keymanager and requestmanager controllers turn into a CertificateRequest")
+	_, err = cmCl.CertmanagerV1().Certificates(namespace).Create(t.Context(), gen.Certificate(crtName, certificateMods...), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	requestA := waitForSingleRequest(t, cmCl, namespace, func(*cmapi.CertificateRequest) bool { return true })
+
+	t.Log("reporting a failureTime on the CertificateRequest and no Ready condition, as a broken external issuer does")
+	requestA.Status.FailureTime = new(metav1.NewTime(fakeClock.Now()))
+	requestA, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(t.Context(), requestA, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.Nil(t, apiutil.GetCertificateRequestCondition(requestA, cmapi.CertificateRequestConditionReady))
+
+	t.Log("waiting for the issuance to be failed, which is what hands it to the trigger controller's backoff")
+	require.NoError(t, wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (bool, error) {
+		crt := mustGetCertificate(t, ctx, cmCl, namespace, crtName)
+		cond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionIssuing)
+		return cond != nil && cond.Status == cmmeta.ConditionFalse && cond.Reason == "Stalled", nil
+	}), "the issuance was never failed")
+
+	crt := mustGetCertificate(t, t.Context(), cmCl, namespace, crtName)
+	require.NotNil(t, crt.Status.FailedIssuanceAttempts)
+	assert.Equal(t, 1, *crt.Status.FailedIssuanceAttempts, "the stalled request is one failure, not one per reconcile")
+	require.NotNil(t, crt.Status.LastFailureTime)
+
+	retryAt := crt.Status.LastFailureTime.Time.Add(backoff)
+
+	t.Log("holding a minute short of the retry deadline, where the replacement must not exist yet")
+	setControllerTime(retryAt.Add(-time.Minute))
+	holdWhile(t, func(ctx context.Context) {
+		reqs := listRequests(t, ctx, cmCl, namespace)
+		require.Len(t, reqs, 1, "a replacement must not be created before the backoff elapses")
+		assert.Equal(t, requestA.UID, reqs[0].UID)
+
+		crt := mustGetCertificate(t, ctx, cmCl, namespace, crtName)
+		require.NotNil(t, crt.Status.FailedIssuanceAttempts)
+		assert.Equal(t, 1, *crt.Status.FailedIssuanceAttempts, "re-reading the same state must not count a second failure")
+	})
+
+	t.Log("crossing the retry deadline, so the trigger controller starts the next issuance and the stalled request is recycled")
+	setControllerTime(retryAt.Add(time.Second))
+	requestB := waitForSingleRequest(t, cmCl, namespace, func(req *cmapi.CertificateRequest) bool {
+		return req.UID != requestA.UID
+	})
+	assert.Equal(t, requestA.Name, requestB.Name, "the replacement is expected to reuse the name, which is why the recycling identifies requests by UID")
+
+	// Which controller path removed the stalled request follows from whether
+	// the key was reused, so pinning that pins the path this ran through.
+	samePublicKey := csrPublicKeysEqual(t, requestA, requestB)
+	if reuseKey {
+		assert.True(t, samePublicKey, "the stalled request must still match the next private key, or it would be removed as a mismatch instead of recycled")
+	} else {
+		assert.False(t, samePublicKey, "the keymanager is expected to have rotated the next private key between issuances")
+	}
+
+	// The point of the second round: the replacement's failure has to be
+	// counted as a new one rather than read as the first one replayed, or the
+	// backoff would stop growing and the retries would never be paced.
+	t.Log("reporting the same incomplete failure on the replacement")
+	requestB.Status.FailureTime = new(metav1.NewTime(fakeClock.Now()))
+	_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(t.Context(), requestB, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (bool, error) {
+		crt := mustGetCertificate(t, ctx, cmCl, namespace, crtName)
+		return crt.Status.FailedIssuanceAttempts != nil && *crt.Status.FailedIssuanceAttempts == 2, nil
+	}), "the replacement's failure was never counted as a second one")
+
+	crt = mustGetCertificate(t, t.Context(), cmCl, namespace, crtName)
+	require.NotNil(t, crt.Status.LastFailureTime)
+
+	// Past the configured maximum, so this crossing does not depend on how the
+	// second backoff is calculated. The first crossing above is the one that
+	// pins the backoff being respected at all.
+	t.Log("crossing the second backoff, so the stalled replacement is itself recycled")
+	setControllerTime(crt.Status.LastFailureTime.Time.Add(maxBackoff + time.Second))
+	requestC := waitForSingleRequest(t, cmCl, namespace, func(req *cmapi.CertificateRequest) bool {
+		return req.UID != requestB.UID
+	})
+
+	t.Log("completing the CertificateRequest, as a working issuer does")
+	certPEM := signRequest(t, kubeClient, cmCl, namespace, crtName, requestC)
+
+	t.Log("waiting for the issuance to complete and the failure state to be cleared")
+	require.NoError(t, wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		crt := mustGetCertificate(t, ctx, cmCl, namespace, crtName)
+
+		// With server-side apply the Issuing condition is set to False with
+		// reason Issued instead of being removed.
+		if cond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionIssuing); cond != nil &&
+			!(cond.Status == cmmeta.ConditionFalse && cond.Reason == "Issued") {
+			return false, nil
+		}
+		if crt.Status.Revision == nil || *crt.Status.Revision != 1 {
+			return false, nil
+		}
+		if crt.Status.FailedIssuanceAttempts != nil || crt.Status.LastFailureTime != nil {
+			return false, nil
+		}
+
+		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return bytes.Equal(secret.Data[corev1.TLSCertKey], certPEM), nil
+	}), "the issuance never recovered")
+}
+
+// holdWhile repeatedly runs assertions, to check that a state the controllers
+// must wait in is one they actually stay in rather than one they happened to be
+// in when it was first read.
+func holdWhile(t *testing.T, assertions func(context.Context)) {
+	t.Helper()
+	for range 5 {
+		assertions(t.Context())
+		if t.Failed() {
+			t.FailNow()
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func listRequests(t *testing.T, ctx context.Context, cmCl cmclient.Interface, namespace string) []cmapi.CertificateRequest {
+	t.Helper()
+	reqs, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	return reqs.Items
+}
+
+func mustGetCertificate(t *testing.T, ctx context.Context, cmCl cmclient.Interface, namespace, name string) *cmapi.Certificate {
+	t.Helper()
+	crt, err := cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return crt
+}
+
+// waitForSingleRequest waits for exactly one matching CertificateRequest to
+// exist, without touching the clock. More than one would mean issuance had
+// stalled a different way, so it is a failure rather than something to wait out.
+func waitForSingleRequest(t *testing.T, cmCl cmclient.Interface, namespace string, match func(*cmapi.CertificateRequest) bool) *cmapi.CertificateRequest {
+	t.Helper()
+	var found *cmapi.CertificateRequest
+	require.NoError(t, wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (bool, error) {
+		reqs := listRequests(t, ctx, cmCl, namespace)
+		if len(reqs) > 1 {
+			return false, fmt.Errorf("expected at most one CertificateRequest, got %d", len(reqs))
+		}
+		if len(reqs) == 1 && match(&reqs[0]) {
+			found = &reqs[0]
+			return true, nil
+		}
+		return false, nil
+	}))
+	return found
+}
+
+func csrPublicKeysEqual(t *testing.T, a, b *cmapi.CertificateRequest) bool {
+	t.Helper()
+	csrA, err := utilpki.DecodeX509CertificateRequestBytes(a.Spec.Request)
+	require.NoError(t, err)
+	csrB, err := utilpki.DecodeX509CertificateRequestBytes(b.Spec.Request)
+	require.NoError(t, err)
+	equal, err := utilpki.PublicKeysEqual(csrA.PublicKey, csrB.PublicKey)
+	require.NoError(t, err)
+	return equal
+}
+
+// signRequest completes a CertificateRequest the way a working issuer would:
+// self-signed with the key the CSR was built from, so the issued certificate's
+// public key matches the CSR.
+func signRequest(t *testing.T, kubeClient kubernetes.Interface, cmCl cmclient.Interface, namespace, crtName string, req *cmapi.CertificateRequest) []byte {
+	t.Helper()
+
+	crt := mustGetCertificate(t, t.Context(), cmCl, namespace, crtName)
+	require.NotNil(t, crt.Status.NextPrivateKeySecretName)
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(t.Context(), *crt.Status.NextPrivateKeySecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	sk, err := utilpki.DecodePrivateKeyBytes(secret.Data[corev1.TLSPrivateKeyKey])
+	require.NoError(t, err)
+
+	template, err := utilpki.CertificateTemplateFromCertificateRequest(req)
+	require.NoError(t, err)
+	certPEM, _, err := utilpki.SignCertificate(template, template, sk.Public(), sk)
+	require.NoError(t, err)
+
+	req = req.DeepCopy()
+	req.Status.Certificate = certPEM
+	req.Status.CA = certPEM
+	apiutil.SetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady, cmmeta.ConditionTrue, cmapi.CertificateRequestReasonIssued, "")
+	_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(t.Context(), req, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	return certPEM
+}

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.37.0
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
+	k8s.io/component-base v0.37.0
 	k8s.io/kube-aggregator v0.37.0
 	k8s.io/kubectl v0.37.0
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
@@ -118,7 +119,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiserver v0.37.0 // indirect
-	k8s.io/component-base v0.37.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0 // indirect


### PR DESCRIPTION
### Pull Request Motivation

#9128 made the stalled state visible; it did not clear it. A `CertificateRequest` that carries `status.failureTime` but no Ready condition still leaves its Certificate at `Issuing=True`, because the guards that would move it on both require a Ready condition: the issuing controller records a failure for `Ready=False/Failed`, and the request manager recycles a request whose Ready reason is `Failed`. Neither sees a request that has no Ready condition at all, so the issuance never fails, never backs off, and never gets a replacement request.

This is the reduced version of this PR, after @wallrj's review. The recovery is now the three existing branches relaxed to treat `Ready == nil && failureTime != nil` the same way, and nothing else. The server-side-apply `resourceVersion`, the delete preconditions and finalizer wait, and the `Issuing=True` diagnostics have been dropped; each of those changes every issuance rather than only stalled ones, and each belongs in its own PR.

### What changed

Three branches, in the order they run:

1. **issuing, previous-issuance guard.** A new adjacent branch waits when an incomplete failure predates the current issuance, so the retry the trigger controller has just started does not count the previous issuance's failure a second time. The existing `Ready=False/Failed` guard is untouched.
2. **issuing, #9128's branch.** Instead of only recording an Event, it calls the existing `failIssueCertificate` with reason `Stalled`. That sets `Issuing=False`, `lastFailureTime` and `failedIssuanceAttempts`, records the Warning, and hands the issuance to the trigger controller's existing backoff. The diagnostic is now durable on the Certificate rather than only in an Event.
3. **request manager, `deleteCurrentFailedRequests`.** An incomplete failure is recycled on the same terms as a `Ready=False/Failed` one: only once the failure has been counted, which the Issuing transition records.

Two predicates in `internal/controller/certificates` keep the two controllers' answers identical:

```go
IsIncompleteFailure(req) bool
IncompleteFailureIsFromPreviousIssuance(req, issuing) bool
```

### Two boundaries the relaxation has to keep

**Denied and InvalidRequest keep their priority.** The previous-issuance guard runs before them, so relaxing it to accept a nil Ready condition would swallow a denied request into "wait for the request manager". A replacement only gets denied again, with no failure counted to pace it. `IsIncompleteFailure` therefore excludes both, which is the same ordering #9118 preserved. There are unit tests for a denied and for an invalid request with no Ready condition and an older failureTime, in both controllers.

**An older failureTime does not by itself mean an older request.** `creationTimestamp` comes from the API server and `failureTime` from the issuer, so an issuer whose clock is behind stamps a request it has just created with a time before the Issuing transition. On `failureTime` alone the issuing controller would wait and the request manager would recycle, forever, with no failure ever recorded and so nothing rate limiting it, a hot loop where master merely stalls. `IncompleteFailureIsFromPreviousIssuance` requires the request's own `creationTimestamp` to predate the transition too.

This narrows the problem rather than closing it: three clocks still feed the comparison, so a controller far enough ahead of the API server can still read a fresh request as an old one. Closing that properly means recording which request UID a failure was counted for, which is API surface I did not want to add here. The existing `Ready=False/Failed` branch makes the same comparison on `failureTime` alone; I left it as it is rather than widen the change, so the asymmetry is deliberate.

### What I dropped, and what is not addressed

Dropped from this PR, to be raised separately: the `resourceVersion` on the server-side-apply payload, the delete preconditions and finalizer wait in the request manager, and the `Issuing=True` diagnostics. The 30 second settling interval is gone entirely. It ran from the issuer's `failureTime`, so an issuer whose clock was behind got no window at all, and failing at once reaches the same backoff.

Not addressed here: a request with `Ready=False/Failed` and **no** `failureTime` stalls the same way, because `metav1.Time.Before` on a nil receiver returns false. Deleting on nil alone is not the fix: the request manager can run before the issuing controller and would replace the request before the failure is counted. That wants its own change, raised as #9327, which also measures how far it reaches: with the default rotation policy the existing key mismatch check replaces the request and the issuance recovers, so it only loops when the private key is reused.

### Testing

Unit tests in both controllers cover: no Ready and no failureTime (ordinary wait); an incomplete failure during this issuance (failed, counted once); an incomplete failure from a previous issuance (waited for, then recycled); a request created during this issuance but stamped with an older failureTime; and denied and invalid requests with no Ready condition and an older failureTime. One more pins #9116's ordering for the new case: an incomplete failure whose CSR no longer matches the next private key is left to the request manager rather than failing the issuance, alongside the cases master already has for a failed and for a denied request. There are direct unit tests for both predicates.

`TestStalledRequestRecovery` runs the whole lifecycle against a real API server with the trigger, keymanager, request manager and issuing controllers, in four combinations: server-side apply on and off, private key rotated and reused. It drives a stalled request through the failure, the backoff, a replacement, **a second incomplete failure on that replacement** (which has to be counted as a new failure rather than the first one replayed), and a second backoff, to an issued certificate in the Secret with the failure counters cleared.

I checked the tests fail without the code rather than assuming it. Each of the five behaviours has a mutation that breaks it and a test that catches it: the request manager no longer treating an incomplete failure as failed; the predicate dropping the `creationTimestamp` term; the predicate dropping the Denied/InvalidRequest exclusion; the issuing controller going back to an Event without failing the issuance; and the previous-issuance wait removed. Moving the new handling above the key check fails the ordering case and three others with it.

Reverting each controller's half separately against the integration test shows both are needed, and why:

- request manager on master, issuing fixed: only the **reused private key** cases fail. With the default rotation policy the keymanager gives the next issuance a new key, the stalled request no longer matches it, and the request manager's existing key-mismatch check removes it before the recycling path is reached.
- issuing on master, request manager fixed: **all four** fail with "the issuance was never failed". Nothing records the failure, so no backoff and no new issuance.

Run locally on `f2cafccb` with Go 1.26.5: the `internal/controller/certificates`, `pkg/controller/certificates` and `pkg/scheduler` unit packages, the issuing, request manager and trigger packages under `-race`, and the whole `test/integration` module.

Presubmit has since run. `make-test` and `make-verify` pass. The upgrade e2e job fails at `helm install`, before it reaches anything in this branch, because `verify-upgrade.sh` picks the upgrade-from version from git tags and the `v1.21.2` chart is not published yet while #9237 is open.

`test/integration/go.mod` gains `k8s.io/component-base` as a direct dependency, because the integration test toggles the `ServerSideApply` feature gate.

Report: https://github.com/cert-manager/cert-manager/issues/9126

### Kind

/kind bug

### Release Note

```release-note
Fixed an issuance that could stall indefinitely when an issuer sets `status.failureTime` on a CertificateRequest without a `Ready` condition. Such a request is now treated as a failure: the issuance is failed with reason `Stalled`, retried under the existing exponential backoff, and the CertificateRequest is replaced on the next attempt.
```

Fixes #9126

*with claude opus-5*



