### PR TITLE
ingress-shim: compare IPAddresses in certNeedsUpdate

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -635,6 +635,16 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 		}
 	}
 
+	if len(a.Spec.IPAddresses) != len(b.Spec.IPAddresses) {
+		return true
+	}
+
+	for i := range a.Spec.IPAddresses {
+		if a.Spec.IPAddresses[i] != b.Spec.IPAddresses[i] {
+			return true
+		}
+	}
+
 	if a.Spec.SecretName != b.Spec.SecretName {
 		return true
 	}

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -1183,6 +1183,67 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			Name:         "should update an existing Certificate resource when the IP SANs change",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"192.0.2.9"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"192.0.2.1"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			DefaultIssuerKind: "Issuer",
+			ExpectedEvents:    []string{`Normal UpdateCertificate Successfully updated Certificate "existing-crt"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						IPAddresses: []string{"192.0.2.9"},
+						SecretName:  "existing-crt",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
 			Name:         "should update an existing Certificate resource with new labels if they do not match those specified on the IngressLike",
 			Issuer:       acmeIssuer,
 			IssuerLister: []runtime.Object{acmeIssuerNewFormat},


### PR DESCRIPTION
### Pull Request Motivation

Fixes #9296.

`certNeedsUpdate` compares `dnsNames`, `secretName`, the issuer reference and the private key settings, but never reads `Spec.IPAddresses`. `buildCertificates` [does set `IPAddresses`](https://github.com/cert-manager/cert-manager/blob/f94d3ea869905732eeb800af40a5c24a2a3c2ff8/pkg/controller/certificate-shim/sync.go#L420) on the desired Certificate, so the new value is computed and then discarded when `certNeedsUpdate` returns false. A change to the IP SANs of an Ingress or Gateway is silently ignored.

As #9296 notes, this also limits what #8978 repairs: a Certificate created by an older cert-manager with duplicate IP SANs keeps its duplicates after the upgrade, and issuance stays stuck on `badCSR` until someone deletes the Certificate by hand.

The change adds an `IPAddresses` comparison in the same shape as the existing `DNSNames` one, immediately after it, so the two read as a pair.

### Verification

New case in `testIngressShim`: an Ingress whose TLS host changes from `192.0.2.1` to `192.0.2.9`, against an existing Certificate holding the old address. On `master` it fails with

```
got unexpected events, exp='[Normal UpdateCertificate Successfully updated Certificate "existing-crt"]' got='[]'
missing action: update  "cert-manager.io/v1, Resource=certificates" in namespace default-unit-test-ns
```

— no update, no event. With this change it passes, and the rest of `./pkg/controller/certificate-shim/` is unaffected.

The test is in the ingress table only. `certNeedsUpdate` is shared by both shims, so the Gateway path is fixed by the same change, but I have not added a Gateway case — happy to if you'd prefer the symmetry.

Scoped deliberately to the comparison. #9295 (the `alt-names` / `ip-sans` annotations re-introducing duplicates) is a separate defect in `translateAnnotations` and is not addressed here.

**Same defect one field over.** While reviewing this change I found that `certNeedsUpdate` also never compares `IssuerRef.Group`, in the block just below the one this PR touches — so changing `cert-manager.io/issuer-group` on an Ingress leaves the Certificate pointing at the old issuer group. `Group` is the field that selects an external issuer rather than cert-manager's built-in `Issuer`/`ClusterIssuer`, so renewals keep being signed by the previous issuer, silently. Raised separately as #9337 to keep this PR narrowly scoped; both touch `certNeedsUpdate`, so whichever lands second may want a trivial rebase.

### Kind

/kind bug

### Release Note

```release-note
ingress-shim: changes to the IP SANs of an Ingress or Gateway are now propagated to existing Certificates.
```
