### PR TITLE
certificate-shim: do not mutate the cached object's labels

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -382,7 +382,10 @@ func buildCertificates(
 
 		dnsNames, ipAddress := splitHosts(hosts)
 
-		labels := ingLike.GetLabels()
+		// The ingresses and gateways controllers pass the informer-cached
+		// object straight in, so clone its labels before deleting from them
+		// and never let the Certificate alias the cached map.
+		labels := maps.Clone(ingLike.GetLabels())
 
 		// Remove applyset labels, as they cause certificates to be
 		// incorrectly pruned.

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -19,6 +19,7 @@ package shimhelper
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	coretesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -5876,6 +5878,98 @@ func Test_splitHosts(t *testing.T) {
 			if !reflect.DeepEqual(gotIPAddresses, tt.wantIPAddresses) {
 				t.Errorf("ipAddresses = %#v, want %#v", gotIPAddresses, tt.wantIPAddresses)
 			}
+		})
+	}
+}
+
+func Test_buildCertificates_doesNotMutateIngressLikeLabels(t *testing.T) {
+	// The ingresses and gateways controllers hand the informer-cached object
+	// to buildCertificates without copying it, so the object passed here
+	// stands in for the object in the shared informer cache.
+	tests := []struct {
+		name    string
+		ingLike metav1.Object
+	}{
+		{
+			name: "ingress",
+			ingLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels: map[string]string{
+						"my-test-label": "should-be-propagated",
+						applysetLabel:   "should-not-be-propagated",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "gateway",
+			ingLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels: map[string]string{
+						"my-test-label": "should-be-propagated",
+						applysetLabel:   "should-not-be-propagated",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: new(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: new(gwapi.Group("core")),
+										Kind:  new(gwapi.Kind("Secret")),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lister := cmlisters.NewCertificateLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}))
+			wantLabels := maps.Clone(test.ingLike.GetLabels())
+
+			newCrts, updateCrts, err := buildCertificates(
+				record.NewFakeRecorder(10), logr.Discard(), lister, test.ingLike,
+				"issuer-name", "ClusterIssuer", "cert-manager.io", nil, controllerpkg.IngressShimOptions{},
+			)
+			require.NoError(t, err)
+			require.Empty(t, updateCrts)
+			require.Len(t, newCrts, 1)
+
+			assert.Equal(t, wantLabels, test.ingLike.GetLabels(), "buildCertificates must not modify the labels of the object it was given")
+
+			crt := newCrts[0]
+			assert.Equal(t, map[string]string{"my-test-label": "should-be-propagated"}, crt.Labels)
+
+			// The Certificate must own its labels map: a later write to it must
+			// not show up on the (cached) input object.
+			crt.Labels["added-by-test"] = "should-not-leak"
+			assert.NotContains(t, test.ingLike.GetLabels(), "added-by-test", "Certificate labels alias the labels of the object passed to buildCertificates")
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9297

## Problem

`buildCertificates` in ingress-shim removes the `applyset.kubernetes.io/part-of` label from the labels map of the Ingress or Gateway it is given. The ingresses and gateways controllers pass the informer lister's object to `sync` without copying it, so the delete mutates the object in the shared informer cache, and the new Certificate's `Labels` aliases that cached map. Every other reader of the cache then sees the label missing until the next watch event replaces the object, and because the gateways and listenerset controllers share the Gateway informer, the delete can race with a concurrent read of the same map.

## Root cause

`pkg/controller/certificate-shim/sync.go` at `24754cdef` (master):

- line 385: `labels := ingLike.GetLabels()` returns the live map of the lister object.
- line 401: `delete(labels, applysetLabel)` mutates that map in place.
- line 409: `Labels: labels` stores the same map on the Certificate.
- lines 428-432: the `DeepCopy()` of `ingLike` happens only after the delete, so it does not protect the cache. The listenerset controller deep-copies before calling `sync`, which is why only Ingress and Gateway are affected.

## Fix

Clone the labels map before deleting from it, the same way `annotations` is cloned a few lines below:

```go
labels := maps.Clone(ingLike.GetLabels())
```

`maps.Clone(nil)` returns `nil` and `delete` on a nil map is a no-op, so objects without labels behave as before. The cached object is never written to, and the Certificate owns its own labels map.

## How tested

New test `Test_buildCertificates_doesNotMutateIngressLikeLabels` in `pkg/controller/certificate-shim/sync_test.go`. It calls `buildCertificates` with an Ingress and with a Gateway that both carry `applyset.kubernetes.io/part-of`, then asserts that the input object still has the label, that the Certificate does not, and that writing to the Certificate's labels does not show up on the input object.

Before the fix (both subtests fail):

```
--- FAIL: Test_buildCertificates_doesNotMutateIngressLikeLabels/ingress
    sync_test.go:5964:
        Error:  Not equal:
                expected: map[string]string{"applyset.kubernetes.io/part-of":"should-not-be-propagated", "my-test-label":"should-be-propagated"}
                actual  : map[string]string{"my-test-label":"should-be-propagated"}
        Messages: buildCertificates must not modify the labels of the object it was given
    sync_test.go:5972:
        Error:  map[string]string{"added-by-test":"should-not-leak", "my-test-label":"should-be-propagated"} should not contain "added-by-test"
        Messages: Certificate labels alias the labels of the object passed to buildCertificates
--- FAIL: Test_buildCertificates_doesNotMutateIngressLikeLabels/gateway
    (same two failures)
FAIL	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim	0.034s
```

After the fix:

```
--- PASS: Test_buildCertificates_doesNotMutateIngressLikeLabels (0.00s)
    --- PASS: Test_buildCertificates_doesNotMutateIngressLikeLabels/ingress (0.00s)
    --- PASS: Test_buildCertificates_doesNotMutateIngressLikeLabels/gateway (0.00s)
ok  	github.com/cert-manager/cert-manager/pkg/controller/certificate-shim	0.034s
```

Also ran `gofmt -l`, `go vet ./pkg/controller/certificate-shim/...` and `go test -race ./pkg/controller/certificate-shim/` (the package passes under the race detector). Note: `go test -race` on the `gateways` and `listenerset` sub-packages reports a pre-existing data race in the test-only `mockWorkqueue` (`controller_test.go`), which reproduces identically on `upstream/master` and is unrelated to this change.

## Links

- https://github.com/cert-manager/cert-manager/issues/9297
- Found during the review of #8978 (https://github.com/cert-manager/cert-manager/pull/8978#issuecomment-5497143708)

### Kind

/kind bug

### Release Note

```release-note
ingress-shim no longer removes the applyset label from cached Ingress and Gateway objects
```

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
