### PR TITLE
Add octo-sts trust policy for the release pipeline

### DIFF
--- a/.github/chainguard/cmrel-publish.sts.yaml
+++ b/.github/chainguard/cmrel-publish.sts.yaml
@@ -1,0 +1,16 @@
+# Trust policy for octo-sts (https://github.com/octo-sts/app).
+#
+# Lets the cert-manager release pipeline (`cmrel gcb publish`, run by Cloud
+# Build in the cert-manager-release GCP project) create the draft GitHub
+# release for a tag and upload its assets. cmrel exchanges the Google ID token
+# of the Cloud Build service account for a short-lived GitHub token that
+# carries only the permissions below. No long-lived token is stored anywhere.
+#
+# The service account is defined in cert-manager/infrastructure, gcp/release.tf.
+issuer: https://accounts.google.com
+subject_pattern: "[0-9]+"
+claim_pattern:
+  email: "cert-manager-release-gcb@cert-manager-release\\.iam\\.gserviceaccount\\.com"
+  email_verified: "true"
+permissions:
+  contents: write


### PR DESCRIPTION
**Adds the octo-sts trust policy that lets the release pipeline create GitHub releases without a stored token.** cert-manager/release#373 changes `cmrel gcb publish` to exchange the Cloud Build service account's Google ID token with [octo-sts](https://github.com/octo-sts/app) for a short-lived GitHub token. This file tells octo-sts which identity to admit and what it may do: `contents: write` on this repository, which covers creating the draft release and uploading its assets.

## Why

The v1.21.2 publish failed with 401 from GitHub. The token it used was a personal access token of the `jetstack-release-bot` user, created in January 2020, and nobody on the project holds that account's login to rotate it (#9237). A token minted per publish from the build's own identity removes the secret and the dependency on an orphaned account.

The octo-sts GitHub App is already installed on every repository in the cert-manager org. This is the first policy that uses it.

## What the policy matches

| Field | Value | Why |
|---|---|---|
| `issuer` | `https://accounts.google.com` | Google ID tokens from the Cloud Build metadata server |
| `subject_pattern` | `[0-9]+` | Google service account subjects are numeric unique IDs. octo-sts anchors the pattern. |
| `claim_pattern.email` | `cert-manager-release-gcb@cert-manager-release.iam.gserviceaccount.com` | The service account defined in cert-manager/infrastructure `gcp/release.tf` |
| `claim_pattern.email_verified` | `true` | Belt and braces on the email claim |
| `permissions.contents` | `write` | Create release, upload assets |

The audience is not set, so octo-sts requires its own domain `octo-sts.dev`, which is what cmrel requests.

## Test plan

- [ ] Merge this before cert-manager/release#373.
- [ ] First real use is the next patch release after v1.21.2, which still uses the rotated PAT.

/kind cleanup

[Claude Fable 5.1]
