### PR TITLE
[release-1.21] fix(acme/ari): adding cert id to status

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -753,6 +753,12 @@ spec:
                         ARI stores the ACME Renewal Information that is fetched from the ACME server
                         in accordance with RFC 9773. This is only populated if the ARI feature gate is enabled.
                       properties:
+                        certID:
+                          description: |-
+                            CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
+                            fetched for. This is used to determine if we need to re-fetch the renewal information
+                            as changed cert id means that ARI fetched before is stale.
+                          type: string
                         explanationURL:
                           description: |-
                             ExplanationURL is a human-readable URL that may explain why the suggested window

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -765,6 +765,12 @@ spec:
                       ARI stores the ACME Renewal Information that is fetched from the ACME server
                       in accordance with RFC 9773. This is only populated if the ARI feature gate is enabled.
                     properties:
+                      certID:
+                        description: |-
+                          CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
+                          fetched for. This is used to determine if we need to re-fetch the renewal information
+                          as changed cert id means that ARI fetched before is stale.
+                        type: string
                       explanationURL:
                         description: |-
                           ExplanationURL is a human-readable URL that may explain why the suggested window

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -732,6 +732,12 @@ type CertificateACMEARIStatus struct {
 	//
 	// +optional
 	LastError string
+	// CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
+	// fetched for. This is used to determine if we need to re-fetch the renewal information
+	// as changed cert id means that ARI fetched before is stale.
+	//
+	// +optional
+	CertID string
 }
 
 type ACMERenewalWindow struct {

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -593,6 +593,7 @@ func autoConvert_v1_CertificateACMEARIStatus_To_certmanager_CertificateACMEARISt
 	out.LastChecked = (*metav1.Time)(unsafe.Pointer(in.LastChecked))
 	out.NextCheck = (*metav1.Time)(unsafe.Pointer(in.NextCheck))
 	out.LastError = in.LastError
+	out.CertID = in.CertID
 	return nil
 }
 
@@ -607,6 +608,7 @@ func autoConvert_certmanager_CertificateACMEARIStatus_To_v1_CertificateACMEARISt
 	out.LastChecked = (*metav1.Time)(unsafe.Pointer(in.LastChecked))
 	out.NextCheck = (*metav1.Time)(unsafe.Pointer(in.NextCheck))
 	out.LastError = in.LastError
+	out.CertID = in.CertID
 	return nil
 }
 

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -290,18 +290,12 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 		// the scheduled wake-up; the gate just compares against the window
 		// start so we reliably renew as soon as the window opens.
 		//
-		// We also ignore the ARI window when it appears to describe a prior
-		// revision of this certificate — i.e. SuggestedWindow.Start is at or
-		// before the current cert's NotBefore. In that case the ACME server's
-		// window cannot meaningfully apply to the certificate currently in
-		// the Secret (we've just renewed and are looking at fresh bytes), so
-		// depending on it would trigger an immediate re-renewal loop. Fall back
-		// to the deterministic renewBefore calculation in that case; the
-		// readiness controller will refresh ARI on its next reconcile.
+		// A window left over from a previous revision cannot reach this point:
+		// the gatherer only populates ARIRenewalInfo when the ARI CertID
+		// recorded in status matches the certificate currently in the Secret.
 		if input.ARIRenewalInfo != nil &&
-			!input.ARIRenewalInfo.SuggestedWindow.Start.IsZero() &&
-			input.ARIRenewalInfo.SuggestedWindow.Start.After(x509Cert.NotBefore) {
-			if c.Now().Before(input.ARIRenewalInfo.SuggestedWindow.Start) {
+			crt.Status.RenewalTime != nil {
+			if c.Now().Before(crt.Status.RenewalTime.Time) {
 				return "", "", false
 			}
 			return reason, message, true

--- a/internal/controller/certificates/policies/checks.go
+++ b/internal/controller/certificates/policies/checks.go
@@ -279,23 +279,24 @@ func CurrentCertificateNearingExpiry(c clock.Clock) Func {
 		reason := Renewing
 		message := fmt.Sprintf("Renewing certificate as renewal was scheduled at %s", input.Certificate.Status.RenewalTime)
 
-		// When ARI information is available, let the renewal purely on whether
-		// the current time has entered the ACME-server-suggested renewal
-		// window. Do NOT call pki.RenewalTime here: that function picks a
-		// random time within the ARI window on every invocation, so calling
-		// it from the trigger controller would return a different result each
-		// reconcile and could cause us to skip renewal forever once we are
-		// inside the window. The random selection still happens in the
-		// readiness controller when setting Status.RenewalTime, which jitters
-		// the scheduled wake-up; the gate just compares against the window
-		// start so we reliably renew as soon as the window opens.
-		//
-		// A window left over from a previous revision cannot reach this point:
-		// the gatherer only populates ARIRenewalInfo when the ARI CertID
-		// recorded in status matches the certificate currently in the Secret.
 		if input.ARIRenewalInfo != nil &&
-			crt.Status.RenewalTime != nil {
-			if c.Now().Before(crt.Status.RenewalTime.Time) {
+			!input.ARIRenewalInfo.SuggestedWindow.Start.IsZero() {
+			window := input.ARIRenewalInfo.SuggestedWindow
+			// RFC 9773 asks clients to select a uniform random time within the
+			// suggested window so the CA can spread renewal load. The readiness
+			// controller picks and persists that time in Status.RenewalTime; gate on
+			// it when it demonstrably falls inside the current window. If it does
+			// not (the window has moved, or the field still holds a renewBefore
+			// value), fall back to the window start so the CA's instruction is never
+			// deferred past the window itself.
+			gateTime := window.Start
+			if rt := crt.Status.RenewalTime; rt != nil &&
+				rt.Time.After(x509Cert.NotBefore) &&
+				!rt.Time.Before(window.Start) &&
+				!rt.Time.After(window.End) {
+				gateTime = rt.Time
+			}
+			if c.Now().Before(gateTime) {
 				return "", "", false
 			}
 			return reason, message, true

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	testcrypto "github.com/cert-manager/cert-manager/test/unit/crypto"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
+	acmeapi "github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
 
 // Runs a full set of tests against the trigger 'policy chain' once it is
@@ -42,11 +43,56 @@ import (
 func Test_NewTriggerPolicyChain(t *testing.T) {
 	clock := &fakeclock.FakeClock{}
 	staticFixedPrivateKey := testcrypto.MustCreatePEMPrivateKey(t)
+
+	// ariCert and ariSecret build the fixtures shared by the ARI gate cases
+	// below: a certificate/secret pair whose X509 cert was issued 30 minutes
+	// ago, matches the spec, and would not renew through the plain renewBefore
+	// calculation unless it is close to the given notAfter.
+	ariCert := func(renewalTime *metav1.Time) *cmapi.Certificate {
+		return &cmapi.Certificate{
+			Spec: cmapi.CertificateSpec{
+				CommonName: "example.com",
+				IssuerRef: cmmeta.IssuerReference{
+					Name:  "testissuer",
+					Kind:  "IssuerKind",
+					Group: "group.example.com",
+				},
+				RenewBefore: &metav1.Duration{Duration: time.Minute * 5},
+			},
+			Status: cmapi.CertificateStatus{
+				RenewalTime: renewalTime,
+			},
+		}
+	}
+	ariSecret := func(notAfter time.Time) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "something",
+				Annotations: map[string]string{
+					cmapi.IssuerNameAnnotationKey:  "testissuer",
+					cmapi.IssuerKindAnnotationKey:  "IssuerKind",
+					cmapi.IssuerGroupAnnotationKey: "group.example.com",
+				},
+			},
+			Data: map[string][]byte{
+				corev1.TLSPrivateKeyKey: staticFixedPrivateKey,
+				corev1.TLSCertKey: testcrypto.MustCreateCertWithNotBeforeAfter(t, staticFixedPrivateKey,
+					&cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.com"}},
+					clock.Now().Add(time.Minute*-30),
+					notAfter,
+				),
+			},
+		}
+	}
+
 	tests := map[string]struct {
 		// policy inputs
 		certificate *cmapi.Certificate
 		request     *cmapi.CertificateRequest
 		secret      *corev1.Secret
+
+		// ariRenewalInfo is the ARI window the gatherer surfaced for the
+		// certificate currently in the Secret, if any.
+		ariRenewalInfo *acmeapi.RenewalInfoResponse
 
 		// expected outputs
 		reason, message string
@@ -543,6 +589,75 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				},
 			},
 		},
+		"trigger renewal at the ARI window start when no jittered renewal time has been recorded": {
+			certificate: ariCert(nil),
+			secret:      ariSecret(clock.Now().Add(time.Hour * 24)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{
+				SuggestedWindow: acmeapi.RenewalInfoWindow{
+					Start: clock.Now().Add(-time.Hour),
+					End:   clock.Now().Add(time.Hour),
+				},
+			},
+			reason:  Renewing,
+			message: "Renewing certificate as renewal was scheduled at <nil>",
+			reissue: true,
+		},
+		"trigger renewal at the ARI window start when the stored renewal time lies outside the window": {
+			// Status.RenewalTime still holds a renewBefore-derived value far
+			// beyond the window, so it must not defer the CA's instruction.
+			certificate: ariCert(&metav1.Time{Time: clock.Now().Add(time.Hour * 72)}),
+			secret:      ariSecret(clock.Now().Add(time.Hour * 24)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{
+				SuggestedWindow: acmeapi.RenewalInfoWindow{
+					Start: clock.Now().Add(-time.Hour),
+					End:   clock.Now().Add(time.Hour),
+				},
+			},
+			reason:  Renewing,
+			message: "Renewing certificate as renewal was scheduled at 0001-01-04 00:00:00 +0000 UTC",
+			reissue: true,
+		},
+		"does not trigger renewal before the jittered renewal time inside an open ARI window": {
+			certificate: ariCert(&metav1.Time{Time: clock.Now().Add(time.Hour)}),
+			secret:      ariSecret(clock.Now().Add(time.Hour * 24)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{
+				SuggestedWindow: acmeapi.RenewalInfoWindow{
+					Start: clock.Now().Add(-time.Hour),
+					End:   clock.Now().Add(time.Hour * 2),
+				},
+			},
+		},
+		"trigger renewal once the jittered renewal time inside the ARI window has passed": {
+			certificate: ariCert(&metav1.Time{Time: clock.Now().Add(time.Minute * -10)}),
+			secret:      ariSecret(clock.Now().Add(time.Hour * 24)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{
+				SuggestedWindow: acmeapi.RenewalInfoWindow{
+					Start: clock.Now().Add(-time.Hour * 2),
+					End:   clock.Now().Add(time.Hour * 2),
+				},
+			},
+			reason:  Renewing,
+			message: "Renewing certificate as renewal was scheduled at 0000-12-31 23:50:00 +0000 UTC",
+			reissue: true,
+		},
+		"does not trigger renewal before the ARI window opens even if the renewBefore point has been reached": {
+			// The certificate expires in 1 minute with renewBefore of 5
+			// minutes, so the plain calculation would renew immediately; the
+			// ACME server's window must win.
+			certificate: ariCert(&metav1.Time{Time: clock.Now().Add(-time.Minute)}),
+			secret:      ariSecret(clock.Now().Add(time.Minute)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{
+				SuggestedWindow: acmeapi.RenewalInfoWindow{
+					Start: clock.Now().Add(time.Minute * 30),
+					End:   clock.Now().Add(time.Hour),
+				},
+			},
+		},
+		"falls back to the renewBefore schedule when ARI information carries no window": {
+			certificate:    ariCert(nil),
+			secret:         ariSecret(clock.Now().Add(time.Hour * 24)),
+			ariRenewalInfo: &acmeapi.RenewalInfoResponse{},
+		},
 		"does not trigger renewal if renewal policy is disabled": {
 			certificate: &cmapi.Certificate{
 				Spec: cmapi.CertificateSpec{
@@ -587,6 +702,7 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				Certificate:            test.certificate,
 				CurrentRevisionRequest: test.request,
 				Secret:                 test.secret,
+				ARIRenewalInfo:         test.ariRenewalInfo,
 			})
 
 			if test.reason != reason {

--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -331,53 +331,19 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 			crt.Status.ACME.ARI.SuggestedWindow.End != nil {
 			if leaf, err := pki.DecodeX509CertificateBytes(secret.Data[corev1.TLSCertKey]); err == nil {
 				if id, err := acmeapi.CertificateARIID(leaf); err == nil && id == crt.Status.ACME.ARI.CertID {
-					windowStart := crt.Status.ACME.ARI.SuggestedWindow.Start.Time
-
-					// The CertID comparison above already establishes that this window
-					// describes the certificate currently held in the Secret, so a window
-					// that opened before that certificate came into existence is not
-					// stale - it is the ACME server asking us to replace a certificate it
-					// has only just issued. Acting on it renews immediately and then hands
-					// the replacement the same instruction, so the window is discarded and
-					// renewal falls back to the deterministic renewBefore calculation.
-					//
-					// Both bounds are checked because neither is sufficient alone. Most
-					// ACME CAs backdate NotBefore (Let's Encrypt by an hour), which makes
-					// that bound too permissive on its own. The CertificateRequest is
-					// created moments before issuance and so is the tighter bound, but it
-					// may have been pruned or restored separately from the Certificate; a
-					// missing one leaves the NotBefore bound in force rather than
-					// withholding the window, since there is no prior revision to protect.
-					//
-					// TODO(@hjoshi123): the bounds here are permissive.
-					// Too permissive and a CA reporting a window starting at the current time
-					// - what a mass-revocation event looks
-					// like - renews repeatedly, since the replacement is handed the same
-					// instruction. Too strict and a legitimate urgent-replacement window is
-					// discarded and renewal silently falls back to renewBefore. A floor scaled to
-					// the certificate's lifetime (ignore a window opening within the first N% of
-					// it) would sharpen both ends, but picking N is a decision about how soon
-					// after issuance an ARI window may legitimately trigger renewal.
-					openedBeforeIssuance := !windowStart.After(leaf.NotBefore)
-					requestCreatedAt := "<no current CertificateRequest>"
-					if curCR != nil {
-						requestCreatedAt = curCR.CreationTimestamp.Time.String()
-						if !windowStart.After(curCR.CreationTimestamp.Time) {
-							openedBeforeIssuance = true
-						}
-					}
-
-					if openedBeforeIssuance {
-						log.V(logf.DebugLevel).Info("Ignoring ACME renewal window that was already open when the current certificate was issued",
-							"windowStart", windowStart, "notBefore", leaf.NotBefore, "requestCreatedAt", requestCreatedAt)
-					} else {
-						i.ARIRenewalInfo = &acmeapi.RenewalInfoResponse{
-							SuggestedWindow: acmeapi.RenewalInfoWindow{
-								Start: crt.Status.ACME.ARI.SuggestedWindow.Start.Time,
-								End:   crt.Status.ACME.ARI.SuggestedWindow.End.Time,
-							},
-							ExplanationURL: crt.Status.ACME.ARI.ExplanationURL,
-						}
+					// The CertID match proves this window was fetched for the
+					// certificate currently in the Secret; a window belonging to a
+					// previous revision can never surface here because renewal changes
+					// the CertID. No issuance-time bound is applied on top: RFC 9773
+					// permits a CA to return an already-open window to request urgent
+					// replacement (e.g. after revocation), including for a certificate
+					// it has only just issued.
+					i.ARIRenewalInfo = &acmeapi.RenewalInfoResponse{
+						SuggestedWindow: acmeapi.RenewalInfoWindow{
+							Start: crt.Status.ACME.ARI.SuggestedWindow.Start.Time,
+							End:   crt.Status.ACME.ARI.SuggestedWindow.End.Time,
+						},
+						ExplanationURL: crt.Status.ACME.ARI.ExplanationURL,
 					}
 				}
 			}

--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -211,6 +211,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
@@ -220,6 +221,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/controller/certificates"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/cert-manager/pkg/util/predicate"
 	acmeapi "github.com/cert-manager/cert-manager/third_party/forked/acme"
 )
@@ -322,13 +324,62 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ACMEUseARI) {
-		if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil && crt.Status.ACME.ARI.SuggestedWindow != nil {
-			i.ARIRenewalInfo = &acmeapi.RenewalInfoResponse{
-				SuggestedWindow: acmeapi.RenewalInfoWindow{
-					Start: crt.Status.ACME.ARI.SuggestedWindow.Start.Time,
-					End:   crt.Status.ACME.ARI.SuggestedWindow.End.Time,
-				},
-				ExplanationURL: crt.Status.ACME.ARI.ExplanationURL,
+		if secret != nil &&
+			crt.Status.ACME != nil && crt.Status.ACME.ARI != nil &&
+			crt.Status.ACME.ARI.SuggestedWindow != nil &&
+			crt.Status.ACME.ARI.SuggestedWindow.Start != nil &&
+			crt.Status.ACME.ARI.SuggestedWindow.End != nil {
+			if leaf, err := pki.DecodeX509CertificateBytes(secret.Data[corev1.TLSCertKey]); err == nil {
+				if id, err := acmeapi.CertificateARIID(leaf); err == nil && id == crt.Status.ACME.ARI.CertID {
+					windowStart := crt.Status.ACME.ARI.SuggestedWindow.Start.Time
+
+					// The CertID comparison above already establishes that this window
+					// describes the certificate currently held in the Secret, so a window
+					// that opened before that certificate came into existence is not
+					// stale - it is the ACME server asking us to replace a certificate it
+					// has only just issued. Acting on it renews immediately and then hands
+					// the replacement the same instruction, so the window is discarded and
+					// renewal falls back to the deterministic renewBefore calculation.
+					//
+					// Both bounds are checked because neither is sufficient alone. Most
+					// ACME CAs backdate NotBefore (Let's Encrypt by an hour), which makes
+					// that bound too permissive on its own. The CertificateRequest is
+					// created moments before issuance and so is the tighter bound, but it
+					// may have been pruned or restored separately from the Certificate; a
+					// missing one leaves the NotBefore bound in force rather than
+					// withholding the window, since there is no prior revision to protect.
+					//
+					// TODO(@hjoshi123): the bounds here are permissive.
+					// Too permissive and a CA reporting a window starting at the current time
+					// - what a mass-revocation event looks
+					// like - renews repeatedly, since the replacement is handed the same
+					// instruction. Too strict and a legitimate urgent-replacement window is
+					// discarded and renewal silently falls back to renewBefore. A floor scaled to
+					// the certificate's lifetime (ignore a window opening within the first N% of
+					// it) would sharpen both ends, but picking N is a decision about how soon
+					// after issuance an ARI window may legitimately trigger renewal.
+					openedBeforeIssuance := !windowStart.After(leaf.NotBefore)
+					requestCreatedAt := "<no current CertificateRequest>"
+					if curCR != nil {
+						requestCreatedAt = curCR.CreationTimestamp.Time.String()
+						if !windowStart.After(curCR.CreationTimestamp.Time) {
+							openedBeforeIssuance = true
+						}
+					}
+
+					if openedBeforeIssuance {
+						log.V(logf.DebugLevel).Info("Ignoring ACME renewal window that was already open when the current certificate was issued",
+							"windowStart", windowStart, "notBefore", leaf.NotBefore, "requestCreatedAt", requestCreatedAt)
+					} else {
+						i.ARIRenewalInfo = &acmeapi.RenewalInfoResponse{
+							SuggestedWindow: acmeapi.RenewalInfoWindow{
+								Start: crt.Status.ACME.ARI.SuggestedWindow.Start.Time,
+								End:   crt.Status.ACME.ARI.SuggestedWindow.End.Time,
+							},
+							ExplanationURL: crt.Status.ACME.ARI.ExplanationURL,
+						}
+					}
+				}
 			}
 		}
 	}

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -2736,6 +2736,13 @@ func schema_pkg_apis_certmanager_v1_CertificateACMEARIStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"certID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was fetched for. This is used to determine if we need to re-fetch the renewal information as changed cert id means that ARI fetched before is stale.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -861,6 +861,13 @@ type CertificateACMEARIStatus struct {
 	//
 	// +optional
 	LastError string `json:"lastError,omitempty"`
+
+	// CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
+	// fetched for. This is used to determine if we need to re-fetch the renewal information
+	// as changed cert id means that ARI fetched before is stale.
+	//
+	// +optional
+	CertID string `json:"certID,omitempty"`
 }
 
 type ACMERenewalWindow struct {

--- a/pkg/client/applyconfigurations/certmanager/v1/certificateacmearistatus.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificateacmearistatus.go
@@ -36,6 +36,11 @@ type CertificateACMEARIStatusApplyConfiguration struct {
 	NextCheck *metav1.Time `json:"nextCheck,omitempty"`
 	// LastError is the last error encountered when checking the ACME server for renewal information, if any.
 	LastError *string `json:"lastError,omitempty"`
+	// CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
+	// fetched for. This is used to determine if we need to re-fetch the renewal information
+	// as changed cert id means that ARI fetched before is stale.
+	//
+	CertID *string `json:"certID,omitempty"`
 }
 
 // CertificateACMEARIStatusApplyConfiguration constructs a declarative configuration of the CertificateACMEARIStatus type for use with
@@ -81,5 +86,13 @@ func (b *CertificateACMEARIStatusApplyConfiguration) WithNextCheck(value metav1.
 // If called multiple times, the LastError field is set to the value of the last call.
 func (b *CertificateACMEARIStatusApplyConfiguration) WithLastError(value string) *CertificateACMEARIStatusApplyConfiguration {
 	b.LastError = &value
+	return b
+}
+
+// WithCertID sets the CertID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CertID field is set to the value of the last call.
+func (b *CertificateACMEARIStatusApplyConfiguration) WithCertID(value string) *CertificateACMEARIStatusApplyConfiguration {
+	b.CertID = &value
 	return b
 }

--- a/pkg/client/applyconfigurations/certmanager/v1/certificateacmearistatus.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificateacmearistatus.go
@@ -39,7 +39,6 @@ type CertificateACMEARIStatusApplyConfiguration struct {
 	// CertID is the ARI CertID (RFC 9773) of the certificate this renewal information was
 	// fetched for. This is used to determine if we need to re-fetch the renewal information
 	// as changed cert id means that ARI fetched before is stale.
-	//
 	CertID *string `json:"certID,omitempty"`
 }
 

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -1191,6 +1191,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.cert-manager.cert-manager.pkg.apis.certmanager.v1.CertificateACMEARIStatus
   map:
     fields:
+    - name: certID
+      type:
+        scalar: string
     - name: explanationURL
       type:
         scalar: string

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -228,7 +228,16 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 
 		// If there is no renewal time from ARI or if the featuregate is disabled.
 		if renewalTime == nil || renewalTime.IsZero() {
-			renewalTime, err = c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, crt.Spec.RenewBefore, crt.Spec.RenewBeforePercentage, crt.Spec.Renewal)
+			// If status already carries an ARI-derived renewal time that is
+			// still valid for the certificate in the Secret, keep it rather
+			// than recalculating from renewBefore. This stops the ARI-picked
+			// time from being overwritten on the reconcile that follows every
+			// ARI fetch.
+			if t := ariRenewalTimeFromStatus(crt, x509cert); t != nil {
+				renewalTime = t
+			} else {
+				renewalTime, err = c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, crt.Spec.RenewBefore, crt.Spec.RenewBeforePercentage, crt.Spec.Renewal)
+			}
 		}
 		if err != nil {
 			reason := policies.WindowError
@@ -278,8 +287,7 @@ func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) t
 }
 
 func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificate, x509cert *x509.Certificate, secret *corev1.Secret, key types.NamespacedName) *metav1.Time {
-	log := logf.FromContext(ctx).WithValues("key", key)
-	ctx = logf.NewContext(ctx, log)
+	log := logf.FromContext(ctx)
 
 	genericIssuer, err := c.helper.GetGenericIssuer(crt.Spec.IssuerRef, crt.Namespace)
 	if err != nil || genericIssuer == nil || genericIssuer.GetSpec().ACME == nil {
@@ -304,15 +312,14 @@ func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificat
 	if err != nil {
 		log.V(logf.DebugLevel).Info("could not compute certificate ID for ARI", "error", err)
 
-		if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil {
-			crt.Status.ACME.ARI.SuggestedWindow = nil
-			crt.Status.ACME.ARI.ExplanationURL = ""
-		}
+		// If we cannot compute the certificate ID, we cannot use ARI for this certificate. Clear any existing ARI status.
+		crt.Status.ACME = nil
+		return nil
 	}
 
 	var staleForCurrentCert bool
 	if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil {
-		staleForCurrentCert = currCertID != crt.Status.ACME.ARI.CertID
+		staleForCurrentCert = crt.Status.ACME.ARI.CertID != "" && currCertID != crt.Status.ACME.ARI.CertID
 	}
 	// The ACME server may move a suggested window at any time, so the periodic
 	// poll has to keep running even when the certificate has not been replaced.
@@ -409,6 +416,30 @@ func (c *controller) getARIInfo(ctx context.Context, genericIssuer cmapi.Generic
 	}
 
 	return ri, nil
+}
+
+func ariRenewalTimeFromStatus(crt *cmapi.Certificate, x509cert *x509.Certificate) *metav1.Time {
+	if crt.Status.ACME == nil || crt.Status.ACME.ARI == nil {
+		return nil
+	}
+	ari := crt.Status.ACME.ARI
+	if ari.SuggestedWindow == nil || ari.SuggestedWindow.Start == nil || ari.SuggestedWindow.End == nil || ari.CertID == "" {
+		return nil
+	}
+
+	id, err := acmeapi.CertificateARIID(x509cert)
+	if err != nil || id != ari.CertID {
+		return nil
+	}
+
+	existing := crt.Status.RenewalTime
+	if existing == nil ||
+		!existing.Time.After(x509cert.NotBefore) ||
+		existing.Time.Before(ari.SuggestedWindow.Start.Time) ||
+		existing.Time.After(ari.SuggestedWindow.End.Time) {
+		return nil
+	}
+	return existing
 }
 
 // updateOrApplyStatus will update the controller status. If the

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -278,6 +278,9 @@ func (c *controller) computeNextCheck(now time.Time, retryAfter time.Duration) t
 }
 
 func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificate, x509cert *x509.Certificate, secret *corev1.Secret, key types.NamespacedName) *metav1.Time {
+	log := logf.FromContext(ctx).WithValues("key", key)
+	ctx = logf.NewContext(ctx, log)
+
 	genericIssuer, err := c.helper.GetGenericIssuer(crt.Spec.IssuerRef, crt.Namespace)
 	if err != nil || genericIssuer == nil || genericIssuer.GetSpec().ACME == nil {
 		return nil
@@ -292,16 +295,27 @@ func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificat
 
 	now := c.clock.Now()
 
-	var (
-		nextCheck   *metav1.Time
-		lastChecked *metav1.Time
-	)
+	var nextCheck *metav1.Time
 	if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil {
 		nextCheck = crt.Status.ACME.ARI.NextCheck
-		lastChecked = crt.Status.ACME.ARI.LastChecked
 	}
 
-	staleForCurrentCert := lastChecked != nil && lastChecked.Time.Before(x509cert.NotBefore)
+	currCertID, err := acmeapi.CertificateARIID(x509cert)
+	if err != nil {
+		log.V(logf.DebugLevel).Info("could not compute certificate ID for ARI", "error", err)
+
+		if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil {
+			crt.Status.ACME.ARI.SuggestedWindow = nil
+			crt.Status.ACME.ARI.ExplanationURL = ""
+		}
+	}
+
+	var staleForCurrentCert bool
+	if crt.Status.ACME != nil && crt.Status.ACME.ARI != nil {
+		staleForCurrentCert = currCertID != crt.Status.ACME.ARI.CertID
+	}
+	// The ACME server may move a suggested window at any time, so the periodic
+	// poll has to keep running even when the certificate has not been replaced.
 	needFetch := nextCheck == nil || !now.Before(nextCheck.Time) || staleForCurrentCert
 	if !needFetch {
 		return nil
@@ -324,6 +338,14 @@ func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificat
 	case err != nil:
 		ariStatus.LastChecked = &metav1.Time{Time: now}
 		ariStatus.LastError = err.Error()
+		// Drop any previously recorded window. Keeping it would leave status
+		// advertising a renewal window belonging to a certificate that is no
+		// longer in the Secret, next to a freshly bumped lastChecked.
+		if staleForCurrentCert {
+			ariStatus.SuggestedWindow = nil
+			ariStatus.ExplanationURL = ""
+		}
+		ariStatus.CertID = currCertID
 		reason := policies.ARIError
 		message := fmt.Sprintf("Could not fetch ACME Renewal Information: %v", err)
 
@@ -340,6 +362,7 @@ func (c *controller) useARIForRenewal(ctx context.Context, crt *cmapi.Certificat
 		ariStatus.LastChecked = &metav1.Time{Time: now}
 		existing := crt.Status.RenewalTime
 		ariStatus.ExplanationURL = ariInfo.ExplanationURL
+		ariStatus.CertID = currCertID
 		ariStatus.SuggestedWindow = &cmapi.ACMERenewalWindow{
 			Start: &metav1.Time{Time: ariInfo.SuggestedWindow.Start},
 			End:   &metav1.Time{Time: ariInfo.SuggestedWindow.End},

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -19,7 +19,10 @@ package readiness
 import (
 	"context"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
@@ -808,6 +811,321 @@ func TestReadinessForARI(t *testing.T) {
 
 			if err := builder.AllActionsExecuted(); err != nil {
 				builder.T.Error(err)
+			}
+		})
+	}
+}
+
+// mustLeafWithAKI returns a leaf certificate signed by a throwaway CA, together
+// with its ARI CertID.
+func mustLeafWithAKI(t *testing.T, notBefore, notAfter time.Time, serial int64) (*x509.Certificate, string) {
+	t.Helper()
+
+	caPK, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             notBefore.Add(-time.Hour),
+		NotAfter:              notAfter.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		PublicKey:             caPK.Public(),
+		IsCA:                  true,
+	}
+	_, caCert, err := pki.SignCertificate(caTmpl, caTmpl, caPK.Public(), caPK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafPK, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		DNSNames:     []string{"example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		PublicKey:    leafPK.Public(),
+	}
+	_, leaf, err := pki.SignCertificate(leafTmpl, caCert, leafPK.Public(), caPK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certID, err := acmeapi.CertificateARIID(leaf)
+	if err != nil {
+		t.Fatalf("test fixture leaf has no usable ARI CertID: %v", err)
+	}
+	return leaf, certID
+}
+
+// mustLeafWithoutAKI returns a self-signed, non-CA leaf. acmeapi.CertificateARIID
+// cannot derive a CertID for it.
+func mustLeafWithoutAKI(t *testing.T, notBefore, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+
+	pk, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(7),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		DNSNames:     []string{"example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		PublicKey:    pk.Public(),
+	}
+	_, leaf, err := pki.SignCertificate(tmpl, tmpl, pk.Public(), pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := acmeapi.CertificateARIID(leaf); err == nil {
+		t.Fatal("expected fixture leaf to have no usable ARI CertID")
+	}
+	return leaf
+}
+
+// TestUseARIForRenewalStaleness covers the decision of whether the ARI block in
+// status still describes the certificate currently held in the Secret.
+//
+// See https://github.com/cert-manager/cert-manager/issues/8993.
+func TestUseARIForRenewalStaleness(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// ACME CAs backdate NotBefore (Let's Encrypt by an hour). Every fixture
+	// here does the same, because backdating is what defeats a staleness check
+	// based on comparing timestamps against NotBefore.
+	notBefore := now.Add(-time.Hour)
+	notAfter := now.Add(89 * 24 * time.Hour)
+
+	currentLeaf, currentCertID := mustLeafWithAKI(t, notBefore, notAfter, 2)
+	_, previousCertID := mustLeafWithAKI(t, now.Add(-90*24*time.Hour), now.Add(time.Hour), 3)
+	noAKILeaf := mustLeafWithoutAKI(t, notBefore, notAfter)
+
+	// A window belonging to the *previous* certificate: it opened shortly
+	// before the renewal that produced currentLeaf, so its start still falls
+	// after currentLeaf's backdated NotBefore.
+	staleWindow := &cmapi.ACMERenewalWindow{
+		Start: &metav1.Time{Time: now.Add(-30 * time.Minute)},
+		End:   &metav1.Time{Time: now.Add(-10 * time.Minute)},
+	}
+	if !staleWindow.Start.Time.After(notBefore) {
+		t.Fatal("fixture error: stale window must start after the current cert's backdated NotBefore")
+	}
+
+	freshWindow := acmeapi.RenewalInfoWindow{
+		Start: now.Add(24 * time.Hour),
+		End:   now.Add(48 * time.Hour),
+	}
+
+	issuer := gen.Issuer("test-issuer",
+		gen.SetIssuerNamespace("testns"),
+		gen.SetIssuerACME(cmacme.ACMEIssuer{
+			RenewalInformationSource: cmacme.ACMERenewalInformationSourceARI,
+		}),
+	)
+	secret := gen.Secret("test-secret",
+		gen.SetSecretNamespace("testns"),
+		gen.SetSecretAnnotations(map[string]string{
+			cmapi.IssuerNameAnnotationKey:  "test-issuer",
+			cmapi.IssuerKindAnnotationKey:  cmapi.IssuerKind,
+			cmapi.IssuerGroupAnnotationKey: "cert-manager.io",
+		}),
+	)
+
+	tests := map[string]struct {
+		leaf *x509.Certificate
+
+		// ari is the pre-existing status.acme.ari block, if any.
+		ari *cmapi.CertificateACMEARIStatus
+
+		// fetchErr, when set, is returned by the fake GetRenewalInfo.
+		fetchErr error
+
+		wantFetches int
+		check       func(t *testing.T, ari *cmapi.CertificateACMEARIStatus)
+	}{
+		"fetches when no ARI information has been recorded yet": {
+			leaf:        currentLeaf,
+			wantFetches: 1,
+			check: func(t *testing.T, ari *cmapi.CertificateACMEARIStatus) {
+				if ari == nil {
+					t.Fatal("expected an ARI status block to be populated")
+				}
+				if ari.CertID != currentCertID {
+					t.Errorf("CertID = %q, want %q", ari.CertID, currentCertID)
+				}
+				if ari.SuggestedWindow == nil || !ari.SuggestedWindow.Start.Time.Equal(freshWindow.Start) {
+					t.Errorf("SuggestedWindow = %v, want start %v", ari.SuggestedWindow, freshWindow.Start)
+				}
+			},
+		},
+		"does not refetch while the CertID matches and nextCheck is in the future": {
+			leaf: currentLeaf,
+			ari: &cmapi.CertificateACMEARIStatus{
+				CertID:      currentCertID,
+				NextCheck:   &metav1.Time{Time: now.Add(time.Hour)},
+				LastChecked: &metav1.Time{Time: now.Add(-time.Minute)},
+				SuggestedWindow: &cmapi.ACMERenewalWindow{
+					Start: &metav1.Time{Time: freshWindow.Start},
+					End:   &metav1.Time{Time: freshWindow.End},
+				},
+			},
+			wantFetches: 0,
+		},
+		"refetches when the recorded CertID belongs to a previous certificate": {
+			leaf: currentLeaf,
+			ari: &cmapi.CertificateACMEARIStatus{
+				CertID:          previousCertID,
+				NextCheck:       &metav1.Time{Time: now.Add(time.Hour)},
+				LastChecked:     &metav1.Time{Time: now.Add(-time.Minute)},
+				SuggestedWindow: staleWindow,
+			},
+			wantFetches: 1,
+			check: func(t *testing.T, ari *cmapi.CertificateACMEARIStatus) {
+				if ari.CertID != currentCertID {
+					t.Errorf("CertID = %q, want it restamped to %q", ari.CertID, currentCertID)
+				}
+				if ari.SuggestedWindow == nil || !ari.SuggestedWindow.Start.Time.Equal(freshWindow.Start) {
+					t.Errorf("SuggestedWindow = %v, want it replaced with start %v", ari.SuggestedWindow, freshWindow.Start)
+				}
+			},
+		},
+		"refetches once nextCheck has elapsed": {
+			leaf: currentLeaf,
+			ari: &cmapi.CertificateACMEARIStatus{
+				CertID:      currentCertID,
+				NextCheck:   &metav1.Time{Time: now.Add(-time.Minute)},
+				LastChecked: &metav1.Time{Time: now.Add(-6 * time.Hour)},
+				SuggestedWindow: &cmapi.ACMERenewalWindow{
+					Start: &metav1.Time{Time: freshWindow.Start},
+					End:   &metav1.Time{Time: freshWindow.End},
+				},
+			},
+			wantFetches: 1,
+		},
+		// A failed fetch must not leave a window describing a superseded
+		// certificate next to a freshly bumped lastChecked - that is the
+		// inconsistency reported in the issue.
+		"a failed fetch does not leave a window from a previous certificate": {
+			leaf: currentLeaf,
+			ari: &cmapi.CertificateACMEARIStatus{
+				CertID:          previousCertID,
+				NextCheck:       &metav1.Time{Time: now.Add(time.Hour)},
+				LastChecked:     &metav1.Time{Time: now.Add(-time.Minute)},
+				SuggestedWindow: staleWindow,
+			},
+			fetchErr:    errors.New("simulated ARI fetch failure"),
+			wantFetches: 1,
+			check: func(t *testing.T, ari *cmapi.CertificateACMEARIStatus) {
+				if ari.LastError == "" {
+					t.Error("expected LastError to be recorded")
+				}
+				if ari.SuggestedWindow != nil {
+					t.Errorf("SuggestedWindow = %v, want nil so status cannot contradict itself", ari.SuggestedWindow)
+				}
+			},
+		},
+		"clears the recorded window when the certificate has no usable CertID": {
+			leaf: noAKILeaf,
+			ari: &cmapi.CertificateACMEARIStatus{
+				CertID:          "",
+				NextCheck:       &metav1.Time{Time: now.Add(time.Hour)},
+				LastChecked:     &metav1.Time{Time: now.Add(-time.Minute)},
+				SuggestedWindow: staleWindow,
+				ExplanationURL:  "https://example.com/why",
+			},
+			wantFetches: 0,
+			check: func(t *testing.T, ari *cmapi.CertificateACMEARIStatus) {
+				if ari.SuggestedWindow != nil {
+					t.Errorf("SuggestedWindow = %v, want nil", ari.SuggestedWindow)
+				}
+				if ari.ExplanationURL != "" {
+					t.Errorf("ExplanationURL = %q, want empty", ari.ExplanationURL)
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, feature.ACMEUseARI, true)
+
+			var fetches int
+			acmeClient := &acmecl.FakeACME{
+				FakeGetRenewalInfo: func(_ context.Context, _ *x509.Certificate) (*acmeapi.RenewalInfoResponse, error) {
+					fetches++
+					if test.fetchErr != nil {
+						return nil, test.fetchErr
+					}
+					return &acmeapi.RenewalInfoResponse{
+						SuggestedWindow: freshWindow,
+						ExplanationURL:  "https://example.com/explanation",
+						RetryAfter:      6 * time.Hour,
+					}, nil
+				},
+			}
+
+			builder := &testpkg.Builder{
+				T:     t,
+				Clock: fakeclock.NewFakeClock(now),
+			}
+			builder.CertManagerObjects = append(builder.CertManagerObjects, issuer)
+			builder.KubeObjects = append(builder.KubeObjects, secret)
+			builder.Init()
+			defer builder.Stop()
+
+			// Register before Start so the informers it requests are synced.
+			w := &controllerWrapper{}
+			if _, _, err := w.Register(builder.Context); err != nil {
+				t.Fatal(err)
+			}
+			w.controller.recorder = new(testpkg.FakeRecorder)
+			w.controller.accountRegistry = &accountstest.FakeRegistry{
+				GetClientFunc: func(string) (acmecl.Interface, error) { return acmeClient, nil },
+			}
+			w.controller.renewalTimeCalculator = renewalTimeBuilder(&metav1.Time{Time: now.Add(24 * time.Hour)}, nil)
+
+			builder.Start()
+
+			crt := &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Spec: cmapi.CertificateSpec{
+					SecretName: "test-secret",
+					DNSNames:   []string{"example.com"},
+					IssuerRef: cmmeta.IssuerReference{
+						Name:  "test-issuer",
+						Kind:  cmapi.IssuerKind,
+						Group: "cert-manager.io",
+					},
+				},
+			}
+			if test.ari != nil {
+				crt.Status.ACME = &cmapi.CertificateACMEStatus{ARI: test.ari.DeepCopy()}
+			}
+
+			key := types.NamespacedName{Namespace: crt.Namespace, Name: crt.Name}
+			w.controller.useARIForRenewal(t.Context(), crt, test.leaf, secret, key)
+
+			if fetches != test.wantFetches {
+				t.Errorf("GetRenewalInfo called %d times, want %d", fetches, test.wantFetches)
+			}
+
+			if test.check != nil {
+				var got *cmapi.CertificateACMEARIStatus
+				if crt.Status.ACME != nil {
+					got = crt.Status.ACME.ARI
+				}
+				if got == nil {
+					t.Fatal("expected status.acme.ari to be present")
+				}
+				test.check(t, got)
 			}
 		})
 	}

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"math/big"
@@ -30,6 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -580,8 +582,6 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 func TestReadinessForARI(t *testing.T) {
 	now := time.Now().UTC()
 	metaNow := metav1.NewTime(now)
-	// private key to be used to generate X509 certificate
-	privKey := testcrypto.MustCreatePEMPrivateKey(t)
 	cert := &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
 		Spec: cmapi.CertificateSpec{
@@ -693,11 +693,17 @@ func TestReadinessForARI(t *testing.T) {
 			// readiness controller's issuer helper can resolve it.
 			builder.CertManagerObjects = append(builder.CertManagerObjects, issuer)
 
+			var leafCertID string
 			if test.secretShouldExist {
 				mods := make([]gen.SecretModifier, 0)
 				// If the test scenario needs a secret with a valid X509 cert.
 				if test.notBefore != nil && test.notAfter != nil {
-					x509Bytes := testcrypto.MustCreateCertWithNotBeforeAfter(t, privKey, cert, test.notBefore.Time, test.notAfter.Time)
+					// The leaf must carry an AKI: without one no ARI CertID
+					// can be computed and the controller clears the ACME
+					// status entirely instead of fetching renewal info.
+					leaf, certID := mustLeafWithAKI(t, test.notBefore.Time, test.notAfter.Time, 41)
+					leafCertID = certID
+					x509Bytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw})
 					mods = append(mods,
 						gen.SetSecretData(map[string][]byte{
 							"tls.crt": x509Bytes,
@@ -756,20 +762,24 @@ func TestReadinessForARI(t *testing.T) {
 				c.Status.NotAfter = test.notAfter
 				c.Status.NotBefore = test.notBefore
 				c.Status.RenewalTime = expectedRenewalTime
-				// Expected ACME ARI status populated by the controller
-				// when ACMEUseARI is enabled. LastChecked is set to the
-				// fake clock's "now" by the controller. NextCheck is
-				// computed with random jitter so it is ignored in the
-				// match below.
-				c.Status.ACME = &cmapi.CertificateACMEStatus{
-					ARI: &cmapi.CertificateACMEARIStatus{
-						ExplanationURL: ariInfo.ExplanationURL,
-						SuggestedWindow: &cmapi.ACMERenewalWindow{
-							Start: &metav1.Time{Time: ariInfo.SuggestedWindow.Start},
-							End:   &metav1.Time{Time: ariInfo.SuggestedWindow.End},
+
+				if ariInfo != nil {
+					// Expected ACME ARI status populated by the controller
+					// when ACMEUseARI is enabled. LastChecked is set to the
+					// fake clock's "now" by the controller. NextCheck is
+					// computed with random jitter so it is ignored in the
+					// match below.
+					c.Status.ACME = &cmapi.CertificateACMEStatus{
+						ARI: &cmapi.CertificateACMEARIStatus{
+							CertID:         leafCertID,
+							ExplanationURL: ariInfo.ExplanationURL,
+							SuggestedWindow: &cmapi.ACMERenewalWindow{
+								Start: &metav1.Time{Time: ariInfo.SuggestedWindow.Start},
+								End:   &metav1.Time{Time: ariInfo.SuggestedWindow.End},
+							},
+							LastChecked: &metaNow,
 						},
-						LastChecked: &metaNow,
-					},
+					}
 				}
 
 				builder.ExpectedActions = append(builder.ExpectedActions,
@@ -926,9 +936,7 @@ func TestUseARIForRenewalStaleness(t *testing.T) {
 
 	issuer := gen.Issuer("test-issuer",
 		gen.SetIssuerNamespace("testns"),
-		gen.SetIssuerACME(cmacme.ACMEIssuer{
-			RenewalInformationSource: cmacme.ACMERenewalInformationSourceARI,
-		}),
+		gen.SetIssuerACME(cmacme.ACMEIssuer{}),
 	)
 	secret := gen.Secret("test-secret",
 		gen.SetSecretNamespace("testns"),
@@ -948,8 +956,9 @@ func TestUseARIForRenewalStaleness(t *testing.T) {
 		// fetchErr, when set, is returned by the fake GetRenewalInfo.
 		fetchErr error
 
-		wantFetches int
-		check       func(t *testing.T, ari *cmapi.CertificateACMEARIStatus)
+		wantFetches           int
+		check                 func(t *testing.T, ari *cmapi.CertificateACMEARIStatus)
+		wantACMEStatusCleared bool
 	}{
 		"fetches when no ARI information has been recorded yet": {
 			leaf:        currentLeaf,
@@ -1032,22 +1041,20 @@ func TestUseARIForRenewalStaleness(t *testing.T) {
 				}
 			},
 		},
-		"clears the recorded window when the certificate has no usable CertID": {
+		"clears the ARI info when the certificate has no usable CertID": {
 			leaf: noAKILeaf,
 			ari: &cmapi.CertificateACMEARIStatus{
-				CertID:          "",
+				CertID:          currentCertID,
 				NextCheck:       &metav1.Time{Time: now.Add(time.Hour)},
 				LastChecked:     &metav1.Time{Time: now.Add(-time.Minute)},
 				SuggestedWindow: staleWindow,
 				ExplanationURL:  "https://example.com/why",
 			},
-			wantFetches: 0,
+			wantFetches:           0,
+			wantACMEStatusCleared: true,
 			check: func(t *testing.T, ari *cmapi.CertificateACMEARIStatus) {
-				if ari.SuggestedWindow != nil {
-					t.Errorf("SuggestedWindow = %v, want nil", ari.SuggestedWindow)
-				}
-				if ari.ExplanationURL != "" {
-					t.Errorf("ExplanationURL = %q, want empty", ari.ExplanationURL)
+				if ari != nil {
+					t.Errorf("expected status.acme.ari to be cleared, got %v", ari)
 				}
 			},
 		},
@@ -1122,10 +1129,262 @@ func TestUseARIForRenewalStaleness(t *testing.T) {
 				if crt.Status.ACME != nil {
 					got = crt.Status.ACME.ARI
 				}
-				if got == nil {
+				if got == nil && !test.wantACMEStatusCleared {
 					t.Fatal("expected status.acme.ari to be present")
 				}
 				test.check(t, got)
+			}
+		})
+	}
+}
+
+// TestARIRenewalTimeFromStatus covers the decision of whether the renewal time
+// already recorded in status was derived from the ARI window of the certificate
+// currently held in the Secret, and can therefore be kept instead of being
+// overwritten by the plain renewBefore calculation.
+func TestARIRenewalTimeFromStatus(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	notBefore := now.Add(-time.Hour)
+	notAfter := now.Add(89 * 24 * time.Hour)
+
+	currentLeaf, currentCertID := mustLeafWithAKI(t, notBefore, notAfter, 11)
+	_, previousCertID := mustLeafWithAKI(t, now.Add(-90*24*time.Hour), now.Add(time.Hour), 12)
+	noAKILeaf := mustLeafWithoutAKI(t, notBefore, notAfter)
+
+	windowStart := &metav1.Time{Time: now.Add(24 * time.Hour)}
+	windowEnd := &metav1.Time{Time: now.Add(48 * time.Hour)}
+	window := &cmapi.ACMERenewalWindow{Start: windowStart, End: windowEnd}
+	inWindow := &metav1.Time{Time: now.Add(36 * time.Hour)}
+
+	crt := func(ari *cmapi.CertificateACMEARIStatus, renewalTime *metav1.Time) *cmapi.Certificate {
+		c := &cmapi.Certificate{}
+		if ari != nil {
+			c.Status.ACME = &cmapi.CertificateACMEStatus{ARI: ari}
+		}
+		c.Status.RenewalTime = renewalTime
+		return c
+	}
+
+	tests := map[string]struct {
+		crt  *cmapi.Certificate
+		leaf *x509.Certificate
+		want *metav1.Time
+	}{
+		"returns the stored renewal time when it falls inside the window of the current certificate": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, inWindow),
+			leaf: currentLeaf,
+			want: inWindow,
+		},
+		"nil when no ACME status has been recorded": {
+			crt:  crt(nil, inWindow),
+			leaf: currentLeaf,
+		},
+		"nil when no window has been recorded": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID}, inWindow),
+			leaf: currentLeaf,
+		},
+		"nil when the recorded window has no end": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: &cmapi.ACMERenewalWindow{Start: windowStart}}, inWindow),
+			leaf: currentLeaf,
+		},
+		"nil when no CertID has been recorded": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{SuggestedWindow: window}, inWindow),
+			leaf: currentLeaf,
+		},
+		"nil when the recorded CertID belongs to a previous certificate": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: previousCertID, SuggestedWindow: window}, inWindow),
+			leaf: currentLeaf,
+		},
+		"nil when the current certificate has no usable CertID": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, inWindow),
+			leaf: noAKILeaf,
+		},
+		"nil when no renewal time has been recorded": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, nil),
+			leaf: currentLeaf,
+		},
+		"nil when the stored renewal time is before the window opens": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, &metav1.Time{Time: now.Add(12 * time.Hour)}),
+			leaf: currentLeaf,
+		},
+		"nil when the stored renewal time is after the window closes": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, &metav1.Time{Time: now.Add(72 * time.Hour)}),
+			leaf: currentLeaf,
+		},
+		"nil when the stored renewal time does not postdate the certificate": {
+			crt:  crt(&cmapi.CertificateACMEARIStatus{CertID: currentCertID, SuggestedWindow: window}, &metav1.Time{Time: notBefore}),
+			leaf: currentLeaf,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ariRenewalTimeFromStatus(test.crt, test.leaf)
+			if (got == nil) != (test.want == nil) || (got != nil && !got.Time.Equal(test.want.Time)) {
+				t.Errorf("ariRenewalTimeFromStatus() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// TestProcessItemARIRenewalTimePersistence verifies that once the readiness
+// controller has written an ARI-derived renewal time to status, the reconciles
+// between ARI fetches keep it instead of overwriting it with the plain
+// renewBefore calculation (which would bounce status.renewalTime on the
+// re-enqueue that follows every ARI fetch).
+func TestProcessItemARIRenewalTimePersistence(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	metaNow := metav1.NewTime(now)
+
+	leaf, leafCertID := mustLeafWithAKI(t, now.Add(-time.Hour), now.Add(89*24*time.Hour), 21)
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw})
+
+	window := &cmapi.ACMERenewalWindow{
+		Start: &metav1.Time{Time: now.Add(24 * time.Hour)},
+		End:   &metav1.Time{Time: now.Add(48 * time.Hour)},
+	}
+	// The jittered pick the controller made inside the window on the reconcile
+	// that fetched ARI.
+	ariPickedTime := metav1.NewTime(now.Add(36 * time.Hour))
+	calculatorTime := metav1.NewTime(now.Add(30 * 24 * time.Hour))
+
+	readyCondition := cmapi.CertificateCondition{
+		Type:               cmapi.CertificateConditionReady,
+		Status:             cmmeta.ConditionTrue,
+		Reason:             ReadyReason,
+		Message:            "ready message",
+		LastTransitionTime: &metaNow,
+	}
+
+	newCert := func(renewalTime *metav1.Time) *cmapi.Certificate {
+		return &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+			Spec: cmapi.CertificateSpec{
+				SecretName: "test-secret",
+				DNSNames:   []string{"example.com"},
+				IssuerRef: cmmeta.IssuerReference{
+					Name:  "test-issuer",
+					Kind:  cmapi.IssuerKind,
+					Group: "cert-manager.io",
+				},
+			},
+			Status: cmapi.CertificateStatus{
+				Conditions:  []cmapi.CertificateCondition{readyCondition},
+				NotBefore:   &metav1.Time{Time: leaf.NotBefore},
+				NotAfter:    &metav1.Time{Time: leaf.NotAfter},
+				RenewalTime: renewalTime,
+				ACME: &cmapi.CertificateACMEStatus{
+					ARI: &cmapi.CertificateACMEARIStatus{
+						CertID:          leafCertID,
+						LastChecked:     &metav1.Time{Time: now.Add(-time.Hour)},
+						NextCheck:       &metav1.Time{Time: now.Add(5 * time.Hour)},
+						SuggestedWindow: window.DeepCopy(),
+					},
+				},
+			},
+		}
+	}
+
+	issuer := gen.Issuer("test-issuer",
+		gen.SetIssuerNamespace("testns"),
+		gen.SetIssuerACME(cmacme.ACMEIssuer{}),
+	)
+	secret := gen.Secret("test-secret",
+		gen.SetSecretNamespace("testns"),
+		gen.SetSecretAnnotations(map[string]string{
+			cmapi.IssuerNameAnnotationKey:  "test-issuer",
+			cmapi.IssuerKindAnnotationKey:  cmapi.IssuerKind,
+			cmapi.IssuerGroupAnnotationKey: "cert-manager.io",
+		}),
+		gen.SetSecretData(map[string][]byte{corev1.TLSCertKey: leafPEM}),
+	)
+
+	tests := map[string]struct {
+		// renewalTime is status.renewalTime going into the reconcile.
+		renewalTime *metav1.Time
+
+		wantCalculatorCalls int
+
+		// wantUpdatedRenewalTime, when set, is the renewal time expected in a
+		// status update. When nil, no status update must happen at all.
+		wantUpdatedRenewalTime *metav1.Time
+	}{
+		"keeps the ARI-derived renewal time between fetches without writing status": {
+			renewalTime:         &ariPickedTime,
+			wantCalculatorCalls: 0,
+		},
+		"recalculates when the stored renewal time falls outside the suggested window": {
+			renewalTime:            &metav1.Time{Time: now.Add(72 * time.Hour)},
+			wantCalculatorCalls:    1,
+			wantUpdatedRenewalTime: &calculatorTime,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, feature.ACMEUseARI, true)
+
+			crt := newCert(test.renewalTime)
+
+			builder := &testpkg.Builder{
+				T:                  t,
+				Clock:              fakeclock.NewFakeClock(now),
+				CertManagerObjects: []runtime.Object{crt, issuer},
+				KubeObjects:        []runtime.Object{secret},
+			}
+			builder.Init()
+			defer builder.Stop()
+
+			// Register before Start so the informers it requests are synced.
+			w := &controllerWrapper{}
+			if _, _, err := w.Register(builder.Context); err != nil {
+				t.Fatal(err)
+			}
+			w.controller.policyEvaluator = policyEvaluatorBuilder(readyCondition)
+			w.controller.recorder = new(testpkg.FakeRecorder)
+			w.controller.accountRegistry = &accountstest.FakeRegistry{
+				GetClientFunc: func(string) (acmecl.Interface, error) {
+					return &acmecl.FakeACME{
+						FakeGetRenewalInfo: func(context.Context, *x509.Certificate) (*acmeapi.RenewalInfoResponse, error) {
+							t.Error("GetRenewalInfo called; nextCheck is in the future and the CertID matches, so no fetch is expected")
+							return nil, errors.New("unexpected ARI fetch")
+						},
+					}, nil
+				},
+			}
+			var calculatorCalls int
+			w.controller.renewalTimeCalculator = func(notBefore, notAfter time.Time, renewBefore *metav1.Duration, renewBeforePercentage *int32, renewalSpec *cmapi.CertificateRenewal, opts ...pki.RenewalTimeOptions) (*metav1.Time, error) {
+				calculatorCalls++
+				return &calculatorTime, nil
+			}
+
+			if test.wantUpdatedRenewalTime != nil {
+				expCrt := newCert(test.wantUpdatedRenewalTime)
+				builder.ExpectedActions = append(builder.ExpectedActions,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
+						expCrt.Namespace,
+						expCrt,
+					)),
+				)
+			}
+
+			builder.Start()
+
+			key := types.NamespacedName{Namespace: crt.Namespace, Name: crt.Name}
+			if err := w.controller.ProcessItem(t.Context(), key); err != nil {
+				t.Fatalf("ProcessItem() error = %v", err)
+			}
+
+			if calculatorCalls != test.wantCalculatorCalls {
+				t.Errorf("renewalTimeCalculator called %d times, want %d", calculatorCalls, test.wantCalculatorCalls)
+			}
+			// With no expected actions this also fails on any unexpected
+			// status write - a reconcile between fetches must not touch the
+			// Certificate at all.
+			if err := builder.AllActionsExecuted(); err != nil {
+				t.Error(err)
 			}
 		})
 	}


### PR DESCRIPTION
Manual cherry-pick of #9203 (fixes #8993) for v1.21.2; the automated cherry-pick [failed with conflicts](https://github.com/cert-manager/cert-manager/pull/9203#issuecomment-5565878356).

All production code is picked unchanged. The conflict was in `readiness_controller_test.go` and the resolution takes the master version of the block. One deliberate deviation in the tests:

- Two new tests set `RenewalInformationSource: cmacme.ACMERenewalInformationSourceARI` on the issuer. That field comes from the per-issuer ARI feature (commit 932a47ac6), which is not on `release-1.21`. Here the [global `ACMEUseARI` feature gate](https://github.com/cert-manager/cert-manager/blob/v1.21.1/pkg/controller/certificates/readiness/readiness_controller.go#L226) covers enablement, and both tests already turn it on, so the field is dropped. Same deviation as #9236.
- A third commit regenerates `zz_generated.conversion.go` and the apply configuration, since `make verify` on this branch needs the `CertID` conversion line and formats the doc comment differently. Output of `make vendor-go generate-codegen`, nothing hand-written.

`go build ./...`, `go vet` and the unit tests for `pkg/controller/certificates/readiness`, `internal/controller/certificates/policies`, `pkg/apis/...` and `internal/apis/...` pass locally.

```release-note
Added `status.acme.ari.certID` to track issuance of new certs and re-fetch ARI from CA. This fixes a renewal loop where a stale ARI window from the previous certificate triggered repeated re-issuance until the CA rate limit was hit.
```

/assign wallrj
/kind bug

[Claude Fable 5.1]

