### PR TITLE
fix(e2e): give each SelfSigned CSR spec its own Secret

### DIFF
--- a/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
+++ b/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go
@@ -28,6 +28,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework"
@@ -43,13 +44,20 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 	f := framework.NewDefaultFramework("certificatesigningrequests-selfsigned-secret")
 
 	var (
-		request *certificatesv1.CertificateSigningRequest
-		issuer  cmapi.GenericIssuer
-		secret  *corev1.Secret
-		bundle  *testcrypto.CryptoBundle
+		request    *certificatesv1.CertificateSigningRequest
+		issuer     cmapi.GenericIssuer
+		secret     *corev1.Secret
+		secretName string
+		bundle     *testcrypto.CryptoBundle
 	)
 
 	JustBeforeEach(func(testingCtx context.Context) {
+		// The ClusterIssuer specs below put this Secret in the cluster
+		// resource namespace, which the framework does not randomise, so a
+		// fixed name would make them collide when Ginkgo runs them in
+		// parallel.
+		secretName = "selfsigned-test-" + rand.String(10)
+
 		var err error
 		bundle, err = testcrypto.CreateCryptoBundle(&cmapi.Certificate{
 			Spec: cmapi.CertificateSpec{CommonName: "selfsigned-test"}}, clock.RealClock{})
@@ -116,6 +124,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 				"tls.key": bundle.PrivateKeyBytes,
 			},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			request, err = f.KubeClientSet.CertificatesV1().CertificateSigningRequests().Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -203,7 +212,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 		request, err = f.KubeClientSet.CertificatesV1().CertificateSigningRequests().Create(testingCtx, &certificatesv1.CertificateSigningRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "selfsigned-",
-				Annotations:  map[string]string{"experimental.cert-manager.io/private-key-secret-name": "selfsigned-test"},
+				Annotations:  map[string]string{"experimental.cert-manager.io/private-key-secret-name": secretName},
 			},
 			Spec: certificatesv1.CertificateSigningRequestSpec{
 				Request:    bundle.CSRBytes,
@@ -238,11 +247,12 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 
 		By("creating Secret with private key should result in the request to be signed")
 		secret, err = f.KubeClientSet.CoreV1().Secrets("cert-manager").Create(testingCtx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: "cert-manager"},
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "cert-manager"},
 			Data: map[string][]byte{
 				"tls.key": bundle.PrivateKeyBytes,
 			},
 		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			request, err = f.KubeClientSet.CertificatesV1().CertificateSigningRequests().Get(testingCtx, request.Name, metav1.GetOptions{})
@@ -257,7 +267,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 		var err error
 		By("creating Secret with missing private key")
 		secret, err = f.KubeClientSet.CoreV1().Secrets("cert-manager").Create(testingCtx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "selfsigned-test", Namespace: "cert-manager"},
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "cert-manager"},
 			Data:       map[string][]byte{},
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -272,7 +282,7 @@ var _ = framework.CertManagerDescribe("CertificateSigningRequests SelfSigned Sec
 		request, err = f.KubeClientSet.CertificatesV1().CertificateSigningRequests().Create(testingCtx, &certificatesv1.CertificateSigningRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "selfsigned-",
-				Annotations:  map[string]string{"experimental.cert-manager.io/private-key-secret-name": "selfsigned-test"},
+				Annotations:  map[string]string{"experimental.cert-manager.io/private-key-secret-name": secretName},
 			},
 			Spec: certificatesv1.CertificateSigningRequestSpec{
 				Request:    bundle.CSRBytes,


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9318.

Two e2e specs create the same Secret, `cert-manager/selfsigned-test`, with the name and the namespace hard-coded. `make/e2e.sh` runs ginkgo with `nodes=40` and `--randomize-all`, so the two sometimes run at the same time on different processes, and the second fails:

```
[FAIL] [cert-manager] CertificateSigningRequests SelfSigned Secret [It] ClusterIssuer:
       private key Secret is updated with a valid private key after the request is created

Unexpected error: secrets "selfsigned-test" already exists (409 AlreadyExists)
```

The spec at [L192](https://github.com/cert-manager/cert-manager/blob/d82aaf75b1554e88e7714b531266044ae95b886a/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go#L192) creates the Secret partway through and deletes it in `JustAfterEach`. The spec at [L254](https://github.com/cert-manager/cert-manager/blob/d82aaf75b1554e88e7714b531266044ae95b886a/test/e2e/suite/certificatesigningrequests/selfsigned/selfsigned.go#L254) creates the same object as its first step. Whichever starts second gets the 409.

The Secret has to live in the cluster resource namespace, because that is where a ClusterIssuer resolves the `experimental.cert-manager.io/private-key-secret-name` annotation, and the framework does not randomise that namespace. The name is the only part we control.

### What changed

Each spec now generates its own Secret name in `JustBeforeEach` and uses the same value in the annotation. Generating it there rather than at tree-construction time also means a retry gets a fresh name — the losing spec holds the Secret for about a second, so a retry that reuses the same name is certain to lose again.

I also asserted the error on two Secret creates that were discarding it. That is not tidying; it changes how often we can even see this bug. `client-go`'s generic `Create` returns a non-nil zero object alongside the error ([`gentype/type.go:244`](https://github.com/kubernetes/client-go/blob/v0.33.0/gentype/type.go#L244)):

```go
func (c *Client[T]) Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error) {
	result := c.newObject()
	err := c.client.Post().
		...
		Into(result)
	return result, err
}
```

So the spec that lost the race carried on with a *nameless* Secret, waited 20 seconds for a signature that was never coming, and then failed teardown with `resource name may not be empty`. Only one of the two specs could produce the clean 409 above. Collisions that went the other way looked like an unrelated signing timeout, so this flake is rarer in the record than it is in reality — worth knowing before triaging #9318 on the basis of "we have only seen it once".

The two `Issuer:` specs keep the fixed name. They write into the framework's per-spec namespace, so their names are already unique.

### How this was tested

- `go build -tags e2e_test ./...` and `go vet -tags e2e_test ./suite/certificatesigningrequests/...` pass in the `test/e2e` module, and `go fmt` reports no change.
- I checked the sibling `test/e2e/suite/certificaterequests/selfsigned/secret.go` suite, which has ClusterIssuer specs of the same shape. It is not affected: a CertificateRequest is namespaced, so its private key Secret is resolved in the CertificateRequest's own namespace even when the issuer is cluster-scoped, and every Secret there already goes into `f.Namespace.Name`. Lines 248, 267 and 318 of the file changed here are the only places in the e2e tree that touch `Secrets("cert-manager")`.

Please be clear about what a green e2e run proves here. It shows the specs still pass and that the annotation and the Secret still agree. It does not prove the race is gone, because the race is rare and a single run would very likely have passed before this change too. The argument is structural: after this, no two specs can ask for the same Secret name.

### Kind

/kind flake

### Release Note

```release-note
NONE
```
