### PR TITLE
[release-1.21] Surface stalled CertificateRequest with failureTime but no Ready condition

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -53,6 +53,7 @@ import (
 
 const (
 	ControllerName = "certificates-issuing"
+	reasonStalled  = "Stalled"
 )
 
 type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, error)
@@ -320,6 +321,21 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	}
 
 	if crReadyCond == nil {
+		if req.Status.FailureTime != nil {
+			// The CertificateRequest has a failureTime but no Ready condition.
+			// This is not reachable via the in-tree issuers, which always set
+			// both in the same update, but can happen with an external issuer
+			// writing failureTime and the Ready condition in separate updates,
+			// or with a partially applied status. Neither this controller nor
+			// the requestmanager controller can make progress from this state
+			// (the requestmanager only cleans up a CertificateRequest whose
+			// Ready condition reason is Failed), so surface it loudly rather
+			// than waiting silently forever.
+			message := fmt.Sprintf("CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", req.Name)
+			log.V(logf.ErrorLevel).Info(message)
+			c.recorder.Event(crt, corev1.EventTypeWarning, reasonStalled, message)
+			return nil
+		}
 		log.V(logf.DebugLevel).Info("CertificateRequest does not have Ready condition, waiting...")
 		return nil
 	}

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -442,7 +442,7 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
-		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, do nothing": {
+		"if certificate is in Issuing state, one CertificateRequest with a failure time but no Ready condition, emit a Stalled event": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{
@@ -453,7 +453,40 @@ func TestIssuingController(t *testing.T) {
 						gen.AddCertificateRequestAnnotations(map[string]string{
 							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
 						}),
-						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Hour * -1)}),
+						// After the Issuing transition, so this is the "stalled
+						// during the current attempt" case, not the earlier
+						// "failed during a previous issuance" case handled above.
+						gen.SetCertificateRequestFailureTime(metav1.Time{Time: metaFixedClockStart.Time.Add(time.Second)}),
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+				ExpectedEvents: []string{
+					fmt.Sprintf("Warning Stalled CertificateRequest %q has a failureTime set but no Ready condition; issuance is stalled. Delete the CertificateRequest to retry.", exampleBundle.CertificateRequest.Name),
+				},
+			},
+			expectedErr: false,
+		},
+		"if certificate is in Issuing state, one CertificateRequest with no failure time and no Ready condition, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequest,
+						// Explicit, so the case keeps covering the missing condition.
+						func(cr *cmapi.CertificateRequest) { cr.Status.Conditions = nil },
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
 					)},
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{


### PR DESCRIPTION
### Pull Request Motivation

Manual cherry-pick of #9128 to release-1.21. Part of #9237.

Prow's `/cherry-pick` cannot apply it because both changed files conflict on release-1.21. The conflicts are unrelated to this change:

- `issuing_controller.go`: the const block on master also has `reasonTemporaryCertificateFailed`, which release-1.21 lacks. Only `reasonStalled` is added here.
- `issuing_controller_test.go`: the surrounding test cases on master come from #9116, which is not on release-1.21. Only the two test cases from #9128 are added here.

The resulting diff is the #9128 diff with one const alignment change. `go test ./pkg/controller/certificates/issuing/...` and `go vet` pass on the branch.

### Kind

/kind bug

### Release Note

```release-note
`cert-manager` now emits a Warning `Stalled` Event and an Info-level log on a Certificate when its current CertificateRequest has a `failureTime` set but no `Ready` condition, a state that previously stalled issuance silently.
```

[Claude Fable 5.1]
