### PR TITLE
fix(logging): scope the related-resource logger to one loop iteration

### DIFF
--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -256,7 +256,7 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 	log := logf.FromContext(ctx).WithValues("Certificate", crt.Name)
 	var remaining []*cmapi.CertificateRequest
 	for _, req := range reqs {
-		log = logf.WithRelatedResource(log, req)
+		log := logf.WithRelatedResource(log, req)
 
 		// Check if there are any 'current' CertificateRequests that
 		// failed during the previous issuance cycle. Those should be

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -175,7 +175,7 @@ func certificateRequestsToDelete(log logr.Logger, limit int, requests []*cmapi.C
 	// Prune and sort all CertificateRequests by their revision number.
 	var revisions []revision
 	for _, req := range requests {
-		log = logf.WithRelatedResource(log, req)
+		log := logf.WithRelatedResource(log, req)
 
 		if req.Annotations == nil || req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey] == "" {
 			log.Error(errors.New("skipping processing request with missing revision"), "")


### PR DESCRIPTION
### Pull Request Motivation

Two loops reassign the logger they were handed instead of deriving a copy for the iteration:

https://github.com/cert-manager/cert-manager/blob/a1cfd3851954a975750b258b6584746f272d4ead/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go#L178

https://github.com/cert-manager/cert-manager/blob/a1cfd3851954a975750b258b6584746f272d4ead/pkg/controller/certificates/requestmanager/requestmanager_controller.go#L259

`WithRelatedResource` calls logr's `WithValues` with fixed keys, and `WithValues` appends, so each iteration stacks another set of fields onto the previous one. Captured with a `funcr` logger over two CertificateRequests:

```
line 0: "msg"="processing" "related_resource_name"="first" "related_resource_namespace"="ns" ...
line 1: "msg"="processing" "related_resource_name"="first" "related_resource_namespace"="ns" ... "related_resource_name"="second" "related_resource_namespace"="ns" ...
```

The stale value comes first, so a consumer that takes the first occurrence of a duplicated key attributes the message to the wrong CertificateRequest. That makes it a correctness problem for anyone reading these logs, not only extra fields.

The two sites differ in how often it bites. `certificateRequestsToDelete` iterates the requests above the revision limit, so by construction there is always more than one. `deleteCurrentFailedRequests` iterates the requests for a single revision, which is normally one, and misattributes only when a Certificate has picked up duplicates.

Changing the assignment to a declaration gives each iteration its own logger and leaves the outer one as the base.

### Testing

`make test` passes on this branch, along with `verify-boilerplate`, `verify-errexit`, `verify-golangci-lint`, `verify-modules`, `verify-licenses` and `verify-generate-go-mod-tidy`. There is no new test: the observable is the field list on a log line, and capturing that in the controller tests would need more machinery than the change deserves. The output above is reproducible in a few lines against `pkg/logs`.

Found while working on #9287, kept separate because it is unrelated to that fix.

### Kind

/kind bug

### Release Note

```release-note
Fixed the certificates-revisionmanager and certificates-requestmanager controllers attaching the related-resource log fields of every CertificateRequest they had already processed to each subsequent log line, which could attribute a message to the wrong CertificateRequest.
```

*with claude opus-5*
