### PR TITLE
certificate-shim: compare ipAddresses in certNeedsUpdate

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -635,14 +636,8 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 		}
 	}
 
-	if len(a.Spec.IPAddresses) != len(b.Spec.IPAddresses) {
+	if !slices.Equal(a.Spec.IPAddresses, b.Spec.IPAddresses) {
 		return true
-	}
-
-	for i := range a.Spec.IPAddresses {
-		if a.Spec.IPAddresses[i] != b.Spec.IPAddresses[i] {
-			return true
-		}
 	}
 
 	if a.Spec.SecretName != b.Spec.SecretName {

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -635,6 +635,16 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 		}
 	}
 
+	if len(a.Spec.IPAddresses) != len(b.Spec.IPAddresses) {
+		return true
+	}
+
+	for i := range a.Spec.IPAddresses {
+		if a.Spec.IPAddresses[i] != b.Spec.IPAddresses[i] {
+			return true
+		}
+	}
+
 	if a.Spec.SecretName != b.Spec.SecretName {
 		return true
 	}

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -1183,6 +1183,67 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			Name:         "should update an existing Certificate resource with different ipAddresses if they do not match those specified on the IngressLike",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"192.0.2.9"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"192.0.2.1"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			DefaultIssuerKind: "Issuer",
+			ExpectedEvents:    []string{`Normal UpdateCertificate Successfully updated Certificate "existing-crt"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"192.0.2.9"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
 			Name:         "should update an existing Certificate resource with new labels if they do not match those specified on the IngressLike",
 			Issuer:       acmeIssuer,
 			IssuerLister: []runtime.Object{acmeIssuerNewFormat},
@@ -5970,6 +6031,84 @@ func Test_buildCertificates_doesNotMutateIngressLikeLabels(t *testing.T) {
 			// not show up on the (cached) input object.
 			crt.Labels["added-by-test"] = "should-not-leak"
 			assert.NotContains(t, test.ingLike.GetLabels(), "added-by-test", "Certificate labels alias the labels of the object passed to buildCertificates")
+		})
+	}
+}
+
+func Test_certNeedsUpdate(t *testing.T) {
+	buildCert := func(ipAddresses []string) *cmapi.Certificate {
+		return &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "crt",
+			},
+			Spec: cmapi.CertificateSpec{
+				DNSNames:    []string{"example.com"},
+				IPAddresses: ipAddresses,
+				SecretName:  "crt",
+				IssuerRef: cmmeta.IssuerReference{
+					Name: "issuer-name",
+					Kind: "Issuer",
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		ipAddresses []string
+		existing    []string
+		want        bool
+	}{
+		{
+			name:        "equal ipAddresses do not need an update",
+			ipAddresses: []string{"192.0.2.1", "2001:db8::1"},
+			existing:    []string{"192.0.2.1", "2001:db8::1"},
+			want:        false,
+		},
+		{
+			name:        "nil and empty ipAddresses are equivalent",
+			ipAddresses: nil,
+			existing:    []string{},
+			want:        false,
+		},
+		{
+			name:        "changed ipAddress needs an update",
+			ipAddresses: []string{"192.0.2.9"},
+			existing:    []string{"192.0.2.1"},
+			want:        true,
+		},
+		{
+			name:        "added ipAddress needs an update",
+			ipAddresses: []string{"192.0.2.1"},
+			existing:    nil,
+			want:        true,
+		},
+		{
+			name:        "removed ipAddress needs an update",
+			ipAddresses: nil,
+			existing:    []string{"192.0.2.1"},
+			want:        true,
+		},
+		{
+			name:        "de-duplicated ipAddresses need an update",
+			ipAddresses: []string{"192.0.2.1"},
+			existing:    []string{"192.0.2.1", "192.0.2.1"},
+			want:        true,
+		},
+		{
+			name:        "re-ordered ipAddresses need an update",
+			ipAddresses: []string{"192.0.2.1", "192.0.2.2"},
+			existing:    []string{"192.0.2.2", "192.0.2.1"},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := certNeedsUpdate(buildCert(tt.existing), buildCert(tt.ipAddresses))
+			if got != tt.want {
+				t.Errorf("certNeedsUpdate() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

ingress-shim never propagated a change of IP SANs to an existing Certificate. `certNeedsUpdate` compares `dnsNames`, `secretName`, `issuerRef`, labels and the private key settings, but it does not look at `spec.ipAddresses` at all, so the shim decides the existing Certificate is already up to date and drops the new value that `buildCertificates` just computed.

## Problem

1. Create an Ingress with `spec.tls[].hosts: ["192.0.2.1"]` and let ingress-shim create the Certificate.
2. Change the host to `192.0.2.9`.
3. The Certificate still has `ipAddresses: [192.0.2.1]`; no `UpdateCertificate` event is emitted.

The same gap limits what #8978 repairs: a Certificate created by an older cert-manager with duplicate IP SANs keeps its duplicates after the upgrade, and issuance stays stuck on `badCSR` until the Certificate is deleted by hand.

## Root cause

`pkg/controller/certificate-shim/sync.go`, `certNeedsUpdate` (line 608): `DNSNames` is compared by length and then element by element (lines 625-633), but there is no equivalent comparison for `IPAddresses`. `buildCertificates` (line 415) does set `IPAddresses` on the desired Certificate, so the change is computed and then discarded when `certNeedsUpdate` returns `false`.

## Fix

Compare `IPAddresses` in `certNeedsUpdate` by length and then element by element, exactly like `DNSNames`. Nothing else needs to change: the non-SSA update path already does `updateCrt.Spec = crt.Spec`, and the SSA path applies `crt` as built, so once `certNeedsUpdate` returns `true` the new IP SANs reach the Certificate.

Tests added in `sync_test.go`:

- `Test_certNeedsUpdate`: equal -> `false`; nil vs empty -> `false`; changed, added, removed, de-duplicated and re-ordered `ipAddresses` -> `true` (re-ordering is treated as a change, matching how `dnsNames` is compared).
- `TestSync` case `should update an existing Certificate resource with different ipAddresses if they do not match those specified on the IngressLike`: an Ingress whose IP-literal host changed from `192.0.2.1` to `192.0.2.9` must produce an update of the existing Certificate.

## How tested

Before the fix (tests only):

```
--- FAIL: Test_certNeedsUpdate (0.00s)
    --- FAIL: Test_certNeedsUpdate/changed_ipAddress_needs_an_update (0.00s)
        sync_test.go:6016: certNeedsUpdate() = false, want true
    --- FAIL: Test_certNeedsUpdate/added_ipAddress_needs_an_update (0.00s)
        sync_test.go:6016: certNeedsUpdate() = false, want true
    --- FAIL: Test_certNeedsUpdate/removed_ipAddress_needs_an_update (0.00s)
        sync_test.go:6016: certNeedsUpdate() = false, want true
    --- FAIL: Test_certNeedsUpdate/de-duplicated_ipAddresses_need_an_update (0.00s)
        sync_test.go:6016: certNeedsUpdate() = false, want true
    --- FAIL: Test_certNeedsUpdate/re-ordered_ipAddresses_need_an_update (0.00s)
        sync_test.go:6016: certNeedsUpdate() = false, want true

=== RUN   TestSync/ingress-shim/should_update_an_existing_Certificate_resource_with_different_ipAddresses_if_they_do_not_match_those_specified_on_the_IngressLike
    sync_test.go:4716: got unexpected events, exp='[Normal UpdateCertificate Successfully updated Certificate "existing-crt"]' got='[]'
    sync_test.go:4719: missing action: update  "cert-manager.io/v1, Resource=certificates" in namespace default-unit-test-ns
```

After the fix:

```
$ go test ./pkg/controller/certificate-shim/...
ok  	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim	89.339s
ok  	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim/gateways	6.432s
ok  	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim/ingresses	6.431s
ok  	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim/listenerset	5.193s
```

`gofmt -l` clean, `go vet ./pkg/controller/certificate-shim/...` clean, `golangci-lint run --config .golangci.yaml ./pkg/controller/certificate-shim/...` reports 0 issues.

## Links

- https://github.com/cert-manager/cert-manager/issues/9296
- Found during the pre-backport review of #8978: https://github.com/cert-manager/cert-manager/pull/8978#issuecomment-5497143708

Fixes #9296

### Kind

/kind bug

### Release Note

```release-note
ingress-shim now updates existing Certificates when the desired IP SANs change
```

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
