### PR TITLE
fix: replace failed CertificateRequests that lack failureTime

### DIFF
--- a/internal/controller/certificates/previous_issuance.go
+++ b/internal/controller/certificates/previous_issuance.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+)
+
+// FailedRequestIsFromPreviousIssuance reports whether req is a
+// Ready=False/Failed CertificateRequest whose failure belongs to an issuance
+// earlier than the one recorded by the Certificate's Issuing condition. Such a
+// request is a leftover from the previous issuance of the same revision and
+// must be replaced rather than re-counted.
+//
+// The failure is dated by status.failureTime. No in-tree issuer can leave that
+// field unset on a failed request (Reporter.Failed writes it together with the
+// Ready condition), but an external issuer can, so when it is unset the Ready
+// condition's lastTransitionTime is used as the fallback.
+//
+// In the fallback case only, the request's creationTimestamp must also predate
+// the Issuing condition's lastTransitionTime. creationTimestamp comes from the
+// API server while lastTransitionTime comes from the issuer, so an issuer
+// whose clock is behind can stamp a request it has just created with a
+// transition time before the current issuance; recycling on that alone would
+// delete and recreate the request on every sync with no failure ever counted
+// to pace it.
+func FailedRequestIsFromPreviousIssuance(req *cmapi.CertificateRequest, issuing *cmapi.CertificateCondition) bool {
+	readyCond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
+	if readyCond == nil || readyCond.Status != cmmeta.ConditionFalse || readyCond.Reason != cmapi.CertificateRequestReasonFailed {
+		return false
+	}
+	if issuing == nil || issuing.LastTransitionTime == nil {
+		return false
+	}
+
+	if req.Status.FailureTime != nil {
+		return req.Status.FailureTime.Before(issuing.LastTransitionTime)
+	}
+
+	// A failed request with no failureTime: date the failure by the Ready
+	// condition's lastTransitionTime instead.
+	if readyCond.LastTransitionTime == nil {
+		return false
+	}
+	return readyCond.LastTransitionTime.Time.Before(issuing.LastTransitionTime.Time) &&
+		req.CreationTimestamp.Time.Before(issuing.LastTransitionTime.Time)
+}

--- a/internal/controller/certificates/previous_issuance_test.go
+++ b/internal/controller/certificates/previous_issuance_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
+)
+
+func TestFailedRequestIsFromPreviousIssuance(t *testing.T) {
+	transition := metav1.NewTime(time.Now())
+	issuing := &cmapi.CertificateCondition{
+		Type:               cmapi.CertificateConditionIssuing,
+		Status:             cmmeta.ConditionTrue,
+		LastTransitionTime: &transition,
+	}
+	failedReadyCond := func(lastTransition *metav1.Time) gen.CertificateRequestModifier {
+		return gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+			Type:               cmapi.CertificateRequestConditionReady,
+			Status:             cmmeta.ConditionFalse,
+			Reason:             cmapi.CertificateRequestReasonFailed,
+			LastTransitionTime: lastTransition,
+		})
+	}
+
+	tests := map[string]struct {
+		mods    []gen.CertificateRequestModifier
+		issuing *cmapi.CertificateCondition
+		want    bool
+	}{
+		// The pre-existing behaviour, unchanged: a failureTime before the
+		// Issuing transition dates the failure to the previous issuance.
+		"failureTime set, before the Issuing transition": {
+			mods: []gen.CertificateRequestModifier{
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(-time.Hour))),
+				failedReadyCond(nil),
+			},
+			issuing: issuing,
+			want:    true,
+		},
+		"failureTime set, after the Issuing transition": {
+			mods: []gen.CertificateRequestModifier{
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(time.Minute))),
+				failedReadyCond(nil),
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		// #9327: a failed request with no failureTime. The Ready condition's
+		// lastTransitionTime dates the failure instead.
+		"no failureTime, Ready condition transitioned before the Issuing transition": {
+			mods: []gen.CertificateRequestModifier{
+				failedReadyCond(&metav1.Time{Time: transition.Add(-time.Hour)}),
+				func(cr *cmapi.CertificateRequest) { cr.CreationTimestamp = metav1.NewTime(transition.Add(-2 * time.Hour)) },
+			},
+			issuing: issuing,
+			want:    true,
+		},
+		"no failureTime, Ready condition transitioned after the Issuing transition": {
+			mods: []gen.CertificateRequestModifier{
+				failedReadyCond(&metav1.Time{Time: transition.Add(time.Minute)}),
+				func(cr *cmapi.CertificateRequest) { cr.CreationTimestamp = metav1.NewTime(transition.Add(-2 * time.Hour)) },
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		// The fallback path must not fire for a request created during this
+		// issuance, however far behind the issuer's clock is.
+		"no failureTime, Ready condition transitioned before the Issuing transition, but request created after it": {
+			mods: []gen.CertificateRequestModifier{
+				failedReadyCond(&metav1.Time{Time: transition.Add(-time.Hour)}),
+				func(cr *cmapi.CertificateRequest) { cr.CreationTimestamp = metav1.NewTime(transition.Add(time.Second)) },
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		"no failureTime and a Ready condition with no lastTransitionTime": {
+			mods: []gen.CertificateRequestModifier{
+				failedReadyCond(nil),
+				func(cr *cmapi.CertificateRequest) { cr.CreationTimestamp = metav1.NewTime(transition.Add(-2 * time.Hour)) },
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		// Not a failed request at all.
+		"Ready condition with a different reason": {
+			mods: []gen.CertificateRequestModifier{
+				gen.AddCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+					Type:               cmapi.CertificateRequestConditionReady,
+					Status:             cmmeta.ConditionFalse,
+					Reason:             cmapi.CertificateRequestReasonPending,
+					LastTransitionTime: &metav1.Time{Time: transition.Add(-time.Hour)},
+				}),
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(-time.Hour))),
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		"no Ready condition": {
+			mods: []gen.CertificateRequestModifier{
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(-time.Hour))),
+			},
+			issuing: issuing,
+			want:    false,
+		},
+		// Degenerate conditions.
+		"no Issuing condition": {
+			mods: []gen.CertificateRequestModifier{
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(-time.Hour))),
+				failedReadyCond(nil),
+			},
+			issuing: nil,
+			want:    false,
+		},
+		"an Issuing condition with no lastTransitionTime is no evidence": {
+			mods: []gen.CertificateRequestModifier{
+				gen.SetCertificateRequestFailureTime(metav1.NewTime(transition.Add(-time.Hour))),
+				failedReadyCond(nil),
+			},
+			issuing: &cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue},
+			want:    false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, FailedRequestIsFromPreviousIssuance(gen.CertificateRequest("test", test.mods...), test.issuing))
+		})
+	}
+}

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -302,8 +302,7 @@ func (c *controller) ProcessItem(ctx context.Context, key types.NamespacedName) 
 	// failed CertificateRequest from the previous issuance for the same
 	// revision. Leave it to the certificate-requests controller to delete the
 	// CertificateRequest and create a new one.
-	if req.Status.FailureTime != nil && crReadyCond != nil &&
-		req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) && crReadyCond.Reason == cmapi.CertificateRequestReasonFailed {
+	if internalcertificates.FailedRequestIsFromPreviousIssuance(req, certIssuingCond) {
 		log.V(logf.InfoLevel).Info("Found a failed CertificateRequest from previous issuance, waiting for it to be deleted...")
 		return nil
 	}

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -257,6 +257,46 @@ func TestIssuingController(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"if certificate is in Issuing state, one CertificateRequest that has failed during previous issuance with no failureTime, do nothing": {
+			certificate: exampleBundle.Certificate,
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{
+					gen.CertificateFrom(issuingCert),
+					// #9327: no in-tree issuer can produce this state
+					// (Reporter.Failed sets the failureTime and the Ready
+					// condition in one update), but an external issuer
+					// writing the Ready condition alone can. The Ready
+					// condition's lastTransitionTime dates the failure.
+					gen.CertificateRequestFrom(exampleBundle.CertificateRequestFailed,
+						gen.AddCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestRevisionAnnotationKey: "2", // Current Certificate revision=1
+						}),
+						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+							Type:               cmapi.CertificateRequestConditionReady,
+							Status:             cmmeta.ConditionFalse,
+							Reason:             cmapi.CertificateRequestReasonFailed,
+							Message:            "The certificate request failed because of reasons",
+							LastTransitionTime: &metav1.Time{Time: metaFixedClockStart.Time.Add(time.Hour * -1)},
+						}),
+						func(cr *cmapi.CertificateRequest) {
+							cr.CreationTimestamp = metav1.Time{Time: metaFixedClockStart.Time.Add(time.Hour * -2)}
+						},
+					)},
+				KubeObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nextPrivateKeySecretName,
+							Namespace: exampleBundle.Certificate.Namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
+						},
+					},
+				},
+				ExpectedActions: []testpkg.Action{},
+			},
+			expectedErr: false,
+		},
 		"if certificate is in Issuing state, one CertificateRequest, and has failed for the first time during this series of attempts, set failed state with one issuance attempt and log event": {
 			certificate: exampleBundle.Certificate,
 			builder: &testpkg.Builder{

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	internalcertificates "github.com/cert-manager/cert-manager/internal/controller/certificates"
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -281,7 +282,7 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 		// same revision). If it is a CertificateRequest that failed
 		// during the previous issuance, then it should be deleted so
 		// that we create a new one for this issuance.
-		if req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) {
+		if internalcertificates.FailedRequestIsFromPreviousIssuance(req, certIssuingCond) {
 			log.V(logf.DebugLevel).Info("Found a failed CertificateRequest for previous issuance of this revision, deleting...")
 			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -714,6 +714,49 @@ func TestProcessItem(t *testing.T) {
 					)), relaxedCertificateRequestMatcher),
 			},
 		},
+		"should recreate the CertificateRequest if the current 'next' CertificateRequest failed during previous issuance cycle with no failureTime set": {
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "exists"},
+					Data:       map[string][]byte{corev1.TLSPrivateKeyKey: bundle1.privateKeyBytes},
+				},
+			},
+			certificate: gen.CertificateFrom(bundle1.certificate,
+				gen.SetCertificateNextPrivateKeySecretName("exists"),
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue, LastTransitionTime: &fixedNow}),
+				gen.SetCertificateRevision(5),
+			),
+			requests: []runtime.Object{
+				// #9327: a failed request with no failureTime, which no
+				// in-tree issuer produces but an external issuer writing
+				// only the Ready condition can. The Ready condition's
+				// lastTransitionTime dates the failure, so the request
+				// must still be replaced.
+				gen.CertificateRequestFrom(bundle1.certificateRequest,
+					gen.SetCertificateRequestName("test-6"),
+					gen.SetCertificateRequestAnnotations(map[string]string{
+						cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+						cmapi.CertificateRequestRevisionAnnotationKey:   "6",
+					}),
+					gen.AddCertificateRequestStatusCondition(failedCRConditionPreviousIssuance),
+					func(cr *cmapi.CertificateRequest) {
+						cr.CreationTimestamp = metav1.Time{Time: fixedNow.Time.Add(time.Hour * -2)}
+					},
+				),
+			},
+			expectedEvents: []string{`Normal Requested Created new CertificateRequest resource "test-6"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "test-6")),
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns",
+					gen.CertificateRequestFrom(bundle1.certificateRequest,
+						gen.SetCertificateRequestName("test-6"),
+						gen.SetCertificateRequestAnnotations(map[string]string{
+							cmapi.CertificateRequestPrivateKeyAnnotationKey: "exists",
+							cmapi.CertificateRequestRevisionAnnotationKey:   "6",
+						}),
+					)), relaxedCertificateRequestMatcher),
+			},
+		},
 		"should do nothing if the CertificateRequest that is valid for spec has failed during this issuance cycle": {
 			secrets: []runtime.Object{
 				&corev1.Secret{


### PR DESCRIPTION
### Summary

Fixes #9327.

A CertificateRequest with `Ready=False` / reason `Failed` and no `status.failureTime` is never replaced when the private key is reused (e.g. `rotationPolicy: Never`). The issue occurs when an external issuer writes the `Ready` condition without also setting `failureTime`, which no in-tree issuer does (`Reporter.Failed` sets both atomically).

The two consumer guards both key on `req.Status.FailureTime` alone, and a nil receiver makes `metav1.Time.Before` return false:

- **`requestmanager_controller.go:284`** — `req.Status.FailureTime.Before(...)` returns false on nil, so `deleteCurrentFailedRequests` keeps the request forever.
- **`issuing_controller.go:305`** — the previous-issuance wait guard requires `FailureTime != nil`, so the same request reaches `failIssueCertificate` on every new issuance and `failedIssuanceAttempts` climbs with no request replacement.

### Changes

**`internal/controller/certificates/previous_issuance.go`** — Shared predicate `FailedRequestIsFromPreviousIssuance` now treats a failed request with no `failureTime` the same way as one with a `failureTime` before the Issuing transition: the `Ready` condition's `lastTransitionTime` dates the failure instead.

In the fallback case only, the request's `creationTimestamp` must also predate the Issuing transition. The Ready condition's `lastTransitionTime` is issuer-stamped while `creationTimestamp` comes from the API server, so an issuer whose clock is behind can stamp a request created during the current issuance with a transition time before it. Recycling on that alone would delete and recreate the request on every sync with no failure ever counted to pace the retry.

A request that failed during the *current* issuance still gets counted exactly once by the issuing controller (per the existing branch that calls `failIssueCertificate`), so the backoff is preserved.

Both consumer controllers now call the shared predicate. The fix shape follows #9287's predicates for the mirror case (incomplete failure = `failureTime` but no Ready).

### Testing

- **Predicate unit tests** (10 cases): both pre-existing behavior (failureTime set, date by that) and the new fallback (no failureTime, date by Ready condition LTT, with/without creationTimestamp clock-skew guards).
- **issuing controller regression test**: wait-on-previous-issuance branch with a nil-failureTime failed request.
- **requestmanager controller regression test**: delete-and-replace branch with a nil-failureTime failed request.

Local serial suite (`go test -p 1 -short`): `issuing` 118s PASS, `requestmanager` 30s PASS.

RED-first verification: revert the controller changes (keep tests), confirm the new tests fail on master (they do — exactly the issue's symptoms).