### PR TITLE
fix: reject duplicate dnsNames and ipAddresses in Certificate webhook

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -111,7 +111,9 @@ spec:
                     Cannot be set if the `literalSubject` field is set.
                   type: string
                 dnsNames:
-                  description: Requested DNS subject alternative names.
+                  description: |-
+                    Requested DNS subject alternative names.
+                    Values must be unique.
                   items:
                     type: string
                   type: array
@@ -140,7 +142,10 @@ spec:
                     issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
                   type: boolean
                 ipAddresses:
-                  description: Requested IP address subject alternative names.
+                  description: |-
+                    Requested IP address subject alternative names.
+                    Values must be unique. Addresses are compared by parsed value, so
+                    equivalent spellings of one address count as duplicates.
                   items:
                     type: string
                   type: array

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -110,7 +110,9 @@ spec:
                   Cannot be set if the `literalSubject` field is set.
                 type: string
               dnsNames:
-                description: Requested DNS subject alternative names.
+                description: |-
+                  Requested DNS subject alternative names.
+                  Values must be unique.
                 items:
                   type: string
                 type: array
@@ -139,7 +141,10 @@ spec:
                   issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
                 type: boolean
               ipAddresses:
-                description: Requested IP address subject alternative names.
+                description: |-
+                  Requested IP address subject alternative names.
+                  Values must be unique. Addresses are compared by parsed value, so
+                  equivalent spellings of one address count as duplicates.
                 items:
                   type: string
                 type: array

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -175,9 +175,12 @@ type CertificateSpec struct {
 	Renewal *CertificateRenewal
 
 	// Requested DNS subject alternative names.
+	// Values must be unique.
 	DNSNames []string
 
 	// Requested IP address subject alternative names.
+	// Values must be unique. Addresses are compared by parsed value, so
+	// equivalent spellings of one address count as duplicates.
 	IPAddresses []string
 
 	// Requested URI subject alternative names.

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -141,6 +141,10 @@ func validateCertificateSpec(crt, oldCrt *internalcmapi.CertificateSpec, fldPath
 		el = append(el, field.TooLong(fldPath.Child("commonName"), commonName, 64))
 	}
 
+	if len(crt.DNSNames) > 0 {
+		el = append(el, validateDNSNames(crt, fldPath)...)
+	}
+
 	if len(crt.IPAddresses) > 0 {
 		el = append(el, validateIPAddresses(crt, fldPath)...)
 	}
@@ -289,16 +293,41 @@ func validateIssuerRef(issuerRef cmmeta.IssuerReference, fldPath *field.Path) fi
 	return el
 }
 
+func validateDNSNames(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+	if len(a.DNSNames) == 0 {
+		return nil
+	}
+	var el field.ErrorList
+	dnsNameSet := sets.NewString()
+	for i, name := range a.DNSNames {
+		if dnsNameSet.Has(name) {
+			el = append(el, field.Duplicate(fldPath.Child("dnsNames").Index(i), name))
+			continue
+		}
+		dnsNameSet.Insert(name)
+	}
+	return el
+}
+
 func validateIPAddresses(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
 	if len(a.IPAddresses) == 0 {
 		return nil
 	}
-	el := field.ErrorList{}
+	var el field.ErrorList
+	// Compare by parsed (canonical) value so equivalent IPv6 spellings collide.
+	ipSet := sets.NewString()
 	for i, d := range a.IPAddresses {
 		ip := net.ParseIP(d)
 		if ip == nil {
 			el = append(el, field.Invalid(fldPath.Child("ipAddresses").Index(i), d, "invalid IP address"))
+			continue
 		}
+		key := ip.String()
+		if ipSet.Has(key) {
+			el = append(el, field.Duplicate(fldPath.Child("ipAddresses").Index(i), d))
+			continue
+		}
+		ipSet.Insert(key)
 	}
 	return el
 }

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -141,13 +141,8 @@ func validateCertificateSpec(crt, oldCrt *internalcmapi.CertificateSpec, fldPath
 		el = append(el, field.TooLong(fldPath.Child("commonName"), commonName, 64))
 	}
 
-	if len(crt.DNSNames) > 0 {
-		el = append(el, validateDNSNames(crt, fldPath)...)
-	}
-
-	if len(crt.IPAddresses) > 0 {
-		el = append(el, validateIPAddresses(crt, fldPath)...)
-	}
+	el = append(el, validateDNSNames(crt, oldCrt, fldPath)...)
+	el = append(el, validateIPAddresses(crt, oldCrt, fldPath)...)
 
 	if len(crt.EmailAddresses) > 0 {
 		el = append(el, validateEmailAddresses(crt, fldPath)...)
@@ -293,13 +288,16 @@ func validateIssuerRef(issuerRef cmmeta.IssuerReference, fldPath *field.Path) fi
 	return el
 }
 
-func validateDNSNames(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
-	if len(a.DNSNames) == 0 {
+func validateDNSNames(crt, oldCrt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+	// Existing Certificates with duplicate dnsNames must remain updateable
+	// (including controller ApplyStatus) while the field is unchanged.
+	if oldCrt != nil && reflect.DeepEqual(oldCrt.DNSNames, crt.DNSNames) {
 		return nil
 	}
-	var el field.ErrorList
-	dnsNameSet := sets.NewString()
-	for i, name := range a.DNSNames {
+
+	el := field.ErrorList{}
+	dnsNameSet := sets.New[string]()
+	for i, name := range crt.DNSNames {
 		if dnsNameSet.Has(name) {
 			el = append(el, field.Duplicate(fldPath.Child("dnsNames").Index(i), name))
 			continue
@@ -309,25 +307,30 @@ func validateDNSNames(a *internalcmapi.CertificateSpec, fldPath *field.Path) fie
 	return el
 }
 
-func validateIPAddresses(a *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
-	if len(a.IPAddresses) == 0 {
+func validateIPAddresses(crt, oldCrt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+	// Existing Certificates with duplicate ipAddresses must remain updateable
+	// (including controller ApplyStatus) while the field is unchanged.
+	if oldCrt != nil && reflect.DeepEqual(oldCrt.IPAddresses, crt.IPAddresses) {
 		return nil
 	}
-	var el field.ErrorList
+
+	el := field.ErrorList{}
 	// Compare by parsed (canonical) value so equivalent IPv6 spellings collide.
-	ipSet := sets.NewString()
-	for i, d := range a.IPAddresses {
+	// Track the first index so errors can name the earlier colliding entry when
+	// the two spellings differ.
+	firstIndex := map[string]int{}
+	for i, d := range crt.IPAddresses {
 		ip := net.ParseIP(d)
 		if ip == nil {
 			el = append(el, field.Invalid(fldPath.Child("ipAddresses").Index(i), d, "invalid IP address"))
 			continue
 		}
 		key := ip.String()
-		if ipSet.Has(key) {
-			el = append(el, field.Duplicate(fldPath.Child("ipAddresses").Index(i), d))
+		if first, ok := firstIndex[key]; ok {
+			el = append(el, field.Invalid(fldPath.Child("ipAddresses").Index(i), d, fmt.Sprintf("duplicates ipAddresses[%d]", first)))
 			continue
 		}
-		ipSet.Insert(key)
+		firstIndex[key] = i
 	}
 	return el
 }

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -438,16 +438,6 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
 			},
 		},
-		"valid certificate with unique dnsNames": {
-			cfg: &internalcmapi.Certificate{
-				Spec: internalcmapi.CertificateSpec{
-					DNSNames:   []string{"example.com", "www.example.com"},
-					SecretName: "abc",
-					IssuerRef:  validIssuerRef,
-				},
-			},
-			a: someAdmissionRequest,
-		},
 		"certificate with duplicate dnsNames": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
@@ -461,16 +451,6 @@ func TestValidateCertificate(t *testing.T) {
 				field.Duplicate(fldPath.Child("dnsNames").Index(2), "example.com"),
 			},
 		},
-		"valid certificate with unique ipAddresses": {
-			cfg: &internalcmapi.Certificate{
-				Spec: internalcmapi.CertificateSpec{
-					IPAddresses: []string{"127.0.0.1", "2001:db8::1"},
-					SecretName:  "abc",
-					IssuerRef:   validIssuerRef,
-				},
-			},
-			a: someAdmissionRequest,
-		},
 		"certificate with duplicate ipAddresses": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
@@ -481,20 +461,7 @@ func TestValidateCertificate(t *testing.T) {
 			},
 			a: someAdmissionRequest,
 			errs: []*field.Error{
-				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "127.0.0.1"),
-			},
-		},
-		"certificate with equivalent IPv6 spellings in ipAddresses": {
-			cfg: &internalcmapi.Certificate{
-				Spec: internalcmapi.CertificateSpec{
-					IPAddresses: []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"},
-					SecretName:  "abc",
-					IssuerRef:   validIssuerRef,
-				},
-			},
-			a: someAdmissionRequest,
-			errs: []*field.Error{
-				field.Duplicate(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1"),
+				field.Invalid(fldPath.Child("ipAddresses").Index(2), "127.0.0.1", "duplicates ipAddresses[0]"),
 			},
 		},
 		"valid certificate with commonName exactly 64 bytes": {
@@ -1101,6 +1068,73 @@ func TestValidateUpdateCertificatePreservesLegacyRenewBeforePercentageOnUnchange
 	assert.Empty(t, warnings)
 }
 
+func TestValidateUpdateCertificateDuplicateSANs(t *testing.T) {
+	fldPath := field.NewPath("spec")
+	cert := func(dnsNames, ipAddresses []string) *internalcmapi.Certificate {
+		return &internalcmapi.Certificate{
+			Spec: internalcmapi.CertificateSpec{
+				DNSNames:    dnsNames,
+				IPAddresses: ipAddresses,
+				SecretName:  "abc",
+				IssuerRef:   validIssuerRef,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		oldCert     *internalcmapi.Certificate
+		newCert     *internalcmapi.Certificate
+		subResource string
+		errs        []*field.Error
+	}{
+		"unchanged duplicate dnsNames on status update are allowed": {
+			oldCert:     cert([]string{"a.example.com", "a.example.com"}, nil),
+			newCert:     cert([]string{"a.example.com", "a.example.com"}, nil),
+			subResource: "status",
+		},
+		"unchanged duplicate ipAddresses on update are allowed": {
+			oldCert: cert(nil, []string{"127.0.0.1", "127.0.0.1"}),
+			newCert: cert(nil, []string{"127.0.0.1", "127.0.0.1"}),
+		},
+		"unchanged equivalent IPv6 spellings on update are allowed": {
+			oldCert: cert(nil, []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"}),
+			newCert: cert(nil, []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"}),
+		},
+		"introducing duplicate dnsNames on update is rejected": {
+			oldCert: cert([]string{"a.example.com"}, nil),
+			newCert: cert([]string{"a.example.com", "a.example.com"}, nil),
+			errs: []*field.Error{
+				field.Duplicate(fldPath.Child("dnsNames").Index(1), "a.example.com"),
+			},
+		},
+		"introducing duplicate ipAddresses on update is rejected": {
+			oldCert: cert(nil, []string{"127.0.0.1"}),
+			newCert: cert(nil, []string{"127.0.0.1", "127.0.0.1"}),
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("ipAddresses").Index(1), "127.0.0.1", "duplicates ipAddresses[0]"),
+			},
+		},
+		"changing ipAddresses to equivalent IPv6 spellings on update is rejected": {
+			oldCert: cert(nil, []string{"2001:db8::1"}),
+			newCert: cert(nil, []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"}),
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1", "duplicates ipAddresses[0]"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			errs, warnings := ValidateUpdateCertificate(&admissionv1.AdmissionRequest{
+				Operation:   admissionv1.Update,
+				SubResource: test.subResource,
+			}, test.oldCert, test.newCert)
+			assert.ElementsMatch(t, test.errs, errs)
+			assert.Empty(t, warnings)
+		})
+	}
+}
+
 func TestValidateUpdateCertificateRejectsChangedRenewBeforePercentageBelowMinimum(t *testing.T) {
 	fldPath := field.NewPath("spec")
 	oldCert := &internalcmapi.Certificate{
@@ -1400,21 +1434,17 @@ func TestValidateDuration(t *testing.T) {
 func Test_validateDNSNames(t *testing.T) {
 	fldPath := field.NewPath("spec")
 	tests := map[string]struct {
-		spec   *internalcmapi.CertificateSpec
+		crt    *internalcmapi.CertificateSpec
+		oldCrt *internalcmapi.CertificateSpec
 		expErr field.ErrorList
 	}{
-		"if no dnsNames defined, expect no error": {
-			spec:   &internalcmapi.CertificateSpec{},
-			expErr: nil,
-		},
 		"if unique dnsNames defined, expect no error": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				DNSNames: []string{"example.com", "www.example.com"},
 			},
-			expErr: nil,
 		},
 		"if duplicate dnsNames defined, expect error": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				DNSNames: []string{"example.com", "www.example.com", "example.com"},
 			},
 			expErr: field.ErrorList{
@@ -1422,7 +1452,7 @@ func Test_validateDNSNames(t *testing.T) {
 			},
 		},
 		"if multiple duplicate dnsNames defined, expect error for each later occurrence": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				DNSNames: []string{"example.com", "example.com", "other.example.com", "example.com"},
 			},
 			expErr: field.ErrorList{
@@ -1430,12 +1460,31 @@ func Test_validateDNSNames(t *testing.T) {
 				field.Duplicate(fldPath.Child("dnsNames").Index(3), "example.com"),
 			},
 		},
+		"if dnsNames unchanged on update including duplicates, expect no error": {
+			crt: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "example.com"},
+			},
+			oldCrt: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "example.com"},
+			},
+		},
+		"if dnsNames change to introduce duplicates on update, expect error": {
+			crt: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "example.com"},
+			},
+			oldCrt: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("dnsNames").Index(1), "example.com"),
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotErr := validateDNSNames(test.spec, fldPath)
-			assert.Equal(t, test.expErr, gotErr)
+			gotErr := validateDNSNames(test.crt, test.oldCrt, fldPath)
+			assert.ElementsMatch(t, test.expErr, gotErr)
 		})
 	}
 }
@@ -1443,21 +1492,17 @@ func Test_validateDNSNames(t *testing.T) {
 func Test_validateIPAddresses(t *testing.T) {
 	fldPath := field.NewPath("spec")
 	tests := map[string]struct {
-		spec   *internalcmapi.CertificateSpec
+		crt    *internalcmapi.CertificateSpec
+		oldCrt *internalcmapi.CertificateSpec
 		expErr field.ErrorList
 	}{
-		"if no ipAddresses defined, expect no error": {
-			spec:   &internalcmapi.CertificateSpec{},
-			expErr: nil,
-		},
 		"if unique ipAddresses defined, expect no error": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				IPAddresses: []string{"127.0.0.1", "10.0.0.1", "2001:db8::1"},
 			},
-			expErr: nil,
 		},
 		"if invalid ipAddress defined, expect error": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				IPAddresses: []string{"blah"},
 			},
 			expErr: field.ErrorList{
@@ -1465,35 +1510,54 @@ func Test_validateIPAddresses(t *testing.T) {
 			},
 		},
 		"if duplicate ipAddresses defined, expect error": {
-			spec: &internalcmapi.CertificateSpec{
+			crt: &internalcmapi.CertificateSpec{
 				IPAddresses: []string{"127.0.0.1", "10.0.0.1", "127.0.0.1"},
 			},
 			expErr: field.ErrorList{
-				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "127.0.0.1"),
+				field.Invalid(fldPath.Child("ipAddresses").Index(2), "127.0.0.1", "duplicates ipAddresses[0]"),
 			},
 		},
-		"if equivalent IPv6 spellings defined, expect error": {
-			spec: &internalcmapi.CertificateSpec{
+		"if equivalent IPv6 spellings defined, expect error naming first index": {
+			crt: &internalcmapi.CertificateSpec{
 				IPAddresses: []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"},
 			},
 			expErr: field.ErrorList{
-				field.Duplicate(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1"),
+				field.Invalid(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1", "duplicates ipAddresses[0]"),
 			},
 		},
-		"if equivalent IPv6 spellings including uppercase defined, expect error": {
-			spec: &internalcmapi.CertificateSpec{
+		"if equivalent IPv6 spellings including uppercase defined, expect error naming first index": {
+			crt: &internalcmapi.CertificateSpec{
 				IPAddresses: []string{"2001:DB8::1", "::1", "2001:db8:0:0:0:0:0:1"},
 			},
 			expErr: field.ErrorList{
-				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "2001:db8:0:0:0:0:0:1"),
+				field.Invalid(fldPath.Child("ipAddresses").Index(2), "2001:db8:0:0:0:0:0:1", "duplicates ipAddresses[0]"),
+			},
+		},
+		"if ipAddresses unchanged on update including duplicates, expect no error": {
+			crt: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "127.0.0.1"},
+			},
+			oldCrt: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "127.0.0.1"},
+			},
+		},
+		"if ipAddresses change to introduce duplicates on update, expect error": {
+			crt: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "10.0.0.1", "127.0.0.1"},
+			},
+			oldCrt: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "10.0.0.1"},
+			},
+			expErr: field.ErrorList{
+				field.Invalid(fldPath.Child("ipAddresses").Index(2), "127.0.0.1", "duplicates ipAddresses[0]"),
 			},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotErr := validateIPAddresses(test.spec, fldPath)
-			assert.Equal(t, test.expErr, gotErr)
+			gotErr := validateIPAddresses(test.crt, test.oldCrt, fldPath)
+			assert.ElementsMatch(t, test.expErr, gotErr)
 		})
 	}
 }

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -438,6 +438,65 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
 			},
 		},
+		"valid certificate with unique dnsNames": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					DNSNames:   []string{"example.com", "www.example.com"},
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+		},
+		"certificate with duplicate dnsNames": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					DNSNames:   []string{"example.com", "www.example.com", "example.com"},
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Duplicate(fldPath.Child("dnsNames").Index(2), "example.com"),
+			},
+		},
+		"valid certificate with unique ipAddresses": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					IPAddresses: []string{"127.0.0.1", "2001:db8::1"},
+					SecretName:  "abc",
+					IssuerRef:   validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+		},
+		"certificate with duplicate ipAddresses": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					IPAddresses: []string{"127.0.0.1", "10.0.0.1", "127.0.0.1"},
+					SecretName:  "abc",
+					IssuerRef:   validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "127.0.0.1"),
+			},
+		},
+		"certificate with equivalent IPv6 spellings in ipAddresses": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					IPAddresses: []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"},
+					SecretName:  "abc",
+					IssuerRef:   validIssuerRef,
+				},
+			},
+			a: someAdmissionRequest,
+			errs: []*field.Error{
+				field.Duplicate(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1"),
+			},
+		},
 		"valid certificate with commonName exactly 64 bytes": {
 			cfg: &internalcmapi.Certificate{
 				Spec: internalcmapi.CertificateSpec{
@@ -1334,6 +1393,107 @@ func TestValidateDuration(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			errs := ValidateDuration(&s.cfg.Spec, fldPath)
 			assert.ElementsMatch(t, errs, s.errs)
+		})
+	}
+}
+
+func Test_validateDNSNames(t *testing.T) {
+	fldPath := field.NewPath("spec")
+	tests := map[string]struct {
+		spec   *internalcmapi.CertificateSpec
+		expErr field.ErrorList
+	}{
+		"if no dnsNames defined, expect no error": {
+			spec:   &internalcmapi.CertificateSpec{},
+			expErr: nil,
+		},
+		"if unique dnsNames defined, expect no error": {
+			spec: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "www.example.com"},
+			},
+			expErr: nil,
+		},
+		"if duplicate dnsNames defined, expect error": {
+			spec: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "www.example.com", "example.com"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("dnsNames").Index(2), "example.com"),
+			},
+		},
+		"if multiple duplicate dnsNames defined, expect error for each later occurrence": {
+			spec: &internalcmapi.CertificateSpec{
+				DNSNames: []string{"example.com", "example.com", "other.example.com", "example.com"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("dnsNames").Index(1), "example.com"),
+				field.Duplicate(fldPath.Child("dnsNames").Index(3), "example.com"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotErr := validateDNSNames(test.spec, fldPath)
+			assert.Equal(t, test.expErr, gotErr)
+		})
+	}
+}
+
+func Test_validateIPAddresses(t *testing.T) {
+	fldPath := field.NewPath("spec")
+	tests := map[string]struct {
+		spec   *internalcmapi.CertificateSpec
+		expErr field.ErrorList
+	}{
+		"if no ipAddresses defined, expect no error": {
+			spec:   &internalcmapi.CertificateSpec{},
+			expErr: nil,
+		},
+		"if unique ipAddresses defined, expect no error": {
+			spec: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "10.0.0.1", "2001:db8::1"},
+			},
+			expErr: nil,
+		},
+		"if invalid ipAddress defined, expect error": {
+			spec: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"blah"},
+			},
+			expErr: field.ErrorList{
+				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
+			},
+		},
+		"if duplicate ipAddresses defined, expect error": {
+			spec: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"127.0.0.1", "10.0.0.1", "127.0.0.1"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "127.0.0.1"),
+			},
+		},
+		"if equivalent IPv6 spellings defined, expect error": {
+			spec: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"2001:db8::1", "2001:db8:0:0:0:0:0:1"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("ipAddresses").Index(1), "2001:db8:0:0:0:0:0:1"),
+			},
+		},
+		"if equivalent IPv6 spellings including uppercase defined, expect error": {
+			spec: &internalcmapi.CertificateSpec{
+				IPAddresses: []string{"2001:DB8::1", "::1", "2001:db8:0:0:0:0:0:1"},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(fldPath.Child("ipAddresses").Index(2), "2001:db8:0:0:0:0:0:1"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotErr := validateIPAddresses(test.spec, fldPath)
+			assert.Equal(t, test.expErr, gotErr)
 		})
 	}
 }

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -3504,7 +3504,7 @@ func schema_pkg_apis_certmanager_v1_CertificateSpec(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Requested DNS subject alternative names.",
+							Description: "Requested DNS subject alternative names. Values must be unique.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3523,7 +3523,7 @@ func schema_pkg_apis_certmanager_v1_CertificateSpec(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Requested IP address subject alternative names.",
+							Description: "Requested IP address subject alternative names. Values must be unique. Addresses are compared by parsed value, so equivalent spellings of one address count as duplicates.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -215,11 +215,14 @@ type CertificateSpec struct {
 	Renewal *CertificateRenewal `json:"renewal,omitempty"`
 
 	// Requested DNS subject alternative names.
+	// Values must be unique.
 	// +optional
 	// +listType=atomic
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// Requested IP address subject alternative names.
+	// Values must be unique. Addresses are compared by parsed value, so
+	// equivalent spellings of one address count as duplicates.
 	// +optional
 	// +listType=atomic
 	IPAddresses []string `json:"ipAddresses,omitempty"`

--- a/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
+++ b/pkg/client/applyconfigurations/certmanager/v1/certificatespec.go
@@ -105,8 +105,11 @@ type CertificateSpecApplyConfiguration struct {
 	// `RenewBefore` then the controller respects `renewBefore` and `renewBeforePercentage`.
 	Renewal *CertificateRenewalApplyConfiguration `json:"renewal,omitempty"`
 	// Requested DNS subject alternative names.
+	// Values must be unique.
 	DNSNames []string `json:"dnsNames,omitempty"`
 	// Requested IP address subject alternative names.
+	// Values must be unique. Addresses are compared by parsed value, so
+	// equivalent spellings of one address count as duplicates.
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 	// Requested URI subject alternative names.
 	URIs []string `json:"uris,omitempty"`


### PR DESCRIPTION
Fixes #9298

### Pull Request Motivation

The Certificate webhook currently accepts `dnsNames` and `ipAddresses` that contain duplicates. With an ACME issuer this never issues: `GenerateCSR` copies SANs verbatim, the ACME order controller collapses identifiers into a set, and the ACME server rejects the mismatch with an opaque `badCSR` / "Unexpected number of identifiers found in CSR" error.
De-duplicating inside `GenerateCSR` alone is intentionally not used: `RequestMatchesSpec` compares CSR SANs to the spec with length-sensitive `equalUnsorted`, so a shorter CSR would never match and controllers would loop.

### Kind

/kind bug

### Release Note

```release-note
Potentially breaking: the Certificate webhook now rejects duplicate `dnsNames` and `ipAddresses`. IP addresses are compared by parsed value, so two spellings of one IPv6 address count as a duplicate. Existing Certificates that already contain duplicates remain updateable while those fields are unchanged.
```

### Changes

- Certificate admission validation rejects duplicate `dnsNames` / `ipAddresses`
- - Ratchet on UPDATE when those fields are unchanged (grandfather existing duplicates)
- - IP duplicate errors name the first colliding index when spellings differ
- - API comments document uniqueness; CRDs regenerated via `make generate`
### Tests

Unit tests cover CREATE duplicates, equivalent IPv6 duplicates, UPDATE unchanged duplicates (allowed, including status), and UPDATE introducing duplicates (rejected).

`go test ./internal/apis/certmanager/validation/ -count=1` → ok
This PR rejects those duplicates at admission so users see the problem on apply. IP addresses are compared by parsed (canonical) value so equivalent IPv6 spellings count as a duplicate.

On UPDATE, duplicate checks are skipped when `dnsNames` / `ipAddresses` are unchanged (including controller `ApplyStatus`), so existing Certificates that already contain duplicates remain updateable. CREATE and UPDATE that change those fields to introduce duplicates are still rejected.

