### PR TITLE
ingress-shim: compare IssuerRef.Group in certNeedsUpdate

### DIFF
--- a/pkg/controller/certificate-shim/sync.go
+++ b/pkg/controller/certificate-shim/sync.go
@@ -647,6 +647,10 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 		return true
 	}
 
+	if a.Spec.IssuerRef.Group != b.Spec.IssuerRef.Group {
+		return true
+	}
+
 	if !ptr.Equal(a.Spec.RevisionHistoryLimit, b.Spec.RevisionHistoryLimit) {
 		return true
 	}

--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -1735,6 +1735,69 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			Name:         "should update an existing Certificate resource with different issuer group if it does not match specified on the IngressLike",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuerNewFormat},
+			IngressLike: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "cert-secret-name",
+						},
+					},
+				},
+			},
+			DefaultIssuerKind: "Issuer",
+			CertificateLister: []runtime.Object{
+				&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-secret-name",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "cert-secret-name",
+						IssuerRef: cmmeta.IssuerReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+			ExpectedEvents: []string{`Normal UpdateCertificate Successfully updated Certificate "cert-secret-name"`},
+			ExpectedUpdate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "cert-secret-name",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildIngressOwnerReferences("ingress-name"),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "cert-secret-name",
+						IssuerRef: cmmeta.IssuerReference{
+							Name:  "issuer-name",
+							Kind:  "Issuer",
+							Group: "cert-manager.io",
+						},
+						Usages: cmapi.DefaultKeyUsages(),
+					},
+				},
+			},
+		},
+		{
 			Name:         "should not update an existing Certificate if there are no changes (testing elements that default to the nil pointer)",
 			Issuer:       acmeIssuer,
 			IssuerLister: []runtime.Object{acmeIssuerNewFormat},


### PR DESCRIPTION
### Pull Request Motivation

`certNeedsUpdate` has the same defect in two adjacent fields. #9302 fixes one of them (`IPAddresses`); this PR fixes the other (`IssuerRef.Group`). They are independent — different hunks, different fields, own tests — and #9302 does not touch `Group`.

`certNeedsUpdate` compares `IssuerRef.Name` and `IssuerRef.Kind`, but never `IssuerRef.Group`:

```go
if a.Spec.IssuerRef.Name != b.Spec.IssuerRef.Name {
	return true
}

if a.Spec.IssuerRef.Kind != b.Spec.IssuerRef.Kind {
	return true
}
// Group is never read
```

`buildCertificates` [does set `Group`](https://github.com/cert-manager/cert-manager/blob/master/pkg/controller/certificate-shim/sync.go#L422), so — exactly as with `IPAddresses` in #9336 — the value is computed and then discarded when `certNeedsUpdate` returns false.

### What `IssuerRef.Group` is, and why this matters

`Group` is the API group of the issuer being referred to. `issuerForIngressLike` resolves it from, in order:

1. the controller's `--default-issuer-group` flag (`defaults.DefaultIssuerGroup`), then
2. the `cert-manager.io/issuer-group` annotation on the Ingress or Gateway, which overrides it.

It is the field that selects an **external issuer** instead of cert-manager's own. `cert-manager.io` means the built-in `Issuer`/`ClusterIssuer`; any other value points at a third-party issuer CRD in that group.

So the user-visible effect is: add or change `cert-manager.io/issuer-group` on an Ingress that already has a Certificate, and nothing happens. The Certificate keeps pointing at the previous group, and renewals keep being signed by the old issuer. Silent, with no event and no error — the same failure shape as #9296.

### Why this cannot cause an update loop

Worth stating explicitly, since a new `certNeedsUpdate` comparison is exactly the kind of change that can cause one if the value is defaulted server-side:

- `SetObjectDefaults_Certificate` (`internal/apis/certmanager/v1/defaults.go`) *does* default an empty `Group` to `cert-manager.io` — but it is registered via `addDefaultingFuncs` into the **webhook-internal** scheme only. The scheme the controller's lister decodes with (`pkg/apis/certmanager/v1/register.go`) registers `addKnownTypes` alone, so the defaulter never runs on the object the shim reads.
- `issuerRef.group` has **no `default:`** in the Certificate CRD schema, and the only `MutatingWebhookConfiguration` in the chart scopes to `certificaterequests`/`CREATE`. Certificates are never mutated on write.
- `Kind` is defaulted by that *same function, two lines up*, carries the same doc-only CRD default, comes from the same `issuerForIngressLike` return, and has been compared at `certNeedsUpdate` for years without flapping. This change is exactly symmetric with it.

Both write paths persist the field: the non-SSA path replaces the whole spec, and SSA marshals the whole spec — and since `Group` is `json:"group,omitempty"`, a desired empty group is dropped and SSA removes the field the shim owns. Converges either way.

### One upgrade note

If an existing shim-managed Certificate has an **empty** stored `group` — written before `Group: issuerGroup` was set on the desired object, or by a run with `--default-issuer-group=""` — this change produces **one** update to `group: cert-manager.io`, then converges. It is not a loop, but on a large cluster it is a visible one-off burst of `UpdateCertificate` events on upgrade.

### Verification

New case in `testIngressShim`: an Ingress annotated `cert-manager.io/issuer-group: cert-manager.io` against an existing Certificate whose `IssuerRef` has no group. Every other field `certNeedsUpdate` compares is identical between the two, so the case isolates `Group`.

On `master` it fails with

```
got unexpected events, exp='[Normal UpdateCertificate Successfully updated Certificate "example-com-tls"]' got='[]'
missing action: update  "cert-manager.io/v1, Resource=certificates" in namespace default-unit-test-ns
```

— no update, no event. With this change it passes, and the rest of `./pkg/controller/certificate-shim/` is unaffected.

As in #9336, the test lives in the ingress table; `certNeedsUpdate` is shared, so the Gateway path is fixed by the same change.

### Relationship to #9302

Both touch `certNeedsUpdate`, in adjacent blocks, so whichever lands second may want a trivial rebase. Entirely happy for this to be folded into #9302 or taken over by the team if that is easier to review — the important part is that the `Group` comparison exists somewhere.

### Kind

/kind bug

### Release Note

```release-note
ingress-shim: changes to the issuer group of an Ingress or Gateway are now propagated to existing Certificates.
```
