### PR TITLE
[release-1.20] Retry the kyverno policy apply until the webhook is up

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -422,7 +422,13 @@ e2e-setup-kyverno: $(call image-tar,kyverno) $(call image-tar,kyvernopre) load-$
 		--set admissionController.initContainer.image.pullPolicy=Never \
 		kyverno kyverno/kyverno >/dev/null
 	@$(KUBECTL) create ns cert-manager >/dev/null 2>&1 || true
-	$(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
+	@i=0; until $(KUBECTL) apply --server-side -f make/config/kyverno/policy.yaml >$(bin_dir)/scratch/kyverno-policy-apply.log 2>&1; do \
+		i=$$((i+1)); \
+		cat $(bin_dir)/scratch/kyverno-policy-apply.log >&2; \
+		if [ $$i -ge 10 ]; then exit 1; fi; \
+		echo "Retrying kyverno policy apply (the kyverno admission webhook can take a few seconds to come up after 'helm upgrade --wait' returns)..." >&2; \
+		sleep 3; \
+	done
 
 # We are using @inteon's fork of Pebble, which adds support for signing CSRs with
 # Ed25519 keys:


### PR DESCRIPTION
Fixes the `ci-cert-manager-release-1.20-e2e-v1-35-bestpractice-install` periodic, which has failed 3 of its last 10 runs.

The kyverno admission webhook registers itself from inside the running pod, after `helm upgrade --wait` has returned. The very next step, `kubectl apply` of `policy.yaml`, lands in that window and fails with `connect: connection refused`, so no test runs. This backports the retry loop that master has had since #9041.

Only the retry hunk is backported. Prow cannot cherry-pick #9041 as a whole: it conflicts on `make/config/kyverno/kustomization.yaml` and `policy.yaml`, because the rest of that PR is the Kyverno 3.8.1 / ValidatingPolicy migration which this branch never took.

<details>
<summary>Evidence</summary>

The failing runs all die in `e2e-setup-kyverno` with the same error, for example [build 2096772800835489792](https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-release-1.20-e2e-v1-35-bestpractice-install/2096772800835489792):

```
/home/prow/go/src/github.com/cert-manager/cert-manager/_bin/tools/kubectl apply --server-side -f make/config/kyverno/policy.yaml >/dev/null
Error from server (InternalError): Internal error occurred: failed calling webhook "mutate-policy.kyverno.svc": failed to call webhook: Post "https://kyverno-svc.kyverno.svc:443/policymutate?timeout=10s": dial tcp 10.0.x.x:443: connect: connection refused
make[1]: *** [make/e2e-setup.mk:411: e2e-setup-kyverno] Error 1
```

The chart (3.6.2) and image (v1.16.2) are unchanged between the last passing and first failing run. The same race broke `ci-cert-manager-release-1.21-e2e-v1-36-bestpractice-install` on every run since 2026-09-04, fixed by #9308.
</details>

```release-note
NONE
```

[Claude Fable 5]
