### PR TITLE
fix(webhook): validate that renewal windows are reachable within the certificate lifetime

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -228,7 +228,7 @@ func validateCertificateSpec(crt, oldCrt *internalcmapi.CertificateSpec, fldPath
 	}
 
 	if crt.Renewal != nil {
-		el = append(el, validateCertificateRenewal(crt, fldPath)...)
+		el = append(el, validateCertificateRenewal(crt, oldCrt, fldPath)...)
 	}
 
 	return el
@@ -509,7 +509,7 @@ func validateKeystores(crt *internalcmapi.CertificateSpec, fldPath *field.Path) 
 	return el
 }
 
-func validateCertificateRenewal(crt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+func validateCertificateRenewal(crt, oldCrt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
 	var el field.ErrorList
 	switch crt.Renewal.Policy {
 	case internalcmapi.RenewBefore:
@@ -524,7 +524,9 @@ func validateCertificateRenewal(crt *internalcmapi.CertificateSpec, fldPath *fie
 
 	if crt.Renewal.Windows != nil {
 		for i, window := range crt.Renewal.Windows {
-			el = append(el, validateCertificateRenewalWindows(window, fldPath.Child("renewal", "windows").Index(i))...)
+			windowPath := fldPath.Child("renewal", "windows").Index(i)
+			el = append(el, validateCertificateRenewalWindows(window, windowPath)...)
+			el = append(el, validateCertificateRenewalWindowFeasibility(crt, oldCrt, window, windowPath)...)
 		}
 	}
 
@@ -547,4 +549,97 @@ func validateCertificateRenewalWindows(window internalcmapi.CertificateRenewalWi
 	}
 
 	return el
+}
+
+const (
+	// renewalWindowCronSamples bounds how many consecutive activations are
+	// inspected when measuring how often a renewal window recurs. Schedules
+	// with an uneven period, such as "0 0 1 * *" which is 28 to 31 days, need
+	// several samples before the shortest gap is seen.
+	renewalWindowCronSamples = 16
+
+	renewalWindowNeverMatches = "cron never matches a date, so this window can never be entered"
+
+	renewalWindowTooInfrequentFmt = "cron matches at most once every %s, which is longer than the %s renewal search range of a certificate with duration %s; whether a window is found at all depends on when the certificate happens to be issued"
+)
+
+// renewalWindowCronEpoch is a fixed reference point for measuring how often a
+// renewal window recurs, so that a given spec always validates the same way.
+// It starts on a leap year so that "29 February" schedules are measured
+// correctly.
+var renewalWindowCronEpoch = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// validateCertificateRenewalWindowFeasibility rejects renewal windows that
+// recur less often than pki.RenewalTime searches. Whether such a window is hit
+// then depends on where the certificate's validity happens to fall, so it
+// cannot be relied on across renewals: when it is missed the Certificate keeps
+// Ready=False with reason WindowError and is renewed outside its windows.
+func validateCertificateRenewalWindowFeasibility(crt, oldCrt *internalcmapi.CertificateSpec, window internalcmapi.CertificateRenewalWindows, fldPath *field.Path) field.ErrorList {
+	var el field.ErrorList
+
+	// These checks build on validateCertificateRenewalWindows, so skip them
+	// when the window is not syntactically valid in the first place.
+	if window.WindowDuration == nil || window.WindowDuration.Duration <= 0 {
+		return el
+	}
+	schedule, err := utilpkg.CronParse(window.Cron, window.Timezone)
+	if err != nil {
+		return el
+	}
+
+	interval, matches := minCronInterval(schedule)
+	if !matches {
+		el = append(el, field.Invalid(fldPath.Child("cron"), window.Cron, renewalWindowNeverMatches))
+		return el
+	}
+	if interval == 0 {
+		// Only a single activation could be measured, so there is nothing to
+		// compare the certificate lifetime against.
+		return el
+	}
+
+	// applyRenewBeforeWithWindows searches for a window start within
+	// [notBefore-windowDuration, notAfter+windowDuration), so this is the
+	// widest range a window start can ever fall into.
+	duration := util.DefaultCertDuration(crt.Duration)
+	searchRange := duration + 2*window.WindowDuration.Duration
+
+	if interval > searchRange && !allowInfeasibleRenewalWindowOnUpdate(crt, oldCrt) {
+		el = append(el, field.Invalid(fldPath.Child("cron"), window.Cron, fmt.Sprintf(renewalWindowTooInfrequentFmt, interval, searchRange, duration)))
+	}
+
+	return el
+}
+
+// minCronInterval returns the shortest gap between consecutive activations of
+// schedule, measured from a fixed epoch. It reports false if the schedule never
+// matches a date, and a zero interval if only one activation could be found.
+func minCronInterval(schedule utilpkg.CronSchedule) (time.Duration, bool) {
+	previous := schedule.Next(renewalWindowCronEpoch)
+	if previous.IsZero() {
+		return 0, false
+	}
+
+	var shortest time.Duration
+	for range renewalWindowCronSamples {
+		next := schedule.Next(previous)
+		if next.IsZero() {
+			break
+		}
+		if gap := next.Sub(previous); shortest == 0 || gap < shortest {
+			shortest = gap
+		}
+		previous = next
+	}
+
+	return shortest, true
+}
+
+// allowInfeasibleRenewalWindowOnUpdate keeps Certificates that were admitted
+// before this validation existed updateable, as long as neither the duration
+// nor the renewal configuration is being changed.
+func allowInfeasibleRenewalWindowOnUpdate(crt, oldCrt *internalcmapi.CertificateSpec) bool {
+	return oldCrt != nil &&
+		reflect.DeepEqual(oldCrt.Duration, crt.Duration) &&
+		reflect.DeepEqual(oldCrt.Renewal, crt.Renewal)
 }

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -986,6 +986,77 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
+		"renewal window that recurs less often than the certificate lives": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					Duration:   &metav1.Duration{Duration: time.Hour},
+					PrivateKey: &internalcmapi.CertificatePrivateKey{
+						RotationPolicy: internalcmapi.RotationPolicyNever,
+					},
+					Renewal: &internalcmapi.CertificateRenewal{
+						Policy: internalcmapi.RenewBefore,
+						Windows: []internalcmapi.CertificateRenewalWindows{
+							{
+								WindowDuration: &metav1.Duration{Duration: time.Minute},
+								Cron:           "0 0 * * *",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("renewal", "windows").Index(0).Child("cron"), "0 0 * * *", fmt.Sprintf(renewalWindowTooInfrequentFmt, 24*time.Hour, time.Hour+2*time.Minute, time.Hour)),
+			},
+		},
+		"renewal window with a cron that never matches a date": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					PrivateKey: &internalcmapi.CertificatePrivateKey{
+						RotationPolicy: internalcmapi.RotationPolicyNever,
+					},
+					Renewal: &internalcmapi.CertificateRenewal{
+						Policy: internalcmapi.RenewBefore,
+						Windows: []internalcmapi.CertificateRenewalWindows{
+							{
+								WindowDuration: &metav1.Duration{Duration: time.Hour},
+								Cron:           "0 0 30 2 *",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("renewal", "windows").Index(0).Child("cron"), "0 0 30 2 *", renewalWindowNeverMatches),
+			},
+		},
+		"long renewal window period is valid for a long lived certificate": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					Duration:   &metav1.Duration{Duration: 365 * 24 * time.Hour},
+					PrivateKey: &internalcmapi.CertificatePrivateKey{
+						RotationPolicy: internalcmapi.RotationPolicyNever,
+					},
+					Renewal: &internalcmapi.CertificateRenewal{
+						Policy: internalcmapi.RenewBefore,
+						Windows: []internalcmapi.CertificateRenewalWindows{
+							{
+								WindowDuration: &metav1.Duration{Duration: time.Hour},
+								Cron:           "0 0 1 * *",
+							},
+						},
+					},
+				},
+			},
+		},
 		"invalid renewal cron with timezone prefix and no schedule": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
@@ -1067,6 +1138,77 @@ func TestValidateUpdateCertificateRejectsChangedRenewBeforePercentageBelowMinimu
 
 	assert.ElementsMatch(t, []*field.Error{
 		field.Invalid(fldPath.Child("renewBeforePercentage"), int32(6), fmt.Sprintf("certificate renewBeforePercentage must result in a renewBefore of at least %s; 6%% of %s is %s", cmapi.MinimumRenewBefore, time.Hour, time.Minute*3+time.Second*36)),
+	}, errs)
+	assert.Empty(t, warnings)
+}
+
+func TestValidateUpdateCertificatePreservesInfeasibleRenewalWindowOnUnchangedUpdate(t *testing.T) {
+	oldCert := &internalcmapi.Certificate{
+		Spec: internalcmapi.CertificateSpec{
+			Duration:   &metav1.Duration{Duration: time.Hour},
+			CommonName: "testcn",
+			SecretName: "abc",
+			IssuerRef:  validIssuerRef,
+			Renewal: &internalcmapi.CertificateRenewal{
+				Policy: internalcmapi.RenewBefore,
+				Windows: []internalcmapi.CertificateRenewalWindows{
+					{
+						WindowDuration: &metav1.Duration{Duration: time.Minute},
+						Cron:           "0 0 * * *",
+					},
+				},
+			},
+		},
+	}
+	newCert := &internalcmapi.Certificate{Spec: oldCert.Spec}
+
+	errs, warnings := ValidateUpdateCertificate(someAdmissionRequest, oldCert, newCert)
+
+	assert.Empty(t, errs)
+	assert.Empty(t, warnings)
+}
+
+func TestValidateUpdateCertificateRejectsInfeasibleRenewalWindowOnChangedUpdate(t *testing.T) {
+	fldPath := field.NewPath("spec")
+	oldCert := &internalcmapi.Certificate{
+		Spec: internalcmapi.CertificateSpec{
+			Duration:   &metav1.Duration{Duration: time.Hour},
+			CommonName: "testcn",
+			SecretName: "abc",
+			IssuerRef:  validIssuerRef,
+			Renewal: &internalcmapi.CertificateRenewal{
+				Policy: internalcmapi.RenewBefore,
+				Windows: []internalcmapi.CertificateRenewalWindows{
+					{
+						WindowDuration: &metav1.Duration{Duration: time.Minute},
+						Cron:           "0 0 * * *",
+					},
+				},
+			},
+		},
+	}
+	newCert := &internalcmapi.Certificate{
+		Spec: internalcmapi.CertificateSpec{
+			Duration:   &metav1.Duration{Duration: time.Hour},
+			CommonName: "testcn",
+			SecretName: "abc",
+			IssuerRef:  validIssuerRef,
+			Renewal: &internalcmapi.CertificateRenewal{
+				Policy: internalcmapi.RenewBefore,
+				Windows: []internalcmapi.CertificateRenewalWindows{
+					{
+						WindowDuration: &metav1.Duration{Duration: 2 * time.Minute},
+						Cron:           "0 0 * * *",
+					},
+				},
+			},
+		},
+	}
+
+	errs, warnings := ValidateUpdateCertificate(someAdmissionRequest, oldCert, newCert)
+
+	assert.ElementsMatch(t, []*field.Error{
+		field.Invalid(fldPath.Child("renewal", "windows").Index(0).Child("cron"), "0 0 * * *", fmt.Sprintf(renewalWindowTooInfrequentFmt, 24*time.Hour, time.Hour+4*time.Minute, time.Hour)),
 	}, errs)
 	assert.Empty(t, warnings)
 }


### PR DESCRIPTION
### Pull Request Motivation

Closes #9146.

`spec.renewal.windows` is validated for cron syntax, timezone and the presence of `windowDuration`, but not for whether a window is reachable at all. A 1 hour certificate with cron `0 0 * * *` and `windowDuration: 1m` is admitted today, and then every reconcile fails to find a window: readiness keeps it at `Ready=False` with reason `WindowError`, and the trigger controller renews outside the windows anyway.

`applyRenewBeforeWithWindows` looks for a window start in `[notBefore-windowDuration, notAfter+windowDuration)`, so `duration + 2*windowDuration` is the widest range a start can fall into. The webhook now measures the shortest gap between cron activations and rejects the window when it is longer than that range, since hitting it would otherwise depend on where the certificate's validity happens to fall. A cron that never matches a date, like `0 0 30 2 *`, is rejected as well.

Existing objects keep working: the check is skipped on update while `spec.duration` and `spec.renewal` are unchanged, the same way `allowLegacyRenewBeforePercentageOnUpdate` does it.

This does not overlap #9109, which fixes the panic on the trigger path. That one is the crash, this one is the class of specs that reach the error. They do touch the same file, so I can rebase whenever #9109 lands.

Locally: `go test ./internal/...` plus the pki, certificates controller and webhook packages pass, and `golangci-lint run` on the changed package with the pinned v2.13.2 reports 0 issues. The new tests fail without the production change.

*Written with Claude Code (Opus 5).*

### Kind

/kind bug

### Release Note

```release-note
The webhook now rejects Certificate renewal windows that recur less often than the certificate's renewal search range, and windows whose cron never matches a date. Existing Certificates keep working until their duration or renewal configuration changes.
```
