### PR TITLE
ingress-shim: de-duplicate SANs after annotations are merged

### DIFF
--- a/pkg/controller/certificate-shim/helper.go
+++ b/pkg/controller/certificate-shim/helper.go
@@ -77,6 +77,9 @@ func translateAnnotations(crt *cmapi.Certificate, ingLikeAnnotations map[string]
 
 	if altNames, found := ingLikeAnnotations[cmapi.AltNamesAnnotationKey]; found && altNames != "" {
 		addDnsNames := strings.Split(altNames, ",")
+		for i, name := range addDnsNames {
+			addDnsNames[i] = strings.TrimSpace(name)
+		}
 		crt.Spec.DNSNames = append(crt.Spec.DNSNames, addDnsNames...)
 	}
 

--- a/pkg/controller/certificate-shim/helper_test.go
+++ b/pkg/controller/certificate-shim/helper_test.go
@@ -398,3 +398,20 @@ func Test_translateAnnotations_validAnnotationValuesWithWhitespace(t *testing.T)
 		assert.Equal(t, []string{"test@example.com", "admin@example.com"}, crt.Spec.EmailAddresses)
 	}
 }
+
+// Test_translateAnnotations_altNamesWithWhitespace is a regression test for
+// cert-manager/cert-manager#9295: unlike the ip-sans branch, the alt-names
+// branch did not trim entries after splitting on ",", so
+// "www.example.com, example.com" produced " example.com" with a leading
+// space. That near-duplicate of a host already present from tls.hosts
+// survived dedupeSANs (which compares by exact string) and the CSR carried
+// a SAN with a leading space.
+func Test_translateAnnotations_altNamesWithWhitespace(t *testing.T) {
+	crt := gen.Certificate("example-cert")
+	err := translateAnnotations(crt, map[string]string{
+		cmapi.AltNamesAnnotationKey: "www.example.com, example.com",
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, []string{"www.example.com", "example.com"}, crt.Spec.DNSNames)
+	}
+}

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -533,17 +533,11 @@ func handleGatewayAPIListeners[L gwapi.Listener | gwapi.ListenerEntry](listeners
 	}
 }
 
-// splitHosts de-duplicates hosts and splits them into DNS names and IP
-// addresses, preserving first-seen order. Duplicates arise when several
-// listeners reference the same Secret and hostname; dropping them keeps the
-// Certificate's SAN count in sync with the ACME order's identifiers.
+// splitHosts splits hosts into DNS names and IP addresses, preserving
+// first-seen order. Any duplicates are left in place; dedupeSANs removes
+// them once the full spec, including annotation-derived SANs, is assembled.
 func splitHosts(hosts []string) (dnsNames, ipAddresses []string) {
-	seen := sets.New[string]()
 	for _, h := range hosts {
-		if seen.Has(h) {
-			continue
-		}
-		seen.Insert(h)
 		if ip := net.ParseIP(h); ip != nil {
 			ipAddresses = append(ipAddresses, h)
 		} else {
@@ -553,38 +547,30 @@ func splitHosts(hosts []string) (dnsNames, ipAddresses []string) {
 	return dnsNames, ipAddresses
 }
 
+// uniqBy returns in with duplicate elements removed, preserving first-seen
+// order. Two elements are duplicates if key returns the same value for both.
+func uniqBy(in []string, key func(string) string) []string {
+	var out []string
+	seen := sets.New[string]()
+	for _, v := range in {
+		k := key(v)
+		if seen.Has(k) {
+			continue
+		}
+		seen.Insert(k)
+		out = append(out, v)
+	}
+	return out
+}
+
 // dedupeSANs removes duplicate values from crt.Spec.DNSNames and
 // crt.Spec.IPAddresses in place, preserving first-seen order. IP addresses
 // are compared by parsed value, so two different spellings of the same
 // address (e.g. "2001:db8::1" and "2001:0db8::1") are treated as duplicates
 // even though splitHosts, which only compares strings, would not catch them.
 func dedupeSANs(crt *cmapi.Certificate) {
-	if len(crt.Spec.DNSNames) > 0 {
-		seen := sets.New[string]()
-		dnsNames := make([]string, 0, len(crt.Spec.DNSNames))
-		for _, name := range crt.Spec.DNSNames {
-			if seen.Has(name) {
-				continue
-			}
-			seen.Insert(name)
-			dnsNames = append(dnsNames, name)
-		}
-		crt.Spec.DNSNames = dnsNames
-	}
-
-	if len(crt.Spec.IPAddresses) > 0 {
-		seen := sets.New[string]()
-		ipAddresses := make([]string, 0, len(crt.Spec.IPAddresses))
-		for _, ipStr := range crt.Spec.IPAddresses {
-			key := net.ParseIP(ipStr).String()
-			if seen.Has(key) {
-				continue
-			}
-			seen.Insert(key)
-			ipAddresses = append(ipAddresses, ipStr)
-		}
-		crt.Spec.IPAddresses = ipAddresses
-	}
+	crt.Spec.DNSNames = uniqBy(crt.Spec.DNSNames, func(name string) string { return name })
+	crt.Spec.IPAddresses = uniqBy(crt.Spec.IPAddresses, func(ipStr string) string { return net.ParseIP(ipStr).String() })
 }
 
 func findCertificatesToBeRemoved(certs []*cmapi.Certificate, ingLike metav1.Object) []string {

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -443,7 +443,7 @@ func buildCertificates(
 		// translateAnnotations appends the alt-names and ip-sans annotation
 		// values without checking against the hosts already collected by
 		// splitHosts above, so the merged spec can contain duplicates again.
-		// Normalise the assembled spec once, after all sources are merged.
+		// Normalize the assembled spec once, after all sources are merged.
 		dedupeSANs(crt)
 
 		// check if a Certificate for this TLS entry already exists, and if it
@@ -576,10 +576,7 @@ func dedupeSANs(crt *cmapi.Certificate) {
 		seen := sets.New[string]()
 		ipAddresses := make([]string, 0, len(crt.Spec.IPAddresses))
 		for _, ipStr := range crt.Spec.IPAddresses {
-			key := ipStr
-			if ip := net.ParseIP(ipStr); ip != nil {
-				key = ip.String()
-			}
+			key := net.ParseIP(ipStr).String()
 			if seen.Has(key) {
 				continue
 			}
@@ -674,6 +671,16 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 
 	for i := range a.Spec.DNSNames {
 		if a.Spec.DNSNames[i] != b.Spec.DNSNames[i] {
+			return true
+		}
+	}
+
+	if len(a.Spec.IPAddresses) != len(b.Spec.IPAddresses) {
+		return true
+	}
+
+	for i := range a.Spec.IPAddresses {
+		if a.Spec.IPAddresses[i] != b.Spec.IPAddresses[i] {
 			return true
 		}
 	}

--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -440,6 +440,12 @@ func buildCertificates(
 			return nil, nil, err
 		}
 
+		// translateAnnotations appends the alt-names and ip-sans annotation
+		// values without checking against the hosts already collected by
+		// splitHosts above, so the merged spec can contain duplicates again.
+		// Normalise the assembled spec once, after all sources are merged.
+		dedupeSANs(crt)
+
 		// check if a Certificate for this TLS entry already exists, and if it
 		// does then skip this entry
 		if existingCrt != nil {
@@ -545,6 +551,43 @@ func splitHosts(hosts []string) (dnsNames, ipAddresses []string) {
 		}
 	}
 	return dnsNames, ipAddresses
+}
+
+// dedupeSANs removes duplicate values from crt.Spec.DNSNames and
+// crt.Spec.IPAddresses in place, preserving first-seen order. IP addresses
+// are compared by parsed value, so two different spellings of the same
+// address (e.g. "2001:db8::1" and "2001:0db8::1") are treated as duplicates
+// even though splitHosts, which only compares strings, would not catch them.
+func dedupeSANs(crt *cmapi.Certificate) {
+	if len(crt.Spec.DNSNames) > 0 {
+		seen := sets.New[string]()
+		dnsNames := make([]string, 0, len(crt.Spec.DNSNames))
+		for _, name := range crt.Spec.DNSNames {
+			if seen.Has(name) {
+				continue
+			}
+			seen.Insert(name)
+			dnsNames = append(dnsNames, name)
+		}
+		crt.Spec.DNSNames = dnsNames
+	}
+
+	if len(crt.Spec.IPAddresses) > 0 {
+		seen := sets.New[string]()
+		ipAddresses := make([]string, 0, len(crt.Spec.IPAddresses))
+		for _, ipStr := range crt.Spec.IPAddresses {
+			key := ipStr
+			if ip := net.ParseIP(ipStr); ip != nil {
+				key = ip.String()
+			}
+			if seen.Has(key) {
+				continue
+			}
+			seen.Insert(key)
+			ipAddresses = append(ipAddresses, ipStr)
+		}
+		crt.Spec.IPAddresses = ipAddresses
+	}
 }
 
 func findCertificatesToBeRemoved(certs []*cmapi.Certificate, ingLike metav1.Object) []string {

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -5973,3 +5973,52 @@ func Test_buildCertificates_doesNotMutateIngressLikeLabels(t *testing.T) {
 		})
 	}
 }
+
+func Test_dedupeSANs(t *testing.T) {
+	tests := []struct {
+		name            string
+		dnsNames        []string
+		ipAddresses     []string
+		wantDNSNames    []string
+		wantIPAddresses []string
+	}{
+		{
+			name:         "de-duplicates DNS names re-introduced by the alt-names annotation",
+			dnsNames:     []string{"example.com", "example.com"},
+			wantDNSNames: []string{"example.com"},
+		},
+		{
+			name:            "de-duplicates IP addresses re-introduced by the ip-sans annotation",
+			ipAddresses:     []string{"192.0.2.1", "192.0.2.1"},
+			wantIPAddresses: []string{"192.0.2.1"},
+		},
+		{
+			name:            "de-duplicates IPv6 addresses that differ only in spelling",
+			ipAddresses:     []string{"2001:db8::1", "2001:0db8::1"},
+			wantIPAddresses: []string{"2001:db8::1"},
+		},
+		{
+			name:         "no duplicates leaves order unchanged",
+			dnsNames:     []string{"example.com", "www.example.com"},
+			wantDNSNames: []string{"example.com", "www.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crt := &cmapi.Certificate{
+				Spec: cmapi.CertificateSpec{
+					DNSNames:    tt.dnsNames,
+					IPAddresses: tt.ipAddresses,
+				},
+			}
+			dedupeSANs(crt)
+			if !reflect.DeepEqual(crt.Spec.DNSNames, tt.wantDNSNames) {
+				t.Errorf("dnsNames = %#v, want %#v", crt.Spec.DNSNames, tt.wantDNSNames)
+			}
+			if !reflect.DeepEqual(crt.Spec.IPAddresses, tt.wantIPAddresses) {
+				t.Errorf("ipAddresses = %#v, want %#v", crt.Spec.IPAddresses, tt.wantIPAddresses)
+			}
+		})
+	}
+}

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -6024,26 +6024,20 @@ func Test_splitHosts(t *testing.T) {
 		wantIPAddresses []string
 	}{
 		{
-			name:         "de-duplicates repeated DNS names, keeping first-seen order",
-			hosts:        []string{"example.com", "www.example.com", "example.com", "www.example.com"},
-			wantDNSNames: []string{"example.com", "www.example.com"},
-		},
-		{
 			name:            "splits DNS names from IPv4 and IPv6 addresses",
 			hosts:           []string{"example.com", "192.0.2.1", "2001:db8::1"},
 			wantDNSNames:    []string{"example.com"},
 			wantIPAddresses: []string{"192.0.2.1", "2001:db8::1"},
 		},
 		{
-			name:            "de-duplicates across both DNS names and IP addresses",
-			hosts:           []string{"example.com", "192.0.2.1", "example.com", "192.0.2.1"},
-			wantDNSNames:    []string{"example.com"},
-			wantIPAddresses: []string{"192.0.2.1"},
-		},
-		{
 			name:         "empty input yields nil slices",
 			hosts:        nil,
 			wantDNSNames: nil,
+		},
+		{
+			name:         "preserves duplicate hosts; de-duplication happens in dedupeSANs",
+			hosts:        []string{"example.com", "example.com"},
+			wantDNSNames: []string{"example.com", "example.com"},
 		},
 	}
 
@@ -6179,6 +6173,18 @@ func Test_dedupeSANs(t *testing.T) {
 			name:         "no duplicates leaves order unchanged",
 			dnsNames:     []string{"example.com", "www.example.com"},
 			wantDNSNames: []string{"example.com", "www.example.com"},
+		},
+		{
+			name:         "de-duplicates repeated DNS names, keeping first-seen order",
+			dnsNames:     []string{"example.com", "www.example.com", "example.com", "www.example.com"},
+			wantDNSNames: []string{"example.com", "www.example.com"},
+		},
+		{
+			name:            "de-duplicates across both DNS names and IP addresses",
+			dnsNames:        []string{"example.com", "example.com"},
+			ipAddresses:     []string{"192.0.2.1", "192.0.2.1"},
+			wantDNSNames:    []string{"example.com"},
+			wantIPAddresses: []string{"192.0.2.1"},
 		},
 	}
 

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -465,6 +465,184 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for cert-manager/cert-manager#9295: alt-names and
+			// ip-sans annotation values that duplicate a host already present in
+			// tls.hosts must not reach the created Certificate twice, otherwise
+			// the CSR carries more SANs than the ACME order has identifiers.
+			Name:   "de-duplicates a host present in both tls.hosts and the alt-names/ip-sans annotations",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.AltNamesAnnotationKey:                 "example.com",
+						cmapi.IPSANAnnotationKey:                    "1.1.1.1",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "1.1.1.1"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:    []string{"example.com"},
+						IPAddresses: []string{"1.1.1.1"},
+						SecretName:  "example-com-tls",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			// Regression test for cert-manager/cert-manager#9295: a Certificate
+			// left over from before this fix can already hold duplicate SANs;
+			// buildCertificates must detect and repair it, not just prevent new
+			// duplicates.
+			Name:   "updates an existing Certificate that already holds duplicate dnsNames",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+						cmapi.AltNamesAnnotationKey:                 "example.com",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com", "example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "existing-crt"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
+			// Regression test for cert-manager/cert-manager#9295 (certNeedsUpdate
+			// gap): before this fix, certNeedsUpdate never compared IPAddresses,
+			// so an existing Certificate whose only duplicates were IP addresses
+			// was reported as already up to date and never repaired.
+			Name:   "updates an existing Certificate that already holds duplicate ipAddresses",
+			Issuer: acmeClusterIssuer,
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"1.1.1.1"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"1.1.1.1", "1.1.1.1"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "existing-crt"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"1.1.1.1"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
 			Name:   "return a single HTTP01 Certificate for an ingress with a single valid TLS entry and HTTP01 annotations using edit-in-place",
 			Issuer: acmeClusterIssuer,
 			IngressLike: &networkingv1.Ingress{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

The `cert-manager.io/alt-names` and `cert-manager.io/ip-sans` ingress-shim annotations are appended onto `crt.Spec.DNSNames` / `crt.Spec.IPAddresses` without checking for values already present from the Ingress/Gateway hosts. This re-introduces the duplicate-SAN bug that #8978 fixed for `splitHosts`: e.g. an Ingress with host `example.com` plus annotation `cert-manager.io/alt-names: "example.com"` produces `dnsNames: [example.com, example.com]`, and ACME issuance then fails with `Unexpected number of identifiers found in CSR`, because `GenerateCSR` copies `Spec.DNSNames` verbatim into the CSR while the ACME order controller collapses identifiers into a set.

Fixes https://github.com/cert-manager/cert-manager/issues/9295

### Kind

/kind bug

### Release Note

```release-note
Fixed a bug where the `cert-manager.io/alt-names` and `cert-manager.io/ip-sans` ingress-shim annotations could re-introduce duplicate DNS names or IP addresses into a Certificate's SANs, causing ACME issuance to fail with a `badCSR` error.
```

### Approach

Added `dedupeSANs`, a single normalisation pass over the assembled `crt.Spec` that runs in `buildCertificates` right after `translateAnnotations`, once all sources (Ingress/Gateway hosts and both annotations) have been merged. It de-duplicates `DNSNames` by string equality and `IPAddresses` by parsed value (`net.ParseIP(ip).String()`), both preserving first-seen order. Comparing IP addresses by parsed value also closes a latent gap in the existing `splitHosts` dedup, which compares strings only and would treat two spellings of the same IPv6 address (e.g. `2001:db8::1` and `2001:0db8::1`) as distinct; no current host source can produce that today, but it's free to fix in the same pass.

### Validation

- `go build ./pkg/controller/certificate-shim/...` passes.
- `go test ./pkg/controller/certificate-shim/...` passes (all four sub-packages).
- Added `Test_dedupeSANs` covering: DNS name dedup, IP dedup, IPv6-spelling dedup, and an unchanged-order case with no duplicates. Verified this test fails without the fix and passes with it: temporarily no-op'd `dedupeSANs`'s body and confirmed three of the four subtests failed with the expected mismatch output, then restored the fix and confirmed all four pass.
- `go vet ./pkg/controller/certificate-shim/...` and `gofmt -l` are clean.
- `golangci-lint run ./pkg/controller/certificate-shim/... --config .golangci.yaml` reports 0 issues.

Fixes #9295