### PR TITLE
[release-1.20] certificate-shim: do not mutate the cached object's labels (#9303)

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -423,7 +423,10 @@ func buildCertificates(
 			}
 		}
 
-		labels := ingLike.GetLabels()
+		// The ingresses and gateways controllers pass the informer-cached
+		// object straight in, so clone its labels before deleting from them
+		// and never let the Certificate alias the cached map.
+		labels := maps.Clone(ingLike.GetLabels())
 
 		// Remove applyset labels, as they cause certificates to be
 		// incorrectly pruned.

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -18,24 +18,29 @@ package shimhelper
 
 import (
 	"errors"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	coretesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
@@ -4656,6 +4661,98 @@ func TestMergeAnnotations(t *testing.T) {
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("mergeAnnotations() = %v, expected %v", result, tt.expected)
 			}
+		})
+	}
+}
+
+func Test_buildCertificates_doesNotMutateIngressLikeLabels(t *testing.T) {
+	// The ingresses and gateways controllers hand the informer-cached object
+	// to buildCertificates without copying it, so the object passed here
+	// stands in for the object in the shared informer cache.
+	tests := []struct {
+		name    string
+		ingLike metav1.Object
+	}{
+		{
+			name: "ingress",
+			ingLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels: map[string]string{
+						"my-test-label": "should-be-propagated",
+						applysetLabel:   "should-not-be-propagated",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "gateway",
+			ingLike: &gwapi.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-name",
+					Namespace: gen.DefaultTestNamespace,
+					Labels: map[string]string{
+						"my-test-label": "should-be-propagated",
+						applysetLabel:   "should-not-be-propagated",
+					},
+					UID: types.UID("gateway-name"),
+				},
+				Spec: gwapi.GatewaySpec{
+					GatewayClassName: "test-gateway",
+					Listeners: []gwapi.Listener{
+						{
+							Hostname: ptrHostname("example.com"),
+							Port:     443,
+							Protocol: gwapi.HTTPSProtocolType,
+							TLS: &gwapi.ListenerTLSConfig{
+								Mode: ptr.To(gwapi.TLSModeTerminate),
+								CertificateRefs: []gwapi.SecretObjectReference{
+									{
+										Group: ptr.To(gwapi.Group("core")),
+										Kind:  ptr.To(gwapi.Kind("Secret")),
+										Name:  "example-com-tls",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lister := cmlisters.NewCertificateLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}))
+			wantLabels := maps.Clone(test.ingLike.GetLabels())
+
+			newCrts, updateCrts, err := buildCertificates(
+				record.NewFakeRecorder(10), logr.Discard(), lister, test.ingLike,
+				"issuer-name", "ClusterIssuer", "cert-manager.io", nil,
+			)
+			require.NoError(t, err)
+			require.Empty(t, updateCrts)
+			require.Len(t, newCrts, 1)
+
+			assert.Equal(t, wantLabels, test.ingLike.GetLabels(), "buildCertificates must not modify the labels of the object it was given")
+
+			crt := newCrts[0]
+			assert.Equal(t, map[string]string{"my-test-label": "should-be-propagated"}, crt.Labels)
+
+			// The Certificate must own its labels map: a later write to it must
+			// not show up on the (cached) input object.
+			crt.Labels["added-by-test"] = "should-not-leak"
+			assert.NotContains(t, test.ingLike.GetLabels(), "added-by-test", "Certificate labels alias the labels of the object passed to buildCertificates")
 		})
 	}
 }


### PR DESCRIPTION
Manual cherry-pick of #9303 (fixes #9297) for the v1.21.2 tracker #9237, requested by @wallrj in https://github.com/cert-manager/cert-manager/pull/9303#pullrequestreview-5143267082; the automated pick conflicts in the test file's import block.

`sync.go` is picked unchanged (the one-line `maps.Clone`). Deviations, all in `sync_test.go`:

- Import block: kept this branch's imports and added only what the new test uses (`maps`, `client-go/tools/cache`, `client-go/tools/record`, `cmlisters`, `testify/require`). The other imports master gained since this branch are not needed here.
- `buildCertificates` on this branch has no `IngressShimOptions` parameter (added in v1.21), so the trailing argument is dropped from the call.
- This branch is on Go 1.25, so the three `new(gwapi.X)` pointer literals become `ptr.To(gwapi.X)` (`k8s.io/utils/ptr` is already imported here).

`go build ./...`, `go vet` and `go test -race ./pkg/controller/certificate-shim/` pass locally on this branch. With this branch's `sync.go` and the new test, both subtests fail; with the pick they pass.

```release-note
ingress-shim no longer removes the applyset label from cached Ingress and Gateway objects
```

/assign wallrj
/kind bug

This backport was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.